### PR TITLE
feat: Implement GPU compression algorithms

### DIFF
--- a/.devcontainer/nvidia-gpu/Dockerfile
+++ b/.devcontainer/nvidia-gpu/Dockerfile
@@ -22,6 +22,20 @@ RUN userdel -r ubuntu || true
 # - NVIDIA Container Toolkit
 # - GPU environment variables (CUDA_HOME, NVIDIA_VISIBLE_DEVICES, etc.)
 
+# Install nvcomp (NVIDIA GPU compression library) for the CUDA 12 toolchain.
+# The redistributable tarball ships include/, lib/ (libnvcomp.so) and CMake
+# package files; installing into /usr/local makes find_package(nvcomp) work.
+ARG NVCOMP_VERSION=4.2.0.11
+RUN set -eux; \
+    cd /tmp; \
+    archive="nvcomp-linux-x86_64-${NVCOMP_VERSION}_cuda12-archive"; \
+    curl -fsSLO "https://developer.download.nvidia.com/compute/nvcomp/redist/nvcomp/linux-x86_64/${archive}.tar.xz"; \
+    tar -xf "${archive}.tar.xz"; \
+    cp -a "${archive}/include/." /usr/local/include/; \
+    cp -a "${archive}/lib/." /usr/local/lib/; \
+    ldconfig; \
+    rm -rf /tmp/nvcomp*
+
 # Remap iowarp user UID/GID to match the host user.
 # This avoids file permission issues with bind-mounted volumes.
 # Override at build time: --build-arg HOST_UID=$(id -u) --build-arg HOST_GID=$(id -g)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -474,6 +474,22 @@ if(CLIO_CTE_ENABLE_COMPRESS)
         endif()
     endif()
 
+    # nvcomp (NVIDIA GPU compression) - optional, requires CUDA.
+    # The redistributable ships nvcomp-config.cmake, so find_package works and
+    # exposes the imported target nvcomp::nvcomp (which pulls in CUDA::cudart).
+    set(CLIO_CTP_ENABLE_NVCOMP OFF)
+    if(CLIO_CORE_ENABLE_CUDA)
+        find_package(nvcomp QUIET)
+        if(nvcomp_FOUND)
+            message(STATUS "found nvcomp ${nvcomp_VERSION} (GPU compression) - target nvcomp::nvcomp")
+            set(CLIO_CTP_ENABLE_NVCOMP ON)
+        else()
+            message(STATUS "nvcomp not found - GPU compression (nvcomp) will be disabled")
+        endif()
+    else()
+        message(STATUS "CLIO_CORE_ENABLE_CUDA is OFF - GPU compression (nvcomp) disabled")
+    endif()
+
     set(COMPRESS_LIBS
         bz2
         ${lzo2_LIBRARIES}
@@ -514,8 +530,15 @@ if(CLIO_CTE_ENABLE_COMPRESS)
         list(APPEND COMPRESS_LIB_DIRS ${libpressio_LIBRARY_DIRS})
     endif()
 
+    # Only add nvcomp if found (imported target carries its own includes)
+    if(CLIO_CTP_ENABLE_NVCOMP)
+        list(APPEND COMPRESS_LIBS nvcomp::nvcomp)
+    endif()
+
     # Make CTP_ENABLE_LIBPRESSIO available to subdirectories (CTP)
     set(CLIO_CTP_ENABLE_LIBPRESSIO ${CLIO_CTP_ENABLE_LIBPRESSIO} CACHE BOOL "Enable LibPressio wrapper (auto-detected)" FORCE)
+    # Make CTP_ENABLE_NVCOMP available to subdirectories (CTP)
+    set(CLIO_CTP_ENABLE_NVCOMP ${CLIO_CTP_ENABLE_NVCOMP} CACHE BOOL "Enable nvcomp GPU compression (auto-detected)" FORCE)
 endif()
 
 # Encryption libraries (conditional)

--- a/context-transfer-engine/compressor/src/compressor_runtime.cc
+++ b/context-transfer-engine/compressor/src/compressor_runtime.cc
@@ -693,12 +693,14 @@ chi::TaskResume Runtime::Compress(ctp::ipc::FullPtr<CompressTask> task,
       CLIO_CO_RETURN;
     }
 
-    // Map compress_lib_ ID to library name
+    // Map compress_lib_ ID to library name. Index 11 ("nvcomp-lz4") is a GPU
+    // compressor; it is only constructible when the build has nvcomp enabled,
+    // otherwise the factory returns null below and it is handled as an error.
     const char* lib_names[] = {"brotli", "bzip2", "blosc2", "fpzip",
                                "lz4",    "lzma",  "snappy", "sz3",
-                               "zfp",    "zlib",  "zstd"};
+                               "zfp",    "zlib",  "zstd",   "nvcomp-lz4"};
     std::string library_name =
-        (context.compress_lib_ >= 0 && context.compress_lib_ <= 10)
+        (context.compress_lib_ >= 0 && context.compress_lib_ <= 11)
             ? lib_names[context.compress_lib_]
             : "zstd";
 
@@ -886,11 +888,11 @@ chi::TaskResume Runtime::Decompress(ctp::ipc::FullPtr<DecompressTask> task,
       int compress_preset = static_cast<int>(header->compress_preset_);
       chi::u64 original_size = header->original_size_;
 
-      // Map compress_lib ID to library name
+      // Map compress_lib ID to library name (index 11 = "nvcomp-lz4", GPU).
       const char* lib_names[] = {"brotli", "bzip2", "blosc2", "fpzip",
                                  "lz4",    "lzma",  "snappy", "sz3",
-                                 "zfp",    "zlib",  "zstd"};
-      std::string library_name = (compress_lib >= 0 && compress_lib <= 10)
+                                 "zfp",    "zlib",  "zstd",   "nvcomp-lz4"};
+      std::string library_name = (compress_lib >= 0 && compress_lib <= 11)
                                      ? lib_names[compress_lib]
                                      : "zstd";
 

--- a/context-transfer-engine/compressor/src/compressor_runtime.cc
+++ b/context-transfer-engine/compressor/src/compressor_runtime.cc
@@ -693,9 +693,13 @@ chi::TaskResume Runtime::Compress(ctp::ipc::FullPtr<CompressTask> task,
       CLIO_CO_RETURN;
     }
 
-    // Map compress_lib_ ID to library name. Index 11 ("nvcomp-lz4") is a GPU
-    // compressor; it is only constructible when the build has nvcomp enabled,
-    // otherwise the factory returns null below and it is handled as an error.
+    // Map compress_lib_ ID to library name. NOTE: this index is the *wire* ID
+    // (the raw array position stored in CompressionHeader.compress_lib_), which
+    // is distinct from CompressionFactory::GetLibraryId's ML scheme
+    // (base_id*10 + preset, e.g. nvcomp-lz4 = 132). Do not feed a factory ML-ID
+    // into this array. Index 11 ("nvcomp-lz4") is a GPU compressor; it is only
+    // constructible when the build has nvcomp enabled, otherwise the factory
+    // returns null below and it is handled as an error.
     const char* lib_names[] = {"brotli", "bzip2", "blosc2", "fpzip",
                                "lz4",    "lzma",  "snappy", "sz3",
                                "zfp",    "zlib",  "zstd",   "nvcomp-lz4"};
