### PR TITLE
Fix nvidia-gpu devcontainer build: exclude oneDPL pstl_offload headers

### DIFF
--- a/.devcontainer/nvidia-gpu/Dockerfile
+++ b/.devcontainer/nvidia-gpu/Dockerfile
@@ -81,7 +81,7 @@ SHELL ["/bin/bash", "-lc"]
 RUN set -eux; \
     git clone --depth 1 -b "${ZFP_SYCL_REF}" https://github.com/alpers-git/zfp.git /tmp/zfp; \
     dpct_inc="$(dirname "$(dirname "$(find /opt/intel/oneapi/dpcpp-ct -name dpct.hpp | head -1)")")"; \
-    dpl_inc="$(dirname "$(dirname "$(dirname "$(find /opt/intel/oneapi/dpl -path '*oneapi/dpl/execution' | head -1)")")")"; \
+    dpl_inc="$(dirname "$(dirname "$(dirname "$(find /opt/intel/oneapi/dpl -path '*oneapi/dpl/execution' -not -path '*pstl_offload*' | head -1)")")")"; \
     if [ -d /opt/adaptivecpp ]; then mv /opt/adaptivecpp /opt/adaptivecpp_hidden; fi; \
     cmake -S /tmp/zfp -B /tmp/zfp/build -DCMAKE_BUILD_TYPE=Release -DZFP_WITH_SYCL=1 \
       -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx \


### PR DESCRIPTION
## Summary

Fixes the `nvidia-gpu` devcontainer build, which failed at the SYCL-enabled `libzfp` step while compiling `syclZFP.cpp`:

```
error: "PSTL offload compiler mode should be enabled to use this header"
```

The Dockerfile auto-detects the oneDPL include directory with `find ... -path '*oneapi/dpl/execution' | head -1`. The Intel oneAPI image ships two matching trees:

- `.../include/pstl_offload/oneapi/dpl/execution` (PSTL-offload headers)
- `.../include/oneapi/dpl/execution` (normal include root)

`find` returned the `pstl_offload` variant first, so `dpl_inc` resolved to `.../include/pstl_offload` and `-I` pulled in headers that `#error` unless the compiler runs in PSTL-offload mode (`-fsycl-pstl-offload`) — which this build doesn't use.

This PR excludes the `pstl_offload` tree with `-not -path '*pstl_offload*'`, so `dpl_inc` resolves to `/opt/intel/oneapi/dpl/2022.6/include`.

## Testing

Rebuilt the full `nvidia-gpu` devcontainer image end to end — it now passes the previously-failing `syclZFP.cpp` compile and builds cleanly through all 10 stages (exit 0).

Fixes #540

🤖 Generated with [Claude Code](https://claude.com/claude-code)
