### PR TITLE
refactor(runtime): rename chimaera.cc→clio_runtime.cc; CLIO_RUNTIME_F…

### DIFF
--- a/context-runtime/include/clio_runtime/clio_runtime.h
+++ b/context-runtime/include/clio_runtime/clio_runtime.h
@@ -91,7 +91,7 @@ bool ClioInitImpl(ChimaeraMode mode, bool default_with_runtime,
 
 /**
  * CLIO_INIT — canonical Clio runtime entry point.  Thin inline wrapper
- * around ClioInitImpl (the heavy lifting lives in chimaera.cc because
+ * around ClioInitImpl (the heavy lifting lives in clio_runtime.cc because
  * it touches the IpcManager / ChimaeraManager singletons whose
  * headers we don't want to drag into clio_runtime.h's transitive
  * include set).  Inline, not a macro, so the call resolves through the
@@ -114,14 +114,17 @@ inline bool CHIMAERA_INIT(ChimaeraMode mode, bool default_with_runtime = false,
 }
 
 /**
- * Finalize CLIO Runtime and release all resources
+ * Finalize CLIO Runtime and release all resources.
  *
- * Calls ClientFinalize on the CLIO Runtime manager to close ZMQ sockets and
- * join background threads. Must be called before process exit to avoid
- * hangs in zmq_ctx_destroy (the CLIO Runtime singleton is heap-allocated so
- * its destructor is never invoked automatically).
+ * Canonical name. Calls ClientFinalize on the CLIO Runtime manager to close
+ * ZMQ sockets and join background threads. Must be called before process exit
+ * to avoid hangs in zmq_ctx_destroy (the CLIO Runtime singleton is
+ * heap-allocated so its destructor is never invoked automatically).
  */
-void CHIMAERA_FINALIZE();
+void CLIO_RUNTIME_FINALIZE();
+
+/** Deprecated alias — calls CLIO_RUNTIME_FINALIZE(). */
+inline void CHIMAERA_FINALIZE() { CLIO_RUNTIME_FINALIZE(); }
 
 }  // namespace clio::run
 
@@ -136,17 +139,7 @@ void CHIMAERA_FINALIZE();
 // CLIO_<X>` backward-compat alias, so legacy code that still uses the
 // CHI_* spelling keeps working unchanged. See rebranding.md for the full
 // migration table.
-//
-// Only one thing needs to live in this umbrella now:
-//   - The finalize macro (its RHS is a function call defined here).
-//     CLIO_INIT / CHIMAERA_INIT are inline functions above (not macros),
-//     so no #define alias is needed for them.
-// The CLIO_RUNTIME_MANAGER macro is canonical (defined in
-// clio_runtime/manager.h) — no alias needed.
 //==============================================================================
-
-// --- Finalize ---
-#define CLIO_RUNTIME_FINALIZE  ::chi::CHIMAERA_FINALIZE
 
 // --- Module namespace alias (chimaera:: -> clio::run::) ---
 // Pulled in last so the alias is visible to every TU that includes this

--- a/context-runtime/src/clio_runtime.cc
+++ b/context-runtime/src/clio_runtime.cc
@@ -91,18 +91,18 @@ bool ClioInitImpl(ChimaeraMode mode, bool default_with_runtime,
     }
   }
 
-  // Register atexit handler so CHIMAERA_FINALIZE runs before static
+  // Register atexit handler so CLIO_RUNTIME_FINALIZE runs before static
   // destructors.  The CLIO Runtime singleton is heap-allocated (GetGlobalPtrVar)
   // so its destructor is never called automatically.  Without this the ZMQ
   // DEALER socket stays open and zmq_ctx_destroy blocks forever at exit.
-  std::atexit(CHIMAERA_FINALIZE);
+  std::atexit(CLIO_RUNTIME_FINALIZE);
 
   // Mark as initialized on success
   s_initialized = true;
   return true;
 }
 
-void CHIMAERA_FINALIZE() {
+void CLIO_RUNTIME_FINALIZE() {
   static bool s_finalized = false;
   if (s_finalized) {
     return;


### PR DESCRIPTION
…INALIZE canonical

Closes #495

- Rename context-runtime/src/chimaera.cc to clio_runtime.cc
- Declare CLIO_RUNTIME_FINALIZE() as the canonical function in clio_runtime.h
- Add inline CHIMAERA_FINALIZE() shim calling CLIO_RUNTIME_FINALIZE() for backwards compatibility with the ~30 existing call sites
- Remove #define CLIO_RUNTIME_FINALIZE ::chi::CHIMAERA_FINALIZE macro
- Update internal atexit registration and function definition in clio_runtime.cc