@@ -888,7 +892,8 @@ chi::TaskResume Runtime::Decompress(ctp::ipc::FullPtr<DecompressTask> task,
       int compress_preset = static_cast<int>(header->compress_preset_);
       chi::u64 original_size = header->original_size_;
 
-      // Map compress_lib ID to library name (index 11 = "nvcomp-lz4", GPU).
+      // Map compress_lib ID to library name. Wire ID (raw array index), NOT the
+      // factory's ML scheme (base_id*10+preset). Index 11 = "nvcomp-lz4" (GPU).
       const char* lib_names[] = {"brotli", "bzip2", "blosc2", "fpzip",
                                  "lz4",    "lzma",  "snappy", "sz3",
                                  "zfp",    "zlib",  "zstd",   "nvcomp-lz4"};

--- a/context-transfer-engine/compressor/src/compressor_runtime.cc
+++ b/context-transfer-engine/compressor/src/compressor_runtime.cc
@@ -693,20 +693,12 @@ chi::TaskResume Runtime::Compress(ctp::ipc::FullPtr<CompressTask> task,
       CLIO_CO_RETURN;
     }
 
-    // Map compress_lib_ ID to library name. NOTE: this index is the *wire* ID
-    // (the raw array position stored in CompressionHeader.compress_lib_), which
-    // is distinct from CompressionFactory::GetLibraryId's ML scheme
-    // (base_id*10 + preset, e.g. nvcomp-lz4 = 132). Do not feed a factory ML-ID
-    // into this array. Index 11 ("nvcomp-lz4") is a GPU compressor; it is only
-    // constructible when the build has nvcomp enabled, otherwise the factory
-    // returns null below and it is handled as an error.
-    const char* lib_names[] = {"brotli", "bzip2", "blosc2", "fpzip",
-                               "lz4",    "lzma",  "snappy", "sz3",
-                               "zfp",    "zlib",  "zstd",   "nvcomp-lz4"};
+    // Map the wire ID (CompressionHeader.compress_lib_) to a library name via
+    // the shared registry in CompressionFactory (single source of truth; out-of-
+    // range falls back to "zstd"). Note the wire ID is a separate namespace from
+    // GetLibraryId's ML scheme (base_id*10 + preset, e.g. nvcomp-lz4 = 132).
     std::string library_name =
-        (context.compress_lib_ >= 0 && context.compress_lib_ <= 11)
-            ? lib_names[context.compress_lib_]
-            : "zstd";
+        ctp::CompressionFactory::NameForWireId(context.compress_lib_);
 
     // Map preset integer to enum
     ctp::CompressionPreset preset = ctp::CompressionPreset::BALANCED;
@@ -892,14 +884,11 @@ chi::TaskResume Runtime::Decompress(ctp::ipc::FullPtr<DecompressTask> task,
       int compress_preset = static_cast<int>(header->compress_preset_);
       chi::u64 original_size = header->original_size_;
 
-      // Map compress_lib ID to library name. Wire ID (raw array index), NOT the
-      // factory's ML scheme (base_id*10+preset). Index 11 = "nvcomp-lz4" (GPU).
-      const char* lib_names[] = {"brotli", "bzip2", "blosc2", "fpzip",
-                                 "lz4",    "lzma",  "snappy", "sz3",
-                                 "zfp",    "zlib",  "zstd",   "nvcomp-lz4"};
-      std::string library_name = (compress_lib >= 0 && compress_lib <= 11)
-                                     ? lib_names[compress_lib]
-                                     : "zstd";
+      // Map the wire ID to a library name via the shared registry (single
+      // source of truth; out-of-range falls back to "zstd"). Wire ID is a
+      // separate namespace from the factory's ML scheme (base_id*10+preset).
+      std::string library_name =
+          ctp::CompressionFactory::NameForWireId(compress_lib);
 
       // Map preset integer to enum
       ctp::CompressionPreset preset = ctp::CompressionPreset::BALANCED;

--- a/context-transfer-engine/compressor/test/test_compressor_functional.cc
+++ b/context-transfer-engine/compressor/test/test_compressor_functional.cc
@@ -59,6 +59,10 @@
 #include <clio_cte/core/core_client.h>
 #include <clio_cte/core/core_tasks.h>
 
+#if CTP_ENABLE_NVCOMP
+#include <cuda_runtime.h>
+#endif
+
 using namespace clio::cte::compressor;
 
 namespace {
@@ -77,6 +81,7 @@ namespace CompLib {
   constexpr int ZFP = 8;
   constexpr int ZLIB = 9;
   constexpr int ZSTD = 10;
+  constexpr int NVCOMP_LZ4 = 11;  // GPU compressor (requires nvcomp build)
 }
 
 /**
@@ -505,6 +510,61 @@ TEST_CASE("Error Handling - Invalid Parameters", "[compressor][functional][error
     CLIO_IPC->FreeBuffer(shm_buffer);
   }
 }
+
+#if CTP_ENABLE_NVCOMP
+/**
+ * Test Case 7: GPU compression via nvcomp (nvcomp-lz4, lib id 11)
+ * Validates the compressor chimod can select and round-trip the GPU compressor
+ * end-to-end (Compress -> PutBlob -> GetBlob -> Decompress). Skips when no GPU.
+ */
+TEST_CASE("NvComp GPU Round-trip", "[compressor][functional][nvcomp][gpu]") {
+  int device_count = 0;
+  if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+    INFO("No CUDA device available; skipping nvcomp functional test");
+    return;
+  }
+
+  CTETestFixture fixture;
+
+  auto original_data = GenerateTestData(64 * 1024, "text");
+
+  // Compress + store via the chimod using the GPU compressor.
+  auto put_buffer = fixture.AllocateAndCopyData(original_data);
+  REQUIRE(!put_buffer.IsNull());
+  ctp::ipc::ShmPtr<> put_blob_data = put_buffer.shm_.template Cast<void>();
+
+  Context context;
+  context.compress_lib_ = CompLib::NVCOMP_LZ4;  // 11
+  context.compress_preset_ = 2;
+
+  auto compress_task = fixture.compressor_client_.AsyncCompress(
+      chi::PoolQuery::Local(), fixture.tag_id_, "test_blob_nvcomp", 0,
+      original_data.size(), put_blob_data, 0.5f, context, 0,
+      fixture.core_pool_id_);
+  compress_task.Wait();
+  REQUIRE(compress_task->return_code_ == 0);
+  CLIO_IPC->FreeBuffer(put_buffer);
+
+  // Retrieve + decompress via the chimod and verify integrity.
+  auto get_buffer = CLIO_IPC->AllocateBuffer(original_data.size());
+  REQUIRE(!get_buffer.IsNull());
+  ctp::ipc::ShmPtr<> get_blob_data = get_buffer.shm_.template Cast<void>();
+
+  auto decompress_task = fixture.compressor_client_.AsyncDecompressExplicit(
+      chi::PoolQuery::Local(), fixture.tag_id_, "test_blob_nvcomp", 0,
+      original_data.size(), 0, get_blob_data, fixture.core_pool_id_);
+  decompress_task.Wait();
+  REQUIRE(decompress_task->return_code_ == 0);
+  REQUIRE(decompress_task->output_size_ == original_data.size());
+
+  auto retrieved_data =
+      fixture.ReadFromSharedMemory(get_buffer, original_data.size());
+  REQUIRE(std::memcmp(original_data.data(), retrieved_data.data(),
+                      original_data.size()) == 0);
+  INFO("nvcomp-lz4 GPU round-trip verified");
+  CLIO_IPC->FreeBuffer(get_buffer);
+}
+#endif  // CTP_ENABLE_NVCOMP
 
 // Main function using simple_test.h framework
 SIMPLE_TEST_MAIN()

--- a/context-transfer-engine/compressor/test/test_compressor_functional.cc
+++ b/context-transfer-engine/compressor/test/test_compressor_functional.cc
@@ -515,7 +515,8 @@ TEST_CASE("Error Handling - Invalid Parameters", "[compressor][functional][error
 /**
  * Test Case 7: GPU compression via nvcomp (nvcomp-lz4, lib id 11)
  * Validates the compressor chimod can select and round-trip the GPU compressor
- * end-to-end (Compress -> PutBlob -> GetBlob -> Decompress). Skips when no GPU.
+ * end-to-end (Compress -> PutBlob -> GetBlob -> Decompress). Returns early
+ * (passes without a skip marker) when no GPU device is present.
  */
 TEST_CASE("NvComp GPU Round-trip", "[compressor][functional][nvcomp][gpu]") {
   int device_count = 0;
@@ -534,7 +535,7 @@ TEST_CASE("NvComp GPU Round-trip", "[compressor][functional][nvcomp][gpu]") {
   ctp::ipc::ShmPtr<> put_blob_data = put_buffer.shm_.template Cast<void>();
 
   Context context;
-  context.compress_lib_ = CompLib::NVCOMP_LZ4;  // 11
+  context.compress_lib_ = CompLib::NVCOMP_LZ4;
   context.compress_preset_ = 2;
 
   auto compress_task = fixture.compressor_client_.AsyncCompress(

--- a/context-transport-primitives/CMakeLists.txt
+++ b/context-transport-primitives/CMakeLists.txt
@@ -320,6 +320,7 @@ endif()
 target_compile_definitions(compress INTERFACE
     CTP_ENABLE_COMPRESS=$<BOOL:${CLIO_CTE_ENABLE_COMPRESS}>
     CTP_ENABLE_LIBPRESSIO=$<BOOL:${CLIO_CTP_ENABLE_LIBPRESSIO}>
+    CTP_ENABLE_NVCOMP=$<BOOL:${CLIO_CTP_ENABLE_NVCOMP}>
 )
 add_library(ctp::compress ALIAS compress)
 

--- a/context-transport-primitives/CMakeLists.txt
+++ b/context-transport-primitives/CMakeLists.txt
@@ -316,6 +316,12 @@ if(CLIO_CTE_ENABLE_COMPRESS)
     if(TARGET dense_nn_predictor)
         target_link_libraries(compress INTERFACE dense_nn_predictor)
     endif()
+    # nvcomp.h includes <cuda_runtime.h>; the nvcomp imported target does not
+    # propagate the CUDA toolkit include dir, so link CUDA::cudart to provide it
+    # to every consumer of ctp::compress (test + CTE compressor module).
+    if(CLIO_CTP_ENABLE_NVCOMP AND TARGET CUDA::cudart)
+        target_link_libraries(compress INTERFACE CUDA::cudart)
+    endif()
 endif()
 target_compile_definitions(compress INTERFACE
     CTP_ENABLE_COMPRESS=$<BOOL:${CLIO_CTE_ENABLE_COMPRESS}>

--- a/context-transport-primitives/include/clio_ctp/compress/compress_factory.h
+++ b/context-transport-primitives/include/clio_ctp/compress/compress_factory.h
@@ -81,6 +81,9 @@ class CompressionFactory {
    *                     Supported: "bzip2", "zstd", "lz4", "zlib", "lzma",
    *                                "brotli", "snappy", "blosc2"
    *                                "zfp", "sz3", "fpzip" (if LibPressio enabled)
+   *                                "nvcomp-lz4", "nvcomp-snappy", "nvcomp-zstd",
+   *                                "nvcomp-gdeflate", "nvcomp-deflate",
+   *                                "nvcomp-ans" (if nvcomp enabled)
    * @param preset Compression preset level (FAST/BALANCED/BEST/DEFAULT)
    * @return Unique pointer to configured compressor instance,
    *         or nullptr if library not found
@@ -251,9 +254,47 @@ class CompressionFactory {
     return nullptr;
 #endif
   }
+  // GPU compressors (nvcomp). Each helper is always defined so its registry row
+  // is valid in every build; it returns nullptr when nvcomp is disabled (the
+  // name/ids still resolve, but GetPreset yields nullptr). All are single-mode.
   static std::unique_ptr<Compressor> MakeNvCompLz4(CompressionPreset) {
 #if CTP_ENABLE_NVCOMP
     return std::make_unique<NvComp>(NvCompAlgo::LZ4);
+#else
+    return nullptr;
+#endif
+  }
+  static std::unique_ptr<Compressor> MakeNvCompSnappy(CompressionPreset) {
+#if CTP_ENABLE_NVCOMP
+    return std::make_unique<NvComp>(NvCompAlgo::SNAPPY);
+#else
+    return nullptr;
+#endif
+  }
+  static std::unique_ptr<Compressor> MakeNvCompZstd(CompressionPreset) {
+#if CTP_ENABLE_NVCOMP
+    return std::make_unique<NvComp>(NvCompAlgo::ZSTD);
+#else
+    return nullptr;
+#endif
+  }
+  static std::unique_ptr<Compressor> MakeNvCompGdeflate(CompressionPreset) {
+#if CTP_ENABLE_NVCOMP
+    return std::make_unique<NvComp>(NvCompAlgo::GDEFLATE);
+#else
+    return nullptr;
+#endif
+  }
+  static std::unique_ptr<Compressor> MakeNvCompDeflate(CompressionPreset) {
+#if CTP_ENABLE_NVCOMP
+    return std::make_unique<NvComp>(NvCompAlgo::DEFLATE);
+#else
+    return nullptr;
+#endif
+  }
+  static std::unique_ptr<Compressor> MakeNvCompAns(CompressionPreset) {
+#if CTP_ENABLE_NVCOMP
+    return std::make_unique<NvComp>(NvCompAlgo::ANS);
 #else
     return nullptr;
 #endif
@@ -280,7 +321,12 @@ class CompressionFactory {
         CompressorInfo{"zfp",         8, 10, false, &MakeZfp},
         CompressorInfo{"zlib",        9,  4, false, &CreateLossless<ZlibWithModes>},
         CompressorInfo{"zstd",       10,  2, false, &CreateLossless<ZstdWithModes>},
-        CompressorInfo{"nvcomp-lz4", 11, 13, true,  &MakeNvCompLz4},
+        CompressorInfo{"nvcomp-lz4",      11, 13, true, &MakeNvCompLz4},
+        CompressorInfo{"nvcomp-snappy",   12, 14, true, &MakeNvCompSnappy},
+        CompressorInfo{"nvcomp-zstd",     13, 15, true, &MakeNvCompZstd},
+        CompressorInfo{"nvcomp-gdeflate", 14, 16, true, &MakeNvCompGdeflate},
+        CompressorInfo{"nvcomp-deflate",  15, 17, true, &MakeNvCompDeflate},
+        CompressorInfo{"nvcomp-ans",      16, 18, true, &MakeNvCompAns},
     };
     return kRegistry;
   }

--- a/context-transport-primitives/include/clio_ctp/compress/compress_factory.h
+++ b/context-transport-primitives/include/clio_ctp/compress/compress_factory.h
@@ -47,6 +47,10 @@
 #include "libpressio_modes.h"
 #endif
 
+#if CTP_ENABLE_NVCOMP
+#include "nvcomp.h"
+#endif
+
 namespace ctp {
 
 /**
@@ -120,6 +124,13 @@ class CompressionFactory {
       return std::make_unique<Blosc>();
     }
 
+#if CTP_ENABLE_NVCOMP
+    // GPU compressors (nvcomp). Single-mode: preset is ignored (LZ4 has no level).
+    if (lib_lower == "nvcomp-lz4") {
+      return std::make_unique<NvComp>(NvCompAlgo::LZ4);
+    }
+#endif
+
 #if CTP_ENABLE_LIBPRESSIO
     // Lossy compressors with LibPressio
     if (lib_lower == "zfp") {
@@ -168,11 +179,15 @@ class CompressionFactory {
     else if (lib_lower == "zfp") base_id = 10;
     else if (lib_lower == "sz3") base_id = 11;
     else if (lib_lower == "fpzip") base_id = 12;
+    // GPU compressors (nvcomp) base IDs (13+)
+#if CTP_ENABLE_NVCOMP
+    else if (lib_lower == "nvcomp-lz4") base_id = 13;
+#endif
 
     if (base_id == 0) return 0;  // Unknown library
 
-    // For single-mode libraries (SNAPPY, Blosc2), always use preset 2 (BALANCED)
-    if (base_id == 7 || base_id == 8) {
+    // For single-mode libraries (SNAPPY, Blosc2, nvcomp), always use preset 2
+    if (base_id == 7 || base_id == 8 || base_id == 13) {
       return base_id * 10 + 2;
     }
 
@@ -214,6 +229,8 @@ class CompressionFactory {
     else if (base_id == 10) library_name = "zfp";
     else if (base_id == 11) library_name = "sz3";
     else if (base_id == 12) library_name = "fpzip";
+    // GPU compressors (nvcomp)
+    else if (base_id == 13) library_name = "nvcomp-lz4";
 
     CompressionPreset preset = CompressionPreset::BALANCED;
     if (preset_id == 1) preset = CompressionPreset::FAST;

--- a/context-transport-primitives/include/clio_ctp/compress/compress_factory.h
+++ b/context-transport-primitives/include/clio_ctp/compress/compress_factory.h
@@ -36,6 +36,8 @@
 
 #if CTP_ENABLE_COMPRESS
 
+#include <array>
+#include <cctype>
 #include <memory>
 #include <string>
 #include "compress.h"
@@ -92,60 +94,14 @@ class CompressionFactory {
   static std::unique_ptr<Compressor> GetPreset(
       const std::string& library_name,
       CompressionPreset preset = CompressionPreset::BALANCED) {
-
-    std::string lib_lower = library_name;
-    for (auto& c : lib_lower) c = std::tolower(c);
-
-    // Lossless compressors with compression level support
-    if (lib_lower == "bzip2") {
-      return CreateLossless<Bzip2WithModes>(preset);
+    const CompressorInfo* info = FindByName(library_name);
+    // info->make is null when the backend is disabled at build time (LibPressio
+    // for lossy, nvcomp for GPU); GetPreset then returns nullptr just as the
+    // old per-name if-chain fell through to "return nullptr".
+    if (info == nullptr || info->make == nullptr) {
+      return nullptr;
     }
-    if (lib_lower == "zstd") {
-      return CreateLossless<ZstdWithModes>(preset);
-    }
-    if (lib_lower == "lz4") {
-      return CreateLossless<Lz4WithModes>(preset);
-    }
-    if (lib_lower == "zlib") {
-      return CreateLossless<ZlibWithModes>(preset);
-    }
-    if (lib_lower == "lzma") {
-      return CreateLossless<LzmaWithModes>(preset);
-    }
-    if (lib_lower == "brotli") {
-      return CreateLossless<BrotliWithModes>(preset);
-    }
-
-    // Lossless compressors without level support (default only)
-    if (lib_lower == "snappy") {
-      return std::make_unique<Snappy>();
-    }
-    if (lib_lower == "blosc" || lib_lower == "blosc2") {
-      return std::make_unique<Blosc>();
-    }
-
-#if CTP_ENABLE_NVCOMP
-    // GPU compressors (nvcomp). Single-mode: preset is ignored (LZ4 has no level).
-    if (lib_lower == "nvcomp-lz4") {
-      return std::make_unique<NvComp>(NvCompAlgo::LZ4);
-    }
-#endif
-
-#if CTP_ENABLE_LIBPRESSIO
-    // Lossy compressors with LibPressio
-    if (lib_lower == "zfp") {
-      return CreateLossy("zfp", preset);
-    }
-    if (lib_lower == "sz3") {
-      return CreateLossy("sz3", preset);
-    }
-    if (lib_lower == "fpzip") {
-      return CreateLossy("fpzip", preset);
-    }
-#endif
-
-    // Unknown library
-    return nullptr;
+    return info->make(preset);
   }
 
   /**
@@ -161,34 +117,12 @@ class CompressionFactory {
    * - Lossy: base_id * 10 + preset (e.g., ZFP_FAST=101, ZFP_BALANCED=102, ZFP_BEST=103)
    */
   static int GetLibraryId(const std::string& library_name, CompressionPreset preset) {
-    std::string lib_lower = library_name;
-    for (auto& c : lib_lower) c = std::tolower(c);
+    const CompressorInfo* info = FindByName(library_name);
+    if (info == nullptr) return 0;  // Unknown library
 
-    int base_id = 0;
-
-    // Lossless base IDs (1-8)
-    if (lib_lower == "bzip2") base_id = 1;
-    else if (lib_lower == "zstd") base_id = 2;
-    else if (lib_lower == "lz4") base_id = 3;
-    else if (lib_lower == "zlib") base_id = 4;
-    else if (lib_lower == "lzma") base_id = 5;
-    else if (lib_lower == "brotli") base_id = 6;
-    else if (lib_lower == "snappy") base_id = 7;
-    else if (lib_lower == "blosc" || lib_lower == "blosc2") base_id = 8;
-    // Lossy base IDs (10+)
-    else if (lib_lower == "zfp") base_id = 10;
-    else if (lib_lower == "sz3") base_id = 11;
-    else if (lib_lower == "fpzip") base_id = 12;
-    // GPU compressors (nvcomp) base IDs (13+)
-#if CTP_ENABLE_NVCOMP
-    else if (lib_lower == "nvcomp-lz4") base_id = 13;
-#endif
-
-    if (base_id == 0) return 0;  // Unknown library
-
-    // For single-mode libraries (SNAPPY, Blosc2, nvcomp), always use preset 2
-    if (base_id == 7 || base_id == 8 || base_id == 13) {
-      return base_id * 10 + 2;
+    // Single-mode libraries (snappy, blosc2, nvcomp) always encode preset 2.
+    if (info->single_mode) {
+      return info->base_id * 10 + 2;
     }
 
     // Encode preset: FAST=1, BALANCED=2, BEST=3, DEFAULT=2
@@ -200,7 +134,7 @@ class CompressionFactory {
       case CompressionPreset::DEFAULT: preset_id = 2; break;
     }
 
-    return base_id * 10 + preset_id;
+    return info->base_id * 10 + preset_id;
   }
 
   /**
@@ -214,23 +148,8 @@ class CompressionFactory {
     int base_id = library_id / 10;
     int preset_id = library_id % 10;
 
-    std::string library_name = "unknown";
-
-    // Lossless libraries
-    if (base_id == 1) library_name = "bzip2";
-    else if (base_id == 2) library_name = "zstd";
-    else if (base_id == 3) library_name = "lz4";
-    else if (base_id == 4) library_name = "zlib";
-    else if (base_id == 5) library_name = "lzma";
-    else if (base_id == 6) library_name = "brotli";
-    else if (base_id == 7) library_name = "snappy";
-    else if (base_id == 8) library_name = "blosc2";
-    // Lossy libraries
-    else if (base_id == 10) library_name = "zfp";
-    else if (base_id == 11) library_name = "sz3";
-    else if (base_id == 12) library_name = "fpzip";
-    // GPU compressors (nvcomp)
-    else if (base_id == 13) library_name = "nvcomp-lz4";
+    const CompressorInfo* info = FindByBaseId(base_id);
+    std::string library_name = info ? info->name : "unknown";
 
     CompressionPreset preset = CompressionPreset::BALANCED;
     if (preset_id == 1) preset = CompressionPreset::FAST;
@@ -238,6 +157,23 @@ class CompressionFactory {
     else if (preset_id == 3) preset = CompressionPreset::BEST;
 
     return {library_name, preset};
+  }
+
+  /**
+   * Map a CTE wire ID to its canonical library name.
+   *
+   * The wire ID is the raw integer stored in CompressionHeader.compress_lib_
+   * (an array index, the on-disk/runtime protocol). It is a SEPARATE, frozen
+   * namespace from GetLibraryId's ML scheme (base_id*10 + preset). Out-of-range
+   * IDs fall back to "zstd" (the historical CTE default). Append-only: never
+   * renumber existing IDs or old compressed blobs become unreadable.
+   *
+   * @param wire_id Integer wire ID (compress_lib_)
+   * @return Canonical library name, or "zstd" if out of range
+   */
+  static std::string NameForWireId(int wire_id) {
+    const CompressorInfo* info = FindByWireId(wire_id);
+    return info ? info->name : "zstd";
   }
 
   /**
@@ -257,6 +193,130 @@ class CompressionFactory {
   }
 
  private:
+  /** Signature of a function that constructs a compressor for a given preset. */
+  using MakeFn = std::unique_ptr<Compressor> (*)(CompressionPreset);
+
+  /**
+   * One row of the compressor registry -- the single source of truth tying a
+   * compressor's canonical name to its two frozen, INDEPENDENT integer
+   * namespaces:
+   *   - wire_id: raw index stored in CompressionHeader.compress_lib_ (the CTE
+   *              on-disk/runtime protocol; resolved by NameForWireId).
+   *   - base_id: ML scheme, encoded as base_id*10 + preset (see GetLibraryId).
+   * Both are append-only: NEVER renumber an existing entry or stored blobs /
+   * trained models break. `make` is nullptr when the backend is unavailable in
+   * this build (LibPressio off for lossy, nvcomp off for GPU); the name and ids
+   * still resolve, but GetPreset then returns nullptr.
+   *
+   * To add a compressor, add ONE row here (plus, for a GPU algorithm, one case
+   * in NvComp::MakeManager). No other edits in this file are needed.
+   */
+  struct CompressorInfo {
+    const char* name;  // canonical lowercase name
+    int wire_id;       // CTE wire/on-disk id (frozen, append-only)
+    int base_id;       // ML scheme base id (frozen, append-only)
+    bool single_mode;  // preset ignored; id always uses preset slot 2
+    MakeFn make;       // constructor, or nullptr if backend disabled
+  };
+
+  // Construction helpers for single-mode and backend-guarded compressors.
+  // (Multi-mode lossless compressors use CreateLossless<T> directly.)
+  static std::unique_ptr<Compressor> MakeSnappy(CompressionPreset) {
+    return std::make_unique<Snappy>();
+  }
+  static std::unique_ptr<Compressor> MakeBlosc(CompressionPreset) {
+    return std::make_unique<Blosc>();
+  }
+  static std::unique_ptr<Compressor> MakeZfp(CompressionPreset preset) {
+#if CTP_ENABLE_LIBPRESSIO
+    return CreateLossy("zfp", preset);
+#else
+    (void)preset;
+    return nullptr;
+#endif
+  }
+  static std::unique_ptr<Compressor> MakeSz3(CompressionPreset preset) {
+#if CTP_ENABLE_LIBPRESSIO
+    return CreateLossy("sz3", preset);
+#else
+    (void)preset;
+    return nullptr;
+#endif
+  }
+  static std::unique_ptr<Compressor> MakeFpzip(CompressionPreset preset) {
+#if CTP_ENABLE_LIBPRESSIO
+    return CreateLossy("fpzip", preset);
+#else
+    (void)preset;
+    return nullptr;
+#endif
+  }
+  static std::unique_ptr<Compressor> MakeNvCompLz4(CompressionPreset) {
+#if CTP_ENABLE_NVCOMP
+    return std::make_unique<NvComp>(NvCompAlgo::LZ4);
+#else
+    return nullptr;
+#endif
+  }
+
+  /**
+   * The compressor registry: the single source of truth (see CompressorInfo).
+   * constexpr std::array -> constant-initialized static data: no heap allocation
+   * and no thread-safe-init guard. The size is deduced (CTAD), so adding a row
+   * stays a one-line change. Iteration over 12 entries is trivial and happens
+   * only once per blob (in the factory setup path), never in the compress loop.
+   */
+  static const auto& Registry() {
+    //                                          name  wire base single  make
+    static constexpr std::array kRegistry = {
+        CompressorInfo{"brotli",      0,  6, false, &CreateLossless<BrotliWithModes>},
+        CompressorInfo{"bzip2",       1,  1, false, &CreateLossless<Bzip2WithModes>},
+        CompressorInfo{"blosc2",      2,  8, true,  &MakeBlosc},
+        CompressorInfo{"fpzip",       3, 12, false, &MakeFpzip},
+        CompressorInfo{"lz4",         4,  3, false, &CreateLossless<Lz4WithModes>},
+        CompressorInfo{"lzma",        5,  5, false, &CreateLossless<LzmaWithModes>},
+        CompressorInfo{"snappy",      6,  7, true,  &MakeSnappy},
+        CompressorInfo{"sz3",         7, 11, false, &MakeSz3},
+        CompressorInfo{"zfp",         8, 10, false, &MakeZfp},
+        CompressorInfo{"zlib",        9,  4, false, &CreateLossless<ZlibWithModes>},
+        CompressorInfo{"zstd",       10,  2, false, &CreateLossless<ZstdWithModes>},
+        CompressorInfo{"nvcomp-lz4", 11, 13, true,  &MakeNvCompLz4},
+    };
+    return kRegistry;
+  }
+
+  /**
+   * Look up a registry entry by (case-insensitive) name; nullptr if unknown.
+   * Accepts the historical "blosc" alias for "blosc2".
+   */
+  static const CompressorInfo* FindByName(const std::string& name) {
+    std::string n = name;
+    for (auto& c : n) {
+      c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    }
+    if (n == "blosc") n = "blosc2";  // historical alias
+    for (const auto& e : Registry()) {
+      if (n == e.name) return &e;
+    }
+    return nullptr;
+  }
+
+  /** Look up a registry entry by CTE wire id; nullptr if none. */
+  static const CompressorInfo* FindByWireId(int wire_id) {
+    for (const auto& e : Registry()) {
+      if (e.wire_id == wire_id) return &e;
+    }
+    return nullptr;
+  }
+
+  /** Look up a registry entry by ML base id; nullptr if none. */
+  static const CompressorInfo* FindByBaseId(int base_id) {
+    for (const auto& e : Registry()) {
+      if (e.base_id == base_id) return &e;
+    }
+    return nullptr;
+  }
+
   template<typename CompressorClass>
   static std::unique_ptr<Compressor> CreateLossless(CompressionPreset preset) {
     LosslessMode mode;

--- a/context-transport-primitives/include/clio_ctp/compress/nvcomp.h
+++ b/context-transport-primitives/include/clio_ctp/compress/nvcomp.h
@@ -82,42 +82,52 @@ class NvComp : public Compressor {
     bool free_out = false;
     bool ok = false;
     do {
-      // Input: use directly if already on the GPU, else stage a H2D copy.
-      d_in = ToDeviceInput(input, input_size, stream, &free_in);
-      if (!d_in) break;
+      // The nvcomp Manager API reports errors by throwing (and compress() is
+      // void, so a throw is its only failure signal); make_shared can also
+      // throw std::bad_alloc. Catch everything so no exception escapes (honoring
+      // the bool contract) and the cleanup block below always runs.
+      try {
+        // Input: use directly if already on the GPU, else stage a H2D copy.
+        d_in = ToDeviceInput(input, input_size, stream, &free_in);
+        if (!d_in) break;
 
-      std::shared_ptr<nvcomp::nvcompManagerBase> mgr = MakeManager(stream);
-      if (!mgr) break;
-      nvcomp::CompressionConfig cfg = mgr->configure_compression(input_size);
+        std::shared_ptr<nvcomp::nvcompManagerBase> mgr = MakeManager(stream);
+        if (!mgr) break;
+        nvcomp::CompressionConfig cfg = mgr->configure_compression(input_size);
 
-      // Output: write straight into the caller's buffer only if it is a GPU
-      // buffer large enough for nvcomp's worst case; otherwise use a temp.
-      // (Device-direct requires >= max_compressed_buffer_size, while the temp
-      // path only needs to fit the actual compressed size -- this asymmetry is
-      // intentional; an in-between device buffer just falls back to temp + D2D.)
-      const bool out_is_device = IsDeviceAccessible(output);
-      if (out_is_device && output_size >= cfg.max_compressed_buffer_size) {
-        d_out = static_cast<uint8_t *>(output);
-      } else {
-        if (cudaMalloc(&d_out, cfg.max_compressed_buffer_size) != cudaSuccess) {
-          break;
+        // Output: write straight into the caller's buffer only if it is a GPU
+        // buffer large enough for nvcomp's worst case; otherwise use a temp.
+        // (Device-direct requires >= max_compressed_buffer_size, while the temp
+        // path only needs to fit the actual compressed size -- this asymmetry
+        // is intentional; an in-between device buffer falls back to temp + D2D.)
+        const bool out_is_device = IsDeviceAccessible(output);
+        if (out_is_device && output_size >= cfg.max_compressed_buffer_size) {
+          d_out = static_cast<uint8_t *>(output);
+        } else {
+          if (cudaMalloc(&d_out, cfg.max_compressed_buffer_size) !=
+              cudaSuccess) {
+            break;
+          }
+          free_out = true;
         }
-        free_out = true;
-      }
 
-      mgr->compress(d_in, d_out, cfg);
-      if (cudaStreamSynchronize(stream) != cudaSuccess) break;
-      size_t comp_size = mgr->get_compressed_output_size(d_out);
-      if (comp_size > output_size) break;  // caller buffer too small
+        mgr->compress(d_in, d_out, cfg);
+        if (cudaStreamSynchronize(stream) != cudaSuccess) break;
+        size_t comp_size = mgr->get_compressed_output_size(d_out);
+        if (comp_size > output_size) break;  // caller buffer too small
 
-      // Deliver to the caller's buffer if we compressed into a temp.
-      if (d_out != static_cast<uint8_t *>(output)) {
-        cudaMemcpyKind kind =
-            out_is_device ? cudaMemcpyDeviceToDevice : cudaMemcpyDeviceToHost;
-        if (cudaMemcpy(output, d_out, comp_size, kind) != cudaSuccess) break;
+        // Deliver to the caller's buffer if we compressed into a temp.
+        if (d_out != static_cast<uint8_t *>(output)) {
+          cudaMemcpyKind kind =
+              out_is_device ? cudaMemcpyDeviceToDevice : cudaMemcpyDeviceToHost;
+          if (cudaMemcpy(output, d_out, comp_size, kind) != cudaSuccess) break;
+        }
+        output_size = comp_size;
+        ok = true;
+      } catch (...) {
+        // ok stays false; free_in/free_out (set before any throwing call) make
+        // the cleanup below release exactly what was allocated.
       }
-      output_size = comp_size;
-      ok = true;
     } while (false);
     if (free_in) cudaFree(d_in);
     if (free_out) cudaFree(d_out);
@@ -137,36 +147,44 @@ class NvComp : public Compressor {
     bool free_out = false;
     bool ok = false;
     do {
-      // Input: use directly if already on the GPU, else stage a H2D copy.
-      d_in = ToDeviceInput(input, input_size, stream, &free_in);
-      if (!d_in) break;
+      // The nvcomp Manager API reports errors by throwing (create_manager,
+      // configure_decompression, and the void decompress() included); catch
+      // everything so no exception escapes and the cleanup below always runs.
+      try {
+        // Input: use directly if already on the GPU, else stage a H2D copy.
+        d_in = ToDeviceInput(input, input_size, stream, &free_in);
+        if (!d_in) break;
 
-      // create_manager parses the NVCOMP_NATIVE header and synchronizes stream.
-      std::shared_ptr<nvcomp::nvcompManagerBase> mgr =
-          nvcomp::create_manager(d_in, stream);
-      if (!mgr) break;
-      nvcomp::DecompressionConfig cfg = mgr->configure_decompression(d_in);
-      if (cfg.decomp_data_size > output_size) break;  // caller buffer too small
+        // create_manager parses the NVCOMP_NATIVE header and syncs the stream.
+        std::shared_ptr<nvcomp::nvcompManagerBase> mgr =
+            nvcomp::create_manager(d_in, stream);
+        if (!mgr) break;
+        nvcomp::DecompressionConfig cfg = mgr->configure_decompression(d_in);
+        if (cfg.decomp_data_size > output_size) break;  // caller buffer too small
 
-      const bool out_is_device = IsDeviceAccessible(output);
-      if (out_is_device) {
-        d_out = static_cast<uint8_t *>(output);
-      } else {
-        if (cudaMalloc(&d_out, cfg.decomp_data_size) != cudaSuccess) break;
-        free_out = true;
-      }
-
-      mgr->decompress(d_out, d_in, cfg);
-      if (cudaStreamSynchronize(stream) != cudaSuccess) break;
-
-      if (d_out != static_cast<uint8_t *>(output)) {
-        if (cudaMemcpy(output, d_out, cfg.decomp_data_size,
-                       cudaMemcpyDeviceToHost) != cudaSuccess) {
-          break;
+        const bool out_is_device = IsDeviceAccessible(output);
+        if (out_is_device) {
+          d_out = static_cast<uint8_t *>(output);
+        } else {
+          if (cudaMalloc(&d_out, cfg.decomp_data_size) != cudaSuccess) break;
+          free_out = true;
         }
+
+        mgr->decompress(d_out, d_in, cfg);
+        if (cudaStreamSynchronize(stream) != cudaSuccess) break;
+
+        if (d_out != static_cast<uint8_t *>(output)) {
+          if (cudaMemcpy(output, d_out, cfg.decomp_data_size,
+                         cudaMemcpyDeviceToHost) != cudaSuccess) {
+            break;
+          }
+        }
+        output_size = cfg.decomp_data_size;
+        ok = true;
+      } catch (...) {
+        // ok stays false; free_in/free_out (set before any throwing call) make
+        // the cleanup below release exactly what was allocated.
       }
-      output_size = cfg.decomp_data_size;
-      ok = true;
     } while (false);
     if (free_in) cudaFree(d_in);
     if (free_out) cudaFree(d_out);

--- a/context-transport-primitives/include/clio_ctp/compress/nvcomp.h
+++ b/context-transport-primitives/include/clio_ctp/compress/nvcomp.h
@@ -37,8 +37,13 @@
 #if CTP_ENABLE_COMPRESS && CTP_ENABLE_NVCOMP
 
 #include <cuda_runtime.h>
+#include <nvcomp/ans.hpp>
+#include <nvcomp/deflate.hpp>
+#include <nvcomp/gdeflate.hpp>
 #include <nvcomp/lz4.hpp>
 #include <nvcomp/nvcompManagerFactory.hpp>
+#include <nvcomp/snappy.hpp>
+#include <nvcomp/zstd.hpp>
 
 #include <cstdint>
 #include <memory>
@@ -47,9 +52,20 @@
 
 namespace ctp {
 
-/** Supported nvcomp GPU compression algorithms. */
+/**
+ * Supported nvcomp GPU compression algorithms. All are general-purpose,
+ * byte-oriented lossless codecs that fit the byte-stream Compressor interface;
+ * each is run with nvcomp's default options (no per-algorithm tuning exposed).
+ * (nvcomp's GZIP manager is decompression-only, so it is intentionally absent;
+ * use DEFLATE for GPU-side deflate-stream compression.)
+ */
 enum class NvCompAlgo {
   LZ4,
+  SNAPPY,
+  ZSTD,
+  GDEFLATE,
+  DEFLATE,
+  ANS,
 };
 
 /**
@@ -243,6 +259,21 @@ class NvComp : public Compressor {
       case NvCompAlgo::LZ4:
         return std::make_shared<nvcomp::LZ4Manager>(
             kChunkSize, nvcompBatchedLZ4DefaultOpts, stream);
+      case NvCompAlgo::SNAPPY:
+        return std::make_shared<nvcomp::SnappyManager>(
+            kChunkSize, nvcompBatchedSnappyDefaultOpts, stream);
+      case NvCompAlgo::ZSTD:
+        return std::make_shared<nvcomp::ZstdManager>(
+            kChunkSize, nvcompBatchedZstdDefaultOpts, stream);
+      case NvCompAlgo::GDEFLATE:
+        return std::make_shared<nvcomp::GdeflateManager>(
+            kChunkSize, nvcompBatchedGdeflateDefaultOpts, stream);
+      case NvCompAlgo::DEFLATE:
+        return std::make_shared<nvcomp::DeflateManager>(
+            kChunkSize, nvcompBatchedDeflateDefaultOpts, stream);
+      case NvCompAlgo::ANS:
+        return std::make_shared<nvcomp::ANSManager>(
+            kChunkSize, nvcompBatchedANSDefaultOpts, stream);
     }
     return nullptr;
   }

--- a/context-transport-primitives/include/clio_ctp/compress/nvcomp.h
+++ b/context-transport-primitives/include/clio_ctp/compress/nvcomp.h
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CTP_SHM_INCLUDE_HSHM_SHM_COMPRESS_NvComp_H_
+#define CTP_SHM_INCLUDE_HSHM_SHM_COMPRESS_NvComp_H_
+
+#if CTP_ENABLE_COMPRESS && CTP_ENABLE_NVCOMP
+
+#include <cuda_runtime.h>
+#include <nvcomp/lz4.hpp>
+#include <nvcomp/nvcompManagerFactory.hpp>
+
+#include <cstdint>
+#include <memory>
+
+#include "compress.h"
+
+namespace ctp {
+
+/** Supported nvcomp GPU compression algorithms. */
+enum class NvCompAlgo {
+  LZ4,
+};
+
+/**
+ * GPU compressor backed by NVIDIA nvcomp's high-level Manager API.
+ *
+ * Implements the synchronous ctp::Compressor interface over host buffers: each
+ * call copies the input to the device, runs the nvcomp manager on a private
+ * CUDA stream, synchronizes, then copies the result back to the host. The
+ * compressed bitstream uses NVCOMP_NATIVE (self-describing) format, so
+ * Decompress can reconstruct the manager directly from the compressed bytes.
+ *
+ * Note: this performs its own H2D/D2H copies because the current Compressor
+ * contract hands us host pointers. A future device-pointer-aware path could
+ * skip the copies when the data is already resident on the GPU.
+ */
+class NvComp : public Compressor {
+ public:
+  explicit NvComp(NvCompAlgo algo = NvCompAlgo::LZ4) : algo_(algo) {}
+
+  bool Compress(void *output, size_t &output_size, void *input,
+                size_t input_size) override {
+    cudaStream_t stream = nullptr;
+    if (cudaStreamCreate(&stream) != cudaSuccess) {
+      return false;
+    }
+    uint8_t *d_in = nullptr;
+    uint8_t *d_out = nullptr;
+    bool ok = false;
+    do {
+      if (cudaMalloc(&d_in, input_size) != cudaSuccess) break;
+      if (cudaMemcpyAsync(d_in, input, input_size, cudaMemcpyHostToDevice,
+                          stream) != cudaSuccess) {
+        break;
+      }
+      std::shared_ptr<nvcomp::nvcompManagerBase> mgr = MakeManager(stream);
+      if (!mgr) break;
+      nvcomp::CompressionConfig cfg = mgr->configure_compression(input_size);
+      if (cudaMalloc(&d_out, cfg.max_compressed_buffer_size) != cudaSuccess) {
+        break;
+      }
+      mgr->compress(d_in, d_out, cfg);
+      if (cudaStreamSynchronize(stream) != cudaSuccess) break;
+      size_t comp_size = mgr->get_compressed_output_size(d_out);
+      if (comp_size > output_size) break;  // caller buffer too small
+      if (cudaMemcpy(output, d_out, comp_size, cudaMemcpyDeviceToHost) !=
+          cudaSuccess) {
+        break;
+      }
+      output_size = comp_size;
+      ok = true;
+    } while (false);
+    if (d_in) cudaFree(d_in);
+    if (d_out) cudaFree(d_out);
+    cudaStreamDestroy(stream);
+    return ok;
+  }
+
+  bool Decompress(void *output, size_t &output_size, void *input,
+                  size_t input_size) override {
+    cudaStream_t stream = nullptr;
+    if (cudaStreamCreate(&stream) != cudaSuccess) {
+      return false;
+    }
+    uint8_t *d_in = nullptr;
+    uint8_t *d_out = nullptr;
+    bool ok = false;
+    do {
+      if (cudaMalloc(&d_in, input_size) != cudaSuccess) break;
+      if (cudaMemcpyAsync(d_in, input, input_size, cudaMemcpyHostToDevice,
+                          stream) != cudaSuccess) {
+        break;
+      }
+      // create_manager parses the NVCOMP_NATIVE header and synchronizes stream.
+      std::shared_ptr<nvcomp::nvcompManagerBase> mgr =
+          nvcomp::create_manager(d_in, stream);
+      if (!mgr) break;
+      nvcomp::DecompressionConfig cfg = mgr->configure_decompression(d_in);
+      if (cfg.decomp_data_size > output_size) break;  // caller buffer too small
+      if (cudaMalloc(&d_out, cfg.decomp_data_size) != cudaSuccess) break;
+      mgr->decompress(d_out, d_in, cfg);
+      if (cudaStreamSynchronize(stream) != cudaSuccess) break;
+      if (cudaMemcpy(output, d_out, cfg.decomp_data_size,
+                     cudaMemcpyDeviceToHost) != cudaSuccess) {
+        break;
+      }
+      output_size = cfg.decomp_data_size;
+      ok = true;
+    } while (false);
+    if (d_in) cudaFree(d_in);
+    if (d_out) cudaFree(d_out);
+    cudaStreamDestroy(stream);
+    return ok;
+  }
+
+ private:
+  /** Default per-chunk uncompressed size for nvcomp managers (64 KiB). */
+  static constexpr size_t kChunkSize = 1 << 16;
+
+  /** Construct the nvcomp manager for the configured algorithm. */
+  std::shared_ptr<nvcomp::nvcompManagerBase> MakeManager(cudaStream_t stream) {
+    switch (algo_) {
+      case NvCompAlgo::LZ4:
+        return std::make_shared<nvcomp::LZ4Manager>(
+            kChunkSize, nvcompBatchedLZ4DefaultOpts, stream);
+    }
+    return nullptr;
+  }
+
+  NvCompAlgo algo_;
+};
+
+}  // namespace ctp
+
+#endif  // CTP_ENABLE_COMPRESS && CTP_ENABLE_NVCOMP
+
+#endif  // CTP_SHM_INCLUDE_HSHM_SHM_COMPRESS_NvComp_H_

--- a/context-transport-primitives/include/clio_ctp/compress/nvcomp.h
+++ b/context-transport-primitives/include/clio_ctp/compress/nvcomp.h
@@ -55,15 +55,16 @@ enum class NvCompAlgo {
 /**
  * GPU compressor backed by NVIDIA nvcomp's high-level Manager API.
  *
- * Implements the synchronous ctp::Compressor interface over host buffers: each
- * call copies the input to the device, runs the nvcomp manager on a private
- * CUDA stream, synchronizes, then copies the result back to the host. The
- * compressed bitstream uses NVCOMP_NATIVE (self-describing) format, so
- * Decompress can reconstruct the manager directly from the compressed bytes.
+ * Implements the synchronous ctp::Compressor interface and runs the nvcomp
+ * manager on a private CUDA stream, synchronizing before returning. Buffers are
+ * handled adaptively: if a pointer already refers to GPU-accessible memory
+ * (device or UVM/managed), it is used in place (zero-copy); otherwise the data
+ * is staged through a temporary device buffer (H2D for inputs, D2H for outputs).
+ * This keeps it correct for host callers while delivering the zero-copy path
+ * automatically whenever the data is already resident on the GPU.
  *
- * Note: this performs its own H2D/D2H copies because the current Compressor
- * contract hands us host pointers. A future device-pointer-aware path could
- * skip the copies when the data is already resident on the GPU.
+ * The compressed bitstream uses NVCOMP_NATIVE (self-describing) format, so
+ * Decompress reconstructs the manager directly from the compressed bytes.
  */
 class NvComp : public Compressor {
  public:
@@ -77,32 +78,49 @@ class NvComp : public Compressor {
     }
     uint8_t *d_in = nullptr;
     uint8_t *d_out = nullptr;
+    bool free_in = false;
+    bool free_out = false;
     bool ok = false;
     do {
-      if (cudaMalloc(&d_in, input_size) != cudaSuccess) break;
-      if (cudaMemcpyAsync(d_in, input, input_size, cudaMemcpyHostToDevice,
-                          stream) != cudaSuccess) {
-        break;
-      }
+      // Input: use directly if already on the GPU, else stage a H2D copy.
+      d_in = ToDeviceInput(input, input_size, stream, &free_in);
+      if (!d_in) break;
+
       std::shared_ptr<nvcomp::nvcompManagerBase> mgr = MakeManager(stream);
       if (!mgr) break;
       nvcomp::CompressionConfig cfg = mgr->configure_compression(input_size);
-      if (cudaMalloc(&d_out, cfg.max_compressed_buffer_size) != cudaSuccess) {
-        break;
+
+      // Output: write straight into the caller's buffer only if it is a GPU
+      // buffer large enough for nvcomp's worst case; otherwise use a temp.
+      // (Device-direct requires >= max_compressed_buffer_size, while the temp
+      // path only needs to fit the actual compressed size -- this asymmetry is
+      // intentional; an in-between device buffer just falls back to temp + D2D.)
+      const bool out_is_device = IsDeviceAccessible(output);
+      if (out_is_device && output_size >= cfg.max_compressed_buffer_size) {
+        d_out = static_cast<uint8_t *>(output);
+      } else {
+        if (cudaMalloc(&d_out, cfg.max_compressed_buffer_size) != cudaSuccess) {
+          break;
+        }
+        free_out = true;
       }
+
       mgr->compress(d_in, d_out, cfg);
       if (cudaStreamSynchronize(stream) != cudaSuccess) break;
       size_t comp_size = mgr->get_compressed_output_size(d_out);
       if (comp_size > output_size) break;  // caller buffer too small
-      if (cudaMemcpy(output, d_out, comp_size, cudaMemcpyDeviceToHost) !=
-          cudaSuccess) {
-        break;
+
+      // Deliver to the caller's buffer if we compressed into a temp.
+      if (d_out != static_cast<uint8_t *>(output)) {
+        cudaMemcpyKind kind =
+            out_is_device ? cudaMemcpyDeviceToDevice : cudaMemcpyDeviceToHost;
+        if (cudaMemcpy(output, d_out, comp_size, kind) != cudaSuccess) break;
       }
       output_size = comp_size;
       ok = true;
     } while (false);
-    if (d_in) cudaFree(d_in);
-    if (d_out) cudaFree(d_out);
+    if (free_in) cudaFree(d_in);
+    if (free_out) cudaFree(d_out);
     cudaStreamDestroy(stream);
     return ok;
   }
@@ -115,31 +133,43 @@ class NvComp : public Compressor {
     }
     uint8_t *d_in = nullptr;
     uint8_t *d_out = nullptr;
+    bool free_in = false;
+    bool free_out = false;
     bool ok = false;
     do {
-      if (cudaMalloc(&d_in, input_size) != cudaSuccess) break;
-      if (cudaMemcpyAsync(d_in, input, input_size, cudaMemcpyHostToDevice,
-                          stream) != cudaSuccess) {
-        break;
-      }
+      // Input: use directly if already on the GPU, else stage a H2D copy.
+      d_in = ToDeviceInput(input, input_size, stream, &free_in);
+      if (!d_in) break;
+
       // create_manager parses the NVCOMP_NATIVE header and synchronizes stream.
       std::shared_ptr<nvcomp::nvcompManagerBase> mgr =
           nvcomp::create_manager(d_in, stream);
       if (!mgr) break;
       nvcomp::DecompressionConfig cfg = mgr->configure_decompression(d_in);
       if (cfg.decomp_data_size > output_size) break;  // caller buffer too small
-      if (cudaMalloc(&d_out, cfg.decomp_data_size) != cudaSuccess) break;
+
+      const bool out_is_device = IsDeviceAccessible(output);
+      if (out_is_device) {
+        d_out = static_cast<uint8_t *>(output);
+      } else {
+        if (cudaMalloc(&d_out, cfg.decomp_data_size) != cudaSuccess) break;
+        free_out = true;
+      }
+
       mgr->decompress(d_out, d_in, cfg);
       if (cudaStreamSynchronize(stream) != cudaSuccess) break;
-      if (cudaMemcpy(output, d_out, cfg.decomp_data_size,
-                     cudaMemcpyDeviceToHost) != cudaSuccess) {
-        break;
+
+      if (d_out != static_cast<uint8_t *>(output)) {
+        if (cudaMemcpy(output, d_out, cfg.decomp_data_size,
+                       cudaMemcpyDeviceToHost) != cudaSuccess) {
+          break;
+        }
       }
       output_size = cfg.decomp_data_size;
       ok = true;
     } while (false);
-    if (d_in) cudaFree(d_in);
-    if (d_out) cudaFree(d_out);
+    if (free_in) cudaFree(d_in);
+    if (free_out) cudaFree(d_out);
     cudaStreamDestroy(stream);
     return ok;
   }
@@ -147,6 +177,47 @@ class NvComp : public Compressor {
  private:
   /** Default per-chunk uncompressed size for nvcomp managers (64 KiB). */
   static constexpr size_t kChunkSize = 1 << 16;
+
+  /**
+   * True if `ptr` can be dereferenced by the GPU directly (device or UVM/
+   * managed memory). Pinned-host and plain-host pointers return false so the
+   * caller stages a copy. A failed query is treated as "not device".
+   */
+  static bool IsDeviceAccessible(const void *ptr) {
+    cudaPointerAttributes attr;
+    cudaError_t err = cudaPointerGetAttributes(&attr, ptr);
+    if (err != cudaSuccess) {
+      cudaGetLastError();  // reset the sticky error from the failed query
+      return false;
+    }
+    return attr.type == cudaMemoryTypeDevice ||
+           attr.type == cudaMemoryTypeManaged;
+  }
+
+  /**
+   * Return a device pointer holding `size` bytes of `input`. If `input` is
+   * already GPU-accessible it is used in place (*owned = false); otherwise a
+   * device buffer is allocated and the data copied H2D on `stream`
+   * (*owned = true). Returns nullptr on failure (*owned = false).
+   */
+  static uint8_t *ToDeviceInput(void *input, size_t size, cudaStream_t stream,
+                                bool *owned) {
+    *owned = false;
+    if (IsDeviceAccessible(input)) {
+      return static_cast<uint8_t *>(input);
+    }
+    uint8_t *d = nullptr;
+    if (cudaMalloc(&d, size) != cudaSuccess) {
+      return nullptr;
+    }
+    if (cudaMemcpyAsync(d, input, size, cudaMemcpyHostToDevice, stream) !=
+        cudaSuccess) {
+      cudaFree(d);
+      return nullptr;
+    }
+    *owned = true;
+    return d;
+  }
 
   /** Construct the nvcomp manager for the configured algorithm. */
   std::shared_ptr<nvcomp::nvcompManagerBase> MakeManager(cudaStream_t stream) {

--- a/context-transport-primitives/test/unit/compress/test_compress.cc
+++ b/context-transport-primitives/test/unit/compress/test_compress.cc
@@ -193,6 +193,44 @@ TEST_CASE("TestNvCompGpu") {
     REQUIRE(raw == std::string(decompressed.data(), raw_size));
   }
 
+  // Device-pointer (zero-copy) path: hand NvComp cudaMalloc'd pointers for both
+  // input and output so it must use them in place rather than staging copies.
+  PAGE_DIVIDE("NvCompLZ4 (device pointers, zero-copy)") {
+    std::string raw;
+    for (int i = 0; i < 1024; ++i) {
+      raw += "GPU-resident data exercises the zero-copy path 9876543210 ";
+    }
+
+    void *d_raw = nullptr;
+    REQUIRE(cudaMalloc(&d_raw, raw.size()) == cudaSuccess);
+    REQUIRE(cudaMemcpy(d_raw, raw.data(), raw.size(),
+                       cudaMemcpyHostToDevice) == cudaSuccess);
+
+    size_t cap = raw.size() + raw.size() / 20 + 4096;
+    void *d_comp = nullptr;
+    REQUIRE(cudaMalloc(&d_comp, cap) == cudaSuccess);
+
+    ctp::NvComp nvcomp(ctp::NvCompAlgo::LZ4);
+    size_t comp_size = cap;
+    REQUIRE(nvcomp.Compress(d_comp, comp_size, d_raw, raw.size()));
+    REQUIRE(comp_size < raw.size());
+
+    void *d_decomp = nullptr;
+    REQUIRE(cudaMalloc(&d_decomp, raw.size()) == cudaSuccess);
+    size_t decomp_size = raw.size();
+    REQUIRE(nvcomp.Decompress(d_decomp, decomp_size, d_comp, comp_size));
+    REQUIRE(decomp_size == raw.size());
+
+    std::vector<char> host_out(raw.size());
+    REQUIRE(cudaMemcpy(host_out.data(), d_decomp, raw.size(),
+                       cudaMemcpyDeviceToHost) == cudaSuccess);
+    REQUIRE(raw == std::string(host_out.data(), raw.size()));
+
+    cudaFree(d_raw);
+    cudaFree(d_comp);
+    cudaFree(d_decomp);
+  }
+
   PAGE_DIVIDE("NvCompLZ4 library id round-trip") {
     int id = ctp::CompressionFactory::GetLibraryId(
         "nvcomp-lz4", ctp::CompressionPreset::BALANCED);

--- a/context-transport-primitives/test/unit/compress/test_compress.cc
+++ b/context-transport-primitives/test/unit/compress/test_compress.cc
@@ -35,6 +35,10 @@
 #include "clio_ctp/compress/compress_factory.h"
 #include <utility>
 
+#if CTP_ENABLE_NVCOMP
+#include <cuda_runtime.h>
+#endif
+
 TEST_CASE("TestCompress") {
   std::string raw = "Hello, World!";
   std::vector<char> compressed(1024);
@@ -130,3 +134,52 @@ TEST_CASE("TestCompress") {
     REQUIRE(raw == std::string(decompressed.data(), raw_size));
   }
 }
+
+#if CTP_ENABLE_NVCOMP
+// GPU compression via nvcomp. Exercised through the CompressionFactory so this
+// also validates the factory registration of "nvcomp-lz4".
+TEST_CASE("TestNvCompGpu") {
+  // nvcomp needs a real GPU. Skip gracefully where none is present (CI, laptops,
+  // Docker without --gpus) so the suite stays green everywhere.
+  int device_count = 0;
+  if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+    WARN("No CUDA device available; skipping nvcomp GPU compression test");
+    return;
+  }
+
+  // Payload larger than nvcomp's chunk/overhead so compression is meaningful.
+  std::string raw;
+  for (int i = 0; i < 4096; ++i) {
+    raw += "The quick brown fox jumps over the lazy dog 0123456789 ";
+  }
+
+  PAGE_DIVIDE("NvCompLZ4 (via factory)") {
+    auto compressor = ctp::CompressionFactory::GetPreset(
+        "nvcomp-lz4", ctp::CompressionPreset::BALANCED);
+    REQUIRE(compressor != nullptr);
+
+    std::vector<char> compressed(raw.size() + raw.size() / 20 + 4096);
+    std::vector<char> decompressed(raw.size() + 16);
+
+    size_t cmpr_size = compressed.size();
+    REQUIRE(compressor->Compress(compressed.data(), cmpr_size,
+                                 raw.data(), raw.size()));
+    REQUIRE(cmpr_size > 0);
+    REQUIRE(cmpr_size <= compressed.size());
+
+    auto decompressor = ctp::CompressionFactory::GetPreset("nvcomp-lz4");
+    REQUIRE(decompressor != nullptr);
+    size_t raw_size = decompressed.size();
+    REQUIRE(decompressor->Decompress(decompressed.data(), raw_size,
+                                     compressed.data(), cmpr_size));
+    REQUIRE(raw == std::string(decompressed.data(), raw_size));
+  }
+
+  PAGE_DIVIDE("NvCompLZ4 library id round-trip") {
+    int id = ctp::CompressionFactory::GetLibraryId(
+        "nvcomp-lz4", ctp::CompressionPreset::BALANCED);
+    REQUIRE(id == 132);  // base id 13, single-mode (BALANCED=2)
+    REQUIRE(ctp::CompressionFactory::GetLibraryInfo(id).first == "nvcomp-lz4");
+  }
+}
+#endif  // CTP_ENABLE_NVCOMP

--- a/context-transport-primitives/test/unit/compress/test_compress.cc
+++ b/context-transport-primitives/test/unit/compress/test_compress.cc
@@ -157,9 +157,15 @@ TEST_CASE("CompressorRegistryMappings") {
     REQUIRE(CompressionFactory::NameForWireId(9) == "zlib");
     REQUIRE(CompressionFactory::NameForWireId(10) == "zstd");
     REQUIRE(CompressionFactory::NameForWireId(11) == "nvcomp-lz4");
-    // Out-of-range falls back to the historical default.
+    REQUIRE(CompressionFactory::NameForWireId(12) == "nvcomp-snappy");
+    REQUIRE(CompressionFactory::NameForWireId(13) == "nvcomp-zstd");
+    REQUIRE(CompressionFactory::NameForWireId(14) == "nvcomp-gdeflate");
+    REQUIRE(CompressionFactory::NameForWireId(15) == "nvcomp-deflate");
+    REQUIRE(CompressionFactory::NameForWireId(16) == "nvcomp-ans");
+    // Out-of-range falls back to the historical default. (Registry rows are
+    // build-independent, so the GPU names above resolve even without nvcomp.)
     REQUIRE(CompressionFactory::NameForWireId(-1) == "zstd");
-    REQUIRE(CompressionFactory::NameForWireId(12) == "zstd");
+    REQUIRE(CompressionFactory::NameForWireId(17) == "zstd");
     REQUIRE(CompressionFactory::NameForWireId(9999) == "zstd");
   }
 
@@ -193,11 +199,15 @@ TEST_CASE("CompressorRegistryMappings") {
     // Unknown library -> 0.
     REQUIRE(CompressionFactory::GetLibraryId("does-not-exist", BAL) == 0);
 
-#if CTP_ENABLE_NVCOMP
-    // GPU compressor: single-mode, base_id 13.
+    // GPU compressors: single-mode (preset forced to 2), base_ids 13-19. These
+    // are build-independent -- the registry rows resolve even without nvcomp.
     REQUIRE(CompressionFactory::GetLibraryId("nvcomp-lz4", FAST) == 132);
     REQUIRE(CompressionFactory::GetLibraryId("nvcomp-lz4", BEST) == 132);
-#endif
+    REQUIRE(CompressionFactory::GetLibraryId("nvcomp-snappy", BAL) == 142);
+    REQUIRE(CompressionFactory::GetLibraryId("nvcomp-zstd", BAL) == 152);
+    REQUIRE(CompressionFactory::GetLibraryId("nvcomp-gdeflate", BAL) == 162);
+    REQUIRE(CompressionFactory::GetLibraryId("nvcomp-deflate", BAL) == 172);
+    REQUIRE(CompressionFactory::GetLibraryId("nvcomp-ans", BAL) == 182);
   }
 
   PAGE_DIVIDE("ML library id -> name + preset (reverse)") {
@@ -215,9 +225,13 @@ TEST_CASE("CompressorRegistryMappings") {
     // Unknown ids -> "unknown".
     REQUIRE(CompressionFactory::GetLibraryInfo(0).first == "unknown");
     REQUIRE(CompressionFactory::GetLibraryInfo(999).first == "unknown");
-#if CTP_ENABLE_NVCOMP
+    // GPU compressors (build-independent).
     REQUIRE(CompressionFactory::GetLibraryInfo(132).first == "nvcomp-lz4");
-#endif
+    REQUIRE(CompressionFactory::GetLibraryInfo(142).first == "nvcomp-snappy");
+    REQUIRE(CompressionFactory::GetLibraryInfo(152).first == "nvcomp-zstd");
+    REQUIRE(CompressionFactory::GetLibraryInfo(162).first == "nvcomp-gdeflate");
+    REQUIRE(CompressionFactory::GetLibraryInfo(172).first == "nvcomp-deflate");
+    REQUIRE(CompressionFactory::GetLibraryInfo(182).first == "nvcomp-ans");
   }
 
   PAGE_DIVIDE("GetPreset constructs known CPU compressors (incl. alias)") {
@@ -260,13 +274,27 @@ TEST_CASE("CompressorRegistryMappings") {
       REQUIRE(payload == std::string(dbuf.data(), dsize));
     }
   }
+
+#if CTP_ENABLE_NVCOMP
+  // GPU compressor construction needs no device (NvComp touches the GPU only on
+  // Compress/Decompress). Confirms every nvcomp registry row has a live make().
+  PAGE_DIVIDE("GetPreset constructs GPU compressors (no device needed)") {
+    const char *gpu_libs[] = {"nvcomp-lz4",      "nvcomp-snappy",
+                              "nvcomp-zstd",     "nvcomp-gdeflate",
+                              "nvcomp-deflate",  "nvcomp-ans"};
+    for (const char *lib : gpu_libs) {
+      INFO("nvcomp format: " << lib);
+      REQUIRE(CompressionFactory::GetPreset(lib) != nullptr);
+    }
+  }
+#endif
 }
 
 #if CTP_ENABLE_NVCOMP
 // GPU compression via nvcomp. Mirrors the CPU compressor coverage above (a
 // direct-class Compress/Decompress round-trip) and adds GPU-specific coverage:
-// a factory round-trip (validates the "nvcomp-lz4" registration) and the
-// library-id encoding round-trip.
+// a per-format factory round-trip over every registered nvcomp codec, the
+// device-pointer zero-copy path, and the library-id encoding round-trip.
 TEST_CASE("TestNvCompGpu") {
   // nvcomp needs a real GPU. Skip gracefully where none is present (CI, laptops,
   // Docker without --gpus) so the suite stays green everywhere.
@@ -356,6 +384,39 @@ TEST_CASE("TestNvCompGpu") {
     cudaFree(d_raw);
     cudaFree(d_comp);
     cudaFree(d_decomp);
+  }
+
+  // Every general-purpose nvcomp format must round-trip through the factory on
+  // real GPU data. Same shape as the CPU "factory round-trip" test above.
+  PAGE_DIVIDE("all nvcomp formats (factory round-trip)") {
+    std::string raw;
+    for (int i = 0; i < 4096; ++i) {
+      raw += "The quick brown fox jumps over the lazy dog 0123456789 ";
+    }
+    const char *gpu_libs[] = {"nvcomp-lz4",      "nvcomp-snappy",
+                              "nvcomp-zstd",     "nvcomp-gdeflate",
+                              "nvcomp-deflate",  "nvcomp-ans"};
+    for (const char *lib : gpu_libs) {
+      INFO("nvcomp format: " << lib);
+      auto compressor = ctp::CompressionFactory::GetPreset(lib);
+      REQUIRE(compressor != nullptr);
+
+      std::vector<char> compressed(raw.size() + raw.size() / 20 + 4096);
+      std::vector<char> decompressed(raw.size() + 16);
+
+      size_t cmpr_size = compressed.size();
+      REQUIRE(compressor->Compress(compressed.data(), cmpr_size,
+                                   raw.data(), raw.size()));
+      REQUIRE(cmpr_size > 0);
+      REQUIRE(cmpr_size < raw.size());  // repetitive data must shrink
+
+      auto decompressor = ctp::CompressionFactory::GetPreset(lib);
+      REQUIRE(decompressor != nullptr);
+      size_t raw_size = decompressed.size();
+      REQUIRE(decompressor->Decompress(decompressed.data(), raw_size,
+                                       compressed.data(), cmpr_size));
+      REQUIRE(raw == std::string(decompressed.data(), raw_size));
+    }
   }
 
   PAGE_DIVIDE("NvCompLZ4 library id round-trip") {

--- a/context-transport-primitives/test/unit/compress/test_compress.cc
+++ b/context-transport-primitives/test/unit/compress/test_compress.cc
@@ -136,8 +136,10 @@ TEST_CASE("TestCompress") {
 }
 
 #if CTP_ENABLE_NVCOMP
-// GPU compression via nvcomp. Exercised through the CompressionFactory so this
-// also validates the factory registration of "nvcomp-lz4".
+// GPU compression via nvcomp. Mirrors the CPU compressor coverage above (a
+// direct-class Compress/Decompress round-trip) and adds GPU-specific coverage:
+// a factory round-trip (validates the "nvcomp-lz4" registration) and the
+// library-id encoding round-trip.
 TEST_CASE("TestNvCompGpu") {
   // nvcomp needs a real GPU. Skip gracefully where none is present (CI, laptops,
   // Docker without --gpus) so the suite stays green everywhere.
@@ -147,13 +149,29 @@ TEST_CASE("TestNvCompGpu") {
     return;
   }
 
-  // Payload larger than nvcomp's chunk/overhead so compression is meaningful.
-  std::string raw;
-  for (int i = 0; i < 4096; ++i) {
-    raw += "The quick brown fox jumps over the lazy dog 0123456789 ";
+  // Parity with the CPU tests: same direct-class round-trip, same small payload
+  // and 1024-byte buffers, same REQUIRE-equality check.
+  PAGE_DIVIDE("NvCompLZ4 (direct class)") {
+    std::string raw = "Hello, World!";
+    std::vector<char> compressed(1024);
+    std::vector<char> decompressed(1024);
+    ctp::NvComp nvcomp(ctp::NvCompAlgo::LZ4);
+    size_t cmpr_size = 1024, raw_size = 1024;
+    REQUIRE(nvcomp.Compress(compressed.data(), cmpr_size,
+                            raw.data(), raw.size()));
+    REQUIRE(nvcomp.Decompress(decompressed.data(), raw_size,
+                              compressed.data(), cmpr_size));
+    REQUIRE(raw == std::string(decompressed.data(), raw_size));
   }
 
+  // Larger, compressible payload exercised through the factory (also proves the
+  // factory dispatches "nvcomp-lz4").
   PAGE_DIVIDE("NvCompLZ4 (via factory)") {
+    std::string raw;
+    for (int i = 0; i < 4096; ++i) {
+      raw += "The quick brown fox jumps over the lazy dog 0123456789 ";
+    }
+
     auto compressor = ctp::CompressionFactory::GetPreset(
         "nvcomp-lz4", ctp::CompressionPreset::BALANCED);
     REQUIRE(compressor != nullptr);
@@ -165,7 +183,7 @@ TEST_CASE("TestNvCompGpu") {
     REQUIRE(compressor->Compress(compressed.data(), cmpr_size,
                                  raw.data(), raw.size()));
     REQUIRE(cmpr_size > 0);
-    REQUIRE(cmpr_size <= compressed.size());
+    REQUIRE(cmpr_size < raw.size());  // large repetitive data must shrink
 
     auto decompressor = ctp::CompressionFactory::GetPreset("nvcomp-lz4");
     REQUIRE(decompressor != nullptr);

--- a/context-transport-primitives/test/unit/compress/test_compress.cc
+++ b/context-transport-primitives/test/unit/compress/test_compress.cc
@@ -135,6 +135,133 @@ TEST_CASE("TestCompress") {
   }
 }
 
+// Characterization test for the compressor registry's frozen ID mappings.
+// These values are the on-disk wire protocol and the ML id scheme; renumbering
+// any of them silently breaks stored blobs / trained models. The expected
+// numbers are transcribed from the historical source and must never drift.
+// (No GPU required: these are pure name<->id lookups.)
+TEST_CASE("CompressorRegistryMappings") {
+  using ctp::CompressionFactory;
+  using ctp::CompressionPreset;
+
+  PAGE_DIVIDE("wire id -> name (CompressionHeader.compress_lib_)") {
+    REQUIRE(CompressionFactory::NameForWireId(0) == "brotli");
+    REQUIRE(CompressionFactory::NameForWireId(1) == "bzip2");
+    REQUIRE(CompressionFactory::NameForWireId(2) == "blosc2");
+    REQUIRE(CompressionFactory::NameForWireId(3) == "fpzip");
+    REQUIRE(CompressionFactory::NameForWireId(4) == "lz4");
+    REQUIRE(CompressionFactory::NameForWireId(5) == "lzma");
+    REQUIRE(CompressionFactory::NameForWireId(6) == "snappy");
+    REQUIRE(CompressionFactory::NameForWireId(7) == "sz3");
+    REQUIRE(CompressionFactory::NameForWireId(8) == "zfp");
+    REQUIRE(CompressionFactory::NameForWireId(9) == "zlib");
+    REQUIRE(CompressionFactory::NameForWireId(10) == "zstd");
+    REQUIRE(CompressionFactory::NameForWireId(11) == "nvcomp-lz4");
+    // Out-of-range falls back to the historical default.
+    REQUIRE(CompressionFactory::NameForWireId(-1) == "zstd");
+    REQUIRE(CompressionFactory::NameForWireId(12) == "zstd");
+    REQUIRE(CompressionFactory::NameForWireId(9999) == "zstd");
+  }
+
+  PAGE_DIVIDE("name + preset -> ML library id (base_id*10 + preset)") {
+    const auto FAST = CompressionPreset::FAST;
+    const auto BAL = CompressionPreset::BALANCED;
+    const auto BEST = CompressionPreset::BEST;
+
+    // Multi-mode lossless: id = base_id*10 + {1,2,3}.
+    REQUIRE(CompressionFactory::GetLibraryId("bzip2", FAST) == 11);
+    REQUIRE(CompressionFactory::GetLibraryId("bzip2", BAL) == 12);
+    REQUIRE(CompressionFactory::GetLibraryId("bzip2", BEST) == 13);
+    REQUIRE(CompressionFactory::GetLibraryId("zstd", BAL) == 22);
+    REQUIRE(CompressionFactory::GetLibraryId("lz4", BAL) == 32);
+    REQUIRE(CompressionFactory::GetLibraryId("zlib", BAL) == 42);
+    REQUIRE(CompressionFactory::GetLibraryId("lzma", BAL) == 52);
+    REQUIRE(CompressionFactory::GetLibraryId("brotli", BEST) == 63);
+
+    // Single-mode: preset forced to 2 (BALANCED) regardless of request.
+    REQUIRE(CompressionFactory::GetLibraryId("snappy", FAST) == 72);
+    REQUIRE(CompressionFactory::GetLibraryId("snappy", BEST) == 72);
+    REQUIRE(CompressionFactory::GetLibraryId("blosc2", FAST) == 82);
+    REQUIRE(CompressionFactory::GetLibraryId("blosc", BEST) == 82);  // alias
+
+    // Lossy (base_id known regardless of LibPressio availability).
+    REQUIRE(CompressionFactory::GetLibraryId("zfp", FAST) == 101);
+    REQUIRE(CompressionFactory::GetLibraryId("zfp", BAL) == 102);
+    REQUIRE(CompressionFactory::GetLibraryId("sz3", BAL) == 112);
+    REQUIRE(CompressionFactory::GetLibraryId("fpzip", BEST) == 123);
+
+    // Unknown library -> 0.
+    REQUIRE(CompressionFactory::GetLibraryId("does-not-exist", BAL) == 0);
+
+#if CTP_ENABLE_NVCOMP
+    // GPU compressor: single-mode, base_id 13.
+    REQUIRE(CompressionFactory::GetLibraryId("nvcomp-lz4", FAST) == 132);
+    REQUIRE(CompressionFactory::GetLibraryId("nvcomp-lz4", BEST) == 132);
+#endif
+  }
+
+  PAGE_DIVIDE("ML library id -> name + preset (reverse)") {
+    REQUIRE(CompressionFactory::GetLibraryInfo(11).first == "bzip2");
+    REQUIRE(CompressionFactory::GetLibraryInfo(11).second ==
+            CompressionPreset::FAST);
+    REQUIRE(CompressionFactory::GetLibraryInfo(13).second ==
+            CompressionPreset::BEST);
+    REQUIRE(CompressionFactory::GetLibraryInfo(22).first == "zstd");
+    REQUIRE(CompressionFactory::GetLibraryInfo(72).first == "snappy");
+    REQUIRE(CompressionFactory::GetLibraryInfo(82).first == "blosc2");
+    REQUIRE(CompressionFactory::GetLibraryInfo(102).first == "zfp");
+    REQUIRE(CompressionFactory::GetLibraryInfo(112).first == "sz3");
+    REQUIRE(CompressionFactory::GetLibraryInfo(122).first == "fpzip");
+    // Unknown ids -> "unknown".
+    REQUIRE(CompressionFactory::GetLibraryInfo(0).first == "unknown");
+    REQUIRE(CompressionFactory::GetLibraryInfo(999).first == "unknown");
+#if CTP_ENABLE_NVCOMP
+    REQUIRE(CompressionFactory::GetLibraryInfo(132).first == "nvcomp-lz4");
+#endif
+  }
+
+  PAGE_DIVIDE("GetPreset constructs known CPU compressors (incl. alias)") {
+    REQUIRE(CompressionFactory::GetPreset("bzip2") != nullptr);
+    REQUIRE(CompressionFactory::GetPreset("zstd") != nullptr);
+    REQUIRE(CompressionFactory::GetPreset("lz4") != nullptr);
+    REQUIRE(CompressionFactory::GetPreset("zlib") != nullptr);
+    REQUIRE(CompressionFactory::GetPreset("lzma") != nullptr);
+    REQUIRE(CompressionFactory::GetPreset("brotli") != nullptr);
+    REQUIRE(CompressionFactory::GetPreset("snappy") != nullptr);
+    REQUIRE(CompressionFactory::GetPreset("blosc2") != nullptr);
+    REQUIRE(CompressionFactory::GetPreset("blosc") != nullptr);  // alias
+    REQUIRE(CompressionFactory::GetPreset("does-not-exist") == nullptr);
+  }
+
+  // Functional guard for the registry's make() column: every registered CPU
+  // compressor must construct AND round-trip through the factory. This catches a
+  // future registry row whose make is forgotten/null/throwing (the anti-footgun
+  // goal of the registry). It does NOT prove make identity (a same-family swap
+  // would still round-trip), which is enforced by inspection of the one-line row.
+  PAGE_DIVIDE("factory round-trip over the CPU compressor set") {
+    std::string payload;
+    for (int i = 0; i < 256; ++i) {
+      payload += "registry round-trip payload 0123456789 ";
+    }
+    const char *cpu_libs[] = {"bzip2", "zstd",   "lz4",    "zlib",
+                              "lzma",  "brotli", "snappy", "blosc2"};
+    for (const char *lib : cpu_libs) {
+      auto comp = CompressionFactory::GetPreset(lib);
+      REQUIRE(comp != nullptr);
+      std::vector<char> cbuf(payload.size() * 2 + 4096);
+      std::vector<char> dbuf(payload.size() + 64);
+      size_t csize = cbuf.size();
+      REQUIRE(comp->Compress(cbuf.data(), csize, payload.data(),
+                             payload.size()));
+      auto decomp = CompressionFactory::GetPreset(lib);
+      REQUIRE(decomp != nullptr);
+      size_t dsize = dbuf.size();
+      REQUIRE(decomp->Decompress(dbuf.data(), dsize, cbuf.data(), csize));
+      REQUIRE(payload == std::string(dbuf.data(), dsize));
+    }
+  }
+}
+
 #if CTP_ENABLE_NVCOMP
 // GPU compression via nvcomp. Mirrors the CPU compressor coverage above (a
 // direct-class Compress/Decompress round-trip) and adds GPU-specific coverage:


### PR DESCRIPTION
Extends transparent compression with NVIDIA's [nvcomp](https://github.com/NVIDIA/nvcomp) GPU compression. GPU compressors are exposed under the existing `ctp::CompressionFactory`.
- This adds `nvcomp 4.2.0.11` to the `nvidia-gpu` devcontainer
- Unit tests modeled after the CPU compressor unit tests are added
- `LZ4`, `snappy`, `gdeflate`, `deflate`, and `ans` are all supported on the GPU. `GZIP` cannot be added since it's nvcomp manager is decompression-only.

There's still a preexisting bug with `test_compressor_functional`, but that test has been modified to also test GPU compressors once the Chimera runtime issue is fixed.