### PR TITLE
fix(bdev): repair filesystem transport compile break in BdevTransport refactor (#571)

### DIFF
--- a/context-runtime/modules/bdev/include/clio_runtime/bdev/transports/bdev_transport.h
+++ b/context-runtime/modules/bdev/include/clio_runtime/bdev/transports/bdev_transport.h
@@ -38,6 +38,7 @@
 #include <clio_runtime/bdev/bdev_tasks.h>
 #include <vector>
 #include <memory>
+#include <string>
 
 namespace clio::run::bdev {
 
@@ -53,10 +54,13 @@ class BdevTransport {
   /**
    * Initialize the transport
    * @param params Creation parameters
+   * @param pool_name Pool name; doubles as the file path (kFile) or S3 bucket
+   *   name (kS3). Carried on the create task, not in CreateParams.
    * @param runtime Pointer to the parent bdev runtime
    * @return true if successful
    */
-  virtual bool Init(const CreateParams& params, Runtime* runtime) = 0;
+  virtual bool Init(const CreateParams& params, const std::string& pool_name,
+                    Runtime* runtime) = 0;
 
   /**
    * Destroy the transport and release resources

--- a/context-runtime/modules/bdev/include/clio_runtime/bdev/transports/fs_bdev_transport.h
+++ b/context-runtime/modules/bdev/include/clio_runtime/bdev/transports/fs_bdev_transport.h
@@ -17,7 +17,7 @@ namespace clio::run::bdev {
  */
 struct WorkerIOContext {
   bool is_initialized_{false};
-  std::unique_ptr<ctp::AsyncIo> async_io_;
+  std::unique_ptr<ctp::AsyncIO> async_io_;
 
   bool Init(const std::string &file_path, chi::u32 io_depth, chi::u32 worker_id);
   void Cleanup();
@@ -28,7 +28,8 @@ class FsBdevTransport : public BdevTransport {
   FsBdevTransport() = default;
   ~FsBdevTransport() override { Destroy(); }
 
-  bool Init(const CreateParams& params, Runtime* runtime) override;
+  bool Init(const CreateParams& params, const std::string& pool_name,
+            Runtime* runtime) override;
   void Destroy() override;
 
   bool AllocateBlocks(size_t size, int worker_id, std::vector<Block>& blocks) override;

--- a/context-runtime/modules/bdev/include/clio_runtime/bdev/transports/mem_bdev_transport.h
+++ b/context-runtime/modules/bdev/include/clio_runtime/bdev/transports/mem_bdev_transport.h
@@ -18,7 +18,8 @@ class MemBdevTransport : public BdevTransport {
   MemBdevTransport() = default;
   ~MemBdevTransport() override { Destroy(); }
 
-  bool Init(const CreateParams& params, Runtime* runtime) override;
+  bool Init(const CreateParams& params, const std::string& pool_name,
+            Runtime* runtime) override;
   void Destroy() override;
 
   bool AllocateBlocks(size_t size, int worker_id, std::vector<Block>& blocks) override;

--- a/context-runtime/modules/bdev/include/clio_runtime/bdev/transports/s3_bdev_transport.h
+++ b/context-runtime/modules/bdev/include/clio_runtime/bdev/transports/s3_bdev_transport.h
@@ -21,7 +21,8 @@ class S3BdevTransport : public BdevTransport {
   S3BdevTransport() = default;
   ~S3BdevTransport() override { Destroy(); }
 
-  bool Init(const CreateParams& params, Runtime* runtime) override;
+  bool Init(const CreateParams& params, const std::string& pool_name,
+            Runtime* runtime) override;
   void Destroy() override;
 
   bool AllocateBlocks(size_t size, int worker_id, std::vector<Block>& blocks) override;

--- a/context-runtime/modules/bdev/src/bdev_runtime.cc
+++ b/context-runtime/modules/bdev/src/bdev_runtime.cc
@@ -75,7 +75,9 @@ chi::TaskResume Runtime::Create(ctp::ipc::FullPtr<CreateTask> task, chi::RunCont
     CLIO_CO_RETURN;
   }
 
-  if (!transport_->Init(params, this)) {
+  // pool_name doubles as the file path (kFile) / S3 bucket (kS3); it lives on
+  // the create task, not in CreateParams.
+  if (!transport_->Init(params, task->pool_name_.str(), this)) {
     HLOG(kError, "Failed to initialize bdev transport");
     task->return_code_ = 2;
     CLIO_CO_RETURN;

--- a/context-runtime/modules/bdev/src/transports/fs_bdev_transport.cc
+++ b/context-runtime/modules/bdev/src/transports/fs_bdev_transport.cc
@@ -8,6 +8,7 @@
 #include <clio_runtime/clio_runtime.h>
 #include <clio_runtime/worker.h>
 #include <clio_runtime/work_orchestrator.h>
+#include <fcntl.h>
 
 namespace clio::run::bdev {
 
@@ -21,15 +22,14 @@ bool WorkerIOContext::Init(const std::string &file_path, chi::u32 io_depth,
   async_io_ = ctp::AsyncIoFactory::Get(io_depth);
 #endif
 
-  if (!async_io_ || !async_io_->Init()) {
-    HLOG(kError, "Failed to initialize generic AsyncIo for worker {}",
-         worker_id);
+  if (!async_io_) {
+    HLOG(kError, "Failed to create AsyncIO backend for worker {}", worker_id);
     return false;
   }
 
-  if (!async_io_->Open(file_path)) {
+  if (!async_io_->Open(file_path, O_RDWR | O_CREAT, 0644)) {
     HLOG(kError, "Worker {} failed to open file {}", worker_id, file_path);
-    async_io_->Cleanup();
+    async_io_.reset();
     return false;
   }
 
@@ -41,29 +41,31 @@ void WorkerIOContext::Cleanup() {
   if (is_initialized_) {
     if (async_io_) {
       async_io_->Close();
-      async_io_->Cleanup();
+      async_io_.reset();
     }
     is_initialized_ = false;
   }
 }
 
-bool FsBdevTransport::Init(const CreateParams& params, Runtime* runtime) {
-  file_path_ = params.file_path_;
+bool FsBdevTransport::Init(const CreateParams& params,
+                           const std::string& pool_name, Runtime* runtime) {
+  // The pool name doubles as the backing file path.
+  file_path_ = pool_name;
   io_depth_ = params.io_depth_;
 
   auto setup_io = ctp::AsyncIoFactory::Get(io_depth_);
-  if (!setup_io->Init()) {
-    HLOG(kError, "Failed to initialize setup AsyncIo for filesystem tier");
+  if (!setup_io) {
+    HLOG(kError, "Failed to create setup AsyncIO backend for filesystem tier");
     return false;
   }
 
-  if (!setup_io->Open(file_path_)) {
+  if (!setup_io->Open(file_path_, O_RDWR | O_CREAT, 0644)) {
     HLOG(kError, "Failed to open bdev file: {}", file_path_);
     return false;
   }
 
   chi::u64 file_size = 0;
-  off_t current_size = setup_io->GetSize();
+  off_t current_size = setup_io->GetFileSize();
   if (current_size < 0) {
     HLOG(kError, "Failed to get file size for: {}", file_path_);
     setup_io->Close();

--- a/context-runtime/modules/bdev/src/transports/mem_bdev_transport.cc
+++ b/context-runtime/modules/bdev/src/transports/mem_bdev_transport.cc
@@ -10,7 +10,8 @@
 
 namespace clio::run::bdev {
 
-bool MemBdevTransport::Init(const CreateParams& params, Runtime* runtime) {
+bool MemBdevTransport::Init(const CreateParams& params,
+                            const std::string& /*pool_name*/, Runtime* runtime) {
   ram_capacity_ = (params.total_size_ == 0) ? DefaultRamCapacityBytes() : params.total_size_;
 
   chi::WorkOrchestrator *work_orchestrator = CLIO_WORK_ORCHESTRATOR;

--- a/context-runtime/modules/bdev/src/transports/s3_bdev_transport.cc
+++ b/context-runtime/modules/bdev/src/transports/s3_bdev_transport.cc
@@ -32,14 +32,15 @@ class PreallocatedStreamBuf : public std::streambuf {
 };
 #endif
 
-bool S3BdevTransport::Init(const CreateParams& params, Runtime* runtime) {
+bool S3BdevTransport::Init(const CreateParams& params,
+                           const std::string& pool_name, Runtime* runtime) {
 #ifdef CLIO_ENABLE_AMAZON_DRIVE
   if (init_count_.fetch_add(1) == 0) {
     Aws::InitAPI(options_);
   }
 
   // The bdev pool_name acts as the bucket name
-  bucket_name_ = Aws::String(params.pool_name_.c_str());
+  bucket_name_ = Aws::String(pool_name.c_str());
 
   Aws::Client::ClientConfiguration clientConfig;
   const char* region_env = std::getenv("AWS_DEFAULT_REGION");


### PR DESCRIPTION
Fixes #581.

## Problem

`dev` fails to compile the `clio_bdev_runtime` target in **every** configuration — including the default `CLIO_ENABLE_AMAZON_DRIVE=OFF`. Although it looks "S3-related", the broken code is the **filesystem** transport extracted by the BdevTransport refactor (#571); the S3 source isn't even compiled by default.

```
fs_bdev_transport.h:20: error: 'AsyncIo' is not a member of 'ctp'
fs_bdev_transport.cc:24: error: 'ctp::AsyncIO' has no member named 'Init'
fs_bdev_transport.cc:51: error: 'CreateParams' has no member named 'file_path_'
fs_bdev_transport.cc:60: error: no matching function for call to 'ctp::AsyncIO::Open(std::string&)'
fs_bdev_transport.cc:66: error: 'ctp::AsyncIO' has no member named 'GetSize'
```

## Root cause

The refactor extracted the file backend out of `bdev_runtime.cc` but wrote it against a **stale async-I/O API** and an **assumed `CreateParams` shape that doesn't exist**. The code it replaced (on `main`) used the correct API, so this is a regression from the extraction.

1. **Stale `ctp::AsyncIO` API**: `AsyncIo`→`AsyncIO`; `Init()`/`Cleanup()` don't exist; `Open(path)`→`Open(path, flags, mode)`; `GetSize()`→`GetFileSize()`.
2. **Missing path plumbing**: the file path / bucket name comes from `task->pool_name_`, but `BdevTransport::Init(const CreateParams&, Runtime*)` never received it — Fs read `params.file_path_` and S3 read `params.pool_name_`, neither of which exist on `CreateParams`.

## Fix

- Correct the `ctp::AsyncIO` usage in `fs_bdev_transport.{h,cc}` (the `Write`/`Read` bodies were already correct — only the setup paths were wrong).
- Add a `pool_name` parameter to `BdevTransport::Init` and all three implementations, and pass `task->pool_name_.str()` from `Runtime::Create`.

## Verification

`cmake --build build --target clio_bdev_runtime` now succeeds with `CLIO_ENABLE_AMAZON_DRIVE=OFF` (default), and the S3 source compiles with it `ON`.

## Out of scope (follow-up in #581)

Building with `CLIO_ENABLE_AMAZON_DRIVE=ON` still fails to **link** (`-laws-cpp-sdk-s3` not found): the AWS SDK is only fetched in the test subdir, and `CLIO_ENABLE_AMAZON_DRIVE` is never propagated as a compile definition (so the S3 backend is silently stubbed even when enabled). That S3-enablement wiring is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)