### PR TITLE
feat(runtime): PoolQuery::ManyToOne collective batch+aggregate (AggregateIn/AggregateOut) (#587)

### DIFF
--- a/context-assimilation-engine/core/include/clio_cae/core/core_runtime.h
+++ b/context-assimilation-engine/core/include/clio_cae/core/core_runtime.h
@@ -70,7 +70,7 @@ class Runtime : public chi::Container {
   void LocalSaveTask(chi::u32 method, chi::DefaultSaveArchive& archive, ctp::ipc::FullPtr<chi::Task> task_ptr) override;
   ctp::ipc::FullPtr<chi::Task> NewCopyTask(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task_ptr, bool deep) override;
   ctp::ipc::FullPtr<chi::Task> NewTask(chi::u32 method) override;
-  void Aggregate(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
+  void AggregateOut(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
                  const ctp::ipc::FullPtr<chi::Task>& replica_task) override;
   void DelTask(chi::u32 method, ctp::ipc::FullPtr<chi::Task> task_ptr) override;
   /**

--- a/context-assimilation-engine/core/include/clio_cae/core/core_tasks.h
+++ b/context-assimilation-engine/core/include/clio_cae/core/core_tasks.h
@@ -279,11 +279,11 @@ struct ParseOmniTask : public chi::Task {
   }
 
   /**
-   * Aggregate replica results into this task
+   * AggregateOut replica results into this task
    * @param other Pointer to the replica task to aggregate from
    */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<ParseOmniTask>());
   }
 };
@@ -358,10 +358,10 @@ struct ProcessHdf5DatasetTask : public chi::Task {
   }
 
   /**
-   * Aggregate replica results into this task
+   * AggregateOut replica results into this task
    */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     auto other = other_base.template Cast<ProcessHdf5DatasetTask>();
     // Keep the first error if any
     if (result_code_ == 0 && other->result_code_ != 0) {
@@ -435,8 +435,8 @@ struct ExportDataTask : public chi::Task {
     bytes_exported_ = other->bytes_exported_;
   }
 
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<ExportDataTask>());
   }
 };

--- a/context-assimilation-engine/core/src/autogen/core_lib_exec.cc
+++ b/context-assimilation-engine/core/src/autogen/core_lib_exec.cc
@@ -545,61 +545,61 @@ ctp::ipc::FullPtr<chi::Task> Runtime::NewTask(chi::u32 method) {
   }
 }
 
-void Runtime::Aggregate(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
+void Runtime::AggregateOut(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
                         const ctp::ipc::FullPtr<chi::Task>& replica_task) {
   switch (method) {
     case Method::kCreate: {
       auto typed_task = orig_task.template Cast<CreateTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kDestroy: {
       auto typed_task = orig_task.template Cast<DestroyTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kMonitor: {
       auto typed_task = orig_task.template Cast<MonitorTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kParseOmni: {
       auto typed_task = orig_task.template Cast<ParseOmniTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kProcessHdf5Dataset: {
       auto typed_task = orig_task.template Cast<ProcessHdf5DatasetTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kExportData: {
       auto typed_task = orig_task.template Cast<ExportDataTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kPutBlob: {
       auto typed_task = orig_task.template Cast<PutBlobTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kGetBlob: {
       auto typed_task = orig_task.template Cast<GetBlobTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kGetOrCreateTag: {
       auto typed_task = orig_task.template Cast<GetOrCreateTagTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kSemanticSearch: {
       auto typed_task = orig_task.template Cast<SemanticSearchTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     default: {
-      orig_task->Aggregate(replica_task);
+      orig_task->AggregateOut(replica_task);
       break;
     }
   }

--- a/context-assimilation-engine/test/unit/test_export_data.cc
+++ b/context-assimilation-engine/test/unit/test_export_data.cc
@@ -37,16 +37,16 @@
  * Unit tests for the CAE ExportData feature and related task structs.
  *
  * Coverage targets (>95%):
- *   - ExportDataTask: default ctor, emplace ctor, Copy, Aggregate,
+ *   - ExportDataTask: default ctor, emplace ctor, Copy, AggregateOut,
  *     SerializeIn, SerializeOut
- *   - ParseOmniTask: default ctor, emplace ctor, Copy, Aggregate,
+ *   - ParseOmniTask: default ctor, emplace ctor, Copy, AggregateOut,
  *     SerializeIn, SerializeOut
- *   - ProcessHdf5DatasetTask: default ctor, emplace ctor, Copy, Aggregate,
+ *   - ProcessHdf5DatasetTask: default ctor, emplace ctor, Copy, AggregateOut,
  *     SerializeIn, SerializeOut
  *   - Runtime::ExportData: empty-tag, binary roundtrip, binary bad path,
  *     unknown format (falls to binary), HDF5 or not-compiled path
  *   - autogen core_lib_exec.cc: kExportData cases in Run, SaveTask, LoadTask,
- *     LocalLoadTask, LocalSaveTask, NewCopyTask, NewTask, Aggregate, DelTask
+ *     LocalLoadTask, LocalSaveTask, NewCopyTask, NewTask, AggregateOut, DelTask
  *     (exercised implicitly via AsyncExportData / AsyncParseOmni)
  */
 
@@ -217,7 +217,7 @@ TEST_CASE("ExportData - Task Copy", "[cae][export][task]") {
   INFO("ExportDataTask Copy OK");
 }
 
-TEST_CASE("ExportData - Task Aggregate", "[cae][export][task]") {
+TEST_CASE("ExportData - Task AggregateOut", "[cae][export][task]") {
   ExportDataFixture f;
 
   auto *ipc = CLIO_IPC;
@@ -235,15 +235,15 @@ TEST_CASE("ExportData - Task Aggregate", "[cae][export][task]") {
   replica->bytes_exported_ = 200;
   replica->result_code_ = 5;
 
-  orig->Aggregate(replica.template Cast<chi::Task>());
+  orig->AggregateOut(replica.template Cast<chi::Task>());
 
-  // Aggregate calls Copy, so orig should now have replica's values
+  // AggregateOut calls Copy, so orig should now have replica's values
   REQUIRE(orig->bytes_exported_ == 200);
   REQUIRE(orig->result_code_ == 5);
 
   ipc->DelTask(orig);
   ipc->DelTask(replica);
-  INFO("ExportDataTask Aggregate OK");
+  INFO("ExportDataTask AggregateOut OK");
 }
 
 TEST_CASE("ExportData - Task SerializeIn roundtrip", "[cae][export][task]") {
@@ -535,7 +535,7 @@ TEST_CASE("ParseOmni - Task Copy", "[cae][export][task]") {
   INFO("ParseOmniTask Copy OK");
 }
 
-TEST_CASE("ParseOmni - Task Aggregate", "[cae][export][task]") {
+TEST_CASE("ParseOmni - Task AggregateOut", "[cae][export][task]") {
   ExportDataFixture f;
 
   auto *ipc = CLIO_IPC;
@@ -554,14 +554,14 @@ TEST_CASE("ParseOmni - Task Aggregate", "[cae][export][task]") {
   rep->num_tasks_scheduled_ = 5;
   rep->result_code_ = 9;
 
-  orig->Aggregate(rep.template Cast<chi::Task>());
+  orig->AggregateOut(rep.template Cast<chi::Task>());
 
   REQUIRE(orig->num_tasks_scheduled_ == 5);
   REQUIRE(orig->result_code_ == 9);
 
   ipc->DelTask(orig);
   ipc->DelTask(rep);
-  INFO("ParseOmniTask Aggregate OK");
+  INFO("ParseOmniTask AggregateOut OK");
 }
 
 TEST_CASE("ParseOmni - Task SerializeIn roundtrip", "[cae][export][task]") {
@@ -695,7 +695,7 @@ TEST_CASE("ProcessHdf5Dataset - Task Copy", "[cae][export][task]") {
   INFO("ProcessHdf5DatasetTask Copy OK");
 }
 
-TEST_CASE("ProcessHdf5Dataset - Task Aggregate keeps first error",
+TEST_CASE("ProcessHdf5Dataset - Task AggregateOut keeps first error",
           "[cae][export][task]") {
   ExportDataFixture f;
 
@@ -715,17 +715,17 @@ TEST_CASE("ProcessHdf5Dataset - Task Aggregate keeps first error",
   rep->error_message_ = chi::priv::string("second_err", CTP_MALLOC);
 
   // orig already has error → keeps its own error, does not overwrite
-  orig->Aggregate(rep.template Cast<chi::Task>());
+  orig->AggregateOut(rep.template Cast<chi::Task>());
 
   REQUIRE(orig->result_code_ == -1);
   REQUIRE(orig->error_message_.str() == "first_err");
 
   ipc->DelTask(orig);
   ipc->DelTask(rep);
-  INFO("ProcessHdf5DatasetTask Aggregate keeps first error OK");
+  INFO("ProcessHdf5DatasetTask AggregateOut keeps first error OK");
 }
 
-TEST_CASE("ProcessHdf5Dataset - Task Aggregate adopts replica error",
+TEST_CASE("ProcessHdf5Dataset - Task AggregateOut adopts replica error",
           "[cae][export][task]") {
   ExportDataFixture f;
 
@@ -744,14 +744,14 @@ TEST_CASE("ProcessHdf5Dataset - Task Aggregate adopts replica error",
   rep->error_message_ = chi::priv::string("rep_err", CTP_MALLOC);
 
   // orig has no error → adopts replica's error
-  orig->Aggregate(rep.template Cast<chi::Task>());
+  orig->AggregateOut(rep.template Cast<chi::Task>());
 
   REQUIRE(orig->result_code_ == -3);
   REQUIRE(orig->error_message_.str() == "rep_err");
 
   ipc->DelTask(orig);
   ipc->DelTask(rep);
-  INFO("ProcessHdf5DatasetTask Aggregate adopts replica error OK");
+  INFO("ProcessHdf5DatasetTask AggregateOut adopts replica error OK");
 }
 
 TEST_CASE("ProcessHdf5Dataset - Task SerializeIn roundtrip",

--- a/context-runtime/include/clio_runtime/batch_manager.h
+++ b/context-runtime/include/clio_runtime/batch_manager.h
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * BSD 3-Clause License. See LICENSE file.
+ */
+
+#ifndef CHIMAERA_INCLUDE_CHIMAERA_BATCH_MANAGER_H_
+#define CHIMAERA_INCLUDE_CHIMAERA_BATCH_MANAGER_H_
+
+#include <cstdint>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+
+#include "clio_runtime/task.h"
+#include "clio_runtime/types.h"
+
+namespace clio::run {
+
+class IpcManager;
+class Worker;
+
+/**
+ * BatchManager — leader-side collective batching + aggregation for the
+ * PoolQuery::ManyToOne routing mode.
+ *
+ * When a ManyToOne task reaches its neighborhood leader, it is parked here
+ * (instead of being executed) and grouped by
+ * (pool_id, method, container_hash, batch_key). After the batch window
+ * (batch_for_ns, measured from the first arrival) elapses, the group is
+ * flushed:
+ *   1. A synthetic aggregate task is built as a copy of the first member,
+ *      and each remaining member is merged in via Container::Aggregate
+ *      (collective input combine).
+ *   2. The aggregate task runs once (flagged TASK_BATCH_AGGREGATE).
+ *   3. On completion (Worker::EndTask), the aggregate's OUT is broadcast back
+ *      into every original task via Container::Aggregate, and each original is
+ *      completed through Worker::EndTask (local future signal or remote
+ *      SendOut to its return node).
+ */
+class BatchManager {
+ public:
+  explicit BatchManager(IpcManager *ipc) : ipc_(ipc) {}
+
+  /**
+   * Park a ManyToOne task into its batch group. Called on the neighborhood
+   * leader from IpcManager::RouteTask. The task already has a RunContext and
+   * a future; both are reachable via task->GetRunCtx().
+   */
+  void Add(const ctp::ipc::FullPtr<Task> &task);
+
+  /**
+   * Flush every group whose batch window has elapsed. Called periodically from
+   * a single worker's run loop on the leader. Safe to call when empty.
+   * @return true if any group is pending or was flushed (so the caller keeps
+   *         spinning to honor the short batch window instead of deep-sleeping).
+   */
+  bool FlushDue(Worker *worker);
+
+  /** True if `task` is a synthetic aggregate task produced by FlushDue. */
+  bool IsAggregate(const ctp::ipc::FullPtr<Task> &task) const;
+
+  /**
+   * Broadcast a completed aggregate's OUT to its batched originals and
+   * complete each one. Called from Worker::EndTask for aggregate tasks.
+   */
+  void OnAggregateComplete(Worker *worker, const ctp::ipc::FullPtr<Task> &agg,
+                           RunContext *agg_rctx);
+
+ private:
+  /** Group identity: matching tasks aggregate together. */
+  struct GroupKey {
+    PoolId pool_id;
+    u32 method;
+    u32 container_hash;
+    u64 batch_key;
+    bool operator==(const GroupKey &o) const {
+      return pool_id == o.pool_id && method == o.method &&
+             container_hash == o.container_hash && batch_key == o.batch_key;
+    }
+  };
+  struct GroupKeyHash {
+    size_t operator()(const GroupKey &k) const {
+      size_t h = std::hash<u64>()(
+          (static_cast<u64>(k.pool_id.major_) << 32) | k.pool_id.minor_);
+      h ^= std::hash<u32>()(k.method) + 0x9e3779b97f4a7c15ULL + (h << 6) +
+           (h >> 2);
+      h ^= std::hash<u32>()(k.container_hash) + 0x9e3779b97f4a7c15ULL +
+           (h << 6) + (h >> 2);
+      h ^= std::hash<u64>()(k.batch_key) + 0x9e3779b97f4a7c15ULL + (h << 6) +
+           (h >> 2);
+      return h;
+    }
+  };
+  struct Group {
+    std::vector<ctp::ipc::FullPtr<Task>> members;
+    u64 deadline_ns = 0;  /**< steady-clock ns of the first arrival + window */
+  };
+
+  /** Monotonic nanoseconds (steady clock). */
+  static u64 NowNs();
+
+  /** Build the aggregate for a flushed group and submit it to run. */
+  void BuildAndSubmit(Worker *worker, const GroupKey &key, Group &group);
+
+  IpcManager *ipc_;
+  std::mutex mu_;
+  std::unordered_map<GroupKey, Group, GroupKeyHash> groups_;
+  /** agg task unique id → its batched originals, awaiting broadcast. */
+  std::mutex pending_mu_;
+  std::unordered_map<u64, std::vector<ctp::ipc::FullPtr<Task>>> pending_;
+};
+
+}  // namespace clio::run
+
+#endif  // CHIMAERA_INCLUDE_CHIMAERA_BATCH_MANAGER_H_

--- a/context-runtime/include/clio_runtime/batch_manager.h
+++ b/context-runtime/include/clio_runtime/batch_manager.h
@@ -33,13 +33,15 @@ class Worker;
  * (batch_for_ns, measured from the first arrival) elapses, the group is
  * flushed:
  *   1. A synthetic aggregate task is built as a copy of the first member,
- *      and each remaining member is merged in via Container::Aggregate
- *      (collective input combine).
+ *      and each remaining member's INPUTS are combined in via
+ *      Container::AggregateIn (the collective input combine).
  *   2. The aggregate task runs once (flagged TASK_BATCH_AGGREGATE).
  *   3. On completion (Worker::EndTask), the aggregate's OUT is broadcast back
- *      into every original task via Container::Aggregate, and each original is
- *      completed through Worker::EndTask (local future signal or remote
- *      SendOut to its return node).
+ *      into every original task via a SerializeOut copy (LocalSaveTask/
+ *      LocalLoadTask, kSerializeOut) — one result distributed 1->N, distinct
+ *      from AggregateOut which is the replica-gather N->1 merge — and each
+ *      original is completed through Worker::EndTask (local future signal or
+ *      remote SendOut to its return node).
  */
 class BatchManager {
  public:

--- a/context-runtime/include/clio_runtime/container.h
+++ b/context-runtime/include/clio_runtime/container.h
@@ -487,7 +487,11 @@ class Container {
   CTP_DLL virtual ctp::ipc::FullPtr<Task> NewTask(u32 method) = 0;
 
   /**
-   * Aggregate replica results into origin task via Container dispatch
+   * Aggregate replica OUTPUTS into the origin task via Container dispatch
+   * (a.k.a. AggregateOut). This is the existing output-merge semantics: every
+   * chimod's per-task Aggregate() merges OUT fields of a replica into the
+   * origin (used by the replica/gather path in RecvOutAggregate and by the
+   * ManyToOne result broadcast).
    * Replaces virtual Task::Aggregate to avoid vtable on Task
    * @param method The method ID for proper task type casting
    * @param orig_task The origin task to aggregate into
@@ -495,6 +499,31 @@ class Container {
    */
   virtual void Aggregate(u32 method, ctp::ipc::FullPtr<Task> orig_task,
                           const ctp::ipc::FullPtr<Task>& replica_task) = 0;
+
+  /** Alias spelling out the direction of Aggregate() — merges OUT fields. */
+  void AggregateOut(u32 method, ctp::ipc::FullPtr<Task> orig_task,
+                    const ctp::ipc::FullPtr<Task>& replica_task) {
+    Aggregate(method, orig_task, replica_task);
+  }
+
+  /**
+   * Aggregate member INPUTS into a collective aggregate task (ManyToOne).
+   * Combines the IN fields of a batched member into the synthetic aggregate
+   * task that will run once for the whole batch. Distinct from Aggregate
+   * (AggregateOut), which merges OUT fields. Default is a no-op: with no
+   * override the aggregate runs as a copy of the first member (e.g. a barrier
+   * / dedup collective). Chimods whose collective combines inputs (sum, max,
+   * concat, ...) override this. Dispatched per method by the chimod.
+   * @param method The method ID for proper task type casting
+   * @param agg_task The synthetic aggregate task to combine into
+   * @param member_task A batched member whose inputs are folded in
+   */
+  virtual void AggregateIn(u32 method, ctp::ipc::FullPtr<Task> agg_task,
+                           const ctp::ipc::FullPtr<Task>& member_task) {
+    (void)method;
+    (void)agg_task;
+    (void)member_task;
+  }
 
   /**
    * Delete a task via Container dispatch with proper type casting

--- a/context-runtime/include/clio_runtime/container.h
+++ b/context-runtime/include/clio_runtime/container.h
@@ -487,29 +487,23 @@ class Container {
   CTP_DLL virtual ctp::ipc::FullPtr<Task> NewTask(u32 method) = 0;
 
   /**
-   * Aggregate replica OUTPUTS into the origin task via Container dispatch
+   * AggregateOut replica OUTPUTS into the origin task via Container dispatch
    * (a.k.a. AggregateOut). This is the existing output-merge semantics: every
-   * chimod's per-task Aggregate() merges OUT fields of a replica into the
+   * chimod's per-task AggregateOut() merges OUT fields of a replica into the
    * origin (used by the replica/gather path in RecvOutAggregate and by the
    * ManyToOne result broadcast).
-   * Replaces virtual Task::Aggregate to avoid vtable on Task
+   * Replaces virtual Task::AggregateOut to avoid vtable on Task
    * @param method The method ID for proper task type casting
    * @param orig_task The origin task to aggregate into
    * @param replica_task The replica task to aggregate from
    */
-  virtual void Aggregate(u32 method, ctp::ipc::FullPtr<Task> orig_task,
+  virtual void AggregateOut(u32 method, ctp::ipc::FullPtr<Task> orig_task,
                           const ctp::ipc::FullPtr<Task>& replica_task) = 0;
 
-  /** Alias spelling out the direction of Aggregate() — merges OUT fields. */
-  void AggregateOut(u32 method, ctp::ipc::FullPtr<Task> orig_task,
-                    const ctp::ipc::FullPtr<Task>& replica_task) {
-    Aggregate(method, orig_task, replica_task);
-  }
-
   /**
-   * Aggregate member INPUTS into a collective aggregate task (ManyToOne).
+   * AggregateOut member INPUTS into a collective aggregate task (ManyToOne).
    * Combines the IN fields of a batched member into the synthetic aggregate
-   * task that will run once for the whole batch. Distinct from Aggregate
+   * task that will run once for the whole batch. Distinct from AggregateOut
    * (AggregateOut), which merges OUT fields. Default is a no-op: with no
    * override the aggregate runs as a copy of the first member (e.g. a barrier
    * / dedup collective). Chimods whose collective combines inputs (sum, max,

--- a/context-runtime/include/clio_runtime/ipc_manager.h
+++ b/context-runtime/include/clio_runtime/ipc_manager.h
@@ -879,6 +879,17 @@ class IpcManager {
    */
   bool IsLeader() const;
 
+  /**
+   * Get the neighborhood leader for a given node: the lowest alive node_id in
+   * the window [base, base + N), base = floor(for_node / N) * N, N =
+   * GetNeighborhoodSize(). Used by ManyToOne routing. Deterministic across the
+   * neighborhood; falls back to for_node if no other alive members.
+   */
+  u64 GetNeighborhoodLeaderNodeId(u64 for_node) const;
+
+  /** Neighborhood leader for this node (GetNeighborhoodLeaderNodeId(self)). */
+  u64 GetNeighborhoodLeaderNodeId() const;
+
   struct DeadNodeEntry {
     u64 node_id;
     std::chrono::steady_clock::time_point detected_at;

--- a/context-runtime/include/clio_runtime/ipc_manager.h
+++ b/context-runtime/include/clio_runtime/ipc_manager.h
@@ -51,6 +51,7 @@
 #include "clio_ctp/util/gpu_intrinsics.h"
 #include "clio_runtime/manager.h"
 #include "clio_runtime/corwlock.h"
+#include "clio_runtime/batch_manager.h"
 #include "clio_runtime/scheduler/scheduler.h"
 #include "clio_runtime/task.h"
 #include "clio_runtime/task_archives.h"
@@ -646,6 +647,14 @@ class IpcManager {
   RouteResult RouteGlobal(Future<Task> &future,
                           const std::vector<PoolQuery> &pool_queries);
 
+  /**
+   * Route a ManyToOne task: forward to the neighborhood leader, or — if this
+   * node is the leader — park it in the BatchManager for collective
+   * batch+aggregate. Returns RouteResult::Local when parked (the worker takes
+   * no further action; completion happens later via the batch flush).
+   */
+  RouteResult RouteManyToOne(Future<Task> &future);
+
   // RouteToGpu / cpu→gpu dispatch removed along with the GPU runtime.
 
   /**
@@ -1198,6 +1207,9 @@ class IpcManager {
    */
   Scheduler *GetScheduler() { return scheduler_.get(); }
 
+  /** Get the ManyToOne batch/aggregation manager (leader-side). */
+  BatchManager *GetBatchManager() { return batch_manager_.get(); }
+
   /**
    * Register an existing shared memory segment into the IpcManager
    * Called by worker when encountering an unknown allocator in a FutureShm
@@ -1498,6 +1510,7 @@ class IpcManager {
 
   // Scheduler for task routing
   std::unique_ptr<Scheduler> scheduler_;
+  std::unique_ptr<BatchManager> batch_manager_;
 
   //============================================================================
   // Per-Process Shared Memory Management

--- a/context-runtime/include/clio_runtime/pool_query.h
+++ b/context-runtime/include/clio_runtime/pool_query.h
@@ -50,7 +50,8 @@ enum class RoutingMode {
   Physical,       /**< Route to specific physical node by ID */
   Dynamic,        /**< Dynamic routing with cache optimization (routes to Monitor) */
   ToLocalCpu,     /**< GPU → CPU direction (the only GPU-related mode) */
-  Null            /**< Do nothing */
+  Null,           /**< Do nothing */
+  ManyToOne       /**< Batch+aggregate matching tasks at the neighborhood leader */
 };
 
 /**
@@ -79,7 +80,8 @@ class PoolQuery {
       : routing_mode_(RoutingMode::Local), hash_value_(0),
         container_id_(kInvalidContainerId),
         range_offset_(0), range_count_(0), node_id_(0), ret_node_(0),
-        net_timeout_(-1.0f), parallelism_(32) {}
+        net_timeout_(-1.0f), parallelism_(32),
+        batch_key_(0), batch_for_ns_(0) {}
 
   /**
    * Copy constructor
@@ -93,7 +95,9 @@ class PoolQuery {
         node_id_(other.node_id_),
         ret_node_(other.ret_node_),
         net_timeout_(other.net_timeout_),
-        parallelism_(other.parallelism_) {}
+        parallelism_(other.parallelism_),
+        batch_key_(other.batch_key_),
+        batch_for_ns_(other.batch_for_ns_) {}
 
   /**
    * Assignment operator
@@ -109,6 +113,8 @@ class PoolQuery {
       ret_node_ = other.ret_node_;
       net_timeout_ = other.net_timeout_;
       parallelism_ = other.parallelism_;
+      batch_key_ = other.batch_key_;
+      batch_for_ns_ = other.batch_for_ns_;
     }
     return *this;
   }
@@ -180,6 +186,24 @@ class PoolQuery {
    * @return PoolQuery configured for dynamic routing with cache optimization
    */
   static PoolQuery Dynamic(float net_timeout = -1);
+
+  /**
+   * Create a many-to-one collective routing pool query.
+   *
+   * Routes the task to the neighborhood leader, which briefly batches all
+   * tasks sharing the same (pool_id, method, container_hash, batch_key) for
+   * a batch_for window, aggregates them into a single task, runs it once,
+   * and broadcasts the result back to every batched task.
+   *
+   * @param container_hash Logical container key (stored in hash_value_);
+   *        also selects the container the aggregate task executes on.
+   * @param batch_key Sub-key to separate concurrent collectives on the same
+   *        (pool_id, method, container_hash). Default 0.
+   * @param batch_for_ns Batching window in nanoseconds. Default 10000 (10us).
+   * @return PoolQuery configured for many-to-one batch aggregation
+   */
+  static PoolQuery ManyToOne(u32 container_hash, u64 batch_key = 0,
+                             u64 batch_for_ns = 10000);
 
   /**
    * Create a pool query for GPU → CPU direction
@@ -371,13 +395,41 @@ class PoolQuery {
   CTP_CROSS_FUN void SetParallelism(u32 parallelism) { parallelism_ = parallelism; }
 
   /**
+   * Check if pool query is in ManyToOne routing mode
+   * @return true if routing mode is ManyToOne
+   */
+  CTP_CROSS_FUN bool IsManyToOneMode() const {
+    return routing_mode_ == RoutingMode::ManyToOne;
+  }
+
+  /**
+   * Get the container hash (ManyToOne). Aliases the hash value: it both
+   * keys the batch and selects the container the aggregate runs on.
+   * @return Container hash for many-to-one batching
+   */
+  CTP_CROSS_FUN u32 GetContainerHash() const { return hash_value_; }
+
+  /**
+   * Get the batch sub-key (ManyToOne)
+   * @return Batch key separating concurrent collectives
+   */
+  CTP_CROSS_FUN u64 GetBatchKey() const { return batch_key_; }
+
+  /**
+   * Get the batching window in nanoseconds (ManyToOne)
+   * @return Batch window in ns
+   */
+  CTP_CROSS_FUN u64 GetBatchForNs() const { return batch_for_ns_; }
+
+  /**
    * Serialization support for any archive type
    * @param ar Archive for serialization
    */
   template <class Archive>
   CTP_CROSS_FUN void serialize(Archive& ar) {
     ar.range(routing_mode_, hash_value_, container_id_, range_offset_,
-             range_count_, node_id_, ret_node_, net_timeout_, parallelism_);
+             range_count_, node_id_, ret_node_, net_timeout_, parallelism_,
+             batch_key_, batch_for_ns_);
   }
 
  private:
@@ -390,6 +442,8 @@ class PoolQuery {
   u32 ret_node_;             /**< Return node ID for distributed responses */
   float net_timeout_;        /**< Per-task network timeout in seconds (-1 = use default) */
   u32 parallelism_;          /**< GPU parallelism: 1 (lane 0), 32 (full warp), >32 (multi-warp) */
+  u64 batch_key_;            /**< ManyToOne: batch sub-key */
+  u64 batch_for_ns_;         /**< ManyToOne: batch window in nanoseconds */
 };
 
 

--- a/context-runtime/include/clio_runtime/pool_query.h
+++ b/context-runtime/include/clio_runtime/pool_query.h
@@ -34,6 +34,8 @@
 #ifndef CHIMAERA_INCLUDE_CHIMAERA_POOL_QUERY_H_
 #define CHIMAERA_INCLUDE_CHIMAERA_POOL_QUERY_H_
 
+#include <type_traits>
+
 #include "clio_runtime/types.h"
 
 namespace clio::run {
@@ -83,46 +85,13 @@ class PoolQuery {
         net_timeout_(-1.0f), parallelism_(32),
         batch_key_(0), batch_for_ns_(0) {}
 
-  /**
-   * Copy constructor
-   */
-  CTP_CROSS_FUN PoolQuery(const PoolQuery& other)
-      : routing_mode_(other.routing_mode_),
-        hash_value_(other.hash_value_),
-        container_id_(other.container_id_),
-        range_offset_(other.range_offset_),
-        range_count_(other.range_count_),
-        node_id_(other.node_id_),
-        ret_node_(other.ret_node_),
-        net_timeout_(other.net_timeout_),
-        parallelism_(other.parallelism_),
-        batch_key_(other.batch_key_),
-        batch_for_ns_(other.batch_for_ns_) {}
-
-  /**
-   * Assignment operator
-   */
-  CTP_CROSS_FUN PoolQuery& operator=(const PoolQuery& other) {
-    if (this != &other) {
-      routing_mode_ = other.routing_mode_;
-      hash_value_ = other.hash_value_;
-      container_id_ = other.container_id_;
-      range_offset_ = other.range_offset_;
-      range_count_ = other.range_count_;
-      node_id_ = other.node_id_;
-      ret_node_ = other.ret_node_;
-      net_timeout_ = other.net_timeout_;
-      parallelism_ = other.parallelism_;
-      batch_key_ = other.batch_key_;
-      batch_for_ns_ = other.batch_for_ns_;
-    }
-    return *this;
-  }
-
-  /**
-   * Destructor
-   */
-  CTP_CROSS_FUN ~PoolQuery() {}
+  // Copy/move/destructor are intentionally left implicit (compiler-generated)
+  // so PoolQuery stays *trivially copyable*. It is raw-byte serialized and
+  // compared (e.g. the CTE transaction log WriteRaw/ReadRaw over
+  // sizeof(PoolQuery) and a memcmp roundtrip check), and is bytewise-copied
+  // across the GPU/host boundary. A hand-written field-wise copy would NOT
+  // copy padding, so two "equal" queries could differ in padding bytes and
+  // fail those raw-byte comparisons. (see static_assert below the class)
 
   // Static factory methods to create different types of PoolQuery
 
@@ -446,6 +415,12 @@ class PoolQuery {
   u64 batch_for_ns_;         /**< ManyToOne: batch window in nanoseconds */
 };
 
+// PoolQuery is raw-byte serialized and memcmp-compared (CTE transaction log,
+// GPU/host bytewise task copies). Keep it trivially copyable so copies preserve
+// every byte (including padding) — a hand-written field-wise copy would not,
+// breaking those raw-byte roundtrips.
+static_assert(std::is_trivially_copyable<PoolQuery>::value,
+              "PoolQuery must remain trivially copyable (raw-byte serialized)");
 
 }  // namespace clio::run
 

--- a/context-runtime/include/clio_runtime/task.h
+++ b/context-runtime/include/clio_runtime/task.h
@@ -465,12 +465,12 @@ class Task {
    * tasks Sets this task's return code to the replica's return code if replica
    * has non-zero return code Accepts any task type that inherits from Task
    *
-   * IMPORTANT: Derived classes that override Aggregate MUST call
-   * Task::Aggregate(replica_task) first before aggregating their own fields.
+   * IMPORTANT: Derived classes that override AggregateOut MUST call
+   * Task::AggregateOut(replica_task) first before aggregating their own fields.
    *
    * @param replica_task The replica task to aggregate from
    */
-  void Aggregate(const ctp::ipc::FullPtr<Task>& replica_task) {
+  void AggregateOut(const ctp::ipc::FullPtr<Task>& replica_task) {
     // Propagate return code from replica to this task
     if (!replica_task.IsNull() && replica_task->GetReturnCode() != 0) {
       SetReturnCode(replica_task->GetReturnCode());

--- a/context-runtime/include/clio_runtime/task.h
+++ b/context-runtime/include/clio_runtime/task.h
@@ -484,6 +484,20 @@ class Task {
   }
 
   /**
+   * Combine a batched member's INPUTS into this aggregate task (ManyToOne).
+   * Counterpart to AggregateOut: AggregateOut merges a replica's OUT fields
+   * (N->1 gather), while AggregateIn folds a member's IN fields into the single
+   * collective aggregate task that runs once for the batch. Default is a no-op
+   * (aggregate = copy of the first member: a barrier/dedup collective). Derived
+   * tasks whose collective combines inputs (sum, max, concat, ...) override it.
+   *
+   * @param member_task The batched member whose inputs are folded in
+   */
+  void AggregateIn(const ctp::ipc::FullPtr<Task>& member_task) {
+    (void)member_task;
+  }
+
+  /**
    * Get the copy space size for serialized task output
    * Derived classes can override to specify custom copy space sizes
    * Default is 4KB (4096 bytes) for most tasks

--- a/context-runtime/include/clio_runtime/types.h
+++ b/context-runtime/include/clio_runtime/types.h
@@ -460,6 +460,10 @@ struct AddressHash {
   BIT_OPT(chi::u32, 7)  ///< Task does not need a response. Wait/co_await return
                         ///< instantly; SendOut, ClientSend, and
                         ///< IpcManager::SendRuntime are skipped.
+#define TASK_BATCH_AGGREGATE \
+  BIT_OPT(chi::u32, 8)  ///< ManyToOne: this is the synthetic aggregate task the
+                        ///< neighborhood leader runs for a batch. On completion,
+                        ///< its OUT is broadcast to the batched original tasks.
 
 // Bulk transfer flags are defined in clio_ctp/lightbeam/lightbeam.h:
 // - BULK_EXPOSE: Bulk is exposed (sender exposes for reading)

--- a/context-runtime/modules/MOD_NAME/clio_mod.yaml
+++ b/context-runtime/modules/MOD_NAME/clio_mod.yaml
@@ -22,3 +22,4 @@ kWaitTest: 23           # Wait test method
 kTestLargeOutput: 24    # Test large output streaming (1MB)
 kGpuSubmit: 25          # GPU task submission test (Part 3)
 kSubtaskTest: 26        # GPU coroutine subtask test
+kManyToOneSum: 27       # ManyToOne collective: AggregateIn sums member inputs

--- a/context-runtime/modules/MOD_NAME/include/clio_runtime/MOD_NAME/MOD_NAME_client.h
+++ b/context-runtime/modules/MOD_NAME/include/clio_runtime/MOD_NAME/MOD_NAME_client.h
@@ -113,6 +113,22 @@ class Client : public chi::ContainerClient {
   }
 
   /**
+   * Submit a ManyToOne collective-sum contribution (asynchronous).
+   * Pass a PoolQuery::ManyToOne(...) so the request is batched + summed at the
+   * neighborhood leader; the resulting future's sum_ is the batch total.
+   * @param pool_query Routing (use PoolQuery::ManyToOne for the collective)
+   * @param value This submitter's contribution
+   * @return Future for the ManyToOneSumTask
+   */
+  chi::Future<ManyToOneSumTask> AsyncManyToOneSum(
+      const chi::PoolQuery& pool_query, chi::u64 value) {
+    auto* ipc_manager = CLIO_CPU_IPC;
+    auto task = ipc_manager->NewTask<ManyToOneSumTask>(
+        chi::CreateTaskId(), pool_id_, pool_query, value);
+    return ipc_manager->Send(task);
+  }
+
+  /**
    * Execute CoMutex test (asynchronous)
    * @param pool_query Pool routing information
    * @param test_id Test identifier

--- a/context-runtime/modules/MOD_NAME/include/clio_runtime/MOD_NAME/MOD_NAME_runtime.h
+++ b/context-runtime/modules/MOD_NAME/include/clio_runtime/MOD_NAME/MOD_NAME_runtime.h
@@ -209,7 +209,7 @@ public:
    * Create a new task of the specified method type
    */
   ctp::ipc::FullPtr<chi::Task> NewTask(chi::u32 method) override;
-  void Aggregate(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
+  void AggregateOut(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
                  const ctp::ipc::FullPtr<chi::Task>& replica_task) override;
   void DelTask(chi::u32 method, ctp::ipc::FullPtr<chi::Task> task_ptr) override;
 

--- a/context-runtime/modules/MOD_NAME/include/clio_runtime/MOD_NAME/MOD_NAME_runtime.h
+++ b/context-runtime/modules/MOD_NAME/include/clio_runtime/MOD_NAME/MOD_NAME_runtime.h
@@ -145,6 +145,13 @@ public:
   chi::TaskResume SubtaskTest(ctp::ipc::FullPtr<SubtaskTestTask> task, chi::RunContext& rctx);
 
   /**
+   * Handle ManyToOneSum task — the aggregate task's value_ already holds the
+   * summed batch input (folded by AggregateIn); echo it into sum_, which is
+   * broadcast back to every batched submitter.
+   */
+  chi::TaskResume ManyToOneSum(ctp::ipc::FullPtr<ManyToOneSumTask> task, chi::RunContext& rctx);
+
+  /**
    * Handle Monitor task - return msgpack-encoded test data
    * Part of the unified kMonitor:9 interface
    */
@@ -211,6 +218,8 @@ public:
   ctp::ipc::FullPtr<chi::Task> NewTask(chi::u32 method) override;
   void AggregateOut(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
                  const ctp::ipc::FullPtr<chi::Task>& replica_task) override;
+  void AggregateIn(chi::u32 method, ctp::ipc::FullPtr<chi::Task> agg_task,
+                   const ctp::ipc::FullPtr<chi::Task>& member_task) override;
   void DelTask(chi::u32 method, ctp::ipc::FullPtr<chi::Task> task_ptr) override;
 
 };

--- a/context-runtime/modules/MOD_NAME/include/clio_runtime/MOD_NAME/MOD_NAME_tasks.h
+++ b/context-runtime/modules/MOD_NAME/include/clio_runtime/MOD_NAME/MOD_NAME_tasks.h
@@ -148,11 +148,11 @@ struct CustomTask : public chi::Task {
   }
 
   /**
-   * Aggregate replica results into this task
+   * AggregateOut replica results into this task
    * @param other Pointer to the replica task to aggregate from
    */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<CustomTask>());
   }
 };
@@ -210,11 +210,11 @@ struct CoMutexTestTask : public chi::Task {
   }
 
   /**
-   * Aggregate replica results into this task
+   * AggregateOut replica results into this task
    * @param other Pointer to the replica task to aggregate from
    */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<CoMutexTestTask>());
   }
 };
@@ -275,11 +275,11 @@ struct CoRwLockTestTask : public chi::Task {
   }
 
   /**
-   * Aggregate replica results into this task
+   * AggregateOut replica results into this task
    * @param other Pointer to the replica task to aggregate from
    */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<CoRwLockTestTask>());
   }
 };
@@ -340,11 +340,11 @@ struct WaitTestTask : public chi::Task {
   }
 
   /**
-   * Aggregate replica results into this task
+   * AggregateOut replica results into this task
    * @param other Pointer to the replica task to aggregate from
    */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<WaitTestTask>());
   }
 };
@@ -398,11 +398,11 @@ struct TestLargeOutputTask : public chi::Task {
   }
 
   /**
-   * Aggregate replica results into this task
+   * AggregateOut replica results into this task
    * @param other Pointer to the replica task to aggregate from
    */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<TestLargeOutputTask>());
   }
 };
@@ -467,11 +467,11 @@ struct GpuSubmitTask : public chi::Task {
   }
 
   /**
-   * Aggregate replica results into this task
+   * AggregateOut replica results into this task
    * @param other Pointer to the replica task to aggregate from
    */
-  CTP_CROSS_FUN void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  CTP_CROSS_FUN void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<GpuSubmitTask>());
   }
 };
@@ -523,8 +523,8 @@ struct SubtaskTestTask : public chi::Task {
     result_value_ = other->result_value_;
   }
 
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<SubtaskTestTask>());
   }
 };

--- a/context-runtime/modules/MOD_NAME/include/clio_runtime/MOD_NAME/MOD_NAME_tasks.h
+++ b/context-runtime/modules/MOD_NAME/include/clio_runtime/MOD_NAME/MOD_NAME_tasks.h
@@ -158,6 +158,68 @@ struct CustomTask : public chi::Task {
 };
 
 /**
+ * ManyToOneSumTask - collective sum, used to exercise AggregateIn for the
+ * PoolQuery::ManyToOne path.
+ *
+ * Each submitter contributes value_. On the neighborhood leader the batch is
+ * folded into one aggregate task via AggregateIn (summing value_), which runs
+ * once and echoes the combined total into sum_; that single result is then
+ * broadcast (SerializeOut copy-back) to every submitter. After completion all
+ * submitters' sum_ equals the sum of the whole batch's value_.
+ */
+struct ManyToOneSumTask : public chi::Task {
+  IN chi::u64 value_;  // this submitter's contribution
+  OUT chi::u64 sum_;   // collective total (broadcast to all members)
+
+  /** SHM default constructor */
+  ManyToOneSumTask() : chi::Task(), value_(0), sum_(0) {}
+
+  /** Emplace constructor */
+  explicit ManyToOneSumTask(const chi::TaskId &task_node,
+                            const chi::PoolId &pool_id,
+                            const chi::PoolQuery &pool_query, chi::u64 value)
+      : chi::Task(task_node, pool_id, pool_query, Method::kManyToOneSum),
+        value_(value), sum_(0) {
+    task_id_ = task_node;
+    pool_id_ = pool_id;
+    method_ = Method::kManyToOneSum;
+    task_flags_.Clear();
+    pool_query_ = pool_query;
+  }
+
+  ~ManyToOneSumTask() {}
+
+  template <typename Archive>
+  CTP_CROSS_FUN void SerializeIn(Archive &ar) {
+    Task::SerializeIn(ar);
+    ar(value_);
+  }
+
+  template <typename Archive>
+  CTP_CROSS_FUN void SerializeOut(Archive &ar) {
+    Task::SerializeOut(ar);
+    ar(sum_);
+  }
+
+  void Copy(const ctp::ipc::FullPtr<ManyToOneSumTask> &other) {
+    Task::Copy(other.template Cast<Task>());
+    value_ = other->value_;
+    sum_ = other->sum_;
+  }
+
+  /** AggregateOut: gather replica OUT — sum partial totals (N->1). */
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
+    sum_ += other_base.template Cast<ManyToOneSumTask>()->sum_;
+  }
+
+  /** AggregateIn: fold a batched member's input contribution into this. */
+  void AggregateIn(const ctp::ipc::FullPtr<chi::Task> &member_base) {
+    value_ += member_base.template Cast<ManyToOneSumTask>()->value_;
+  }
+};
+
+/**
  * CoMutexTestTask - Test CoMutex functionality
  */
 struct CoMutexTestTask : public chi::Task {

--- a/context-runtime/modules/MOD_NAME/include/clio_runtime/MOD_NAME/autogen/MOD_NAME_methods.h
+++ b/context-runtime/modules/MOD_NAME/include/clio_runtime/MOD_NAME/autogen/MOD_NAME_methods.h
@@ -25,8 +25,9 @@ GLOBAL_CROSS_CONST chi::u32 kWaitTest = 23;
 GLOBAL_CROSS_CONST chi::u32 kTestLargeOutput = 24;
 GLOBAL_CROSS_CONST chi::u32 kGpuSubmit = 25;
 GLOBAL_CROSS_CONST chi::u32 kSubtaskTest = 26;
+GLOBAL_CROSS_CONST chi::u32 kManyToOneSum = 27;
 
-GLOBAL_CROSS_CONST chi::u32 kMaxMethodId = 27;
+GLOBAL_CROSS_CONST chi::u32 kMaxMethodId = 28;
 
 inline const std::vector<std::string>& GetMethodNames() {
   static const std::vector<std::string> names = [] {
@@ -41,6 +42,7 @@ inline const std::vector<std::string>& GetMethodNames() {
     v[24] = "TestLargeOutput";
     v[25] = "GpuSubmit";
     v[26] = "SubtaskTest";
+    v[27] = "ManyToOneSum";
     return v;
   }();
   return names;

--- a/context-runtime/modules/MOD_NAME/src/MOD_NAME_runtime.cc
+++ b/context-runtime/modules/MOD_NAME/src/MOD_NAME_runtime.cc
@@ -46,7 +46,7 @@ namespace clio::run::MOD_NAME {
 
 // Method implementations for Runtime class
 
-// Virtual method implementations (Init, Run, Del, SaveTask, LoadTask, NewCopy, Aggregate) now in autogen/MOD_NAME_lib_exec.cc
+// Virtual method implementations (Init, Run, Del, SaveTask, LoadTask, NewCopy, AggregateOut) now in autogen/MOD_NAME_lib_exec.cc
 
 //===========================================================================
 // Method implementations

--- a/context-runtime/modules/MOD_NAME/src/MOD_NAME_runtime.cc
+++ b/context-runtime/modules/MOD_NAME/src/MOD_NAME_runtime.cc
@@ -85,6 +85,19 @@ chi::TaskResume Runtime::Custom(ctp::ipc::FullPtr<CustomTask> task, chi::RunCont
   CLIO_TASK_BODY_END
 }
 
+chi::TaskResume Runtime::ManyToOneSum(ctp::ipc::FullPtr<ManyToOneSumTask> task,
+                                      chi::RunContext &rctx) {
+  CLIO_TASK_BODY_BEGIN
+  // On the neighborhood leader the batch was folded into this aggregate task by
+  // AggregateIn, so value_ already holds the sum of every member's input. Echo
+  // it into the OUT field; the engine broadcasts sum_ back to all submitters.
+  task->sum_ = task->value_;
+  HLOG(kDebug, "MOD_NAME: ManyToOneSum total={}", task->sum_);
+  (void)rctx;
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
 chi::TaskResume Runtime::Destroy(ctp::ipc::FullPtr<DestroyTask> task, chi::RunContext &rctx) {
   CLIO_TASK_BODY_BEGIN
   HLOG(kDebug, "MOD_NAME: Executing Destroy task - Pool ID: {}",

--- a/context-runtime/modules/MOD_NAME/src/autogen/MOD_NAME_lib_exec.cc
+++ b/context-runtime/modules/MOD_NAME/src/autogen/MOD_NAME_lib_exec.cc
@@ -58,6 +58,12 @@ chi::TaskResume Runtime::Run(chi::u32 method, ctp::ipc::FullPtr<chi::Task> task_
       CLIO_CO_AWAIT(Custom(typed_task, rctx));
       break;
     }
+    case Method::kManyToOneSum: {
+      // Cast task FullPtr to specific type
+      ctp::ipc::FullPtr<ManyToOneSumTask> typed_task = task_ptr.template Cast<ManyToOneSumTask>();
+      CLIO_CO_AWAIT(ManyToOneSum(typed_task, rctx));
+      break;
+    }
     case Method::kCoMutexTest: {
       // Cast task FullPtr to specific type
       ctp::ipc::FullPtr<CoMutexTestTask> typed_task = task_ptr.template Cast<CoMutexTestTask>();
@@ -126,6 +132,11 @@ void Runtime::SaveTask(chi::u32 method, chi::SaveTaskArchive& archive,
       archive << *typed_task.ptr_;
       break;
     }
+    case Method::kManyToOneSum: {
+      auto typed_task = task_ptr.template Cast<ManyToOneSumTask>();
+      archive << *typed_task.ptr_;
+      break;
+    }
     case Method::kCoMutexTest: {
       auto typed_task = task_ptr.template Cast<CoMutexTestTask>();
       archive << *typed_task.ptr_;
@@ -183,6 +194,11 @@ void Runtime::LoadTask(chi::u32 method, chi::LoadTaskArchive& archive,
     }
     case Method::kCustom: {
       auto typed_task = task_ptr.template Cast<CustomTask>();
+      archive >> *typed_task.ptr_;
+      break;
+    }
+    case Method::kManyToOneSum: {
+      auto typed_task = task_ptr.template Cast<ManyToOneSumTask>();
       archive >> *typed_task.ptr_;
       break;
     }
@@ -254,6 +270,12 @@ void Runtime::LocalLoadTask(chi::u32 method, chi::DefaultLoadArchive& archive,
     }
     case Method::kCustom: {
       auto typed_task = task_ptr.template Cast<CustomTask>();
+      // Use archive operator which respects msg_type
+      archive >> *typed_task.ptr_;
+      break;
+    }
+    case Method::kManyToOneSum: {
+      auto typed_task = task_ptr.template Cast<ManyToOneSumTask>();
       // Use archive operator which respects msg_type
       archive >> *typed_task.ptr_;
       break;
@@ -332,6 +354,12 @@ void Runtime::LocalSaveTask(chi::u32 method, chi::DefaultSaveArchive& archive,
     }
     case Method::kCustom: {
       auto typed_task = task_ptr.template Cast<CustomTask>();
+      // Use archive operator which respects msg_type
+      archive << *typed_task.ptr_;
+      break;
+    }
+    case Method::kManyToOneSum: {
+      auto typed_task = task_ptr.template Cast<ManyToOneSumTask>();
       // Use archive operator which respects msg_type
       archive << *typed_task.ptr_;
       break;
@@ -425,6 +453,17 @@ ctp::ipc::FullPtr<chi::Task> Runtime::NewCopyTask(chi::u32 method, ctp::ipc::Ful
       if (!new_task_ptr.IsNull()) {
         // Copy task fields (includes base Task fields)
         auto task_typed = orig_task_ptr.template Cast<CustomTask>();
+        new_task_ptr->Copy(task_typed);
+        return new_task_ptr.template Cast<chi::Task>();
+      }
+      break;
+    }
+    case Method::kManyToOneSum: {
+      // Allocate new task
+      auto new_task_ptr = ipc_manager->NewTask<ManyToOneSumTask>();
+      if (!new_task_ptr.IsNull()) {
+        // Copy task fields (includes base Task fields)
+        auto task_typed = orig_task_ptr.template Cast<ManyToOneSumTask>();
         new_task_ptr->Copy(task_typed);
         return new_task_ptr.template Cast<chi::Task>();
       }
@@ -534,6 +573,10 @@ ctp::ipc::FullPtr<chi::Task> Runtime::NewTask(chi::u32 method) {
       auto new_task_ptr = ipc_manager->NewTask<CustomTask>();
       return new_task_ptr.template Cast<chi::Task>();
     }
+    case Method::kManyToOneSum: {
+      auto new_task_ptr = ipc_manager->NewTask<ManyToOneSumTask>();
+      return new_task_ptr.template Cast<chi::Task>();
+    }
     case Method::kCoMutexTest: {
       auto new_task_ptr = ipc_manager->NewTask<CoMutexTestTask>();
       return new_task_ptr.template Cast<chi::Task>();
@@ -588,6 +631,11 @@ void Runtime::AggregateOut(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_ta
       typed_task->AggregateOut(replica_task);
       break;
     }
+    case Method::kManyToOneSum: {
+      auto typed_task = orig_task.template Cast<ManyToOneSumTask>();
+      typed_task->AggregateOut(replica_task);
+      break;
+    }
     case Method::kCoMutexTest: {
       auto typed_task = orig_task.template Cast<CoMutexTestTask>();
       typed_task->AggregateOut(replica_task);
@@ -625,6 +673,71 @@ void Runtime::AggregateOut(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_ta
   }
 }
 
+void Runtime::AggregateIn(chi::u32 method, ctp::ipc::FullPtr<chi::Task> agg_task,
+                        const ctp::ipc::FullPtr<chi::Task>& member_task) {
+  switch (method) {
+    case Method::kCreate: {
+      auto typed_task = agg_task.template Cast<CreateTask>();
+      typed_task->AggregateIn(member_task);
+      break;
+    }
+    case Method::kDestroy: {
+      auto typed_task = agg_task.template Cast<DestroyTask>();
+      typed_task->AggregateIn(member_task);
+      break;
+    }
+    case Method::kMonitor: {
+      auto typed_task = agg_task.template Cast<MonitorTask>();
+      typed_task->AggregateIn(member_task);
+      break;
+    }
+    case Method::kCustom: {
+      auto typed_task = agg_task.template Cast<CustomTask>();
+      typed_task->AggregateIn(member_task);
+      break;
+    }
+    case Method::kManyToOneSum: {
+      auto typed_task = agg_task.template Cast<ManyToOneSumTask>();
+      typed_task->AggregateIn(member_task);
+      break;
+    }
+    case Method::kCoMutexTest: {
+      auto typed_task = agg_task.template Cast<CoMutexTestTask>();
+      typed_task->AggregateIn(member_task);
+      break;
+    }
+    case Method::kCoRwLockTest: {
+      auto typed_task = agg_task.template Cast<CoRwLockTestTask>();
+      typed_task->AggregateIn(member_task);
+      break;
+    }
+    case Method::kWaitTest: {
+      auto typed_task = agg_task.template Cast<WaitTestTask>();
+      typed_task->AggregateIn(member_task);
+      break;
+    }
+    case Method::kTestLargeOutput: {
+      auto typed_task = agg_task.template Cast<TestLargeOutputTask>();
+      typed_task->AggregateIn(member_task);
+      break;
+    }
+    case Method::kGpuSubmit: {
+      auto typed_task = agg_task.template Cast<GpuSubmitTask>();
+      typed_task->AggregateIn(member_task);
+      break;
+    }
+    case Method::kSubtaskTest: {
+      auto typed_task = agg_task.template Cast<SubtaskTestTask>();
+      typed_task->AggregateIn(member_task);
+      break;
+    }
+    default: {
+      agg_task->AggregateIn(member_task);
+      break;
+    }
+  }
+}
+
 void Runtime::DelTask(chi::u32 method, ctp::ipc::FullPtr<chi::Task> task_ptr) {
   auto* ipc_manager = CLIO_IPC;
   if (!ipc_manager) return;
@@ -643,6 +756,10 @@ void Runtime::DelTask(chi::u32 method, ctp::ipc::FullPtr<chi::Task> task_ptr) {
     }
     case Method::kCustom: {
       ipc_manager->DelTask(task_ptr.template Cast<CustomTask>());
+      break;
+    }
+    case Method::kManyToOneSum: {
+      ipc_manager->DelTask(task_ptr.template Cast<ManyToOneSumTask>());
       break;
     }
     case Method::kCoMutexTest: {

--- a/context-runtime/modules/MOD_NAME/src/autogen/MOD_NAME_lib_exec.cc
+++ b/context-runtime/modules/MOD_NAME/src/autogen/MOD_NAME_lib_exec.cc
@@ -565,61 +565,61 @@ ctp::ipc::FullPtr<chi::Task> Runtime::NewTask(chi::u32 method) {
   }
 }
 
-void Runtime::Aggregate(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
+void Runtime::AggregateOut(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
                         const ctp::ipc::FullPtr<chi::Task>& replica_task) {
   switch (method) {
     case Method::kCreate: {
       auto typed_task = orig_task.template Cast<CreateTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kDestroy: {
       auto typed_task = orig_task.template Cast<DestroyTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kMonitor: {
       auto typed_task = orig_task.template Cast<MonitorTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kCustom: {
       auto typed_task = orig_task.template Cast<CustomTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kCoMutexTest: {
       auto typed_task = orig_task.template Cast<CoMutexTestTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kCoRwLockTest: {
       auto typed_task = orig_task.template Cast<CoRwLockTestTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kWaitTest: {
       auto typed_task = orig_task.template Cast<WaitTestTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kTestLargeOutput: {
       auto typed_task = orig_task.template Cast<TestLargeOutputTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kGpuSubmit: {
       auto typed_task = orig_task.template Cast<GpuSubmitTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kSubtaskTest: {
       auto typed_task = orig_task.template Cast<SubtaskTestTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     default: {
-      orig_task->Aggregate(replica_task);
+      orig_task->AggregateOut(replica_task);
       break;
     }
   }

--- a/context-runtime/modules/MOD_NAME/test/test_comutex.cc
+++ b/context-runtime/modules/MOD_NAME/test/test_comutex.cc
@@ -1098,5 +1098,42 @@ TEST_CASE("CoMutex and CoRwLock Integration", "[integration]") {
   }
 }
 
+// ManyToOne collective: exercises Container::AggregateIn. Several submitters
+// contribute value_ with PoolQuery::ManyToOne sharing one (container_hash,
+// batch_key). The neighborhood leader batches them, AggregateIn sums the
+// inputs into one aggregate task, the handler echoes the total into sum_, and
+// that single result is broadcast back to every submitter. Each submitter must
+// observe the whole batch's total.
+TEST_CASE("ManyToOne AggregateIn collective sum", "[manytoone][aggregatein]") {
+  CoMutexTestFixture fixture;
+  REQUIRE(g_initialized);
+  REQUIRE(fixture.createModNamePool());
+
+  clio::run::MOD_NAME::Client client(fixture.getTestPoolId());
+  auto create_task = client.AsyncCreate(
+      chi::PoolQuery::Dynamic(), "manytoone_pool", fixture.getTestPoolId());
+  create_task.Wait();
+  client.pool_id_ = create_task->new_pool_id_;
+  REQUIRE(create_task->return_code_ == 0);
+
+  constexpr chi::u32 kN = 5;
+  chi::u64 expected = 0;  // sum(1..kN)
+  std::vector<chi::Future<clio::run::MOD_NAME::ManyToOneSumTask>> futs;
+  for (chi::u32 i = 1; i <= kN; ++i) {
+    expected += i;
+    auto q = chi::PoolQuery::ManyToOne(/*container_hash=*/0, /*batch_key=*/0,
+                                       /*batch_for_ns=*/2'000'000);
+    futs.push_back(client.AsyncManyToOneSum(q, i));
+  }
+
+  // Every submitter sees the broadcast collective total.
+  for (chi::u32 i = 0; i < kN; ++i) {
+    futs[i].Wait();
+    REQUIRE(futs[i]->return_code_ == 0);
+    REQUIRE(futs[i]->sum_ == expected);
+  }
+  INFO("ManyToOne collective sum verified: " << expected);
+}
+
 // Main function to run all tests
 SIMPLE_TEST_MAIN()

--- a/context-runtime/modules/admin/include/clio_runtime/admin/admin_runtime.h
+++ b/context-runtime/modules/admin/include/clio_runtime/admin/admin_runtime.h
@@ -384,7 +384,7 @@ public:
    * Create a new task of the specified method type
    */
   ctp::ipc::FullPtr<chi::Task> NewTask(chi::u32 method) override;
-  void Aggregate(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
+  void AggregateOut(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
                  const ctp::ipc::FullPtr<chi::Task>& replica_task) override;
   void DelTask(chi::u32 method, ctp::ipc::FullPtr<chi::Task> task_ptr) override;
 

--- a/context-runtime/modules/admin/include/clio_runtime/admin/admin_tasks.h
+++ b/context-runtime/modules/admin/include/clio_runtime/admin/admin_tasks.h
@@ -360,9 +360,9 @@ struct BaseCreateTask : public chi::Task {
 #endif
   }
 
-  /** Aggregate replica results into this task */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  /** AggregateOut replica results into this task */
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<BaseCreateTask>());
   }
 
@@ -475,9 +475,9 @@ struct DestroyPoolTask : public chi::Task {
     error_message_ = other->error_message_;
   }
 
-  /** Aggregate replica results into this task */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  /** AggregateOut replica results into this task */
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<DestroyPoolTask>());
   }
 };
@@ -553,9 +553,9 @@ struct StopRuntimeTask : public chi::Task {
     error_message_ = other->error_message_;
   }
 
-  /** Aggregate replica results into this task */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  /** AggregateOut replica results into this task */
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<StopRuntimeTask>());
   }
 };
@@ -615,9 +615,9 @@ struct FlushTask : public chi::Task {
     total_work_done_ = other->total_work_done_;
   }
 
-  /** Aggregate replica results into this task */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  /** AggregateOut replica results into this task */
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<FlushTask>());
   }
 };
@@ -690,9 +690,9 @@ struct SendTask : public chi::Task {
     error_message_ = other->error_message_;
   }
 
-  /** Aggregate replica results into this task */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  /** AggregateOut replica results into this task */
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<SendTask>());
   }
 };
@@ -759,9 +759,9 @@ struct RecvTask : public chi::Task {
     error_message_ = other->error_message_;
   }
 
-  /** Aggregate replica results into this task */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  /** AggregateOut replica results into this task */
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<RecvTask>());
   }
 };
@@ -882,8 +882,8 @@ struct ClientConnectTask : public chi::Task {
            sizeof(gpu2gpu_ipc_handle_bytes_));
   }
 
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<ClientConnectTask>());
   }
 };
@@ -927,8 +927,8 @@ struct ClientRecvTask : public chi::Task {
     tasks_received_ = other->tasks_received_;
   }
 
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<ClientRecvTask>());
   }
 };
@@ -972,8 +972,8 @@ struct ClientSendTask : public chi::Task {
     tasks_sent_ = other->tasks_sent_;
   }
 
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<ClientSendTask>());
   }
 };
@@ -1038,9 +1038,9 @@ struct WreapDeadIpcsTask : public chi::Task {
     reaped_count_ = other->reaped_count_;
   }
 
-  /** Aggregate replica results into this task */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  /** AggregateOut replica results into this task */
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<WreapDeadIpcsTask>());
   }
 };
@@ -1086,8 +1086,8 @@ struct MonitorTask : public chi::Task {
     results_ = other->results_;
   }
 
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     auto other = other_base.template Cast<MonitorTask>();
     for (auto &[k, v] : other->results_) {
       results_[k] = std::move(v);
@@ -1275,10 +1275,10 @@ struct SubmitBatchTask : public chi::Task {
   }
 
   /**
-   * Aggregate replica results into this task
+   * AggregateOut replica results into this task
    */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<SubmitBatchTask>());
   }
 };
@@ -1404,8 +1404,8 @@ struct RegisterMemoryTask : public chi::Task {
     success_ = other->success_;
   }
 
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<RegisterMemoryTask>());
   }
 };
@@ -1453,8 +1453,8 @@ struct RestartContainersTask : public chi::Task {
     error_message_ = other->error_message_;
   }
 
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<RestartContainersTask>());
   }
 };
@@ -1500,8 +1500,8 @@ struct ListContainersTask : public chi::Task {
     pool_ids_ = other->pool_ids_;
   }
 
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     auto other = other_base.template Cast<ListContainersTask>();
     for (auto &n : other->pool_names_) {
       pool_names_.push_back(n);
@@ -1566,8 +1566,8 @@ struct AddNodeTask : public chi::Task {
     error_message_ = other->error_message_;
   }
 
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<AddNodeTask>());
   }
 };
@@ -1629,8 +1629,8 @@ struct ChangeAddressTableTask : public chi::Task {
     error_message_ = other->error_message_;
   }
 
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<ChangeAddressTableTask>());
   }
 };
@@ -1686,8 +1686,8 @@ struct MigrateContainersTask : public chi::Task {
     error_message_ = other->error_message_;
   }
 
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<MigrateContainersTask>());
   }
 };
@@ -1726,8 +1726,8 @@ struct HeartbeatTask : public chi::Task {
     Task::Copy(other.template Cast<Task>());
   }
 
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<HeartbeatTask>());
   }
 };
@@ -1766,8 +1766,8 @@ struct HeartbeatProbeTask : public chi::Task {
     Task::Copy(other.template Cast<Task>());
   }
 
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<HeartbeatProbeTask>());
   }
 };
@@ -1816,8 +1816,8 @@ struct ProbeRequestTask : public chi::Task {
     probe_result_ = other->probe_result_;
   }
 
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<ProbeRequestTask>());
   }
 };
@@ -1879,8 +1879,8 @@ struct RecoverContainersTask : public chi::Task {
     error_message_ = other->error_message_;
   }
 
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<RecoverContainersTask>());
   }
 };
@@ -1895,7 +1895,7 @@ struct SystemStats {
   size_t ram_total_bytes_;      // Total physical RAM
   size_t ram_available_bytes_;  // Available RAM
   float ram_usage_pct_;         // (1 - avail/total) * 100
-  float cpu_usage_pct_;         // Aggregate CPU util 0-100
+  float cpu_usage_pct_;         // AggregateOut CPU util 0-100
   uint32_t gpu_count_;          // 0 if no GPUs
   float gpu_usage_pct_;         // Average GPU compute util
   float hbm_usage_pct_;         // Average GPU memory util
@@ -1950,8 +1950,8 @@ struct SystemMonitorTask : public chi::Task {
     Task::Copy(other.template Cast<Task>());
   }
 
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<SystemMonitorTask>());
   }
 };
@@ -1998,8 +1998,8 @@ struct AnnounceShutdownTask : public chi::Task {
     shutting_down_node_id_ = other->shutting_down_node_id_;
   }
 
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<AnnounceShutdownTask>());
   }
 };

--- a/context-runtime/modules/admin/src/admin_runtime.cc
+++ b/context-runtime/modules/admin/src/admin_runtime.cc
@@ -70,7 +70,7 @@ namespace clio::run::admin {
 // Method implementations for Runtime class
 
 // Virtual method implementations (Init, Run, Del, SaveTask, LoadTask, NewCopy,
-// Aggregate) now in autogen/admin_lib_exec.cc
+// AggregateOut) now in autogen/admin_lib_exec.cc
 
 //===========================================================================
 // Method implementations

--- a/context-runtime/modules/admin/src/autogen/admin_lib_exec.cc
+++ b/context-runtime/modules/admin/src/autogen/admin_lib_exec.cc
@@ -1296,146 +1296,146 @@ ctp::ipc::FullPtr<chi::Task> Runtime::NewTask(chi::u32 method) {
   }
 }
 
-void Runtime::Aggregate(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
+void Runtime::AggregateOut(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
                         const ctp::ipc::FullPtr<chi::Task>& replica_task) {
   switch (method) {
     case Method::kCreate: {
       auto typed_task = orig_task.template Cast<CreateTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kDestroy: {
       auto typed_task = orig_task.template Cast<DestroyTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kMonitor: {
       auto typed_task = orig_task.template Cast<MonitorTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kGetOrCreatePool: {
       auto typed_task = orig_task.template Cast<admin::GetOrCreatePoolTask<admin::CreateParams>>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kDestroyPool: {
       auto typed_task = orig_task.template Cast<DestroyPoolTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kStopRuntime: {
       auto typed_task = orig_task.template Cast<StopRuntimeTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kFlush: {
       auto typed_task = orig_task.template Cast<FlushTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kSend: {
       auto typed_task = orig_task.template Cast<SendTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kRecv: {
       auto typed_task = orig_task.template Cast<RecvTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kClientConnect: {
       auto typed_task = orig_task.template Cast<ClientConnectTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kSubmitBatch: {
       auto typed_task = orig_task.template Cast<SubmitBatchTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kWreapDeadIpcs: {
       auto typed_task = orig_task.template Cast<WreapDeadIpcsTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kClientRecv: {
       auto typed_task = orig_task.template Cast<ClientRecvTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kClientSend: {
       auto typed_task = orig_task.template Cast<ClientSendTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kRegisterMemory: {
       auto typed_task = orig_task.template Cast<RegisterMemoryTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kRestartContainers: {
       auto typed_task = orig_task.template Cast<RestartContainersTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kAddNode: {
       auto typed_task = orig_task.template Cast<AddNodeTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kChangeAddressTable: {
       auto typed_task = orig_task.template Cast<ChangeAddressTableTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kMigrateContainers: {
       auto typed_task = orig_task.template Cast<MigrateContainersTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kHeartbeat: {
       auto typed_task = orig_task.template Cast<HeartbeatTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kHeartbeatProbe: {
       auto typed_task = orig_task.template Cast<HeartbeatProbeTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kProbeRequest: {
       auto typed_task = orig_task.template Cast<ProbeRequestTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kRecoverContainers: {
       auto typed_task = orig_task.template Cast<RecoverContainersTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kSystemMonitor: {
       auto typed_task = orig_task.template Cast<SystemMonitorTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kAnnounceShutdown: {
       auto typed_task = orig_task.template Cast<AnnounceShutdownTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kRegisterGpuContainer: {
       auto typed_task = orig_task.template Cast<RegisterGpuContainerTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kListContainers: {
       auto typed_task = orig_task.template Cast<ListContainersTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     default: {
-      orig_task->Aggregate(replica_task);
+      orig_task->AggregateOut(replica_task);
       break;
     }
   }

--- a/context-runtime/modules/admin/test/test_task_archive.cc
+++ b/context-runtime/modules/admin/test/test_task_archive.cc
@@ -617,10 +617,10 @@ public:
     (void)task_ptr;
   }
 
-  void Aggregate(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
+  void AggregateOut(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
                  const ctp::ipc::FullPtr<chi::Task>& replica_task) override {
     (void)method;
-    orig_task->Aggregate(replica_task);
+    orig_task->AggregateOut(replica_task);
   }
 
   void DelTask(chi::u32 method, ctp::ipc::FullPtr<chi::Task> task_ptr) override {

--- a/context-runtime/modules/bdev/include/clio_runtime/bdev/bdev_runtime.h
+++ b/context-runtime/modules/bdev/include/clio_runtime/bdev/bdev_runtime.h
@@ -71,7 +71,7 @@ class Runtime : public chi::Container {
   ctp::ipc::FullPtr<chi::Task> NewCopyTask(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task_ptr,
                                         bool deep) override;
   ctp::ipc::FullPtr<chi::Task> NewTask(chi::u32 method) override;
-  void Aggregate(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
+  void AggregateOut(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
                  const ctp::ipc::FullPtr<chi::Task>& replica_task) override;
   void DelTask(chi::u32 method, ctp::ipc::FullPtr<chi::Task> task_ptr) override;
 

--- a/context-runtime/modules/bdev/include/clio_runtime/bdev/bdev_tasks.h
+++ b/context-runtime/modules/bdev/include/clio_runtime/bdev/bdev_tasks.h
@@ -369,9 +369,9 @@ struct AllocateBlocksTask : public chi::Task {
     blocks_ = other->blocks_;
   }
 
-  /** Aggregate replica results into this task */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  /** AggregateOut replica results into this task */
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<AllocateBlocksTask>());
   }
 };
@@ -444,9 +444,9 @@ struct FreeBlocksTask : public chi::Task {
     blocks_ = other->blocks_;
   }
 
-  /** Aggregate replica results into this task */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  /** AggregateOut replica results into this task */
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<FreeBlocksTask>());
   }
 };
@@ -510,9 +510,9 @@ struct WriteTask : public chi::Task {
     blocks_.FixupSvoPtr();
   }
 
-  /** Aggregate */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  /** AggregateOut */
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<WriteTask>());
   }
 
@@ -592,9 +592,9 @@ struct ReadTask : public chi::Task {
     blocks_.FixupSvoPtr();
   }
 
-  /** Aggregate */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  /** AggregateOut */
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<ReadTask>());
   }
 
@@ -663,9 +663,9 @@ struct GetStatsTask : public chi::Task {
     remaining_size_ = other->remaining_size_;
   }
 
-  /** Aggregate replica results into this task */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  /** AggregateOut replica results into this task */
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<GetStatsTask>());
   }
 };
@@ -729,8 +729,8 @@ struct UpdateTask : public chi::Task {
     alignment_   = other->alignment_;
   }
 
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<UpdateTask>());
   }
 };

--- a/context-runtime/modules/bdev/src/autogen/bdev_lib_exec.cc
+++ b/context-runtime/modules/bdev/src/autogen/bdev_lib_exec.cc
@@ -522,56 +522,56 @@ ctp::ipc::FullPtr<chi::Task> Runtime::NewTask(chi::u32 method) {
   }
 }
 
-void Runtime::Aggregate(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
+void Runtime::AggregateOut(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
                         const ctp::ipc::FullPtr<chi::Task>& replica_task) {
   switch (method) {
     case Method::kCreate: {
       auto typed_task = orig_task.template Cast<CreateTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kDestroy: {
       auto typed_task = orig_task.template Cast<DestroyTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kMonitor: {
       auto typed_task = orig_task.template Cast<MonitorTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kAllocateBlocks: {
       auto typed_task = orig_task.template Cast<AllocateBlocksTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kFreeBlocks: {
       auto typed_task = orig_task.template Cast<FreeBlocksTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kWrite: {
       auto typed_task = orig_task.template Cast<WriteTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kRead: {
       auto typed_task = orig_task.template Cast<ReadTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kGetStats: {
       auto typed_task = orig_task.template Cast<GetStatsTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kUpdate: {
       auto typed_task = orig_task.template Cast<UpdateTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     default: {
-      orig_task->Aggregate(replica_task);
+      orig_task->AggregateOut(replica_task);
       break;
     }
   }

--- a/context-runtime/modules/bdev/test/test_bdev_chimod.cc
+++ b/context-runtime/modules/bdev/test/test_bdev_chimod.cc
@@ -1586,6 +1586,65 @@ TEST_CASE("bdev_parallel_io_operations", "[bdev][parallel][io]") {
 }
 
 //==============================================================================
+// ManyToOne collective batch + aggregate (#587)
+//==============================================================================
+
+// Submits several AllocateBlocks tasks with PoolQuery::ManyToOne sharing the
+// same (container_hash, batch_key). On a single node the local node IS the
+// neighborhood leader, so the tasks are parked, batched within the batch_for
+// window, aggregated into one task, executed once, and the result is broadcast
+// back to every submitter. Each submitter's future must complete with the
+// aggregate's blocks.
+TEST_CASE("bdev_manytoone_batch", "[bdev][manytoone]") {
+  // WIP (#587): opt-in only. The collective batch+aggregate path currently
+  // hangs — batched members are parked on the leader but their futures are not
+  // yet completed (flush/aggregate completion path under debug). Guarded so the
+  // shared bdev suite stays green; run explicitly with CLIO_TEST_MANYTOONE=1.
+  if (std::getenv("CLIO_TEST_MANYTOONE") == nullptr) {
+    HLOG(kInfo, "Skipping bdev_manytoone_batch (set CLIO_TEST_MANYTOONE=1)");
+    return;
+  }
+  BdevChimodFixture fixture;
+  REQUIRE(g_initialized);
+  std::this_thread::sleep_for(100ms);
+
+  chi::PoolId custom_pool_id(8009, 0);
+  clio::run::bdev::Client bdev_client(custom_pool_id);
+
+  const chi::u64 ram_size = 1024 * 1024;
+  std::string pool_name =
+      "manytoone_" + std::to_string(getpid()) + "_" + std::to_string(8009);
+  bool bdev_success = BdevChimodFixture::CreateBdevAsync(
+      bdev_client, chi::PoolQuery::Dynamic(), pool_name, custom_pool_id,
+      clio::run::bdev::BdevType::kRam, ram_size);
+  REQUIRE(bdev_success);
+  std::this_thread::sleep_for(100ms);
+
+  // Submit a batch of ManyToOne allocations sharing one (hash, key). A 2ms
+  // window comfortably covers issuing all requests before the flush fires.
+  constexpr int kBatch = 4;
+  constexpr chi::u32 kContainerHash = 0;
+  constexpr chi::u64 kBatchKey = 0;
+  constexpr chi::u64 kBatchForNs = 2'000'000;  // 2ms
+
+  std::vector<chi::Future<clio::run::bdev::AllocateBlocksTask>> futures;
+  futures.reserve(kBatch);
+  for (int i = 0; i < kBatch; ++i) {
+    auto q = chi::PoolQuery::ManyToOne(kContainerHash, kBatchKey, kBatchForNs);
+    futures.push_back(bdev_client.AsyncAllocateBlocks(q, k4KB));
+  }
+
+  // Every submitter must complete successfully with the broadcast result.
+  for (int i = 0; i < kBatch; ++i) {
+    futures[i].Wait();
+    REQUIRE(futures[i]->return_code_ == 0);
+    REQUIRE(futures[i]->blocks_.size() > 0);
+    HLOG(kInfo, "ManyToOne member {} got {} block(s)", i,
+         futures[i]->blocks_.size());
+  }
+}
+
+//==============================================================================
 // MAIN TEST RUNNER
 //==============================================================================
 

--- a/context-runtime/modules/bdev/test/test_bdev_chimod.cc
+++ b/context-runtime/modules/bdev/test/test_bdev_chimod.cc
@@ -1596,14 +1596,6 @@ TEST_CASE("bdev_parallel_io_operations", "[bdev][parallel][io]") {
 // back to every submitter. Each submitter's future must complete with the
 // aggregate's blocks.
 TEST_CASE("bdev_manytoone_batch", "[bdev][manytoone]") {
-  // WIP (#587): opt-in only. The collective batch+aggregate path currently
-  // hangs — batched members are parked on the leader but their futures are not
-  // yet completed (flush/aggregate completion path under debug). Guarded so the
-  // shared bdev suite stays green; run explicitly with CLIO_TEST_MANYTOONE=1.
-  if (std::getenv("CLIO_TEST_MANYTOONE") == nullptr) {
-    HLOG(kInfo, "Skipping bdev_manytoone_batch (set CLIO_TEST_MANYTOONE=1)");
-    return;
-  }
   BdevChimodFixture fixture;
   REQUIRE(g_initialized);
   std::this_thread::sleep_for(100ms);

--- a/context-runtime/src/batch_manager.cc
+++ b/context-runtime/src/batch_manager.cc
@@ -102,10 +102,16 @@ void BatchManager::BuildAndSubmit(Worker * /*worker*/, const GroupKey &key,
   }
 
   // Run the aggregate locally on the leader as a fresh, self-owned task.
+  // NewCopyTask copied the member's task_flags_ but NOT its host_run_ctx_
+  // (Task::Copy leaves run ctx per-task). Clear the execution-lifecycle flags
+  // the member had accumulated (routed/started/run-ctx-exists) so the submit
+  // path runs BeginTask and gives this aggregate its OWN RunContext + future.
+  // Without this the aggregate inherits TASK_RUN_CTX_EXISTS with a null run
+  // ctx, BeginTask is skipped, and the aggregate never executes (members hang).
   agg->task_id_ = CreateTaskId();
   agg->pool_query_ = PoolQuery::Local();
   agg->SetFlags(TASK_BATCH_AGGREGATE);
-  agg->ClearFlags(TASK_ROUTED);
+  agg->ClearFlags(TASK_ROUTED | TASK_STARTED | TASK_RUN_CTX_EXISTS);
 
   // Remember the originals to broadcast to when the aggregate completes.
   {

--- a/context-runtime/src/batch_manager.cc
+++ b/context-runtime/src/batch_manager.cc
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * BSD 3-Clause License. See LICENSE file.
+ */
+
+/**
+ * BatchManager implementation — see batch_manager.h for the design.
+ */
+
+#include "clio_runtime/batch_manager.h"
+
+#include <chrono>
+#include <utility>
+
+#include "clio_runtime/container.h"
+#include "clio_runtime/ipc_manager.h"
+#include "clio_runtime/pool_manager.h"
+#include "clio_runtime/pool_query.h"
+#include "clio_runtime/singletons.h"
+#include "clio_runtime/worker.h"
+
+namespace clio::run {
+
+u64 BatchManager::NowNs() {
+  return static_cast<u64>(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(
+          std::chrono::steady_clock::now().time_since_epoch())
+          .count());
+}
+
+void BatchManager::Add(const ctp::ipc::FullPtr<Task> &task) {
+  const PoolQuery &q = task->pool_query_;
+  GroupKey key{task->pool_id_, task->method_, q.GetContainerHash(),
+               q.GetBatchKey()};
+  std::lock_guard<std::mutex> lk(mu_);
+  Group &group = groups_[key];
+  if (group.members.empty()) {
+    // First arrival starts the batch window.
+    u64 window = q.GetBatchForNs();
+    group.deadline_ns = NowNs() + window;
+  }
+  group.members.push_back(task);
+}
+
+bool BatchManager::FlushDue(Worker *worker) {
+  std::vector<std::pair<GroupKey, Group>> due;
+  bool pending_remains = false;
+  {
+    std::lock_guard<std::mutex> lk(mu_);
+    if (groups_.empty()) {
+      return false;
+    }
+    u64 now = NowNs();
+    for (auto it = groups_.begin(); it != groups_.end();) {
+      if (now >= it->second.deadline_ns) {
+        due.emplace_back(it->first, std::move(it->second));
+        it = groups_.erase(it);
+      } else {
+        ++it;
+      }
+    }
+    pending_remains = !groups_.empty();
+  }
+  for (auto &[key, group] : due) {
+    BuildAndSubmit(worker, key, group);
+  }
+  // Report busy if we flushed anything or still have groups awaiting their
+  // window, so the leader worker keeps polling rather than deep-sleeping.
+  return !due.empty() || pending_remains;
+}
+
+void BatchManager::BuildAndSubmit(Worker * /*worker*/, const GroupKey &key,
+                                  Group &group) {
+  if (group.members.empty()) {
+    return;
+  }
+  auto *pool_manager = CLIO_POOL_MANAGER;
+  Container *container = pool_manager->GetStaticContainer(key.pool_id);
+  if (container == nullptr) {
+    HLOG(kError, "BatchManager: no container for pool {} (dropping {} tasks)",
+         key.pool_id, group.members.size());
+    return;
+  }
+
+  // Aggregate task = a copy of the first member; merge the rest in as inputs.
+  ctp::ipc::FullPtr<Task> agg =
+      container->NewCopyTask(key.method, group.members[0], /*deep=*/true);
+  if (agg.IsNull()) {
+    HLOG(kError, "BatchManager: NewCopyTask failed for pool {} method {}",
+         key.pool_id, key.method);
+    return;
+  }
+  for (size_t i = 1; i < group.members.size(); ++i) {
+    container->Aggregate(key.method, agg, group.members[i]);
+  }
+
+  // Run the aggregate locally on the leader as a fresh, self-owned task.
+  agg->task_id_ = CreateTaskId();
+  agg->pool_query_ = PoolQuery::Local();
+  agg->SetFlags(TASK_BATCH_AGGREGATE);
+  agg->ClearFlags(TASK_ROUTED);
+
+  // Remember the originals to broadcast to when the aggregate completes.
+  {
+    std::lock_guard<std::mutex> lk(pending_mu_);
+    pending_[agg->task_id_.unique_] = std::move(group.members);
+  }
+
+  ipc_->Send(agg);
+}
+
+bool BatchManager::IsAggregate(const ctp::ipc::FullPtr<Task> &task) const {
+  return !task.IsNull() && task->task_flags_.Any(TASK_BATCH_AGGREGATE);
+}
+
+void BatchManager::OnAggregateComplete(Worker *worker,
+                                       const ctp::ipc::FullPtr<Task> &agg,
+                                       RunContext *agg_rctx) {
+  std::vector<ctp::ipc::FullPtr<Task>> members;
+  {
+    std::lock_guard<std::mutex> lk(pending_mu_);
+    auto it = pending_.find(agg->task_id_.unique_);
+    if (it == pending_.end()) {
+      return;
+    }
+    members = std::move(it->second);
+    pending_.erase(it);
+  }
+
+  auto *pool_manager = CLIO_POOL_MANAGER;
+  Container *container =
+      (agg_rctx != nullptr && agg_rctx->container_ != nullptr)
+          ? agg_rctx->container_
+          : pool_manager->GetStaticContainer(agg->pool_id_);
+  if (container == nullptr) {
+    HLOG(kError, "BatchManager: no container to broadcast aggregate for pool {}",
+         agg->pool_id_);
+    return;
+  }
+
+  u32 rc = agg->GetReturnCode();
+  for (auto &member : members) {
+    // Broadcast: copy the aggregate's OUT into each original (collective).
+    container->Aggregate(member->method_, member, agg);
+    member->SetReturnCode(rc);
+    member->SetCompleter(agg->GetCompleter());
+    // Complete the original: local future signal or remote SendOut.
+    RunContext *m_rctx = member->GetRunCtx();
+    if (m_rctx == nullptr) {
+      HLOG(kError, "BatchManager: batched task has no RunContext, cannot end");
+      continue;
+    }
+    m_rctx->container_ = container;
+    worker->EndTask(member, m_rctx, false);
+  }
+}
+
+}  // namespace clio::run

--- a/context-runtime/src/batch_manager.cc
+++ b/context-runtime/src/batch_manager.cc
@@ -94,8 +94,11 @@ void BatchManager::BuildAndSubmit(Worker * /*worker*/, const GroupKey &key,
          key.pool_id, key.method);
     return;
   }
+  // Combine each remaining member's INPUTS into the aggregate (AggregateIn).
+  // Default is a no-op, so without a chimod override the aggregate is simply a
+  // copy of the first member (barrier/dedup collective).
   for (size_t i = 1; i < group.members.size(); ++i) {
-    container->Aggregate(key.method, agg, group.members[i]);
+    container->AggregateIn(key.method, agg, group.members[i]);
   }
 
   // Run the aggregate locally on the leader as a fresh, self-owned task.

--- a/context-runtime/src/batch_manager.cc
+++ b/context-runtime/src/batch_manager.cc
@@ -86,7 +86,7 @@ void BatchManager::BuildAndSubmit(Worker * /*worker*/, const GroupKey &key,
     return;
   }
 
-  // Aggregate task = a copy of the first member; merge the rest in as inputs.
+  // Aggregate task = a copy of the first member; combine the rest in as inputs.
   ctp::ipc::FullPtr<Task> agg =
       container->NewCopyTask(key.method, group.members[0], /*deep=*/true);
   if (agg.IsNull()) {
@@ -146,11 +146,24 @@ void BatchManager::OnAggregateComplete(Worker *worker,
   }
 
   u32 rc = agg->GetReturnCode();
+  ContainerId completer = agg->GetCompleter();
+  u32 method = agg->method_;
+
+  // Serialize the aggregate's OUT fields once. ManyToOne distributes the single
+  // collective result to every member via SerializeOut copy-back (the original
+  // spec's `member->SerializeOut(aggregate)`), NOT AggregateOut — that is the
+  // replica-gather (N->1) merge. Here it is one result broadcast 1->N.
+  chi::priv::vector<char> out_buf(CLIO_PRIV_ALLOC);
+  chi::DefaultSaveArchive save_ar(chi::LocalMsgType::kSerializeOut, out_buf);
+  container->LocalSaveTask(method, save_ar, agg);
+
   for (auto &member : members) {
-    // Broadcast: copy the aggregate's OUT into each original (collective).
-    container->Aggregate(member->method_, member, agg);
+    // Copy the aggregate's OUT into this member (broadcast).
+    chi::DefaultLoadArchive load_ar(save_ar.GetMutableData());
+    load_ar.Reset(chi::LocalMsgType::kSerializeOut);
+    container->LocalLoadTask(member->method_, load_ar, member);
     member->SetReturnCode(rc);
-    member->SetCompleter(agg->GetCompleter());
+    member->SetCompleter(completer);
     // Complete the original: local future signal or remote SendOut.
     RunContext *m_rctx = member->GetRunCtx();
     if (m_rctx == nullptr) {

--- a/context-runtime/src/ipc/ipc_run2run.cc
+++ b/context-runtime/src/ipc/ipc_run2run.cc
@@ -539,10 +539,10 @@ int IpcManagerRun2Run::RecvOutAggregate(
 
     ctp::ipc::FullPtr<chi::Task> replica = origin_rctx->subtasks_[replica_id];
 
-    // Aggregate via the Container so the concrete task type's Aggregate()
-    // runs (which merges OUT fields like bdev's blocks_). Task::Aggregate is
+    // AggregateOut via the Container so the concrete task type's AggregateOut()
+    // runs (which merges OUT fields like bdev's blocks_). Task::AggregateOut is
     // intentionally non-virtual to keep Task vtable-free, so calling
-    // origin_task->Aggregate(replica) here would slice to the base and drop
+    // origin_task->AggregateOut(replica) here would slice to the base and drop
     // every derived OUT field — leaving callers with empty results.
     chi::Container *container =
         CLIO_POOL_MANAGER->GetStaticContainer(origin_task->pool_id_);
@@ -551,7 +551,7 @@ int IpcManagerRun2Run::RecvOutAggregate(
            origin_task->pool_id_);
       continue;
     }
-    container->Aggregate(origin_task->method_, origin_task, replica);
+    container->AggregateOut(origin_task->method_, origin_task, replica);
 
     HLOG(kDebug, "[RecvOut] Task {}", origin_task->task_id_);
 

--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -1199,6 +1199,32 @@ u64 IpcManager::GetLeaderNodeId() const {
 
 bool IpcManager::IsLeader() const { return GetNodeId() == GetLeaderNodeId(); }
 
+u64 IpcManager::GetNeighborhoodLeaderNodeId(u64 for_node) const {
+  // The neighborhood is the window [base, base + N) where N is the configured
+  // neighborhood size and base = floor(for_node / N) * N. The leader is the
+  // lowest *alive* node in that window. Computed from local SWIM membership,
+  // so every node in the neighborhood agrees deterministically. Falls back to
+  // for_node itself if the window has no other alive members.
+  u32 n = CLIO_CONFIG_MANAGER->GetNeighborhoodSize();
+  if (n == 0) {
+    n = 1;
+  }
+  u64 base = (for_node / n) * n;
+  u64 end = base + n;
+  u64 leader = std::numeric_limits<u64>::max();
+  for (const auto &[id, host] : hostfile_map_) {
+    if (host.state == NodeState::kAlive && host.node_id >= base &&
+        host.node_id < end && host.node_id < leader) {
+      leader = host.node_id;
+    }
+  }
+  return (leader == std::numeric_limits<u64>::max()) ? for_node : leader;
+}
+
+u64 IpcManager::GetNeighborhoodLeaderNodeId() const {
+  return GetNeighborhoodLeaderNodeId(GetNodeId());
+}
+
 u64 IpcManager::AddNode(const std::string &ip_address, u32 port) {
   (void)port;  // Port stored elsewhere (ConfigManager) for now
 
@@ -2778,8 +2804,10 @@ bool IpcManager::IsTaskLocal(const FullPtr<Task> & /*task_ptr*/,
     case RoutingMode::DirectHash:
     case RoutingMode::Range:
     case RoutingMode::Broadcast:
-      // These modes should have been resolved to Physical queries by now
-      // If we still see them here, they are not local
+    case RoutingMode::ManyToOne:
+      // These modes should have been resolved (ManyToOne → Local on the
+      // neighborhood leader, else Physical) by now. If we still see them
+      // here, they are not local.
       return false;
 
     case RoutingMode::ToLocalCpu:

--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -401,6 +401,9 @@ bool IpcManager::ServerInit() {
     HLOG(kDebug, "Scheduler initialized: {}", sched_name);
   }
 
+  // ManyToOne collective batch/aggregation manager (leader-side).
+  batch_manager_ = std::make_unique<BatchManager>(this);
+
   // Create lightbeam transports for client task reception
   {
     u32 port = config->GetPort();
@@ -2687,6 +2690,14 @@ RouteResult IpcManager::RouteTask(Future<Task> &future, bool force_enqueue) {
     return RouteResult::ExecHere;
   }
 
+  // ManyToOne collective routing is handled before the normal resolve path:
+  // forward to the neighborhood leader, or park into the batch manager if we
+  // are the leader. (The aggregate task the leader later runs is a plain
+  // Local task and does not re-enter this branch.)
+  if (task_ptr->pool_query_.IsManyToOneMode()) {
+    return RouteManyToOne(future);
+  }
+
   // Only call ScheduleTask for Dynamic pool queries.
   // ScheduleTask resolves Dynamic routing into concrete modes (e.g.,
   // Broadcast, DirectHash, Local). Concrete routing modes (Range, Physical,
@@ -2746,6 +2757,25 @@ RouteResult IpcManager::RouteTask(Future<Task> &future, bool force_enqueue) {
   } else {
     return RouteGlobal(future, pool_queries);
   }
+}
+
+RouteResult IpcManager::RouteManyToOne(Future<Task> &future) {
+  FullPtr<Task> task_ptr = future.GetTaskPtr();
+  u64 leader = GetNeighborhoodLeaderNodeId();
+  if (leader == GetNodeId()) {
+    // We are the neighborhood leader: park the task into its batch group. The
+    // batch flusher aggregates, runs once, and completes each member later.
+    // RouteResult::Local tells the worker the task is owned elsewhere now and
+    // must not be executed here.
+    task_ptr->SetFlags(TASK_ROUTED);
+    batch_manager_->Add(task_ptr);
+    return RouteResult::Local;
+  }
+  // Forward to the leader. pool_query_ stays ManyToOne so the leader re-enters
+  // this path and batches; only the network address is the leader node.
+  std::vector<PoolQuery> pool_queries = {PoolQuery::Physical((u32)leader)};
+  pool_queries[0].SetReturnNode(GetNodeId());
+  return RouteGlobal(future, pool_queries);
 }
 
 bool IpcManager::IsTaskLocal(const FullPtr<Task> & /*task_ptr*/,
@@ -2962,6 +2992,12 @@ std::vector<PoolQuery> IpcManager::ResolvePoolQuery(
     case RoutingMode::Null:
       // GPU producer-only ToLocalCpu and Null modes pass through.
       result = {query};
+      break;
+    case RoutingMode::ManyToOne:
+      // ManyToOne is intercepted in RouteTask (RouteManyToOne) before reaching
+      // here. If it ever falls through, resolve to the neighborhood leader.
+      result = {PoolQuery::Physical(
+          (u32)GetNeighborhoodLeaderNodeId())};
       break;
   }
 

--- a/context-runtime/src/pool_query.cc
+++ b/context-runtime/src/pool_query.cc
@@ -119,6 +119,20 @@ PoolQuery PoolQuery::Dynamic(float net_timeout) {
   return query;
 }
 
+PoolQuery PoolQuery::ManyToOne(u32 container_hash, u64 batch_key,
+                               u64 batch_for_ns) {
+  PoolQuery query;
+  query.routing_mode_ = RoutingMode::ManyToOne;
+  query.hash_value_ = container_hash;
+  query.container_id_ = 0;
+  query.range_offset_ = 0;
+  query.range_count_ = 0;
+  query.node_id_ = 0;
+  query.batch_key_ = batch_key;
+  query.batch_for_ns_ = batch_for_ns;
+  return query;
+}
+
 PoolQuery PoolQuery::FromString(const std::string& str) {
   // Convert to lowercase for case-insensitive comparison
   std::string lower_str = str;
@@ -150,6 +164,21 @@ PoolQuery PoolQuery::FromString(const std::string& str) {
   } else if (lower_str.rfind("physical:", 0) == 0) {
     u32 node_id = std::stoul(lower_str.substr(9));
     return PoolQuery::Physical(node_id);
+  } else if (lower_str.rfind("many_to_one:", 0) == 0) {
+    // Format: many_to_one:<container_hash>[:<batch_key>[:<batch_for_ns>]]
+    std::string rest = lower_str.substr(12);
+    size_t c1 = rest.find(':');
+    u32 container_hash = std::stoul(rest.substr(0, c1));
+    u64 batch_key = 0, batch_for_ns = 10000;
+    if (c1 != std::string::npos) {
+      std::string rest2 = rest.substr(c1 + 1);
+      size_t c2 = rest2.find(':');
+      batch_key = std::stoull(rest2.substr(0, c2));
+      if (c2 != std::string::npos) {
+        batch_for_ns = std::stoull(rest2.substr(c2 + 1));
+      }
+    }
+    return PoolQuery::ManyToOne(container_hash, batch_key, batch_for_ns);
   } else {
     throw std::invalid_argument(
         "Invalid PoolQuery string: '" + str + "'");
@@ -172,6 +201,9 @@ std::string PoolQuery::ToString() const {
       return "range:" + std::to_string(range_offset_) + ":" + std::to_string(range_count_);
     case RoutingMode::Physical:
       return "physical:" + std::to_string(node_id_);
+    case RoutingMode::ManyToOne:
+      return "many_to_one:" + std::to_string(hash_value_) + ":" +
+             std::to_string(batch_key_) + ":" + std::to_string(batch_for_ns_);
     default:
       return "unknown";
   }

--- a/context-runtime/src/worker.cc
+++ b/context-runtime/src/worker.cc
@@ -266,6 +266,18 @@ void Worker::Run() {
     // Check blocked queue for completed tasks at end of each iteration
     ContinueBlockedTasks(false);
 
+    // ManyToOne: flush due collective batches on the neighborhood leader.
+    // Driven from a single worker to avoid redundant locking; FlushDue is a
+    // cheap no-op when no batches are pending. Treat pending batches as work so
+    // this worker keeps polling and honors the short (e.g. 10us) batch window
+    // instead of deep-sleeping.
+    if (worker_id_ == 0) {
+      BatchManager *bm = CLIO_IPC->GetBatchManager();
+      if (bm != nullptr && bm->FlushDue(this)) {
+        did_work_ = true;
+      }
+    }
+
     // Increment iteration counter
     iteration_count_++;
 
@@ -1014,6 +1026,21 @@ void Worker::EndTask(const FullPtr<Task> &task_ptr, RunContext *run_ctx,
   container->ReinforceWallModel(
       task_ptr->method_, run_ctx->predicted_wall_us_, actual_wall_us,
       run_ctx->predicted_stat_);
+
+  // ManyToOne aggregate task: this synthetic task has no external waiter. On
+  // completion, broadcast its OUT to the batched originals (which completes
+  // each of them), then delete the aggregate. Done after the model
+  // reinforcement above so load accounting stays consistent.
+  if (task_ptr->task_flags_.Any(TASK_BATCH_AGGREGATE)) {
+    BatchManager *bm = CLIO_IPC->GetBatchManager();
+    if (bm != nullptr) {
+      bm->OnAggregateComplete(this, task_ptr, run_ctx);
+    }
+    container->UpdateWork(task_ptr, *run_ctx, -1);
+    task_ptr->ClearFlags(TASK_DATA_OWNER);
+    container->DelTask(task_ptr->method_, task_ptr);
+    return;
+  }
 
   // Get task properties at the start
   bool is_remote = task_ptr->IsRemote();

--- a/context-runtime/test/unit/autogen_more/test_autogen_methods_sweep.cc
+++ b/context-runtime/test/unit/autogen_more/test_autogen_methods_sweep.cc
@@ -10,7 +10,7 @@
  *
  * The per-method tests in test_autogen_coverage.cc exercise the autogen
  * lib_exec dispatch functions (SaveTask, LoadTask, AllocLoadTask,
- * LocalSaveTask, LocalLoadTask, LocalAllocLoadTask, NewCopyTask, Aggregate)
+ * LocalSaveTask, LocalLoadTask, LocalAllocLoadTask, NewCopyTask, AggregateOut)
  * only for the low-numbered methods. This file sweeps EVERY method id of the
  * admin, bdev, and MOD_NAME modules through the full dispatch battery so the
  * remaining switch arms (and the task serialization/copy code in the
@@ -145,12 +145,12 @@ void SweepMethod(chi::Container &container, chi::u32 method) {
     }
   }
 
-  // --- Aggregate via the container dispatch switch (the per-method tests
-  // call task->Aggregate directly, leaving the dispatch arms uncovered).
+  // --- AggregateOut via the container dispatch switch (the per-method tests
+  // call task->AggregateOut directly, leaving the dispatch arms uncovered).
   {
     auto replica = container.NewTask(method);
     if (!replica.IsNull()) {
-      container.Aggregate(method, task, replica);
+      container.AggregateOut(method, task, replica);
       container.DelTask(method, replica);
     }
   }

--- a/context-runtime/test/unit/cli/test_clio_run_cli.cc
+++ b/context-runtime/test/unit/cli/test_clio_run_cli.cc
@@ -323,7 +323,7 @@ TEST_CASE("RefreshRepo - generates methods header and lib_exec source",
   REQUIRE(Contains(s, "void Runtime::LocalSaveTask("));
   REQUIRE(Contains(s, "Runtime::NewCopyTask("));
   REQUIRE(Contains(s, "Runtime::NewTask("));
-  REQUIRE(Contains(s, "void Runtime::Aggregate("));
+  REQUIRE(Contains(s, "void Runtime::AggregateOut("));
   REQUIRE(Contains(s, "void Runtime::DelTask("));
   REQUIRE(Contains(s, "case Method::kGetOrCreateThing:"));
 

--- a/context-runtime/test/unit/external-chimod/modules/simple_mod/include/chimaera/simple_mod/simple_mod_runtime.h
+++ b/context-runtime/test/unit/external-chimod/modules/simple_mod/include/chimaera/simple_mod/simple_mod_runtime.h
@@ -156,7 +156,7 @@ public:
    * Create a new task of the specified method type (auto-generated)
    */
   ctp::ipc::FullPtr<chi::Task> NewTask(chi::u32 method) override;
-  void Aggregate(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
+  void AggregateOut(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
                  const ctp::ipc::FullPtr<chi::Task>& replica_task) override;
   void DelTask(chi::u32 method, ctp::ipc::FullPtr<chi::Task> task_ptr) override;
 

--- a/context-runtime/test/unit/external-chimod/modules/simple_mod/include/chimaera/simple_mod/simple_mod_tasks.h
+++ b/context-runtime/test/unit/external-chimod/modules/simple_mod/include/chimaera/simple_mod/simple_mod_tasks.h
@@ -137,11 +137,11 @@ struct FlushTask : public chi::Task {
   }
 
   /**
-   * Aggregate replica results into this task
+   * AggregateOut replica results into this task
    * @param other Pointer to the replica task to aggregate from
    */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<FlushTask>());
   }
 };

--- a/context-runtime/test/unit/external-chimod/modules/simple_mod/src/autogen/simple_mod_lib_exec.cc
+++ b/context-runtime/test/unit/external-chimod/modules/simple_mod/src/autogen/simple_mod_lib_exec.cc
@@ -131,11 +131,11 @@ ctp::ipc::FullPtr<chi::Task> Runtime::NewTask(chi::u32 method) {
   }
 }
 
-void Runtime::Aggregate(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
+void Runtime::AggregateOut(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
                         const ctp::ipc::FullPtr<chi::Task>& replica_task) {
   switch (method) {
     default: {
-      orig_task->Aggregate(replica_task);
+      orig_task->AggregateOut(replica_task);
       break;
     }
   }

--- a/context-runtime/test/unit/test_autogen_coverage.cc
+++ b/context-runtime/test/unit/test_autogen_coverage.cc
@@ -2,7 +2,7 @@
  * Comprehensive unit tests for autogen code coverage
  *
  * This test file exercises the SaveTask, LoadTask, NewTask, NewCopyTask,
- * and Aggregate methods in the autogen lib_exec.cc files to increase
+ * and AggregateOut methods in the autogen lib_exec.cc files to increase
  * code coverage.
  *
  * Target autogen files:
@@ -315,7 +315,7 @@ TEST_CASE("Autogen - Admin NewCopyTask", "[autogen][admin][copytask]") {
   }
 }
 
-TEST_CASE("Autogen - Admin Aggregate", "[autogen][admin][aggregate]") {
+TEST_CASE("Autogen - Admin AggregateOut", "[autogen][admin][aggregate]") {
   EnsureInitialized();
 
   auto* ipc_manager = CLIO_IPC;
@@ -327,7 +327,7 @@ TEST_CASE("Autogen - Admin Aggregate", "[autogen][admin][aggregate]") {
     return;
   }
 
-  SECTION("Aggregate for FlushTask") {
+  SECTION("AggregateOut for FlushTask") {
     auto origin_task = ipc_manager->NewTask<clio::run::admin::FlushTask>(
         chi::CreateTaskId(), chi::kAdminPoolId, chi::PoolQuery::Local());
     auto replica_task = ipc_manager->NewTask<clio::run::admin::FlushTask>(
@@ -342,14 +342,14 @@ TEST_CASE("Autogen - Admin Aggregate", "[autogen][admin][aggregate]") {
 
     ctp::ipc::FullPtr<chi::Task> origin_ptr = origin_task.template Cast<chi::Task>();
     ctp::ipc::FullPtr<chi::Task> replica_ptr = replica_task.template Cast<chi::Task>();
-    origin_ptr.ptr_->Aggregate(replica_ptr.template Cast<chi::Task>());
+    origin_ptr.ptr_->AggregateOut(replica_ptr.template Cast<chi::Task>());
 
-    INFO("Aggregate for FlushTask completed");
+    INFO("AggregateOut for FlushTask completed");
     CLIO_IPC->DelTask(origin_task);
     CLIO_IPC->DelTask(replica_task);
   }
 
-  SECTION("Aggregate for MonitorTask") {
+  SECTION("AggregateOut for MonitorTask") {
     auto origin_task = ipc_manager->NewTask<clio::run::admin::MonitorTask>(
         chi::CreateTaskId(), chi::kAdminPoolId, chi::PoolQuery::Local(), std::string("status"));
     auto replica_task = ipc_manager->NewTask<clio::run::admin::MonitorTask>(
@@ -364,9 +364,9 @@ TEST_CASE("Autogen - Admin Aggregate", "[autogen][admin][aggregate]") {
 
     ctp::ipc::FullPtr<chi::Task> origin_ptr = origin_task.template Cast<chi::Task>();
     ctp::ipc::FullPtr<chi::Task> replica_ptr = replica_task.template Cast<chi::Task>();
-    origin_ptr.ptr_->Aggregate(replica_ptr.template Cast<chi::Task>());
+    origin_ptr.ptr_->AggregateOut(replica_ptr.template Cast<chi::Task>());
 
-    INFO("Aggregate for MonitorTask completed");
+    INFO("AggregateOut for MonitorTask completed");
     CLIO_IPC->DelTask(origin_task);
     CLIO_IPC->DelTask(replica_task);
   }
@@ -703,11 +703,11 @@ TEST_CASE("Autogen - Admin StopRuntimeTask coverage", "[autogen][admin][stoprunt
         CLIO_IPC->DelTask(copied_task);
       }
 
-      // Test Aggregate
+      // Test AggregateOut
       auto replica_task = container->NewTask(clio::run::admin::Method::kStopRuntime);
       if (!replica_task.IsNull()) {
-        new_task.ptr_->Aggregate(replica_task.template Cast<chi::Task>());
-        INFO("Aggregate for StopRuntimeTask succeeded");
+        new_task.ptr_->AggregateOut(replica_task.template Cast<chi::Task>());
+        INFO("AggregateOut for StopRuntimeTask succeeded");
         CLIO_IPC->DelTask(replica_task);
       }
 
@@ -755,11 +755,11 @@ TEST_CASE("Autogen - Admin DestroyPoolTask coverage", "[autogen][admin][destroyp
         CLIO_IPC->DelTask(copied_task);
       }
 
-      // Aggregate
+      // AggregateOut
       auto replica_task = container->NewTask(clio::run::admin::Method::kDestroyPool);
       if (!replica_task.IsNull()) {
-        new_task.ptr_->Aggregate(replica_task.template Cast<chi::Task>());
-        INFO("Aggregate for DestroyPoolTask succeeded");
+        new_task.ptr_->AggregateOut(replica_task.template Cast<chi::Task>());
+        INFO("AggregateOut for DestroyPoolTask succeeded");
         CLIO_IPC->DelTask(replica_task);
       }
 
@@ -792,11 +792,11 @@ TEST_CASE("Autogen - Admin SubmitBatchTask coverage", "[autogen][admin][submitba
         CLIO_IPC->DelTask(copied_task);
       }
 
-      // Aggregate
+      // AggregateOut
       auto replica_task = container->NewTask(clio::run::admin::Method::kSubmitBatch);
       if (!replica_task.IsNull()) {
-        new_task.ptr_->Aggregate(replica_task.template Cast<chi::Task>());
-        INFO("Aggregate for SubmitBatchTask succeeded");
+        new_task.ptr_->AggregateOut(replica_task.template Cast<chi::Task>());
+        INFO("AggregateOut for SubmitBatchTask succeeded");
         CLIO_IPC->DelTask(replica_task);
       }
 
@@ -829,11 +829,11 @@ TEST_CASE("Autogen - Admin CreateTask and DestroyTask coverage", "[autogen][admi
         CLIO_IPC->DelTask(copied_task);
       }
 
-      // Aggregate
+      // AggregateOut
       auto replica_task = container->NewTask(clio::run::admin::Method::kCreate);
       if (!replica_task.IsNull()) {
-        new_task.ptr_->Aggregate(replica_task.template Cast<chi::Task>());
-        INFO("Aggregate for CreateTask succeeded");
+        new_task.ptr_->AggregateOut(replica_task.template Cast<chi::Task>());
+        INFO("AggregateOut for CreateTask succeeded");
         CLIO_IPC->DelTask(replica_task);
       }
 
@@ -853,11 +853,11 @@ TEST_CASE("Autogen - Admin CreateTask and DestroyTask coverage", "[autogen][admi
         CLIO_IPC->DelTask(copied_task);
       }
 
-      // Aggregate
+      // AggregateOut
       auto replica_task = container->NewTask(clio::run::admin::Method::kDestroy);
       if (!replica_task.IsNull()) {
-        new_task.ptr_->Aggregate(replica_task.template Cast<chi::Task>());
-        INFO("Aggregate for DestroyTask succeeded");
+        new_task.ptr_->AggregateOut(replica_task.template Cast<chi::Task>());
+        INFO("AggregateOut for DestroyTask succeeded");
         CLIO_IPC->DelTask(replica_task);
       }
 
@@ -890,11 +890,11 @@ TEST_CASE("Autogen - Admin GetOrCreatePoolTask coverage", "[autogen][admin][geto
         CLIO_IPC->DelTask(copied_task);
       }
 
-      // Aggregate
+      // AggregateOut
       auto replica_task = container->NewTask(clio::run::admin::Method::kGetOrCreatePool);
       if (!replica_task.IsNull()) {
-        new_task.ptr_->Aggregate(replica_task.template Cast<chi::Task>());
-        INFO("Aggregate for GetOrCreatePoolTask succeeded");
+        new_task.ptr_->AggregateOut(replica_task.template Cast<chi::Task>());
+        INFO("AggregateOut for GetOrCreatePoolTask succeeded");
         CLIO_IPC->DelTask(replica_task);
       }
 
@@ -927,11 +927,11 @@ TEST_CASE("Autogen - Admin SendTask and RecvTask coverage", "[autogen][admin][se
         CLIO_IPC->DelTask(copied_task);
       }
 
-      // Aggregate
+      // AggregateOut
       auto replica_task = container->NewTask(clio::run::admin::Method::kSend);
       if (!replica_task.IsNull()) {
-        new_task.ptr_->Aggregate(replica_task.template Cast<chi::Task>());
-        INFO("Aggregate for SendTask succeeded");
+        new_task.ptr_->AggregateOut(replica_task.template Cast<chi::Task>());
+        INFO("AggregateOut for SendTask succeeded");
         CLIO_IPC->DelTask(replica_task);
       }
 
@@ -951,11 +951,11 @@ TEST_CASE("Autogen - Admin SendTask and RecvTask coverage", "[autogen][admin][se
         CLIO_IPC->DelTask(copied_task);
       }
 
-      // Aggregate
+      // AggregateOut
       auto replica_task = container->NewTask(clio::run::admin::Method::kRecv);
       if (!replica_task.IsNull()) {
-        new_task.ptr_->Aggregate(replica_task.template Cast<chi::Task>());
-        INFO("Aggregate for RecvTask succeeded");
+        new_task.ptr_->AggregateOut(replica_task.template Cast<chi::Task>());
+        INFO("AggregateOut for RecvTask succeeded");
         CLIO_IPC->DelTask(replica_task);
       }
 
@@ -1540,7 +1540,7 @@ TEST_CASE("Autogen - CTE BlobQueryTask coverage", "[autogen][cte][blobquery]") {
 }
 
 //==============================================================================
-// CTE Core - Copy and Aggregate Tests for Higher Coverage
+// CTE Core - Copy and AggregateOut Tests for Higher Coverage
 //==============================================================================
 
 TEST_CASE("Autogen - CTE Task Copy operations", "[autogen][cte][copy]") {
@@ -1597,57 +1597,57 @@ TEST_CASE("Autogen - CTE Task Copy operations", "[autogen][cte][copy]") {
   }
 }
 
-TEST_CASE("Autogen - CTE Task Aggregate operations", "[autogen][cte][aggregate]") {
+TEST_CASE("Autogen - CTE Task AggregateOut operations", "[autogen][cte][aggregate]") {
   EnsureInitialized();
 
   auto* ipc_manager = CLIO_IPC;
 
-  SECTION("Aggregate for ListTargetsTask") {
+  SECTION("AggregateOut for ListTargetsTask") {
     auto origin_task = ipc_manager->NewTask<clio::cte::core::ListTargetsTask>();
     auto replica_task = ipc_manager->NewTask<clio::cte::core::ListTargetsTask>();
 
     if (!origin_task.IsNull() && !replica_task.IsNull()) {
       // Add some test data to replica
       replica_task->target_names_.push_back("test_target");
-      origin_task->Aggregate(replica_task.template Cast<chi::Task>());
-      INFO("ListTargetsTask Aggregate completed");
+      origin_task->AggregateOut(replica_task.template Cast<chi::Task>());
+      INFO("ListTargetsTask AggregateOut completed");
       REQUIRE(origin_task->target_names_.size() == 1);
       CLIO_IPC->DelTask(origin_task);
       CLIO_IPC->DelTask(replica_task);
     }
   }
 
-  SECTION("Aggregate for GetTagSizeTask") {
+  SECTION("AggregateOut for GetTagSizeTask") {
     auto origin_task = ipc_manager->NewTask<clio::cte::core::GetTagSizeTask>();
     auto replica_task = ipc_manager->NewTask<clio::cte::core::GetTagSizeTask>();
 
     if (!origin_task.IsNull() && !replica_task.IsNull()) {
       origin_task->tag_size_ = 100;
       replica_task->tag_size_ = 200;
-      origin_task->Aggregate(replica_task.template Cast<chi::Task>());
-      INFO("GetTagSizeTask Aggregate completed");
+      origin_task->AggregateOut(replica_task.template Cast<chi::Task>());
+      INFO("GetTagSizeTask AggregateOut completed");
       REQUIRE(origin_task->tag_size_ == 300);
       CLIO_IPC->DelTask(origin_task);
       CLIO_IPC->DelTask(replica_task);
     }
   }
 
-  SECTION("Aggregate for GetContainedBlobsTask") {
+  SECTION("AggregateOut for GetContainedBlobsTask") {
     auto origin_task = ipc_manager->NewTask<clio::cte::core::GetContainedBlobsTask>();
     auto replica_task = ipc_manager->NewTask<clio::cte::core::GetContainedBlobsTask>();
 
     if (!origin_task.IsNull() && !replica_task.IsNull()) {
       replica_task->blob_names_.push_back("blob1");
       replica_task->blob_names_.push_back("blob2");
-      origin_task->Aggregate(replica_task.template Cast<chi::Task>());
-      INFO("GetContainedBlobsTask Aggregate completed");
+      origin_task->AggregateOut(replica_task.template Cast<chi::Task>());
+      INFO("GetContainedBlobsTask AggregateOut completed");
       REQUIRE(origin_task->blob_names_.size() == 2);
       CLIO_IPC->DelTask(origin_task);
       CLIO_IPC->DelTask(replica_task);
     }
   }
 
-  SECTION("Aggregate for TagQueryTask") {
+  SECTION("AggregateOut for TagQueryTask") {
     auto origin_task = ipc_manager->NewTask<clio::cte::core::TagQueryTask>();
     auto replica_task = ipc_manager->NewTask<clio::cte::core::TagQueryTask>();
 
@@ -1655,15 +1655,15 @@ TEST_CASE("Autogen - CTE Task Aggregate operations", "[autogen][cte][aggregate]"
       replica_task->total_tags_matched_ = 5;
       replica_task->results_.push_back("tag1");
       origin_task->total_tags_matched_ = 3;
-      origin_task->Aggregate(replica_task.template Cast<chi::Task>());
-      INFO("TagQueryTask Aggregate completed");
+      origin_task->AggregateOut(replica_task.template Cast<chi::Task>());
+      INFO("TagQueryTask AggregateOut completed");
       REQUIRE(origin_task->total_tags_matched_ == 8);
       CLIO_IPC->DelTask(origin_task);
       CLIO_IPC->DelTask(replica_task);
     }
   }
 
-  SECTION("Aggregate for BlobQueryTask") {
+  SECTION("AggregateOut for BlobQueryTask") {
     auto origin_task = ipc_manager->NewTask<clio::cte::core::BlobQueryTask>();
     auto replica_task = ipc_manager->NewTask<clio::cte::core::BlobQueryTask>();
 
@@ -1672,8 +1672,8 @@ TEST_CASE("Autogen - CTE Task Aggregate operations", "[autogen][cte][aggregate]"
       replica_task->tag_names_.push_back("tag1");
       replica_task->blob_names_.push_back("blob1");
       origin_task->total_blobs_matched_ = 5;
-      origin_task->Aggregate(replica_task.template Cast<chi::Task>());
-      INFO("BlobQueryTask Aggregate completed");
+      origin_task->AggregateOut(replica_task.template Cast<chi::Task>());
+      INFO("BlobQueryTask AggregateOut completed");
       REQUIRE(origin_task->total_blobs_matched_ == 15);
       CLIO_IPC->DelTask(origin_task);
       CLIO_IPC->DelTask(replica_task);
@@ -1685,7 +1685,7 @@ TEST_CASE("Autogen - CTE Task Aggregate operations", "[autogen][cte][aggregate]"
 // Additional Bdev Task-Level Tests for Higher Coverage
 //==============================================================================
 
-TEST_CASE("Autogen - Bdev Task Copy and Aggregate", "[autogen][bdev][copy][aggregate]") {
+TEST_CASE("Autogen - Bdev Task Copy and AggregateOut", "[autogen][bdev][copy][aggregate]") {
   EnsureInitialized();
 
   auto* ipc_manager = CLIO_IPC;
@@ -1702,13 +1702,13 @@ TEST_CASE("Autogen - Bdev Task Copy and Aggregate", "[autogen][bdev][copy][aggre
     }
   }
 
-  SECTION("Aggregate for GetStatsTask") {
+  SECTION("AggregateOut for GetStatsTask") {
     auto task1 = ipc_manager->NewTask<clio::run::bdev::GetStatsTask>();
     auto task2 = ipc_manager->NewTask<clio::run::bdev::GetStatsTask>();
 
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1->Aggregate(task2.template Cast<chi::Task>());
-      INFO("GetStatsTask Aggregate completed");
+      task1->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("GetStatsTask AggregateOut completed");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
@@ -1853,7 +1853,7 @@ TEST_CASE("Autogen - Admin Container SaveTask/LoadTask all methods", "[autogen][
 }
 
 //==============================================================================
-// Admin Task additional Copy and Aggregate tests
+// Admin Task additional Copy and AggregateOut tests
 //==============================================================================
 
 TEST_CASE("Autogen - Admin Additional Task operations", "[autogen][admin][additional]") {
@@ -1903,43 +1903,43 @@ TEST_CASE("Autogen - Admin Additional Task operations", "[autogen][admin][additi
     }
   }
 
-  SECTION("Aggregate for additional Admin task types") {
-    // Test Aggregate for CreateTask
+  SECTION("AggregateOut for additional Admin task types") {
+    // Test AggregateOut for CreateTask
     auto create1 = ipc_manager->NewTask<clio::run::admin::CreateTask>();
     auto create2 = ipc_manager->NewTask<clio::run::admin::CreateTask>();
     if (!create1.IsNull() && !create2.IsNull()) {
-      create1->Aggregate(create2.template Cast<chi::Task>());
-      INFO("CreateTask Aggregate completed");
+      create1->AggregateOut(create2.template Cast<chi::Task>());
+      INFO("CreateTask AggregateOut completed");
       CLIO_IPC->DelTask(create1);
       CLIO_IPC->DelTask(create2);
     }
 
-    // Test Aggregate for DestroyTask
+    // Test AggregateOut for DestroyTask
     auto destroy1 = ipc_manager->NewTask<clio::run::admin::DestroyTask>();
     auto destroy2 = ipc_manager->NewTask<clio::run::admin::DestroyTask>();
     if (!destroy1.IsNull() && !destroy2.IsNull()) {
-      destroy1->Aggregate(destroy2.template Cast<chi::Task>());
-      INFO("DestroyTask Aggregate completed");
+      destroy1->AggregateOut(destroy2.template Cast<chi::Task>());
+      INFO("DestroyTask AggregateOut completed");
       CLIO_IPC->DelTask(destroy1);
       CLIO_IPC->DelTask(destroy2);
     }
 
-    // Test Aggregate for StopRuntimeTask
+    // Test AggregateOut for StopRuntimeTask
     auto stop1 = ipc_manager->NewTask<clio::run::admin::StopRuntimeTask>();
     auto stop2 = ipc_manager->NewTask<clio::run::admin::StopRuntimeTask>();
     if (!stop1.IsNull() && !stop2.IsNull()) {
-      stop1->Aggregate(stop2.template Cast<chi::Task>());
-      INFO("StopRuntimeTask Aggregate completed");
+      stop1->AggregateOut(stop2.template Cast<chi::Task>());
+      INFO("StopRuntimeTask AggregateOut completed");
       CLIO_IPC->DelTask(stop1);
       CLIO_IPC->DelTask(stop2);
     }
 
-    // Test Aggregate for DestroyPoolTask
+    // Test AggregateOut for DestroyPoolTask
     auto pool1 = ipc_manager->NewTask<clio::run::admin::DestroyPoolTask>();
     auto pool2 = ipc_manager->NewTask<clio::run::admin::DestroyPoolTask>();
     if (!pool1.IsNull() && !pool2.IsNull()) {
-      pool1->Aggregate(pool2.template Cast<chi::Task>());
-      INFO("DestroyPoolTask Aggregate completed");
+      pool1->AggregateOut(pool2.template Cast<chi::Task>());
+      INFO("DestroyPoolTask AggregateOut completed");
       CLIO_IPC->DelTask(pool1);
       CLIO_IPC->DelTask(pool2);
     }
@@ -2016,7 +2016,7 @@ TEST_CASE("Autogen - CAE ProcessHdf5DatasetTask coverage", "[autogen][cae][proce
   }
 }
 
-TEST_CASE("Autogen - CAE Task Copy and Aggregate", "[autogen][cae][copy][aggregate]") {
+TEST_CASE("Autogen - CAE Task Copy and AggregateOut", "[autogen][cae][copy][aggregate]") {
   EnsureInitialized();
 
   auto* ipc_manager = CLIO_IPC;
@@ -2045,25 +2045,25 @@ TEST_CASE("Autogen - CAE Task Copy and Aggregate", "[autogen][cae][copy][aggrega
     }
   }
 
-  SECTION("Aggregate for ParseOmniTask") {
+  SECTION("AggregateOut for ParseOmniTask") {
     auto task1 = ipc_manager->NewTask<clio::cae::core::ParseOmniTask>();
     auto task2 = ipc_manager->NewTask<clio::cae::core::ParseOmniTask>();
 
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1->Aggregate(task2.template Cast<chi::Task>());
-      INFO("ParseOmniTask Aggregate completed");
+      task1->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("ParseOmniTask AggregateOut completed");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
   }
 
-  SECTION("Aggregate for ProcessHdf5DatasetTask") {
+  SECTION("AggregateOut for ProcessHdf5DatasetTask") {
     auto task1 = ipc_manager->NewTask<clio::cae::core::ProcessHdf5DatasetTask>();
     auto task2 = ipc_manager->NewTask<clio::cae::core::ProcessHdf5DatasetTask>();
 
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1->Aggregate(task2.template Cast<chi::Task>());
-      INFO("ProcessHdf5DatasetTask Aggregate completed");
+      task1->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("ProcessHdf5DatasetTask AggregateOut completed");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
@@ -2071,7 +2071,7 @@ TEST_CASE("Autogen - CAE Task Copy and Aggregate", "[autogen][cae][copy][aggrega
 }
 
 //==============================================================================
-// Additional CTE Task Copy and Aggregate Tests for Higher Coverage
+// Additional CTE Task Copy and AggregateOut Tests for Higher Coverage
 //==============================================================================
 
 TEST_CASE("Autogen - CTE Additional Task Coverage", "[autogen][cte][additional]") {
@@ -2224,150 +2224,150 @@ TEST_CASE("Autogen - CTE Additional Task Coverage", "[autogen][cte][additional]"
   }
 }
 
-TEST_CASE("Autogen - CTE Additional Aggregate Tests", "[autogen][cte][aggregate]") {
+TEST_CASE("Autogen - CTE Additional AggregateOut Tests", "[autogen][cte][aggregate]") {
   EnsureInitialized();
 
   auto* ipc_manager = CLIO_IPC;
 
-  SECTION("Aggregate for UnregisterTargetTask") {
+  SECTION("AggregateOut for UnregisterTargetTask") {
     auto task1 = ipc_manager->NewTask<clio::cte::core::UnregisterTargetTask>();
     auto task2 = ipc_manager->NewTask<clio::cte::core::UnregisterTargetTask>();
 
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1->Aggregate(task2.template Cast<chi::Task>());
-      INFO("UnregisterTargetTask Aggregate completed");
+      task1->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("UnregisterTargetTask AggregateOut completed");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
   }
 
-  SECTION("Aggregate for StatTargetsTask") {
+  SECTION("AggregateOut for StatTargetsTask") {
     auto task1 = ipc_manager->NewTask<clio::cte::core::StatTargetsTask>();
     auto task2 = ipc_manager->NewTask<clio::cte::core::StatTargetsTask>();
 
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1->Aggregate(task2.template Cast<chi::Task>());
-      INFO("StatTargetsTask Aggregate completed");
+      task1->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("StatTargetsTask AggregateOut completed");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
   }
 
-  SECTION("Aggregate for ReorganizeBlobTask") {
+  SECTION("AggregateOut for ReorganizeBlobTask") {
     auto task1 = ipc_manager->NewTask<clio::cte::core::ReorganizeBlobTask>();
     auto task2 = ipc_manager->NewTask<clio::cte::core::ReorganizeBlobTask>();
 
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1->Aggregate(task2.template Cast<chi::Task>());
-      INFO("ReorganizeBlobTask Aggregate completed");
+      task1->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("ReorganizeBlobTask AggregateOut completed");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
   }
 
-  SECTION("Aggregate for DelBlobTask") {
+  SECTION("AggregateOut for DelBlobTask") {
     auto task1 = ipc_manager->NewTask<clio::cte::core::DelBlobTask>();
     auto task2 = ipc_manager->NewTask<clio::cte::core::DelBlobTask>();
 
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1->Aggregate(task2.template Cast<chi::Task>());
-      INFO("DelBlobTask Aggregate completed");
+      task1->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("DelBlobTask AggregateOut completed");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
   }
 
-  SECTION("Aggregate for DelTagTask") {
+  SECTION("AggregateOut for DelTagTask") {
     auto task1 = ipc_manager->NewTask<clio::cte::core::DelTagTask>();
     auto task2 = ipc_manager->NewTask<clio::cte::core::DelTagTask>();
 
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1->Aggregate(task2.template Cast<chi::Task>());
-      INFO("DelTagTask Aggregate completed");
+      task1->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("DelTagTask AggregateOut completed");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
   }
 
-  SECTION("Aggregate for GetBlobScoreTask") {
+  SECTION("AggregateOut for GetBlobScoreTask") {
     auto task1 = ipc_manager->NewTask<clio::cte::core::GetBlobScoreTask>();
     auto task2 = ipc_manager->NewTask<clio::cte::core::GetBlobScoreTask>();
 
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1->Aggregate(task2.template Cast<chi::Task>());
-      INFO("GetBlobScoreTask Aggregate completed");
+      task1->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("GetBlobScoreTask AggregateOut completed");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
   }
 
-  SECTION("Aggregate for GetBlobSizeTask") {
+  SECTION("AggregateOut for GetBlobSizeTask") {
     auto task1 = ipc_manager->NewTask<clio::cte::core::GetBlobSizeTask>();
     auto task2 = ipc_manager->NewTask<clio::cte::core::GetBlobSizeTask>();
 
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1->Aggregate(task2.template Cast<chi::Task>());
-      INFO("GetBlobSizeTask Aggregate completed");
+      task1->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("GetBlobSizeTask AggregateOut completed");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
   }
 
-  SECTION("Aggregate for PollTelemetryLogTask") {
+  SECTION("AggregateOut for PollTelemetryLogTask") {
     auto task1 = ipc_manager->NewTask<clio::cte::core::PollTelemetryLogTask>();
     auto task2 = ipc_manager->NewTask<clio::cte::core::PollTelemetryLogTask>();
 
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1->Aggregate(task2.template Cast<chi::Task>());
-      INFO("PollTelemetryLogTask Aggregate completed");
+      task1->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("PollTelemetryLogTask AggregateOut completed");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
   }
 
-  SECTION("Aggregate for RegisterTargetTask") {
+  SECTION("AggregateOut for RegisterTargetTask") {
     auto task1 = ipc_manager->NewTask<clio::cte::core::RegisterTargetTask>();
     auto task2 = ipc_manager->NewTask<clio::cte::core::RegisterTargetTask>();
 
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1->Aggregate(task2.template Cast<chi::Task>());
-      INFO("RegisterTargetTask Aggregate completed");
+      task1->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("RegisterTargetTask AggregateOut completed");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
   }
 
-  SECTION("Aggregate for GetOrCreateTagTask") {
+  SECTION("AggregateOut for GetOrCreateTagTask") {
     auto task1 = ipc_manager->NewTask<clio::cte::core::GetOrCreateTagTask<clio::cte::core::CreateParams>>();
     auto task2 = ipc_manager->NewTask<clio::cte::core::GetOrCreateTagTask<clio::cte::core::CreateParams>>();
 
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1->Aggregate(task2.template Cast<chi::Task>());
-      INFO("GetOrCreateTagTask Aggregate completed");
+      task1->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("GetOrCreateTagTask AggregateOut completed");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
   }
 
-  SECTION("Aggregate for PutBlobTask") {
+  SECTION("AggregateOut for PutBlobTask") {
     auto task1 = ipc_manager->NewTask<clio::cte::core::PutBlobTask>();
     auto task2 = ipc_manager->NewTask<clio::cte::core::PutBlobTask>();
 
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1->Aggregate(task2.template Cast<chi::Task>());
-      INFO("PutBlobTask Aggregate completed");
+      task1->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("PutBlobTask AggregateOut completed");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
   }
 
-  SECTION("Aggregate for GetBlobTask") {
+  SECTION("AggregateOut for GetBlobTask") {
     auto task1 = ipc_manager->NewTask<clio::cte::core::GetBlobTask>();
     auto task2 = ipc_manager->NewTask<clio::cte::core::GetBlobTask>();
 
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1->Aggregate(task2.template Cast<chi::Task>());
-      INFO("GetBlobTask Aggregate completed");
+      task1->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("GetBlobTask AggregateOut completed");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
@@ -2431,49 +2431,49 @@ TEST_CASE("Autogen - Bdev Additional Task Coverage", "[autogen][bdev][additional
     }
   }
 
-  SECTION("Aggregate for AllocateBlocksTask") {
+  SECTION("AggregateOut for AllocateBlocksTask") {
     auto task1 = ipc_manager->NewTask<clio::run::bdev::AllocateBlocksTask>();
     auto task2 = ipc_manager->NewTask<clio::run::bdev::AllocateBlocksTask>();
 
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1->Aggregate(task2.template Cast<chi::Task>());
-      INFO("AllocateBlocksTask Aggregate completed");
+      task1->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("AllocateBlocksTask AggregateOut completed");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
   }
 
-  SECTION("Aggregate for FreeBlocksTask") {
+  SECTION("AggregateOut for FreeBlocksTask") {
     auto task1 = ipc_manager->NewTask<clio::run::bdev::FreeBlocksTask>();
     auto task2 = ipc_manager->NewTask<clio::run::bdev::FreeBlocksTask>();
 
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1->Aggregate(task2.template Cast<chi::Task>());
-      INFO("FreeBlocksTask Aggregate completed");
+      task1->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("FreeBlocksTask AggregateOut completed");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
   }
 
-  SECTION("Aggregate for WriteTask") {
+  SECTION("AggregateOut for WriteTask") {
     auto task1 = ipc_manager->NewTask<clio::run::bdev::WriteTask>();
     auto task2 = ipc_manager->NewTask<clio::run::bdev::WriteTask>();
 
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1->Aggregate(task2.template Cast<chi::Task>());
-      INFO("WriteTask Aggregate completed");
+      task1->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("WriteTask AggregateOut completed");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
   }
 
-  SECTION("Aggregate for ReadTask") {
+  SECTION("AggregateOut for ReadTask") {
     auto task1 = ipc_manager->NewTask<clio::run::bdev::ReadTask>();
     auto task2 = ipc_manager->NewTask<clio::run::bdev::ReadTask>();
 
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1->Aggregate(task2.template Cast<chi::Task>());
-      INFO("ReadTask Aggregate completed");
+      task1->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("ReadTask AggregateOut completed");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
@@ -2531,43 +2531,43 @@ TEST_CASE("Autogen - Admin Additional Task Coverage", "[autogen][admin][addition
     }
   }
 
-  SECTION("Aggregate for FlushTask") {
+  SECTION("AggregateOut for FlushTask") {
     auto task1 = ipc_manager->NewTask<clio::run::admin::FlushTask>(
         chi::CreateTaskId(), chi::kAdminPoolId, chi::PoolQuery::Local());
     auto task2 = ipc_manager->NewTask<clio::run::admin::FlushTask>(
         chi::CreateTaskId(), chi::kAdminPoolId, chi::PoolQuery::Local());
 
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1->Aggregate(task2.template Cast<chi::Task>());
-      INFO("FlushTask Aggregate completed");
+      task1->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("FlushTask AggregateOut completed");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
   }
 
-  SECTION("Aggregate for MonitorTask") {
+  SECTION("AggregateOut for MonitorTask") {
     auto task1 = ipc_manager->NewTask<clio::run::admin::MonitorTask>(
         chi::CreateTaskId(), chi::kAdminPoolId, chi::PoolQuery::Local(), std::string("status"));
     auto task2 = ipc_manager->NewTask<clio::run::admin::MonitorTask>(
         chi::CreateTaskId(), chi::kAdminPoolId, chi::PoolQuery::Local(), std::string("status"));
 
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1->Aggregate(task2.template Cast<chi::Task>());
-      INFO("MonitorTask Aggregate completed");
+      task1->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("MonitorTask AggregateOut completed");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
   }
 
-  SECTION("Aggregate for ClientConnectTask") {
+  SECTION("AggregateOut for ClientConnectTask") {
     auto task1 = ipc_manager->NewTask<clio::run::admin::ClientConnectTask>(
         chi::CreateTaskId(), chi::kAdminPoolId, chi::PoolQuery::Local());
     auto task2 = ipc_manager->NewTask<clio::run::admin::ClientConnectTask>(
         chi::CreateTaskId(), chi::kAdminPoolId, chi::PoolQuery::Local());
 
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1->Aggregate(task2.template Cast<chi::Task>());
-      INFO("ClientConnectTask Aggregate completed");
+      task1->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("ClientConnectTask AggregateOut completed");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
@@ -2882,12 +2882,12 @@ TEST_CASE("Autogen - Admin Container advanced operations", "[autogen][admin][con
     }
   }
 
-  SECTION("Admin Container Aggregate for multiple methods") {
+  SECTION("Admin Container AggregateOut for multiple methods") {
     auto task1a = admin_container->NewTask(clio::run::admin::Method::kFlush);
     auto task1b = admin_container->NewTask(clio::run::admin::Method::kFlush);
     if (!task1a.IsNull() && !task1b.IsNull()) {
-      task1a.ptr_->Aggregate(task1b.template Cast<chi::Task>());
-      INFO("Admin Container Aggregate for Flush completed");
+      task1a.ptr_->AggregateOut(task1b.template Cast<chi::Task>());
+      INFO("Admin Container AggregateOut for Flush completed");
       CLIO_IPC->DelTask(task1a);
       CLIO_IPC->DelTask(task1b);
     }
@@ -2895,8 +2895,8 @@ TEST_CASE("Autogen - Admin Container advanced operations", "[autogen][admin][con
     auto task2a = admin_container->NewTask(clio::run::admin::Method::kClientConnect);
     auto task2b = admin_container->NewTask(clio::run::admin::Method::kClientConnect);
     if (!task2a.IsNull() && !task2b.IsNull()) {
-      task2a.ptr_->Aggregate(task2b.template Cast<chi::Task>());
-      INFO("Admin Container Aggregate for ClientConnect completed");
+      task2a.ptr_->AggregateOut(task2b.template Cast<chi::Task>());
+      INFO("Admin Container AggregateOut for ClientConnect completed");
       CLIO_IPC->DelTask(task2a);
       CLIO_IPC->DelTask(task2b);
     }
@@ -2904,7 +2904,7 @@ TEST_CASE("Autogen - Admin Container advanced operations", "[autogen][admin][con
 }
 
 //==============================================================================
-// Additional CTE Copy/Aggregate tests for more coverage
+// Additional CTE Copy/AggregateOut tests for more coverage
 //==============================================================================
 
 TEST_CASE("Autogen - CTE Comprehensive Copy tests", "[autogen][cte][copy][comprehensive]") {
@@ -2936,10 +2936,10 @@ TEST_CASE("Autogen - CTE Comprehensive Copy tests", "[autogen][cte][copy][compre
 }
 
 //==============================================================================
-// Additional Bdev Copy/Aggregate tests for more coverage
+// Additional Bdev Copy/AggregateOut tests for more coverage
 //==============================================================================
 
-TEST_CASE("Autogen - Bdev Comprehensive Copy and Aggregate", "[autogen][bdev][comprehensive]") {
+TEST_CASE("Autogen - Bdev Comprehensive Copy and AggregateOut", "[autogen][bdev][comprehensive]") {
   EnsureInitialized();
 
   auto* ipc_manager = CLIO_IPC;
@@ -2956,13 +2956,13 @@ TEST_CASE("Autogen - Bdev Comprehensive Copy and Aggregate", "[autogen][bdev][co
     }
   }
 
-  SECTION("Additional Aggregate for Bdev tasks") {
-    // Aggregate for GetStatsTask
+  SECTION("Additional AggregateOut for Bdev tasks") {
+    // AggregateOut for GetStatsTask
     auto stats1 = ipc_manager->NewTask<clio::run::bdev::GetStatsTask>();
     auto stats2 = ipc_manager->NewTask<clio::run::bdev::GetStatsTask>();
     if (!stats1.IsNull() && !stats2.IsNull()) {
-      stats1->Aggregate(stats2.template Cast<chi::Task>());
-      INFO("GetStatsTask Aggregate completed");
+      stats1->AggregateOut(stats2.template Cast<chi::Task>());
+      INFO("GetStatsTask AggregateOut completed");
       CLIO_IPC->DelTask(stats1);
       CLIO_IPC->DelTask(stats2);
     }
@@ -2995,12 +2995,12 @@ TEST_CASE("Autogen - CAE Comprehensive tests", "[autogen][cae][comprehensive]") 
     }
   }
 
-  SECTION("Aggregate for CAE tasks") {
+  SECTION("AggregateOut for CAE tasks") {
     auto task1 = ipc_manager->NewTask<clio::cae::core::ParseOmniTask>();
     auto task2 = ipc_manager->NewTask<clio::cae::core::ParseOmniTask>();
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1->Aggregate(task2.template Cast<chi::Task>());
-      INFO("ParseOmniTask Aggregate completed");
+      task1->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("ParseOmniTask AggregateOut completed");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
@@ -3008,8 +3008,8 @@ TEST_CASE("Autogen - CAE Comprehensive tests", "[autogen][cae][comprehensive]") 
     auto hdf1 = ipc_manager->NewTask<clio::cae::core::ProcessHdf5DatasetTask>();
     auto hdf2 = ipc_manager->NewTask<clio::cae::core::ProcessHdf5DatasetTask>();
     if (!hdf1.IsNull() && !hdf2.IsNull()) {
-      hdf1->Aggregate(hdf2.template Cast<chi::Task>());
-      INFO("ProcessHdf5DatasetTask Aggregate completed");
+      hdf1->AggregateOut(hdf2.template Cast<chi::Task>());
+      INFO("ProcessHdf5DatasetTask AggregateOut completed");
       CLIO_IPC->DelTask(hdf1);
       CLIO_IPC->DelTask(hdf2);
     }
@@ -3017,10 +3017,10 @@ TEST_CASE("Autogen - CAE Comprehensive tests", "[autogen][cae][comprehensive]") 
 }
 
 //==============================================================================
-// Additional Admin Copy/Aggregate tests for more coverage
+// Additional Admin Copy/AggregateOut tests for more coverage
 //==============================================================================
 
-TEST_CASE("Autogen - Admin Comprehensive Copy and Aggregate", "[autogen][admin][comprehensive]") {
+TEST_CASE("Autogen - Admin Comprehensive Copy and AggregateOut", "[autogen][admin][comprehensive]") {
   EnsureInitialized();
 
   auto* ipc_manager = CLIO_IPC;
@@ -3058,33 +3058,33 @@ TEST_CASE("Autogen - Admin Comprehensive Copy and Aggregate", "[autogen][admin][
 
   }
 
-  SECTION("More Aggregate tests for Admin") {
-    // Aggregate for SubmitBatchTask
+  SECTION("More AggregateOut tests for Admin") {
+    // AggregateOut for SubmitBatchTask
     auto batch1 = ipc_manager->NewTask<clio::run::admin::SubmitBatchTask>();
     auto batch2 = ipc_manager->NewTask<clio::run::admin::SubmitBatchTask>();
     if (!batch1.IsNull() && !batch2.IsNull()) {
-      batch1->Aggregate(batch2.template Cast<chi::Task>());
-      INFO("SubmitBatchTask Aggregate completed");
+      batch1->AggregateOut(batch2.template Cast<chi::Task>());
+      INFO("SubmitBatchTask AggregateOut completed");
       CLIO_IPC->DelTask(batch1);
       CLIO_IPC->DelTask(batch2);
     }
 
-    // Aggregate for SendTask
+    // AggregateOut for SendTask
     auto send1 = ipc_manager->NewTask<clio::run::admin::SendTask>();
     auto send2 = ipc_manager->NewTask<clio::run::admin::SendTask>();
     if (!send1.IsNull() && !send2.IsNull()) {
-      send1->Aggregate(send2.template Cast<chi::Task>());
-      INFO("SendTask Aggregate completed");
+      send1->AggregateOut(send2.template Cast<chi::Task>());
+      INFO("SendTask AggregateOut completed");
       CLIO_IPC->DelTask(send1);
       CLIO_IPC->DelTask(send2);
     }
 
-    // Aggregate for RecvTask
+    // AggregateOut for RecvTask
     auto recv1 = ipc_manager->NewTask<clio::run::admin::RecvTask>();
     auto recv2 = ipc_manager->NewTask<clio::run::admin::RecvTask>();
     if (!recv1.IsNull() && !recv2.IsNull()) {
-      recv1->Aggregate(recv2.template Cast<chi::Task>());
-      INFO("RecvTask Aggregate completed");
+      recv1->AggregateOut(recv2.template Cast<chi::Task>());
+      INFO("RecvTask AggregateOut completed");
       CLIO_IPC->DelTask(recv1);
       CLIO_IPC->DelTask(recv2);
     }
@@ -3821,8 +3821,8 @@ TEST_CASE("Autogen - More Bdev Container coverage", "[autogen][bdev][more]") {
     auto alloc2 = ipc_manager->NewTask<clio::run::bdev::AllocateBlocksTask>();
     if (!alloc1.IsNull() && !alloc2.IsNull()) {
       alloc2->Copy(alloc1);
-      alloc1->Aggregate(alloc2.template Cast<chi::Task>());
-      INFO("AllocateBlocksTask Copy+Aggregate completed");
+      alloc1->AggregateOut(alloc2.template Cast<chi::Task>());
+      INFO("AllocateBlocksTask Copy+AggregateOut completed");
       CLIO_IPC->DelTask(alloc1);
       CLIO_IPC->DelTask(alloc2);
     }
@@ -3832,8 +3832,8 @@ TEST_CASE("Autogen - More Bdev Container coverage", "[autogen][bdev][more]") {
     auto free2 = ipc_manager->NewTask<clio::run::bdev::FreeBlocksTask>();
     if (!free1.IsNull() && !free2.IsNull()) {
       free2->Copy(free1);
-      free1->Aggregate(free2.template Cast<chi::Task>());
-      INFO("FreeBlocksTask Copy+Aggregate completed");
+      free1->AggregateOut(free2.template Cast<chi::Task>());
+      INFO("FreeBlocksTask Copy+AggregateOut completed");
       CLIO_IPC->DelTask(free1);
       CLIO_IPC->DelTask(free2);
     }
@@ -3843,8 +3843,8 @@ TEST_CASE("Autogen - More Bdev Container coverage", "[autogen][bdev][more]") {
     auto write2 = ipc_manager->NewTask<clio::run::bdev::WriteTask>();
     if (!write1.IsNull() && !write2.IsNull()) {
       write2->Copy(write1);
-      write1->Aggregate(write2.template Cast<chi::Task>());
-      INFO("WriteTask Copy+Aggregate completed");
+      write1->AggregateOut(write2.template Cast<chi::Task>());
+      INFO("WriteTask Copy+AggregateOut completed");
       CLIO_IPC->DelTask(write1);
       CLIO_IPC->DelTask(write2);
     }
@@ -3854,8 +3854,8 @@ TEST_CASE("Autogen - More Bdev Container coverage", "[autogen][bdev][more]") {
     auto read2 = ipc_manager->NewTask<clio::run::bdev::ReadTask>();
     if (!read1.IsNull() && !read2.IsNull()) {
       read2->Copy(read1);
-      read1->Aggregate(read2.template Cast<chi::Task>());
-      INFO("ReadTask Copy+Aggregate completed");
+      read1->AggregateOut(read2.template Cast<chi::Task>());
+      INFO("ReadTask Copy+AggregateOut completed");
       CLIO_IPC->DelTask(read1);
       CLIO_IPC->DelTask(read2);
     }
@@ -3865,8 +3865,8 @@ TEST_CASE("Autogen - More Bdev Container coverage", "[autogen][bdev][more]") {
     auto stats2 = ipc_manager->NewTask<clio::run::bdev::GetStatsTask>();
     if (!stats1.IsNull() && !stats2.IsNull()) {
       stats2->Copy(stats1);
-      stats1->Aggregate(stats2.template Cast<chi::Task>());
-      INFO("GetStatsTask Copy+Aggregate completed");
+      stats1->AggregateOut(stats2.template Cast<chi::Task>());
+      INFO("GetStatsTask Copy+AggregateOut completed");
       CLIO_IPC->DelTask(stats1);
       CLIO_IPC->DelTask(stats2);
     }
@@ -3874,7 +3874,7 @@ TEST_CASE("Autogen - More Bdev Container coverage", "[autogen][bdev][more]") {
 }
 
 //==============================================================================
-// CAE Container NewCopyTask and Aggregate coverage
+// CAE Container NewCopyTask and AggregateOut coverage
 //==============================================================================
 
 TEST_CASE("Autogen - CAE Container operations", "[autogen][cae][container][ops]") {
@@ -3882,14 +3882,14 @@ TEST_CASE("Autogen - CAE Container operations", "[autogen][cae][container][ops]"
 
   auto* ipc_manager = CLIO_IPC;
 
-  SECTION("CAE task Copy and Aggregate") {
+  SECTION("CAE task Copy and AggregateOut") {
     // ParseOmniTask
     auto parse1 = ipc_manager->NewTask<clio::cae::core::ParseOmniTask>();
     auto parse2 = ipc_manager->NewTask<clio::cae::core::ParseOmniTask>();
     if (!parse1.IsNull() && !parse2.IsNull()) {
       parse2->Copy(parse1);
-      parse1->Aggregate(parse2.template Cast<chi::Task>());
-      INFO("ParseOmniTask Copy+Aggregate completed");
+      parse1->AggregateOut(parse2.template Cast<chi::Task>());
+      INFO("ParseOmniTask Copy+AggregateOut completed");
       CLIO_IPC->DelTask(parse1);
       CLIO_IPC->DelTask(parse2);
     }
@@ -3899,8 +3899,8 @@ TEST_CASE("Autogen - CAE Container operations", "[autogen][cae][container][ops]"
     auto hdf2 = ipc_manager->NewTask<clio::cae::core::ProcessHdf5DatasetTask>();
     if (!hdf1.IsNull() && !hdf2.IsNull()) {
       hdf2->Copy(hdf1);
-      hdf1->Aggregate(hdf2.template Cast<chi::Task>());
-      INFO("ProcessHdf5DatasetTask Copy+Aggregate completed");
+      hdf1->AggregateOut(hdf2.template Cast<chi::Task>());
+      INFO("ProcessHdf5DatasetTask Copy+AggregateOut completed");
       CLIO_IPC->DelTask(hdf1);
       CLIO_IPC->DelTask(hdf2);
     }
@@ -3908,153 +3908,153 @@ TEST_CASE("Autogen - CAE Container operations", "[autogen][cae][container][ops]"
 }
 
 //==============================================================================
-// More CTE Copy and Aggregate tests for remaining tasks
+// More CTE Copy and AggregateOut tests for remaining tasks
 //==============================================================================
 
-TEST_CASE("Autogen - CTE Remaining tasks Copy and Aggregate", "[autogen][cte][remaining]") {
+TEST_CASE("Autogen - CTE Remaining tasks Copy and AggregateOut", "[autogen][cte][remaining]") {
   EnsureInitialized();
 
   auto* ipc_manager = CLIO_IPC;
 
-  SECTION("DelBlobTask Copy+Aggregate") {
+  SECTION("DelBlobTask Copy+AggregateOut") {
     auto task1 = ipc_manager->NewTask<clio::cte::core::DelBlobTask>();
     auto task2 = ipc_manager->NewTask<clio::cte::core::DelBlobTask>();
     if (!task1.IsNull() && !task2.IsNull()) {
       task2->Copy(task1);
-      task1->Aggregate(task2.template Cast<chi::Task>());
-      INFO("DelBlobTask Copy+Aggregate completed");
+      task1->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("DelBlobTask Copy+AggregateOut completed");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
   }
 
-  SECTION("DelTagTask Copy+Aggregate") {
+  SECTION("DelTagTask Copy+AggregateOut") {
     auto task1 = ipc_manager->NewTask<clio::cte::core::DelTagTask>();
     auto task2 = ipc_manager->NewTask<clio::cte::core::DelTagTask>();
     if (!task1.IsNull() && !task2.IsNull()) {
       task2->Copy(task1);
-      task1->Aggregate(task2.template Cast<chi::Task>());
-      INFO("DelTagTask Copy+Aggregate completed");
+      task1->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("DelTagTask Copy+AggregateOut completed");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
   }
 
-  SECTION("GetTagSizeTask Copy+Aggregate") {
+  SECTION("GetTagSizeTask Copy+AggregateOut") {
     auto task1 = ipc_manager->NewTask<clio::cte::core::GetTagSizeTask>();
     auto task2 = ipc_manager->NewTask<clio::cte::core::GetTagSizeTask>();
     if (!task1.IsNull() && !task2.IsNull()) {
       task2->Copy(task1);
-      task1->Aggregate(task2.template Cast<chi::Task>());
-      INFO("GetTagSizeTask Copy+Aggregate completed");
+      task1->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("GetTagSizeTask Copy+AggregateOut completed");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
   }
 
-  SECTION("PollTelemetryLogTask Copy+Aggregate") {
+  SECTION("PollTelemetryLogTask Copy+AggregateOut") {
     auto task1 = ipc_manager->NewTask<clio::cte::core::PollTelemetryLogTask>();
     auto task2 = ipc_manager->NewTask<clio::cte::core::PollTelemetryLogTask>();
     if (!task1.IsNull() && !task2.IsNull()) {
       task2->Copy(task1);
-      task1->Aggregate(task2.template Cast<chi::Task>());
-      INFO("PollTelemetryLogTask Copy+Aggregate completed");
+      task1->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("PollTelemetryLogTask Copy+AggregateOut completed");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
   }
 
-  SECTION("GetBlobScoreTask Copy+Aggregate") {
+  SECTION("GetBlobScoreTask Copy+AggregateOut") {
     auto task1 = ipc_manager->NewTask<clio::cte::core::GetBlobScoreTask>();
     auto task2 = ipc_manager->NewTask<clio::cte::core::GetBlobScoreTask>();
     if (!task1.IsNull() && !task2.IsNull()) {
       task2->Copy(task1);
-      task1->Aggregate(task2.template Cast<chi::Task>());
-      INFO("GetBlobScoreTask Copy+Aggregate completed");
+      task1->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("GetBlobScoreTask Copy+AggregateOut completed");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
   }
 
-  SECTION("GetBlobSizeTask Copy+Aggregate") {
+  SECTION("GetBlobSizeTask Copy+AggregateOut") {
     auto task1 = ipc_manager->NewTask<clio::cte::core::GetBlobSizeTask>();
     auto task2 = ipc_manager->NewTask<clio::cte::core::GetBlobSizeTask>();
     if (!task1.IsNull() && !task2.IsNull()) {
       task2->Copy(task1);
-      task1->Aggregate(task2.template Cast<chi::Task>());
-      INFO("GetBlobSizeTask Copy+Aggregate completed");
+      task1->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("GetBlobSizeTask Copy+AggregateOut completed");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
   }
 
-  SECTION("GetContainedBlobsTask Copy+Aggregate") {
+  SECTION("GetContainedBlobsTask Copy+AggregateOut") {
     auto task1 = ipc_manager->NewTask<clio::cte::core::GetContainedBlobsTask>();
     auto task2 = ipc_manager->NewTask<clio::cte::core::GetContainedBlobsTask>();
     if (!task1.IsNull() && !task2.IsNull()) {
       task2->Copy(task1);
-      task1->Aggregate(task2.template Cast<chi::Task>());
-      INFO("GetContainedBlobsTask Copy+Aggregate completed");
+      task1->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("GetContainedBlobsTask Copy+AggregateOut completed");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
   }
 
-  SECTION("TagQueryTask Copy+Aggregate") {
+  SECTION("TagQueryTask Copy+AggregateOut") {
     auto task1 = ipc_manager->NewTask<clio::cte::core::TagQueryTask>();
     auto task2 = ipc_manager->NewTask<clio::cte::core::TagQueryTask>();
     if (!task1.IsNull() && !task2.IsNull()) {
       task2->Copy(task1);
-      task1->Aggregate(task2.template Cast<chi::Task>());
-      INFO("TagQueryTask Copy+Aggregate completed");
+      task1->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("TagQueryTask Copy+AggregateOut completed");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
   }
 
-  SECTION("BlobQueryTask Copy+Aggregate") {
+  SECTION("BlobQueryTask Copy+AggregateOut") {
     auto task1 = ipc_manager->NewTask<clio::cte::core::BlobQueryTask>();
     auto task2 = ipc_manager->NewTask<clio::cte::core::BlobQueryTask>();
     if (!task1.IsNull() && !task2.IsNull()) {
       task2->Copy(task1);
-      task1->Aggregate(task2.template Cast<chi::Task>());
-      INFO("BlobQueryTask Copy+Aggregate completed");
+      task1->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("BlobQueryTask Copy+AggregateOut completed");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
   }
 
-  SECTION("ReorganizeBlobTask Copy+Aggregate") {
+  SECTION("ReorganizeBlobTask Copy+AggregateOut") {
     auto task1 = ipc_manager->NewTask<clio::cte::core::ReorganizeBlobTask>();
     auto task2 = ipc_manager->NewTask<clio::cte::core::ReorganizeBlobTask>();
     if (!task1.IsNull() && !task2.IsNull()) {
       task2->Copy(task1);
-      task1->Aggregate(task2.template Cast<chi::Task>());
-      INFO("ReorganizeBlobTask Copy+Aggregate completed");
+      task1->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("ReorganizeBlobTask Copy+AggregateOut completed");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
   }
 
-  SECTION("StatTargetsTask Copy+Aggregate") {
+  SECTION("StatTargetsTask Copy+AggregateOut") {
     auto task1 = ipc_manager->NewTask<clio::cte::core::StatTargetsTask>();
     auto task2 = ipc_manager->NewTask<clio::cte::core::StatTargetsTask>();
     if (!task1.IsNull() && !task2.IsNull()) {
       task2->Copy(task1);
-      task1->Aggregate(task2.template Cast<chi::Task>());
-      INFO("StatTargetsTask Copy+Aggregate completed");
+      task1->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("StatTargetsTask Copy+AggregateOut completed");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
   }
 
-  SECTION("UnregisterTargetTask Copy+Aggregate") {
+  SECTION("UnregisterTargetTask Copy+AggregateOut") {
     auto task1 = ipc_manager->NewTask<clio::cte::core::UnregisterTargetTask>();
     auto task2 = ipc_manager->NewTask<clio::cte::core::UnregisterTargetTask>();
     if (!task1.IsNull() && !task2.IsNull()) {
       task2->Copy(task1);
-      task1->Aggregate(task2.template Cast<chi::Task>());
-      INFO("UnregisterTargetTask Copy+Aggregate completed");
+      task1->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("UnregisterTargetTask Copy+AggregateOut completed");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
@@ -4187,10 +4187,10 @@ TEST_CASE("Autogen - Admin NewCopyTask comprehensive", "[autogen][admin][newcopy
 }
 
 //==============================================================================
-// Admin Container comprehensive Aggregate coverage
+// Admin Container comprehensive AggregateOut coverage
 //==============================================================================
 
-TEST_CASE("Autogen - Admin Aggregate comprehensive", "[autogen][admin][aggregate][comprehensive]") {
+TEST_CASE("Autogen - Admin AggregateOut comprehensive", "[autogen][admin][aggregate][comprehensive]") {
   EnsureInitialized();
 
   auto* ipc_manager = CLIO_IPC;
@@ -4202,100 +4202,100 @@ TEST_CASE("Autogen - Admin Aggregate comprehensive", "[autogen][admin][aggregate
     return;
   }
 
-  SECTION("Aggregate for Create") {
+  SECTION("AggregateOut for Create") {
     auto t1 = admin_container->NewTask(clio::run::admin::Method::kCreate);
     auto t2 = admin_container->NewTask(clio::run::admin::Method::kCreate);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
-      INFO("Admin Aggregate for Create completed");
+      t1.ptr_->AggregateOut(t2.template Cast<chi::Task>());
+      INFO("Admin AggregateOut for Create completed");
       CLIO_IPC->DelTask(t1);
       CLIO_IPC->DelTask(t2);
     }
   }
 
-  SECTION("Aggregate for Destroy") {
+  SECTION("AggregateOut for Destroy") {
     auto t1 = admin_container->NewTask(clio::run::admin::Method::kDestroy);
     auto t2 = admin_container->NewTask(clio::run::admin::Method::kDestroy);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
-      INFO("Admin Aggregate for Destroy completed");
+      t1.ptr_->AggregateOut(t2.template Cast<chi::Task>());
+      INFO("Admin AggregateOut for Destroy completed");
       CLIO_IPC->DelTask(t1);
       CLIO_IPC->DelTask(t2);
     }
   }
 
-  SECTION("Aggregate for StopRuntime") {
+  SECTION("AggregateOut for StopRuntime") {
     auto t1 = admin_container->NewTask(clio::run::admin::Method::kStopRuntime);
     auto t2 = admin_container->NewTask(clio::run::admin::Method::kStopRuntime);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
-      INFO("Admin Aggregate for StopRuntime completed");
+      t1.ptr_->AggregateOut(t2.template Cast<chi::Task>());
+      INFO("Admin AggregateOut for StopRuntime completed");
       CLIO_IPC->DelTask(t1);
       CLIO_IPC->DelTask(t2);
     }
   }
 
-  SECTION("Aggregate for DestroyPool") {
+  SECTION("AggregateOut for DestroyPool") {
     auto t1 = admin_container->NewTask(clio::run::admin::Method::kDestroyPool);
     auto t2 = admin_container->NewTask(clio::run::admin::Method::kDestroyPool);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
-      INFO("Admin Aggregate for DestroyPool completed");
+      t1.ptr_->AggregateOut(t2.template Cast<chi::Task>());
+      INFO("Admin AggregateOut for DestroyPool completed");
       CLIO_IPC->DelTask(t1);
       CLIO_IPC->DelTask(t2);
     }
   }
 
-  SECTION("Aggregate for GetOrCreatePool") {
+  SECTION("AggregateOut for GetOrCreatePool") {
     auto t1 = admin_container->NewTask(clio::run::admin::Method::kGetOrCreatePool);
     auto t2 = admin_container->NewTask(clio::run::admin::Method::kGetOrCreatePool);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
-      INFO("Admin Aggregate for GetOrCreatePool completed");
+      t1.ptr_->AggregateOut(t2.template Cast<chi::Task>());
+      INFO("Admin AggregateOut for GetOrCreatePool completed");
       CLIO_IPC->DelTask(t1);
       CLIO_IPC->DelTask(t2);
     }
   }
 
-  SECTION("Aggregate for SubmitBatch") {
+  SECTION("AggregateOut for SubmitBatch") {
     auto t1 = admin_container->NewTask(clio::run::admin::Method::kSubmitBatch);
     auto t2 = admin_container->NewTask(clio::run::admin::Method::kSubmitBatch);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
-      INFO("Admin Aggregate for SubmitBatch completed");
+      t1.ptr_->AggregateOut(t2.template Cast<chi::Task>());
+      INFO("Admin AggregateOut for SubmitBatch completed");
       CLIO_IPC->DelTask(t1);
       CLIO_IPC->DelTask(t2);
     }
   }
 
-  SECTION("Aggregate for Send") {
+  SECTION("AggregateOut for Send") {
     auto t1 = admin_container->NewTask(clio::run::admin::Method::kSend);
     auto t2 = admin_container->NewTask(clio::run::admin::Method::kSend);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
-      INFO("Admin Aggregate for Send completed");
+      t1.ptr_->AggregateOut(t2.template Cast<chi::Task>());
+      INFO("Admin AggregateOut for Send completed");
       CLIO_IPC->DelTask(t1);
       CLIO_IPC->DelTask(t2);
     }
   }
 
-  SECTION("Aggregate for Recv") {
+  SECTION("AggregateOut for Recv") {
     auto t1 = admin_container->NewTask(clio::run::admin::Method::kRecv);
     auto t2 = admin_container->NewTask(clio::run::admin::Method::kRecv);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
-      INFO("Admin Aggregate for Recv completed");
+      t1.ptr_->AggregateOut(t2.template Cast<chi::Task>());
+      INFO("Admin AggregateOut for Recv completed");
       CLIO_IPC->DelTask(t1);
       CLIO_IPC->DelTask(t2);
     }
   }
 
-  SECTION("Aggregate for Monitor") {
+  SECTION("AggregateOut for Monitor") {
     auto t1 = admin_container->NewTask(clio::run::admin::Method::kMonitor);
     auto t2 = admin_container->NewTask(clio::run::admin::Method::kMonitor);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
-      INFO("Admin Aggregate for Monitor completed");
+      t1.ptr_->AggregateOut(t2.template Cast<chi::Task>());
+      INFO("Admin AggregateOut for Monitor completed");
       CLIO_IPC->DelTask(t1);
       CLIO_IPC->DelTask(t2);
     }
@@ -4694,12 +4694,12 @@ TEST_CASE("Autogen - Bdev All Methods Comprehensive", "[autogen][bdev][all][comp
       load_in >> *loaded_in;
       INFO("AllocateBlocksTask SerializeIn completed");
 
-      // Copy and Aggregate
+      // Copy and AggregateOut
       auto task2 = ipc_manager->NewTask<clio::run::bdev::AllocateBlocksTask>();
       if (!task2.IsNull()) {
         task2->Copy(task);
-        task->Aggregate(task2.template Cast<chi::Task>());
-        INFO("AllocateBlocksTask Copy+Aggregate completed");
+        task->AggregateOut(task2.template Cast<chi::Task>());
+        INFO("AllocateBlocksTask Copy+AggregateOut completed");
         CLIO_IPC->DelTask(task2);
       }
 
@@ -4722,8 +4722,8 @@ TEST_CASE("Autogen - Bdev All Methods Comprehensive", "[autogen][bdev][all][comp
       auto task2 = ipc_manager->NewTask<clio::run::bdev::FreeBlocksTask>();
       if (!task2.IsNull()) {
         task2->Copy(task);
-        task->Aggregate(task2.template Cast<chi::Task>());
-        INFO("FreeBlocksTask Copy+Aggregate completed");
+        task->AggregateOut(task2.template Cast<chi::Task>());
+        INFO("FreeBlocksTask Copy+AggregateOut completed");
         CLIO_IPC->DelTask(task2);
       }
 
@@ -4746,8 +4746,8 @@ TEST_CASE("Autogen - Bdev All Methods Comprehensive", "[autogen][bdev][all][comp
       auto task2 = ipc_manager->NewTask<clio::run::bdev::WriteTask>();
       if (!task2.IsNull()) {
         task2->Copy(task);
-        task->Aggregate(task2.template Cast<chi::Task>());
-        INFO("WriteTask Copy+Aggregate completed");
+        task->AggregateOut(task2.template Cast<chi::Task>());
+        INFO("WriteTask Copy+AggregateOut completed");
         CLIO_IPC->DelTask(task2);
       }
 
@@ -4770,8 +4770,8 @@ TEST_CASE("Autogen - Bdev All Methods Comprehensive", "[autogen][bdev][all][comp
       auto task2 = ipc_manager->NewTask<clio::run::bdev::ReadTask>();
       if (!task2.IsNull()) {
         task2->Copy(task);
-        task->Aggregate(task2.template Cast<chi::Task>());
-        INFO("ReadTask Copy+Aggregate completed");
+        task->AggregateOut(task2.template Cast<chi::Task>());
+        INFO("ReadTask Copy+AggregateOut completed");
         CLIO_IPC->DelTask(task2);
       }
 
@@ -4794,8 +4794,8 @@ TEST_CASE("Autogen - Bdev All Methods Comprehensive", "[autogen][bdev][all][comp
       auto task2 = ipc_manager->NewTask<clio::run::bdev::GetStatsTask>();
       if (!task2.IsNull()) {
         task2->Copy(task);
-        task->Aggregate(task2.template Cast<chi::Task>());
-        INFO("GetStatsTask Copy+Aggregate completed");
+        task->AggregateOut(task2.template Cast<chi::Task>());
+        INFO("GetStatsTask Copy+AggregateOut completed");
         CLIO_IPC->DelTask(task2);
       }
 
@@ -4827,7 +4827,7 @@ TEST_CASE("Autogen - Admin All Methods Comprehensive", "[autogen][admin][all][co
       auto task2 = ipc_manager->NewTask<clio::run::admin::CreateTask>();
       if (!task2.IsNull()) {
         task2->Copy(task);
-        task->Aggregate(task2.template Cast<chi::Task>());
+        task->AggregateOut(task2.template Cast<chi::Task>());
         CLIO_IPC->DelTask(task2);
       }
       INFO("CreateTask full coverage completed");
@@ -4849,7 +4849,7 @@ TEST_CASE("Autogen - Admin All Methods Comprehensive", "[autogen][admin][all][co
       auto task2 = ipc_manager->NewTask<clio::run::admin::DestroyTask>();
       if (!task2.IsNull()) {
         task2->Copy(task);
-        task->Aggregate(task2.template Cast<chi::Task>());
+        task->AggregateOut(task2.template Cast<chi::Task>());
         CLIO_IPC->DelTask(task2);
       }
       INFO("DestroyTask full coverage completed");
@@ -4871,7 +4871,7 @@ TEST_CASE("Autogen - Admin All Methods Comprehensive", "[autogen][admin][all][co
       auto task2 = ipc_manager->NewTask<clio::run::admin::StopRuntimeTask>();
       if (!task2.IsNull()) {
         task2->Copy(task);
-        task->Aggregate(task2.template Cast<chi::Task>());
+        task->AggregateOut(task2.template Cast<chi::Task>());
         CLIO_IPC->DelTask(task2);
       }
       INFO("StopRuntimeTask full coverage completed");
@@ -4893,7 +4893,7 @@ TEST_CASE("Autogen - Admin All Methods Comprehensive", "[autogen][admin][all][co
       auto task2 = ipc_manager->NewTask<clio::run::admin::DestroyPoolTask>();
       if (!task2.IsNull()) {
         task2->Copy(task);
-        task->Aggregate(task2.template Cast<chi::Task>());
+        task->AggregateOut(task2.template Cast<chi::Task>());
         CLIO_IPC->DelTask(task2);
       }
       INFO("DestroyPoolTask full coverage completed");
@@ -4915,7 +4915,7 @@ TEST_CASE("Autogen - Admin All Methods Comprehensive", "[autogen][admin][all][co
       auto task2 = ipc_manager->NewTask<clio::run::admin::SubmitBatchTask>();
       if (!task2.IsNull()) {
         task2->Copy(task);
-        task->Aggregate(task2.template Cast<chi::Task>());
+        task->AggregateOut(task2.template Cast<chi::Task>());
         CLIO_IPC->DelTask(task2);
       }
       INFO("SubmitBatchTask full coverage completed");
@@ -4937,7 +4937,7 @@ TEST_CASE("Autogen - Admin All Methods Comprehensive", "[autogen][admin][all][co
       auto task2 = ipc_manager->NewTask<clio::run::admin::SendTask>();
       if (!task2.IsNull()) {
         task2->Copy(task);
-        task->Aggregate(task2.template Cast<chi::Task>());
+        task->AggregateOut(task2.template Cast<chi::Task>());
         CLIO_IPC->DelTask(task2);
       }
       INFO("SendTask full coverage completed");
@@ -4959,7 +4959,7 @@ TEST_CASE("Autogen - Admin All Methods Comprehensive", "[autogen][admin][all][co
       auto task2 = ipc_manager->NewTask<clio::run::admin::RecvTask>();
       if (!task2.IsNull()) {
         task2->Copy(task);
-        task->Aggregate(task2.template Cast<chi::Task>());
+        task->AggregateOut(task2.template Cast<chi::Task>());
         CLIO_IPC->DelTask(task2);
       }
       INFO("RecvTask full coverage completed");
@@ -4984,7 +4984,7 @@ TEST_CASE("Autogen - Admin All Methods Comprehensive", "[autogen][admin][all][co
           chi::CreateTaskId(), chi::kAdminPoolId, chi::PoolQuery::Local());
       if (!task2.IsNull()) {
         task2->Copy(task);
-        task->Aggregate(task2.template Cast<chi::Task>());
+        task->AggregateOut(task2.template Cast<chi::Task>());
         CLIO_IPC->DelTask(task2);
       }
       INFO("FlushTask full coverage completed");
@@ -5009,7 +5009,7 @@ TEST_CASE("Autogen - Admin All Methods Comprehensive", "[autogen][admin][all][co
           chi::CreateTaskId(), chi::kAdminPoolId, chi::PoolQuery::Local(), std::string("status"));
       if (!task2.IsNull()) {
         task2->Copy(task);
-        task->Aggregate(task2.template Cast<chi::Task>());
+        task->AggregateOut(task2.template Cast<chi::Task>());
         CLIO_IPC->DelTask(task2);
       }
       INFO("MonitorTask full coverage completed");
@@ -5034,7 +5034,7 @@ TEST_CASE("Autogen - Admin All Methods Comprehensive", "[autogen][admin][all][co
           chi::CreateTaskId(), chi::kAdminPoolId, chi::PoolQuery::Local());
       if (!task2.IsNull()) {
         task2->Copy(task);
-        task->Aggregate(task2.template Cast<chi::Task>());
+        task->AggregateOut(task2.template Cast<chi::Task>());
         CLIO_IPC->DelTask(task2);
       }
       INFO("ClientConnectTask full coverage completed");
@@ -5074,12 +5074,12 @@ TEST_CASE("Autogen - CAE All Methods Comprehensive", "[autogen][cae][all][compre
       load_out >> *loaded_out;
       INFO("ParseOmniTask SerializeOut completed");
 
-      // Copy and Aggregate
+      // Copy and AggregateOut
       auto task2 = ipc_manager->NewTask<clio::cae::core::ParseOmniTask>();
       if (!task2.IsNull()) {
         task2->Copy(task);
-        task->Aggregate(task2.template Cast<chi::Task>());
-        INFO("ParseOmniTask Copy+Aggregate completed");
+        task->AggregateOut(task2.template Cast<chi::Task>());
+        INFO("ParseOmniTask Copy+AggregateOut completed");
         CLIO_IPC->DelTask(task2);
       }
 
@@ -5110,12 +5110,12 @@ TEST_CASE("Autogen - CAE All Methods Comprehensive", "[autogen][cae][all][compre
       load_out >> *loaded_out;
       INFO("ProcessHdf5DatasetTask SerializeOut completed");
 
-      // Copy and Aggregate
+      // Copy and AggregateOut
       auto task2 = ipc_manager->NewTask<clio::cae::core::ProcessHdf5DatasetTask>();
       if (!task2.IsNull()) {
         task2->Copy(task);
-        task->Aggregate(task2.template Cast<chi::Task>());
-        INFO("ProcessHdf5DatasetTask Copy+Aggregate completed");
+        task->AggregateOut(task2.template Cast<chi::Task>());
+        INFO("ProcessHdf5DatasetTask Copy+AggregateOut completed");
         CLIO_IPC->DelTask(task2);
       }
 
@@ -5153,9 +5153,9 @@ TEST_CASE("Autogen - CTE Full Coverage Per Task", "[autogen][cte][full]") {
       lo.msg_type_ = chi::MsgType::kSerializeOut;
       auto l2 = ipc_manager->NewTask<clio::cte::core::RegisterTargetTask>();
       lo >> *l2;
-      // Copy and Aggregate
+      // Copy and AggregateOut
       t2->Copy(t1);
-      t1->Aggregate(t2.template Cast<chi::Task>());
+      t1->AggregateOut(t2.template Cast<chi::Task>());
       INFO("RegisterTargetTask full completed");
       CLIO_IPC->DelTask(l1);
       CLIO_IPC->DelTask(l2);
@@ -5181,7 +5181,7 @@ TEST_CASE("Autogen - CTE Full Coverage Per Task", "[autogen][cte][full]") {
       auto l2 = ipc_manager->NewTask<clio::cte::core::UnregisterTargetTask>();
       lo >> *l2;
       t2->Copy(t1);
-      t1->Aggregate(t2.template Cast<chi::Task>());
+      t1->AggregateOut(t2.template Cast<chi::Task>());
       INFO("UnregisterTargetTask full completed");
       CLIO_IPC->DelTask(l1);
       CLIO_IPC->DelTask(l2);
@@ -5207,7 +5207,7 @@ TEST_CASE("Autogen - CTE Full Coverage Per Task", "[autogen][cte][full]") {
       auto l2 = ipc_manager->NewTask<clio::cte::core::ListTargetsTask>();
       lo >> *l2;
       t2->Copy(t1);
-      t1->Aggregate(t2.template Cast<chi::Task>());
+      t1->AggregateOut(t2.template Cast<chi::Task>());
       INFO("ListTargetsTask full completed");
       CLIO_IPC->DelTask(l1);
       CLIO_IPC->DelTask(l2);
@@ -5233,7 +5233,7 @@ TEST_CASE("Autogen - CTE Full Coverage Per Task", "[autogen][cte][full]") {
       auto l2 = ipc_manager->NewTask<clio::cte::core::StatTargetsTask>();
       lo >> *l2;
       t2->Copy(t1);
-      t1->Aggregate(t2.template Cast<chi::Task>());
+      t1->AggregateOut(t2.template Cast<chi::Task>());
       INFO("StatTargetsTask full completed");
       CLIO_IPC->DelTask(l1);
       CLIO_IPC->DelTask(l2);
@@ -5259,7 +5259,7 @@ TEST_CASE("Autogen - CTE Full Coverage Per Task", "[autogen][cte][full]") {
       auto l2 = ipc_manager->NewTask<clio::cte::core::PutBlobTask>();
       lo >> *l2;
       t2->Copy(t1);
-      t1->Aggregate(t2.template Cast<chi::Task>());
+      t1->AggregateOut(t2.template Cast<chi::Task>());
       INFO("PutBlobTask full completed");
       CLIO_IPC->DelTask(l1);
       CLIO_IPC->DelTask(l2);
@@ -5285,7 +5285,7 @@ TEST_CASE("Autogen - CTE Full Coverage Per Task", "[autogen][cte][full]") {
       auto l2 = ipc_manager->NewTask<clio::cte::core::GetBlobTask>();
       lo >> *l2;
       t2->Copy(t1);
-      t1->Aggregate(t2.template Cast<chi::Task>());
+      t1->AggregateOut(t2.template Cast<chi::Task>());
       INFO("GetBlobTask full completed");
       CLIO_IPC->DelTask(l1);
       CLIO_IPC->DelTask(l2);
@@ -5311,7 +5311,7 @@ TEST_CASE("Autogen - CTE Full Coverage Per Task", "[autogen][cte][full]") {
       auto l2 = ipc_manager->NewTask<clio::cte::core::ReorganizeBlobTask>();
       lo >> *l2;
       t2->Copy(t1);
-      t1->Aggregate(t2.template Cast<chi::Task>());
+      t1->AggregateOut(t2.template Cast<chi::Task>());
       INFO("ReorganizeBlobTask full completed");
       CLIO_IPC->DelTask(l1);
       CLIO_IPC->DelTask(l2);
@@ -5337,7 +5337,7 @@ TEST_CASE("Autogen - CTE Full Coverage Per Task", "[autogen][cte][full]") {
       auto l2 = ipc_manager->NewTask<clio::cte::core::DelBlobTask>();
       lo >> *l2;
       t2->Copy(t1);
-      t1->Aggregate(t2.template Cast<chi::Task>());
+      t1->AggregateOut(t2.template Cast<chi::Task>());
       INFO("DelBlobTask full completed");
       CLIO_IPC->DelTask(l1);
       CLIO_IPC->DelTask(l2);
@@ -5363,7 +5363,7 @@ TEST_CASE("Autogen - CTE Full Coverage Per Task", "[autogen][cte][full]") {
       auto l2 = ipc_manager->NewTask<clio::cte::core::DelTagTask>();
       lo >> *l2;
       t2->Copy(t1);
-      t1->Aggregate(t2.template Cast<chi::Task>());
+      t1->AggregateOut(t2.template Cast<chi::Task>());
       INFO("DelTagTask full completed");
       CLIO_IPC->DelTask(l1);
       CLIO_IPC->DelTask(l2);
@@ -5389,7 +5389,7 @@ TEST_CASE("Autogen - CTE Full Coverage Per Task", "[autogen][cte][full]") {
       auto l2 = ipc_manager->NewTask<clio::cte::core::GetTagSizeTask>();
       lo >> *l2;
       t2->Copy(t1);
-      t1->Aggregate(t2.template Cast<chi::Task>());
+      t1->AggregateOut(t2.template Cast<chi::Task>());
       INFO("GetTagSizeTask full completed");
       CLIO_IPC->DelTask(l1);
       CLIO_IPC->DelTask(l2);
@@ -5415,7 +5415,7 @@ TEST_CASE("Autogen - CTE Full Coverage Per Task", "[autogen][cte][full]") {
       auto l2 = ipc_manager->NewTask<clio::cte::core::PollTelemetryLogTask>();
       lo >> *l2;
       t2->Copy(t1);
-      t1->Aggregate(t2.template Cast<chi::Task>());
+      t1->AggregateOut(t2.template Cast<chi::Task>());
       INFO("PollTelemetryLogTask full completed");
       CLIO_IPC->DelTask(l1);
       CLIO_IPC->DelTask(l2);
@@ -5441,7 +5441,7 @@ TEST_CASE("Autogen - CTE Full Coverage Per Task", "[autogen][cte][full]") {
       auto l2 = ipc_manager->NewTask<clio::cte::core::GetBlobScoreTask>();
       lo >> *l2;
       t2->Copy(t1);
-      t1->Aggregate(t2.template Cast<chi::Task>());
+      t1->AggregateOut(t2.template Cast<chi::Task>());
       INFO("GetBlobScoreTask full completed");
       CLIO_IPC->DelTask(l1);
       CLIO_IPC->DelTask(l2);
@@ -5467,7 +5467,7 @@ TEST_CASE("Autogen - CTE Full Coverage Per Task", "[autogen][cte][full]") {
       auto l2 = ipc_manager->NewTask<clio::cte::core::GetBlobSizeTask>();
       lo >> *l2;
       t2->Copy(t1);
-      t1->Aggregate(t2.template Cast<chi::Task>());
+      t1->AggregateOut(t2.template Cast<chi::Task>());
       INFO("GetBlobSizeTask full completed");
       CLIO_IPC->DelTask(l1);
       CLIO_IPC->DelTask(l2);
@@ -5493,7 +5493,7 @@ TEST_CASE("Autogen - CTE Full Coverage Per Task", "[autogen][cte][full]") {
       auto l2 = ipc_manager->NewTask<clio::cte::core::GetContainedBlobsTask>();
       lo >> *l2;
       t2->Copy(t1);
-      t1->Aggregate(t2.template Cast<chi::Task>());
+      t1->AggregateOut(t2.template Cast<chi::Task>());
       INFO("GetContainedBlobsTask full completed");
       CLIO_IPC->DelTask(l1);
       CLIO_IPC->DelTask(l2);
@@ -5519,7 +5519,7 @@ TEST_CASE("Autogen - CTE Full Coverage Per Task", "[autogen][cte][full]") {
       auto l2 = ipc_manager->NewTask<clio::cte::core::TagQueryTask>();
       lo >> *l2;
       t2->Copy(t1);
-      t1->Aggregate(t2.template Cast<chi::Task>());
+      t1->AggregateOut(t2.template Cast<chi::Task>());
       INFO("TagQueryTask full completed");
       CLIO_IPC->DelTask(l1);
       CLIO_IPC->DelTask(l2);
@@ -5545,7 +5545,7 @@ TEST_CASE("Autogen - CTE Full Coverage Per Task", "[autogen][cte][full]") {
       auto l2 = ipc_manager->NewTask<clio::cte::core::BlobQueryTask>();
       lo >> *l2;
       t2->Copy(t1);
-      t1->Aggregate(t2.template Cast<chi::Task>());
+      t1->AggregateOut(t2.template Cast<chi::Task>());
       INFO("BlobQueryTask full completed");
       CLIO_IPC->DelTask(l1);
       CLIO_IPC->DelTask(l2);
@@ -5558,7 +5558,7 @@ TEST_CASE("Autogen - CTE Full Coverage Per Task", "[autogen][cte][full]") {
 //==============================================================================
 // CTE Runtime Container Method Coverage Tests
 // These tests directly exercise the Runtime::SaveTask, LoadTask, DelTask,
-// NewTask, NewCopyTask, and Aggregate methods in CTE lib_exec.cc
+// NewTask, NewCopyTask, and AggregateOut methods in CTE lib_exec.cc
 //==============================================================================
 
 TEST_CASE("Autogen - CTE Runtime Container Methods", "[autogen][cte][runtime]") {
@@ -6097,228 +6097,228 @@ TEST_CASE("Autogen - CTE Runtime Container Methods", "[autogen][cte][runtime]") 
     INFO("CTE Runtime::NewCopyTask tests completed");
   }
 
-  SECTION("CTE Runtime Aggregate all methods") {
-    INFO("Testing CTE Runtime::Aggregate for all methods");
+  SECTION("CTE Runtime AggregateOut all methods") {
+    INFO("Testing CTE Runtime::AggregateOut for all methods");
 
-    // Test Aggregate for CreateTask
+    // Test AggregateOut for CreateTask
     auto t1_c = ipc_manager->NewTask<clio::cte::core::CreateTask>();
     auto t2_c = ipc_manager->NewTask<clio::cte::core::CreateTask>();
     if (!t1_c.IsNull() && !t2_c.IsNull()) {
       ctp::ipc::FullPtr<chi::Task> ptr1 = t1_c.template Cast<chi::Task>();
       ctp::ipc::FullPtr<chi::Task> ptr2 = t2_c.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1.ptr_->AggregateOut(ptr2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_c);
       CLIO_IPC->DelTask(t2_c);
     }
 
-    // Test Aggregate for DestroyTask
+    // Test AggregateOut for DestroyTask
     auto t1_d = ipc_manager->NewTask<clio::cte::core::DestroyTask>();
     auto t2_d = ipc_manager->NewTask<clio::cte::core::DestroyTask>();
     if (!t1_d.IsNull() && !t2_d.IsNull()) {
       ctp::ipc::FullPtr<chi::Task> ptr1 = t1_d.template Cast<chi::Task>();
       ctp::ipc::FullPtr<chi::Task> ptr2 = t2_d.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1.ptr_->AggregateOut(ptr2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_d);
       CLIO_IPC->DelTask(t2_d);
     }
 
-    // Test Aggregate for RegisterTargetTask
+    // Test AggregateOut for RegisterTargetTask
     auto t1_r = ipc_manager->NewTask<clio::cte::core::RegisterTargetTask>();
     auto t2_r = ipc_manager->NewTask<clio::cte::core::RegisterTargetTask>();
     if (!t1_r.IsNull() && !t2_r.IsNull()) {
       ctp::ipc::FullPtr<chi::Task> ptr1 = t1_r.template Cast<chi::Task>();
       ctp::ipc::FullPtr<chi::Task> ptr2 = t2_r.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1.ptr_->AggregateOut(ptr2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_r);
       CLIO_IPC->DelTask(t2_r);
     }
 
-    // Test Aggregate for UnregisterTargetTask
+    // Test AggregateOut for UnregisterTargetTask
     auto t1_u = ipc_manager->NewTask<clio::cte::core::UnregisterTargetTask>();
     auto t2_u = ipc_manager->NewTask<clio::cte::core::UnregisterTargetTask>();
     if (!t1_u.IsNull() && !t2_u.IsNull()) {
       ctp::ipc::FullPtr<chi::Task> ptr1 = t1_u.template Cast<chi::Task>();
       ctp::ipc::FullPtr<chi::Task> ptr2 = t2_u.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1.ptr_->AggregateOut(ptr2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_u);
       CLIO_IPC->DelTask(t2_u);
     }
 
-    // Test Aggregate for ListTargetsTask
+    // Test AggregateOut for ListTargetsTask
     auto t1_l = ipc_manager->NewTask<clio::cte::core::ListTargetsTask>();
     auto t2_l = ipc_manager->NewTask<clio::cte::core::ListTargetsTask>();
     if (!t1_l.IsNull() && !t2_l.IsNull()) {
       ctp::ipc::FullPtr<chi::Task> ptr1 = t1_l.template Cast<chi::Task>();
       ctp::ipc::FullPtr<chi::Task> ptr2 = t2_l.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1.ptr_->AggregateOut(ptr2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_l);
       CLIO_IPC->DelTask(t2_l);
     }
 
-    // Test Aggregate for PutBlobTask
+    // Test AggregateOut for PutBlobTask
     auto t1_p = ipc_manager->NewTask<clio::cte::core::PutBlobTask>();
     auto t2_p = ipc_manager->NewTask<clio::cte::core::PutBlobTask>();
     if (!t1_p.IsNull() && !t2_p.IsNull()) {
       ctp::ipc::FullPtr<chi::Task> ptr1 = t1_p.template Cast<chi::Task>();
       ctp::ipc::FullPtr<chi::Task> ptr2 = t2_p.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1.ptr_->AggregateOut(ptr2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_p);
       CLIO_IPC->DelTask(t2_p);
     }
 
-    // Test Aggregate for GetBlobTask
+    // Test AggregateOut for GetBlobTask
     auto t1_g = ipc_manager->NewTask<clio::cte::core::GetBlobTask>();
     auto t2_g = ipc_manager->NewTask<clio::cte::core::GetBlobTask>();
     if (!t1_g.IsNull() && !t2_g.IsNull()) {
       ctp::ipc::FullPtr<chi::Task> ptr1 = t1_g.template Cast<chi::Task>();
       ctp::ipc::FullPtr<chi::Task> ptr2 = t2_g.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1.ptr_->AggregateOut(ptr2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_g);
       CLIO_IPC->DelTask(t2_g);
     }
 
-    // Test Aggregate for StatTargetsTask
+    // Test AggregateOut for StatTargetsTask
     auto t1_st = ipc_manager->NewTask<clio::cte::core::StatTargetsTask>();
     auto t2_st = ipc_manager->NewTask<clio::cte::core::StatTargetsTask>();
     if (!t1_st.IsNull() && !t2_st.IsNull()) {
       ctp::ipc::FullPtr<chi::Task> ptr1 = t1_st.template Cast<chi::Task>();
       ctp::ipc::FullPtr<chi::Task> ptr2 = t2_st.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1.ptr_->AggregateOut(ptr2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_st);
       CLIO_IPC->DelTask(t2_st);
     }
 
-    // Test Aggregate for GetOrCreateTagTask
+    // Test AggregateOut for GetOrCreateTagTask
     auto t1_gt = ipc_manager->NewTask<clio::cte::core::GetOrCreateTagTask<clio::cte::core::CreateParams>>();
     auto t2_gt = ipc_manager->NewTask<clio::cte::core::GetOrCreateTagTask<clio::cte::core::CreateParams>>();
     if (!t1_gt.IsNull() && !t2_gt.IsNull()) {
       ctp::ipc::FullPtr<chi::Task> ptr1 = t1_gt.template Cast<chi::Task>();
       ctp::ipc::FullPtr<chi::Task> ptr2 = t2_gt.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1.ptr_->AggregateOut(ptr2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_gt);
       CLIO_IPC->DelTask(t2_gt);
     }
 
-    // Test Aggregate for ReorganizeBlobTask
+    // Test AggregateOut for ReorganizeBlobTask
     auto t1_re = ipc_manager->NewTask<clio::cte::core::ReorganizeBlobTask>();
     auto t2_re = ipc_manager->NewTask<clio::cte::core::ReorganizeBlobTask>();
     if (!t1_re.IsNull() && !t2_re.IsNull()) {
       ctp::ipc::FullPtr<chi::Task> ptr1 = t1_re.template Cast<chi::Task>();
       ctp::ipc::FullPtr<chi::Task> ptr2 = t2_re.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1.ptr_->AggregateOut(ptr2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_re);
       CLIO_IPC->DelTask(t2_re);
     }
 
-    // Test Aggregate for DelBlobTask
+    // Test AggregateOut for DelBlobTask
     auto t1_db = ipc_manager->NewTask<clio::cte::core::DelBlobTask>();
     auto t2_db = ipc_manager->NewTask<clio::cte::core::DelBlobTask>();
     if (!t1_db.IsNull() && !t2_db.IsNull()) {
       ctp::ipc::FullPtr<chi::Task> ptr1 = t1_db.template Cast<chi::Task>();
       ctp::ipc::FullPtr<chi::Task> ptr2 = t2_db.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1.ptr_->AggregateOut(ptr2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_db);
       CLIO_IPC->DelTask(t2_db);
     }
 
-    // Test Aggregate for DelTagTask
+    // Test AggregateOut for DelTagTask
     auto t1_dt = ipc_manager->NewTask<clio::cte::core::DelTagTask>();
     auto t2_dt = ipc_manager->NewTask<clio::cte::core::DelTagTask>();
     if (!t1_dt.IsNull() && !t2_dt.IsNull()) {
       ctp::ipc::FullPtr<chi::Task> ptr1 = t1_dt.template Cast<chi::Task>();
       ctp::ipc::FullPtr<chi::Task> ptr2 = t2_dt.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1.ptr_->AggregateOut(ptr2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_dt);
       CLIO_IPC->DelTask(t2_dt);
     }
 
-    // Test Aggregate for GetTagSizeTask
+    // Test AggregateOut for GetTagSizeTask
     auto t1_ts = ipc_manager->NewTask<clio::cte::core::GetTagSizeTask>();
     auto t2_ts = ipc_manager->NewTask<clio::cte::core::GetTagSizeTask>();
     if (!t1_ts.IsNull() && !t2_ts.IsNull()) {
       ctp::ipc::FullPtr<chi::Task> ptr1 = t1_ts.template Cast<chi::Task>();
       ctp::ipc::FullPtr<chi::Task> ptr2 = t2_ts.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1.ptr_->AggregateOut(ptr2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_ts);
       CLIO_IPC->DelTask(t2_ts);
     }
 
-    // Test Aggregate for PollTelemetryLogTask
+    // Test AggregateOut for PollTelemetryLogTask
     auto t1_tl = ipc_manager->NewTask<clio::cte::core::PollTelemetryLogTask>();
     auto t2_tl = ipc_manager->NewTask<clio::cte::core::PollTelemetryLogTask>();
     if (!t1_tl.IsNull() && !t2_tl.IsNull()) {
       ctp::ipc::FullPtr<chi::Task> ptr1 = t1_tl.template Cast<chi::Task>();
       ctp::ipc::FullPtr<chi::Task> ptr2 = t2_tl.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1.ptr_->AggregateOut(ptr2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_tl);
       CLIO_IPC->DelTask(t2_tl);
     }
 
-    // Test Aggregate for GetBlobScoreTask
+    // Test AggregateOut for GetBlobScoreTask
     auto t1_sc = ipc_manager->NewTask<clio::cte::core::GetBlobScoreTask>();
     auto t2_sc = ipc_manager->NewTask<clio::cte::core::GetBlobScoreTask>();
     if (!t1_sc.IsNull() && !t2_sc.IsNull()) {
       ctp::ipc::FullPtr<chi::Task> ptr1 = t1_sc.template Cast<chi::Task>();
       ctp::ipc::FullPtr<chi::Task> ptr2 = t2_sc.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1.ptr_->AggregateOut(ptr2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_sc);
       CLIO_IPC->DelTask(t2_sc);
     }
 
-    // Test Aggregate for GetBlobSizeTask
+    // Test AggregateOut for GetBlobSizeTask
     auto t1_bs = ipc_manager->NewTask<clio::cte::core::GetBlobSizeTask>();
     auto t2_bs = ipc_manager->NewTask<clio::cte::core::GetBlobSizeTask>();
     if (!t1_bs.IsNull() && !t2_bs.IsNull()) {
       ctp::ipc::FullPtr<chi::Task> ptr1 = t1_bs.template Cast<chi::Task>();
       ctp::ipc::FullPtr<chi::Task> ptr2 = t2_bs.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1.ptr_->AggregateOut(ptr2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_bs);
       CLIO_IPC->DelTask(t2_bs);
     }
 
-    // Test Aggregate for GetContainedBlobsTask
+    // Test AggregateOut for GetContainedBlobsTask
     auto t1_cb = ipc_manager->NewTask<clio::cte::core::GetContainedBlobsTask>();
     auto t2_cb = ipc_manager->NewTask<clio::cte::core::GetContainedBlobsTask>();
     if (!t1_cb.IsNull() && !t2_cb.IsNull()) {
       ctp::ipc::FullPtr<chi::Task> ptr1 = t1_cb.template Cast<chi::Task>();
       ctp::ipc::FullPtr<chi::Task> ptr2 = t2_cb.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1.ptr_->AggregateOut(ptr2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_cb);
       CLIO_IPC->DelTask(t2_cb);
     }
 
-    // Test Aggregate for TagQueryTask
+    // Test AggregateOut for TagQueryTask
     auto t1_tq = ipc_manager->NewTask<clio::cte::core::TagQueryTask>();
     auto t2_tq = ipc_manager->NewTask<clio::cte::core::TagQueryTask>();
     if (!t1_tq.IsNull() && !t2_tq.IsNull()) {
       ctp::ipc::FullPtr<chi::Task> ptr1 = t1_tq.template Cast<chi::Task>();
       ctp::ipc::FullPtr<chi::Task> ptr2 = t2_tq.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1.ptr_->AggregateOut(ptr2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_tq);
       CLIO_IPC->DelTask(t2_tq);
     }
 
-    // Test Aggregate for BlobQueryTask
+    // Test AggregateOut for BlobQueryTask
     auto t1_bq = ipc_manager->NewTask<clio::cte::core::BlobQueryTask>();
     auto t2_bq = ipc_manager->NewTask<clio::cte::core::BlobQueryTask>();
     if (!t1_bq.IsNull() && !t2_bq.IsNull()) {
       ctp::ipc::FullPtr<chi::Task> ptr1 = t1_bq.template Cast<chi::Task>();
       ctp::ipc::FullPtr<chi::Task> ptr2 = t2_bq.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1.ptr_->AggregateOut(ptr2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_bq);
       CLIO_IPC->DelTask(t2_bq);
     }
 
-    // Test Aggregate for unknown method (default case)
+    // Test AggregateOut for unknown method (default case)
     auto t1_unk = ipc_manager->NewTask<chi::Task>();
     auto t2_unk = ipc_manager->NewTask<chi::Task>();
     if (!t1_unk.IsNull() && !t2_unk.IsNull()) {
-      t1_unk.ptr_->Aggregate(t2_unk.template Cast<chi::Task>());
+      t1_unk.ptr_->AggregateOut(t2_unk.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_unk);
       CLIO_IPC->DelTask(t2_unk);
     }
 
-    INFO("CTE Runtime::Aggregate tests completed");
+    INFO("CTE Runtime::AggregateOut tests completed");
   }
 
   SECTION("CTE Runtime GetOrCreateTag SaveTask test") {
@@ -6551,15 +6551,15 @@ TEST_CASE("Autogen - Bdev Runtime Container Methods", "[autogen][bdev][runtime]"
     INFO("Bdev Runtime::NewCopyTask tests completed");
   }
 
-  SECTION("Bdev Runtime Aggregate all methods") {
-    INFO("Testing Bdev Runtime::Aggregate for all methods");
+  SECTION("Bdev Runtime AggregateOut all methods") {
+    INFO("Testing Bdev Runtime::AggregateOut for all methods");
 
     auto t1_c = ipc_manager->NewTask<clio::run::bdev::CreateTask>();
     auto t2_c = ipc_manager->NewTask<clio::run::bdev::CreateTask>();
     if (!t1_c.IsNull() && !t2_c.IsNull()) {
       ctp::ipc::FullPtr<chi::Task> ptr1 = t1_c.template Cast<chi::Task>();
       ctp::ipc::FullPtr<chi::Task> ptr2 = t2_c.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1.ptr_->AggregateOut(ptr2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_c);
       CLIO_IPC->DelTask(t2_c);
     }
@@ -6569,7 +6569,7 @@ TEST_CASE("Autogen - Bdev Runtime Container Methods", "[autogen][bdev][runtime]"
     if (!t1_d.IsNull() && !t2_d.IsNull()) {
       ctp::ipc::FullPtr<chi::Task> ptr1 = t1_d.template Cast<chi::Task>();
       ctp::ipc::FullPtr<chi::Task> ptr2 = t2_d.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1.ptr_->AggregateOut(ptr2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_d);
       CLIO_IPC->DelTask(t2_d);
     }
@@ -6579,7 +6579,7 @@ TEST_CASE("Autogen - Bdev Runtime Container Methods", "[autogen][bdev][runtime]"
     if (!t1_a.IsNull() && !t2_a.IsNull()) {
       ctp::ipc::FullPtr<chi::Task> ptr1 = t1_a.template Cast<chi::Task>();
       ctp::ipc::FullPtr<chi::Task> ptr2 = t2_a.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1.ptr_->AggregateOut(ptr2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_a);
       CLIO_IPC->DelTask(t2_a);
     }
@@ -6589,7 +6589,7 @@ TEST_CASE("Autogen - Bdev Runtime Container Methods", "[autogen][bdev][runtime]"
     if (!t1_f.IsNull() && !t2_f.IsNull()) {
       ctp::ipc::FullPtr<chi::Task> ptr1 = t1_f.template Cast<chi::Task>();
       ctp::ipc::FullPtr<chi::Task> ptr2 = t2_f.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1.ptr_->AggregateOut(ptr2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_f);
       CLIO_IPC->DelTask(t2_f);
     }
@@ -6599,7 +6599,7 @@ TEST_CASE("Autogen - Bdev Runtime Container Methods", "[autogen][bdev][runtime]"
     if (!t1_w.IsNull() && !t2_w.IsNull()) {
       ctp::ipc::FullPtr<chi::Task> ptr1 = t1_w.template Cast<chi::Task>();
       ctp::ipc::FullPtr<chi::Task> ptr2 = t2_w.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1.ptr_->AggregateOut(ptr2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_w);
       CLIO_IPC->DelTask(t2_w);
     }
@@ -6609,7 +6609,7 @@ TEST_CASE("Autogen - Bdev Runtime Container Methods", "[autogen][bdev][runtime]"
     if (!t1_r.IsNull() && !t2_r.IsNull()) {
       ctp::ipc::FullPtr<chi::Task> ptr1 = t1_r.template Cast<chi::Task>();
       ctp::ipc::FullPtr<chi::Task> ptr2 = t2_r.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1.ptr_->AggregateOut(ptr2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_r);
       CLIO_IPC->DelTask(t2_r);
     }
@@ -6619,12 +6619,12 @@ TEST_CASE("Autogen - Bdev Runtime Container Methods", "[autogen][bdev][runtime]"
     if (!t1_s.IsNull() && !t2_s.IsNull()) {
       ctp::ipc::FullPtr<chi::Task> ptr1 = t1_s.template Cast<chi::Task>();
       ctp::ipc::FullPtr<chi::Task> ptr2 = t2_s.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1.ptr_->AggregateOut(ptr2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_s);
       CLIO_IPC->DelTask(t2_s);
     }
 
-    INFO("Bdev Runtime::Aggregate tests completed");
+    INFO("Bdev Runtime::AggregateOut tests completed");
   }
 }
 
@@ -6909,8 +6909,8 @@ TEST_CASE("Autogen - CAE Runtime Container Methods", "[autogen][cae][runtime]") 
     INFO("CAE Runtime::NewCopyTask tests completed");
   }
 
-  SECTION("CAE Runtime Aggregate all methods") {
-    INFO("Testing CAE Runtime::Aggregate for all methods");
+  SECTION("CAE Runtime AggregateOut all methods") {
+    INFO("Testing CAE Runtime::AggregateOut for all methods");
 
     // Test kCreate
     auto t1_c = ipc_manager->NewTask<clio::cae::core::CreateTask>();
@@ -6918,7 +6918,7 @@ TEST_CASE("Autogen - CAE Runtime Container Methods", "[autogen][cae][runtime]") 
     if (!t1_c.IsNull() && !t2_c.IsNull()) {
       ctp::ipc::FullPtr<chi::Task> ptr1 = t1_c.template Cast<chi::Task>();
       ctp::ipc::FullPtr<chi::Task> ptr2 = t2_c.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1.ptr_->AggregateOut(ptr2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_c);
       CLIO_IPC->DelTask(t2_c);
     }
@@ -6927,7 +6927,7 @@ TEST_CASE("Autogen - CAE Runtime Container Methods", "[autogen][cae][runtime]") 
     auto t1_d = ipc_manager->NewTask<chi::Task>();
     auto t2_d = ipc_manager->NewTask<chi::Task>();
     if (!t1_d.IsNull() && !t2_d.IsNull()) {
-      t1_d.ptr_->Aggregate(t2_d.template Cast<chi::Task>());
+      t1_d.ptr_->AggregateOut(t2_d.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_d);
       CLIO_IPC->DelTask(t2_d);
     }
@@ -6938,7 +6938,7 @@ TEST_CASE("Autogen - CAE Runtime Container Methods", "[autogen][cae][runtime]") 
     if (!t1_p.IsNull() && !t2_p.IsNull()) {
       ctp::ipc::FullPtr<chi::Task> ptr1 = t1_p.template Cast<chi::Task>();
       ctp::ipc::FullPtr<chi::Task> ptr2 = t2_p.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1.ptr_->AggregateOut(ptr2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_p);
       CLIO_IPC->DelTask(t2_p);
     }
@@ -6949,7 +6949,7 @@ TEST_CASE("Autogen - CAE Runtime Container Methods", "[autogen][cae][runtime]") 
     if (!t1_h.IsNull() && !t2_h.IsNull()) {
       ctp::ipc::FullPtr<chi::Task> ptr1 = t1_h.template Cast<chi::Task>();
       ctp::ipc::FullPtr<chi::Task> ptr2 = t2_h.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1.ptr_->AggregateOut(ptr2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_h);
       CLIO_IPC->DelTask(t2_h);
     }
@@ -6958,12 +6958,12 @@ TEST_CASE("Autogen - CAE Runtime Container Methods", "[autogen][cae][runtime]") 
     auto t1_u = ipc_manager->NewTask<chi::Task>();
     auto t2_u = ipc_manager->NewTask<chi::Task>();
     if (!t1_u.IsNull() && !t2_u.IsNull()) {
-      t1_u.ptr_->Aggregate(t2_u.template Cast<chi::Task>());
+      t1_u.ptr_->AggregateOut(t2_u.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_u);
       CLIO_IPC->DelTask(t2_u);
     }
 
-    INFO("CAE Runtime::Aggregate tests completed");
+    INFO("CAE Runtime::AggregateOut tests completed");
   }
 }
 
@@ -7069,21 +7069,21 @@ TEST_CASE("Autogen - CAE Task Serialization Methods", "[autogen][cae][serialize]
     INFO("ProcessHdf5DatasetTask Copy test passed");
   }
 
-  SECTION("ProcessHdf5DatasetTask Aggregate with error propagation") {
+  SECTION("ProcessHdf5DatasetTask AggregateOut with error propagation") {
     auto task1 = ipc_manager->NewTask<clio::cae::core::ProcessHdf5DatasetTask>();
     auto task2 = ipc_manager->NewTask<clio::cae::core::ProcessHdf5DatasetTask>();
     if (!task1.IsNull() && !task2.IsNull()) {
       // Set error in task2
       task2->result_code_ = 42;
 
-      // Aggregate should propagate error
-      task1->Aggregate(task2.template Cast<chi::Task>());
+      // AggregateOut should propagate error
+      task1->AggregateOut(task2.template Cast<chi::Task>());
       REQUIRE(task1->result_code_ == 42);
 
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
-    INFO("ProcessHdf5DatasetTask Aggregate with error propagation test passed");
+    INFO("ProcessHdf5DatasetTask AggregateOut with error propagation test passed");
   }
 }
 
@@ -7494,8 +7494,8 @@ TEST_CASE("Autogen - MOD_NAME Runtime Container Methods", "[autogen][mod_name][r
     INFO("MOD_NAME Runtime::NewCopyTask tests completed");
   }
 
-  SECTION("MOD_NAME Runtime Aggregate all methods") {
-    INFO("Testing MOD_NAME Runtime::Aggregate for all methods");
+  SECTION("MOD_NAME Runtime AggregateOut all methods") {
+    INFO("Testing MOD_NAME Runtime::AggregateOut for all methods");
 
     // Test kCreate
     auto t1_c = ipc_manager->NewTask<clio::run::MOD_NAME::CreateTask>();
@@ -7503,7 +7503,7 @@ TEST_CASE("Autogen - MOD_NAME Runtime Container Methods", "[autogen][mod_name][r
     if (!t1_c.IsNull() && !t2_c.IsNull()) {
       ctp::ipc::FullPtr<chi::Task> ptr1 = t1_c.template Cast<chi::Task>();
       ctp::ipc::FullPtr<chi::Task> ptr2 = t2_c.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1.ptr_->AggregateOut(ptr2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_c);
       CLIO_IPC->DelTask(t2_c);
     }
@@ -7514,7 +7514,7 @@ TEST_CASE("Autogen - MOD_NAME Runtime Container Methods", "[autogen][mod_name][r
     if (!t1_d.IsNull() && !t2_d.IsNull()) {
       ctp::ipc::FullPtr<chi::Task> ptr1 = t1_d.template Cast<chi::Task>();
       ctp::ipc::FullPtr<chi::Task> ptr2 = t2_d.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1.ptr_->AggregateOut(ptr2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_d);
       CLIO_IPC->DelTask(t2_d);
     }
@@ -7525,7 +7525,7 @@ TEST_CASE("Autogen - MOD_NAME Runtime Container Methods", "[autogen][mod_name][r
     if (!t1_cu.IsNull() && !t2_cu.IsNull()) {
       ctp::ipc::FullPtr<chi::Task> ptr1 = t1_cu.template Cast<chi::Task>();
       ctp::ipc::FullPtr<chi::Task> ptr2 = t2_cu.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1.ptr_->AggregateOut(ptr2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_cu);
       CLIO_IPC->DelTask(t2_cu);
     }
@@ -7536,7 +7536,7 @@ TEST_CASE("Autogen - MOD_NAME Runtime Container Methods", "[autogen][mod_name][r
     if (!t1_cm.IsNull() && !t2_cm.IsNull()) {
       ctp::ipc::FullPtr<chi::Task> ptr1 = t1_cm.template Cast<chi::Task>();
       ctp::ipc::FullPtr<chi::Task> ptr2 = t2_cm.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1.ptr_->AggregateOut(ptr2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_cm);
       CLIO_IPC->DelTask(t2_cm);
     }
@@ -7547,7 +7547,7 @@ TEST_CASE("Autogen - MOD_NAME Runtime Container Methods", "[autogen][mod_name][r
     if (!t1_cr.IsNull() && !t2_cr.IsNull()) {
       ctp::ipc::FullPtr<chi::Task> ptr1 = t1_cr.template Cast<chi::Task>();
       ctp::ipc::FullPtr<chi::Task> ptr2 = t2_cr.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1.ptr_->AggregateOut(ptr2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_cr);
       CLIO_IPC->DelTask(t2_cr);
     }
@@ -7558,7 +7558,7 @@ TEST_CASE("Autogen - MOD_NAME Runtime Container Methods", "[autogen][mod_name][r
     if (!t1_w.IsNull() && !t2_w.IsNull()) {
       ctp::ipc::FullPtr<chi::Task> ptr1 = t1_w.template Cast<chi::Task>();
       ctp::ipc::FullPtr<chi::Task> ptr2 = t2_w.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1.ptr_->AggregateOut(ptr2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_w);
       CLIO_IPC->DelTask(t2_w);
     }
@@ -7567,12 +7567,12 @@ TEST_CASE("Autogen - MOD_NAME Runtime Container Methods", "[autogen][mod_name][r
     auto t1_u = ipc_manager->NewTask<chi::Task>();
     auto t2_u = ipc_manager->NewTask<chi::Task>();
     if (!t1_u.IsNull() && !t2_u.IsNull()) {
-      t1_u.ptr_->Aggregate(t2_u.template Cast<chi::Task>());
+      t1_u.ptr_->AggregateOut(t2_u.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t1_u);
       CLIO_IPC->DelTask(t2_u);
     }
 
-    INFO("MOD_NAME Runtime::Aggregate tests completed");
+    INFO("MOD_NAME Runtime::AggregateOut tests completed");
   }
 }
 
@@ -7640,52 +7640,52 @@ TEST_CASE("Autogen - MOD_NAME Task Serialization", "[autogen][mod_name][serializ
     INFO("WaitTestTask serialization test passed");
   }
 
-  SECTION("CustomTask Copy and Aggregate") {
+  SECTION("CustomTask Copy and AggregateOut") {
     auto task1 = ipc_manager->NewTask<clio::run::MOD_NAME::CustomTask>();
     auto task2 = ipc_manager->NewTask<clio::run::MOD_NAME::CustomTask>();
     if (!task1.IsNull() && !task2.IsNull()) {
       task1->Copy(task2);
-      task1->Aggregate(task2.template Cast<chi::Task>());
+      task1->AggregateOut(task2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
-    INFO("CustomTask Copy and Aggregate test passed");
+    INFO("CustomTask Copy and AggregateOut test passed");
   }
 
-  SECTION("CoMutexTestTask Copy and Aggregate") {
+  SECTION("CoMutexTestTask Copy and AggregateOut") {
     auto task1 = ipc_manager->NewTask<clio::run::MOD_NAME::CoMutexTestTask>();
     auto task2 = ipc_manager->NewTask<clio::run::MOD_NAME::CoMutexTestTask>();
     if (!task1.IsNull() && !task2.IsNull()) {
       task1->Copy(task2);
-      task1->Aggregate(task2.template Cast<chi::Task>());
+      task1->AggregateOut(task2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
-    INFO("CoMutexTestTask Copy and Aggregate test passed");
+    INFO("CoMutexTestTask Copy and AggregateOut test passed");
   }
 
-  SECTION("CoRwLockTestTask Copy and Aggregate") {
+  SECTION("CoRwLockTestTask Copy and AggregateOut") {
     auto task1 = ipc_manager->NewTask<clio::run::MOD_NAME::CoRwLockTestTask>();
     auto task2 = ipc_manager->NewTask<clio::run::MOD_NAME::CoRwLockTestTask>();
     if (!task1.IsNull() && !task2.IsNull()) {
       task1->Copy(task2);
-      task1->Aggregate(task2.template Cast<chi::Task>());
+      task1->AggregateOut(task2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
-    INFO("CoRwLockTestTask Copy and Aggregate test passed");
+    INFO("CoRwLockTestTask Copy and AggregateOut test passed");
   }
 
-  SECTION("WaitTestTask Copy and Aggregate") {
+  SECTION("WaitTestTask Copy and AggregateOut") {
     auto task1 = ipc_manager->NewTask<clio::run::MOD_NAME::WaitTestTask>();
     auto task2 = ipc_manager->NewTask<clio::run::MOD_NAME::WaitTestTask>();
     if (!task1.IsNull() && !task2.IsNull()) {
       task1->Copy(task2);
-      task1->Aggregate(task2.template Cast<chi::Task>());
+      task1->AggregateOut(task2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
-    INFO("WaitTestTask Copy and Aggregate test passed");
+    INFO("WaitTestTask Copy and AggregateOut test passed");
   }
 }
 
@@ -7768,15 +7768,15 @@ TEST_CASE("Autogen - CTE ListTargetsTask coverage", "[autogen][cte][listtargets]
     INFO("ListTargetsTask Copy test passed");
   }
 
-  SECTION("ListTargetsTask Aggregate") {
+  SECTION("ListTargetsTask AggregateOut") {
     auto task1 = ipc_manager->NewTask<clio::cte::core::ListTargetsTask>();
     auto task2 = ipc_manager->NewTask<clio::cte::core::ListTargetsTask>();
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1->Aggregate(task2.template Cast<chi::Task>());
+      task1->AggregateOut(task2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
-    INFO("ListTargetsTask Aggregate test passed");
+    INFO("ListTargetsTask AggregateOut test passed");
   }
 }
 
@@ -7828,15 +7828,15 @@ TEST_CASE("Autogen - CTE StatTargetsTask coverage", "[autogen][cte][stattargets]
     INFO("StatTargetsTask Copy test passed");
   }
 
-  SECTION("StatTargetsTask Aggregate") {
+  SECTION("StatTargetsTask AggregateOut") {
     auto task1 = ipc_manager->NewTask<clio::cte::core::StatTargetsTask>();
     auto task2 = ipc_manager->NewTask<clio::cte::core::StatTargetsTask>();
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1->Aggregate(task2.template Cast<chi::Task>());
+      task1->AggregateOut(task2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
-    INFO("StatTargetsTask Aggregate test passed");
+    INFO("StatTargetsTask AggregateOut test passed");
   }
 }
 
@@ -7888,15 +7888,15 @@ TEST_CASE("Autogen - CTE RegisterTargetTask coverage", "[autogen][cte][registert
     INFO("RegisterTargetTask Copy test passed");
   }
 
-  SECTION("RegisterTargetTask Aggregate") {
+  SECTION("RegisterTargetTask AggregateOut") {
     auto task1 = ipc_manager->NewTask<clio::cte::core::RegisterTargetTask>();
     auto task2 = ipc_manager->NewTask<clio::cte::core::RegisterTargetTask>();
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1->Aggregate(task2.template Cast<chi::Task>());
+      task1->AggregateOut(task2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
-    INFO("RegisterTargetTask Aggregate test passed");
+    INFO("RegisterTargetTask AggregateOut test passed");
   }
 }
 
@@ -7923,16 +7923,16 @@ TEST_CASE("Autogen - CTE TagQueryTask coverage", "[autogen][cte][tagquery]") {
     INFO("TagQueryTask serialization tests passed");
   }
 
-  SECTION("TagQueryTask Copy and Aggregate") {
+  SECTION("TagQueryTask Copy and AggregateOut") {
     auto task1 = ipc_manager->NewTask<clio::cte::core::TagQueryTask>();
     auto task2 = ipc_manager->NewTask<clio::cte::core::TagQueryTask>();
     if (!task1.IsNull() && !task2.IsNull()) {
       task1->Copy(task2);
-      task1->Aggregate(task2.template Cast<chi::Task>());
+      task1->AggregateOut(task2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
-    INFO("TagQueryTask Copy and Aggregate test passed");
+    INFO("TagQueryTask Copy and AggregateOut test passed");
   }
 }
 
@@ -7959,16 +7959,16 @@ TEST_CASE("Autogen - CTE BlobQueryTask coverage", "[autogen][cte][blobquery]") {
     INFO("BlobQueryTask serialization tests passed");
   }
 
-  SECTION("BlobQueryTask Copy and Aggregate") {
+  SECTION("BlobQueryTask Copy and AggregateOut") {
     auto task1 = ipc_manager->NewTask<clio::cte::core::BlobQueryTask>();
     auto task2 = ipc_manager->NewTask<clio::cte::core::BlobQueryTask>();
     if (!task1.IsNull() && !task2.IsNull()) {
       task1->Copy(task2);
-      task1->Aggregate(task2.template Cast<chi::Task>());
+      task1->AggregateOut(task2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
-    INFO("BlobQueryTask Copy and Aggregate test passed");
+    INFO("BlobQueryTask Copy and AggregateOut test passed");
   }
 }
 
@@ -7995,16 +7995,16 @@ TEST_CASE("Autogen - CTE UnregisterTargetTask coverage", "[autogen][cte][unregis
     INFO("UnregisterTargetTask serialization tests passed");
   }
 
-  SECTION("UnregisterTargetTask Copy and Aggregate") {
+  SECTION("UnregisterTargetTask Copy and AggregateOut") {
     auto task1 = ipc_manager->NewTask<clio::cte::core::UnregisterTargetTask>();
     auto task2 = ipc_manager->NewTask<clio::cte::core::UnregisterTargetTask>();
     if (!task1.IsNull() && !task2.IsNull()) {
       task1->Copy(task2);
-      task1->Aggregate(task2.template Cast<chi::Task>());
+      task1->AggregateOut(task2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
-    INFO("UnregisterTargetTask Copy and Aggregate test passed");
+    INFO("UnregisterTargetTask Copy and AggregateOut test passed");
   }
 }
 
@@ -8031,16 +8031,16 @@ TEST_CASE("Autogen - CTE GetBlobSizeTask coverage", "[autogen][cte][getblobsize]
     INFO("GetBlobSizeTask serialization tests passed");
   }
 
-  SECTION("GetBlobSizeTask Copy and Aggregate") {
+  SECTION("GetBlobSizeTask Copy and AggregateOut") {
     auto task1 = ipc_manager->NewTask<clio::cte::core::GetBlobSizeTask>();
     auto task2 = ipc_manager->NewTask<clio::cte::core::GetBlobSizeTask>();
     if (!task1.IsNull() && !task2.IsNull()) {
       task1->Copy(task2);
-      task1->Aggregate(task2.template Cast<chi::Task>());
+      task1->AggregateOut(task2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
-    INFO("GetBlobSizeTask Copy and Aggregate test passed");
+    INFO("GetBlobSizeTask Copy and AggregateOut test passed");
   }
 }
 
@@ -8067,16 +8067,16 @@ TEST_CASE("Autogen - CTE GetBlobScoreTask coverage", "[autogen][cte][getblobscor
     INFO("GetBlobScoreTask serialization tests passed");
   }
 
-  SECTION("GetBlobScoreTask Copy and Aggregate") {
+  SECTION("GetBlobScoreTask Copy and AggregateOut") {
     auto task1 = ipc_manager->NewTask<clio::cte::core::GetBlobScoreTask>();
     auto task2 = ipc_manager->NewTask<clio::cte::core::GetBlobScoreTask>();
     if (!task1.IsNull() && !task2.IsNull()) {
       task1->Copy(task2);
-      task1->Aggregate(task2.template Cast<chi::Task>());
+      task1->AggregateOut(task2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
-    INFO("GetBlobScoreTask Copy and Aggregate test passed");
+    INFO("GetBlobScoreTask Copy and AggregateOut test passed");
   }
 }
 
@@ -8103,16 +8103,16 @@ TEST_CASE("Autogen - CTE PollTelemetryLogTask coverage", "[autogen][cte][polltel
     INFO("PollTelemetryLogTask serialization tests passed");
   }
 
-  SECTION("PollTelemetryLogTask Copy and Aggregate") {
+  SECTION("PollTelemetryLogTask Copy and AggregateOut") {
     auto task1 = ipc_manager->NewTask<clio::cte::core::PollTelemetryLogTask>();
     auto task2 = ipc_manager->NewTask<clio::cte::core::PollTelemetryLogTask>();
     if (!task1.IsNull() && !task2.IsNull()) {
       task1->Copy(task2);
-      task1->Aggregate(task2.template Cast<chi::Task>());
+      task1->AggregateOut(task2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
-    INFO("PollTelemetryLogTask Copy and Aggregate test passed");
+    INFO("PollTelemetryLogTask Copy and AggregateOut test passed");
   }
 }
 
@@ -8139,16 +8139,16 @@ TEST_CASE("Autogen - CTE GetContainedBlobsTask coverage", "[autogen][cte][getcon
     INFO("GetContainedBlobsTask serialization tests passed");
   }
 
-  SECTION("GetContainedBlobsTask Copy and Aggregate") {
+  SECTION("GetContainedBlobsTask Copy and AggregateOut") {
     auto task1 = ipc_manager->NewTask<clio::cte::core::GetContainedBlobsTask>();
     auto task2 = ipc_manager->NewTask<clio::cte::core::GetContainedBlobsTask>();
     if (!task1.IsNull() && !task2.IsNull()) {
       task1->Copy(task2);
-      task1->Aggregate(task2.template Cast<chi::Task>());
+      task1->AggregateOut(task2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
-    INFO("GetContainedBlobsTask Copy and Aggregate test passed");
+    INFO("GetContainedBlobsTask Copy and AggregateOut test passed");
   }
 }
 
@@ -8759,12 +8759,12 @@ TEST_CASE("Autogen - Bdev Container NewCopyTask coverage", "[autogen][bdev][cont
     }
   }
 
-  SECTION("Aggregate for WriteTask") {
+  SECTION("AggregateOut for WriteTask") {
     auto task1 = container->NewTask(clio::run::bdev::Method::kWrite);
     auto task2 = container->NewTask(clio::run::bdev::Method::kWrite);
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1.ptr_->Aggregate(task2.template Cast<chi::Task>());
-      INFO("Aggregate for WriteTask succeeded");
+      task1.ptr_->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("AggregateOut for WriteTask succeeded");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
@@ -8811,23 +8811,23 @@ TEST_CASE("Autogen - Admin Container NewCopyTask coverage", "[autogen][admin][co
     }
   }
 
-  SECTION("Aggregate for SendTask") {
+  SECTION("AggregateOut for SendTask") {
     auto task1 = container->NewTask(clio::run::admin::Method::kSend);
     auto task2 = container->NewTask(clio::run::admin::Method::kSend);
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1.ptr_->Aggregate(task2.template Cast<chi::Task>());
-      INFO("Aggregate for SendTask succeeded");
+      task1.ptr_->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("AggregateOut for SendTask succeeded");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
   }
 
-  SECTION("Aggregate for RecvTask") {
+  SECTION("AggregateOut for RecvTask") {
     auto task1 = container->NewTask(clio::run::admin::Method::kRecv);
     auto task2 = container->NewTask(clio::run::admin::Method::kRecv);
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1.ptr_->Aggregate(task2.template Cast<chi::Task>());
-      INFO("Aggregate for RecvTask succeeded");
+      task1.ptr_->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("AggregateOut for RecvTask succeeded");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
@@ -8874,12 +8874,12 @@ TEST_CASE("Autogen - CTE Container NewCopyTask coverage", "[autogen][cte][contai
     }
   }
 
-  SECTION("Aggregate for GetBlobTask") {
+  SECTION("AggregateOut for GetBlobTask") {
     auto task1 = container->NewTask(clio::cte::core::Method::kGetBlob);
     auto task2 = container->NewTask(clio::cte::core::Method::kGetBlob);
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1.ptr_->Aggregate(task2.template Cast<chi::Task>());
-      INFO("Aggregate for GetBlobTask succeeded");
+      task1.ptr_->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("AggregateOut for GetBlobTask succeeded");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
@@ -9346,7 +9346,7 @@ TEST_CASE("Autogen - CAE Container NewCopyTask coverage", "[autogen][cae][contai
   }
 }
 
-TEST_CASE("Autogen - CAE Container Aggregate coverage", "[autogen][cae][container][aggregate]") {
+TEST_CASE("Autogen - CAE Container AggregateOut coverage", "[autogen][cae][container][aggregate]") {
   EnsureInitialized();
 
   auto* ipc_manager = CLIO_IPC;
@@ -9361,34 +9361,34 @@ TEST_CASE("Autogen - CAE Container Aggregate coverage", "[autogen][cae][containe
     return;
   }
 
-  SECTION("Aggregate for CreateTask") {
+  SECTION("AggregateOut for CreateTask") {
     auto task1 = container->NewTask(clio::cae::core::Method::kCreate);
     auto task2 = container->NewTask(clio::cae::core::Method::kCreate);
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1.ptr_->Aggregate(task2.template Cast<chi::Task>());
-      INFO("Aggregate for CreateTask succeeded");
+      task1.ptr_->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("AggregateOut for CreateTask succeeded");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
   }
 
-  SECTION("Aggregate for ParseOmniTask") {
+  SECTION("AggregateOut for ParseOmniTask") {
     auto task1 = container->NewTask(clio::cae::core::Method::kParseOmni);
     auto task2 = container->NewTask(clio::cae::core::Method::kParseOmni);
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1.ptr_->Aggregate(task2.template Cast<chi::Task>());
-      INFO("Aggregate for ParseOmniTask succeeded");
+      task1.ptr_->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("AggregateOut for ParseOmniTask succeeded");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
   }
 
-  SECTION("Aggregate for ProcessHdf5DatasetTask") {
+  SECTION("AggregateOut for ProcessHdf5DatasetTask") {
     auto task1 = container->NewTask(clio::cae::core::Method::kProcessHdf5Dataset);
     auto task2 = container->NewTask(clio::cae::core::Method::kProcessHdf5Dataset);
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1.ptr_->Aggregate(task2.template Cast<chi::Task>());
-      INFO("Aggregate for ProcessHdf5DatasetTask succeeded");
+      task1.ptr_->AggregateOut(task2.template Cast<chi::Task>());
+      INFO("AggregateOut for ProcessHdf5DatasetTask succeeded");
       CLIO_IPC->DelTask(task1);
       CLIO_IPC->DelTask(task2);
     }
@@ -9644,15 +9644,15 @@ TEST_CASE("Autogen - Admin WreapDeadIpcs Container Methods", "[autogen][admin][w
     }
   }
 
-  SECTION("WreapDeadIpcs Aggregate") {
+  SECTION("WreapDeadIpcs AggregateOut") {
     auto t1 = container->NewTask(clio::run::admin::Method::kWreapDeadIpcs);
     auto t2 = container->NewTask(clio::run::admin::Method::kWreapDeadIpcs);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
+      t1.ptr_->AggregateOut(t2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t2);
     }
     if (!t1.IsNull()) CLIO_IPC->DelTask(t1);
-    INFO("WreapDeadIpcs Aggregate completed");
+    INFO("WreapDeadIpcs AggregateOut completed");
   }
 
   SECTION("WreapDeadIpcs LocalSaveTask/LocalLoadTask") {
@@ -10045,15 +10045,15 @@ TEST_CASE("Autogen - CTE GetTargetInfo Container Methods", "[autogen][cte][getta
     }
   }
 
-  SECTION("GetTargetInfo Aggregate") {
+  SECTION("GetTargetInfo AggregateOut") {
     auto t1 = cte_runtime.NewTask(clio::cte::core::Method::kGetTargetInfo);
     auto t2 = cte_runtime.NewTask(clio::cte::core::Method::kGetTargetInfo);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
+      t1.ptr_->AggregateOut(t2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t2);
     }
     if (!t1.IsNull()) CLIO_IPC->DelTask(t1);
-    INFO("CTE GetTargetInfo Aggregate completed");
+    INFO("CTE GetTargetInfo AggregateOut completed");
   }
 }
 
@@ -10280,15 +10280,15 @@ TEST_CASE("Autogen - Admin Default Case Coverage", "[autogen][admin][default]") 
     INFO("Admin default NewTask completed");
   }
 
-  SECTION("Default Aggregate") {
+  SECTION("Default AggregateOut") {
     auto t1 = container->NewTask(clio::run::admin::Method::kFlush);
     auto t2 = container->NewTask(clio::run::admin::Method::kFlush);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
+      t1.ptr_->AggregateOut(t2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t2);
     }
     if (!t1.IsNull()) CLIO_IPC->DelTask(t1);
-    INFO("Admin default Aggregate completed");
+    INFO("Admin default AggregateOut completed");
   }
 }
 
@@ -10376,15 +10376,15 @@ TEST_CASE("Autogen - Bdev Default Case Coverage", "[autogen][bdev][default]") {
     INFO("Bdev default NewTask completed");
   }
 
-  SECTION("Default Aggregate") {
+  SECTION("Default AggregateOut") {
     auto t1 = bdev_runtime.NewTask(clio::run::bdev::Method::kGetStats);
     auto t2 = bdev_runtime.NewTask(clio::run::bdev::Method::kGetStats);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
+      t1.ptr_->AggregateOut(t2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t2);
     }
     if (!t1.IsNull()) CLIO_IPC->DelTask(t1);
-    INFO("Bdev default Aggregate completed");
+    INFO("Bdev default AggregateOut completed");
   }
 }
 
@@ -10505,15 +10505,15 @@ TEST_CASE("Autogen - CTE Default Case Coverage", "[autogen][cte][default]") {
     INFO("CTE default NewTask completed");
   }
 
-  SECTION("Default Aggregate") {
+  SECTION("Default AggregateOut") {
     auto t1 = cte_runtime.NewTask(clio::cte::core::Method::kGetTagSize);
     auto t2 = cte_runtime.NewTask(clio::cte::core::Method::kGetTagSize);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
+      t1.ptr_->AggregateOut(t2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t2);
     }
     if (!t1.IsNull()) CLIO_IPC->DelTask(t1);
-    INFO("CTE default Aggregate completed");
+    INFO("CTE default AggregateOut completed");
   }
 }
 
@@ -10761,11 +10761,11 @@ TEST_CASE("Autogen - Admin StopRuntimeTask full coverage", "[autogen][admin][sto
         CLIO_IPC->DelTask(copy);
       }
 
-      // Test Aggregate
+      // Test AggregateOut
       auto agg = ipc_manager->NewTask<clio::run::admin::StopRuntimeTask>(
           chi::CreateTaskId(), chi::kAdminPoolId, chi::PoolQuery::Local());
       if (!agg.IsNull()) {
-        agg->Aggregate(task.template Cast<chi::Task>());
+        agg->AggregateOut(task.template Cast<chi::Task>());
         CLIO_IPC->DelTask(agg);
       }
 
@@ -10809,11 +10809,11 @@ TEST_CASE("Autogen - Admin SendTask full coverage", "[autogen][admin][sendtask][
         CLIO_IPC->DelTask(copy);
       }
 
-      // Test Aggregate
+      // Test AggregateOut
       auto agg = ipc_manager->NewTask<clio::run::admin::SendTask>(
           chi::CreateTaskId(), chi::kAdminPoolId, chi::PoolQuery::Local());
       if (!agg.IsNull()) {
-        agg->Aggregate(task.template Cast<chi::Task>());
+        agg->AggregateOut(task.template Cast<chi::Task>());
         CLIO_IPC->DelTask(agg);
       }
 
@@ -10897,11 +10897,11 @@ TEST_CASE("Autogen - Admin WreapDeadIpcsTask full coverage", "[autogen][admin][w
         CLIO_IPC->DelTask(copy);
       }
 
-      // Test Aggregate
+      // Test AggregateOut
       auto agg = ipc_manager->NewTask<clio::run::admin::WreapDeadIpcsTask>(
           chi::CreateTaskId(), chi::kAdminPoolId, chi::PoolQuery::Local());
       if (!agg.IsNull()) {
-        agg->Aggregate(task.template Cast<chi::Task>());
+        agg->AggregateOut(task.template Cast<chi::Task>());
         CLIO_IPC->DelTask(agg);
       }
 
@@ -11102,48 +11102,48 @@ TEST_CASE("Autogen - Admin Container StopRuntime", "[autogen][admin][container][
     }
   }
 
-  SECTION("Aggregate for kStopRuntime") {
+  SECTION("AggregateOut for kStopRuntime") {
     auto t1 = admin_runtime.NewTask(clio::run::admin::Method::kStopRuntime);
     auto t2 = admin_runtime.NewTask(clio::run::admin::Method::kStopRuntime);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
+      t1.ptr_->AggregateOut(t2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t2);
     }
     if (!t1.IsNull()) CLIO_IPC->DelTask(t1);
-    INFO("Admin kStopRuntime Aggregate completed");
+    INFO("Admin kStopRuntime AggregateOut completed");
   }
 
-  SECTION("Aggregate for kSend") {
+  SECTION("AggregateOut for kSend") {
     auto t1 = admin_runtime.NewTask(clio::run::admin::Method::kSend);
     auto t2 = admin_runtime.NewTask(clio::run::admin::Method::kSend);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
+      t1.ptr_->AggregateOut(t2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t2);
     }
     if (!t1.IsNull()) CLIO_IPC->DelTask(t1);
-    INFO("Admin kSend Aggregate completed");
+    INFO("Admin kSend AggregateOut completed");
   }
 
-  SECTION("Aggregate for kRecv") {
+  SECTION("AggregateOut for kRecv") {
     auto t1 = admin_runtime.NewTask(clio::run::admin::Method::kRecv);
     auto t2 = admin_runtime.NewTask(clio::run::admin::Method::kRecv);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
+      t1.ptr_->AggregateOut(t2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t2);
     }
     if (!t1.IsNull()) CLIO_IPC->DelTask(t1);
-    INFO("Admin kRecv Aggregate completed");
+    INFO("Admin kRecv AggregateOut completed");
   }
 
-  SECTION("Aggregate for kWreapDeadIpcs") {
+  SECTION("AggregateOut for kWreapDeadIpcs") {
     auto t1 = admin_runtime.NewTask(clio::run::admin::Method::kWreapDeadIpcs);
     auto t2 = admin_runtime.NewTask(clio::run::admin::Method::kWreapDeadIpcs);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
+      t1.ptr_->AggregateOut(t2.template Cast<chi::Task>());
       CLIO_IPC->DelTask(t2);
     }
     if (!t1.IsNull()) CLIO_IPC->DelTask(t1);
-    INFO("Admin kWreapDeadIpcs Aggregate completed");
+    INFO("Admin kWreapDeadIpcs AggregateOut completed");
   }
 
   SECTION("LocalSaveTask for kStopRuntime") {
@@ -11296,11 +11296,11 @@ TEST_CASE("Autogen - Admin Container StopRuntime", "[autogen][admin][container][
 }
 
 // ============================================================================
-// CTE Task SerializeIn/SerializeOut/Copy/Aggregate coverage
+// CTE Task SerializeIn/SerializeOut/Copy/AggregateOut coverage
 // These call the methods directly to cover core_tasks.h template instantiations
 // ============================================================================
 
-// Helper macro to test SerializeIn, SerializeOut, Copy, and Aggregate for a CTE task
+// Helper macro to test SerializeIn, SerializeOut, Copy, and AggregateOut for a CTE task
 #define TEST_CTE_TASK_METHODS(TaskType, task_label) \
 TEST_CASE("Autogen - CTE " task_label " methods", "[autogen][cte][methods][" task_label "]") { \
   EnsureInitialized(); \
@@ -11339,12 +11339,12 @@ TEST_CASE("Autogen - CTE " task_label " methods", "[autogen][cte][methods][" tas
     if (!t2.IsNull()) CLIO_IPC->DelTask(t2); \
   } \
   \
-  SECTION("Aggregate") { \
+  SECTION("AggregateOut") { \
     auto t1 = ipc_manager->NewTask<TaskType>(); \
     auto t2 = ipc_manager->NewTask<TaskType>(); \
     if (!t1.IsNull() && !t2.IsNull()) { \
-      t1->Aggregate(t2.template Cast<chi::Task>()); \
-      INFO(task_label " Aggregate completed"); \
+      t1->AggregateOut(t2.template Cast<chi::Task>()); \
+      INFO(task_label " AggregateOut completed"); \
     } \
     if (!t1.IsNull()) CLIO_IPC->DelTask(t1); \
     if (!t2.IsNull()) CLIO_IPC->DelTask(t2); \
@@ -11408,12 +11408,12 @@ TEST_CASE("Autogen - CTE GetOrCreateTagTask methods", "[autogen][cte][methods][G
     if (!t2.IsNull()) CLIO_IPC->DelTask(t2);
   }
 
-  SECTION("Aggregate") {
+  SECTION("AggregateOut") {
     auto t1 = ipc_manager->NewTask<TagCreateTask>();
     auto t2 = ipc_manager->NewTask<TagCreateTask>();
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1->Aggregate(t2.template Cast<chi::Task>());
-      INFO("GetOrCreateTagTask Aggregate completed");
+      t1->AggregateOut(t2.template Cast<chi::Task>());
+      INFO("GetOrCreateTagTask AggregateOut completed");
     }
     if (!t1.IsNull()) CLIO_IPC->DelTask(t1);
     if (!t2.IsNull()) CLIO_IPC->DelTask(t2);
@@ -12407,7 +12407,7 @@ TEST_CASE("Autogen - CTE Container NewTask/DelTask", "[autogen][cte][container][
 }
 
 // ==========================================================================
-// CTE Container NewCopyTask and Aggregate dispatch tests
+// CTE Container NewCopyTask and AggregateOut dispatch tests
 // ==========================================================================
 TEST_CASE("Autogen - CTE Container NewCopyTask dispatch", "[autogen][cte][container][newcopy]") {
   EnsureInitialized();
@@ -12432,8 +12432,8 @@ TEST_CASE("Autogen - CTE Container NewCopyTask dispatch", "[autogen][cte][contai
     }
   }
 
-  SECTION("Aggregate dispatch for CTE methods") {
-    // Exercise Aggregate dispatch in core_lib_exec.cc
+  SECTION("AggregateOut dispatch for CTE methods") {
+    // Exercise AggregateOut dispatch in core_lib_exec.cc
     chi::u32 methods[] = {
       clio::cte::core::Method::kRegisterTarget,
       clio::cte::core::Method::kUnregisterTarget,
@@ -12454,14 +12454,14 @@ TEST_CASE("Autogen - CTE Container NewCopyTask dispatch", "[autogen][cte][contai
       auto t1 = cte_runtime.NewTask(method);
       auto t2 = cte_runtime.NewTask(method);
       if (!t1.IsNull() && !t2.IsNull()) {
-        t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
+        t1.ptr_->AggregateOut(t2.template Cast<chi::Task>());
         CLIO_IPC->DelTask(t2);
       }
       if (!t1.IsNull()) {
         CLIO_IPC->DelTask(t1);
       }
     }
-    INFO("CTE Aggregate dispatch for all methods completed");
+    INFO("CTE AggregateOut dispatch for all methods completed");
   }
 }
 

--- a/context-runtime/util/clio_run_cmd_refresh_repo.cc
+++ b/context-runtime/util/clio_run_cmd_refresh_repo.cc
@@ -551,6 +551,28 @@ class ChiModGenerator {
     oss << "  }\n";
     oss << "}\n";
     oss << "\n";
+    // Generate AggregateIn method - dispatches to typed task's AggregateIn
+    // (ManyToOne collective input combine; default per-task is a no-op).
+    oss << "void Runtime::AggregateIn(chi::u32 method, ctp::ipc::FullPtr<chi::Task> agg_task,\n";
+    oss << "                        const ctp::ipc::FullPtr<chi::Task>& member_task) {\n";
+    oss << "  switch (method) {\n";
+
+    for (const auto& method : methods) {
+      std::string task_type = GetTaskTypeName(method.method_name, chimod_name);
+      oss << "    case Method::" << method.constant_name << ": {\n";
+      oss << "      auto typed_task = agg_task.template Cast<" << task_type << ">();\n";
+      oss << "      typed_task->AggregateIn(member_task);\n";
+      oss << "      break;\n";
+      oss << "    }\n";
+    }
+
+    oss << "    default: {\n";
+    oss << "      agg_task->AggregateIn(member_task);\n";
+    oss << "      break;\n";
+    oss << "    }\n";
+    oss << "  }\n";
+    oss << "}\n";
+    oss << "\n";
 
     // Generate DelTask method - dispatches to typed task deletion
     oss << "void Runtime::DelTask(chi::u32 method, ctp::ipc::FullPtr<chi::Task> task_ptr) {\n";

--- a/context-runtime/util/clio_run_cmd_refresh_repo.cc
+++ b/context-runtime/util/clio_run_cmd_refresh_repo.cc
@@ -39,7 +39,7 @@
  *
  * The libexec source files implement Container virtual API methods (Run, Del,
  * SaveTask, LoadTask, AllocLoadTask, LocalLoadTask, LocalAllocLoadTask,
- * NewCopy, Aggregate) with switch-case dispatch.
+ * NewCopy, AggregateOut) with switch-case dispatch.
  *
  * Usage:
  *     chimaera repo refresh <chimod_repo_path>
@@ -530,8 +530,8 @@ class ChiModGenerator {
     oss << "  }\n";
     oss << "}\n";
     oss << "\n";
-    // Generate Aggregate method - dispatches to typed task's Aggregate
-    oss << "void Runtime::Aggregate(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,\n";
+    // Generate AggregateOut method - dispatches to typed task's AggregateOut
+    oss << "void Runtime::AggregateOut(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,\n";
     oss << "                        const ctp::ipc::FullPtr<chi::Task>& replica_task) {\n";
     oss << "  switch (method) {\n";
 
@@ -539,13 +539,13 @@ class ChiModGenerator {
       std::string task_type = GetTaskTypeName(method.method_name, chimod_name);
       oss << "    case Method::" << method.constant_name << ": {\n";
       oss << "      auto typed_task = orig_task.template Cast<" << task_type << ">();\n";
-      oss << "      typed_task->Aggregate(replica_task);\n";
+      oss << "      typed_task->AggregateOut(replica_task);\n";
       oss << "      break;\n";
       oss << "    }\n";
     }
 
     oss << "    default: {\n";
-    oss << "      orig_task->Aggregate(replica_task);\n";
+    oss << "      orig_task->AggregateOut(replica_task);\n";
     oss << "      break;\n";
     oss << "    }\n";
     oss << "  }\n";

--- a/context-runtime/util/clio_run_cmd_refresh_repo.cc
+++ b/context-runtime/util/clio_run_cmd_refresh_repo.cc
@@ -39,7 +39,7 @@
  *
  * The libexec source files implement Container virtual API methods (Run, Del,
  * SaveTask, LoadTask, AllocLoadTask, LocalLoadTask, LocalAllocLoadTask,
- * NewCopy, AggregateOut) with switch-case dispatch.
+ * NewCopy, AggregateOut, AggregateIn) with switch-case dispatch.
  *
  * Usage:
  *     chimaera repo refresh <chimod_repo_path>

--- a/context-transfer-engine/benchmark/clio_cte_semantic_bench.cc
+++ b/context-transfer-engine/benchmark/clio_cte_semantic_bench.cc
@@ -40,7 +40,7 @@
  * 2. Issues ONE broadcast SemanticSearch for that keyword and asks for a
  *    configurable number of top-k results. With a broadcast query every
  *    tag-owning container scores its slice and returns its local top-k;
- *    SemanticSearchTask::Aggregate then merges those partial sets and keeps
+ *    SemanticSearchTask::AggregateOut then merges those partial sets and keeps
  *    the global top-k by descending BM25 score.
  *
  * On completion it prints an overall retrieval-performance summary — the

--- a/context-transfer-engine/compressor/include/clio_cte/compressor/compressor_runtime.h
+++ b/context-transfer-engine/compressor/include/clio_cte/compressor/compressor_runtime.h
@@ -169,7 +169,7 @@ private:
   ctp::ipc::FullPtr<chi::Task> NewCopyTask(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task_ptr,
                                         bool deep) override;
   ctp::ipc::FullPtr<chi::Task> NewTask(chi::u32 method) override;
-  void Aggregate(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
+  void AggregateOut(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
                  const ctp::ipc::FullPtr<chi::Task>& replica_task) override;
   void DelTask(chi::u32 method, ctp::ipc::FullPtr<chi::Task> task_ptr) override;
   void LocalLoadTask(chi::u32 method, chi::DefaultLoadArchive &archive,

--- a/context-transfer-engine/compressor/include/clio_cte/compressor/compressor_tasks.h
+++ b/context-transfer-engine/compressor/include/clio_cte/compressor/compressor_tasks.h
@@ -439,7 +439,7 @@ struct DecompressTask : public chi::Task {
  */
 struct NodeLoadSample {
   chi::u32 node_id_;          ///< Node ID being sampled
-  float cpu_usage_pct_;       ///< Aggregate CPU utilization (0-100)
+  float cpu_usage_pct_;       ///< AggregateOut CPU utilization (0-100)
   float worker_load_us_;      ///< Sum of WorkerStats::load_ across all workers (us)
   chi::u32 num_queued_tasks_; ///< Sum of queued tasks across all workers
   chi::u32 num_blocked_tasks_;///< Sum of blocked tasks across all workers

--- a/context-transfer-engine/compressor/src/autogen/compressor_lib_exec.cc
+++ b/context-transfer-engine/compressor/src/autogen/compressor_lib_exec.cc
@@ -469,51 +469,51 @@ ctp::ipc::FullPtr<chi::Task> Runtime::NewTask(chi::u32 method) {
   }
 }
 
-void Runtime::Aggregate(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
+void Runtime::AggregateOut(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
                         const ctp::ipc::FullPtr<chi::Task>& replica_task) {
   switch (method) {
     case Method::kCreate: {
       auto typed_task = orig_task.template Cast<CreateTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kDestroy: {
       auto typed_task = orig_task.template Cast<DestroyTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kMonitor: {
       auto typed_task = orig_task.template Cast<MonitorTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kDynamicSchedule: {
       auto typed_task = orig_task.template Cast<DynamicScheduleTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kCompress: {
       auto typed_task = orig_task.template Cast<CompressTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kDecompress: {
       auto typed_task = orig_task.template Cast<DecompressTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kPollNodeLoad: {
       auto typed_task = orig_task.template Cast<PollNodeLoadTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kPollConsumers: {
       auto typed_task = orig_task.template Cast<PollConsumersTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     default: {
-      orig_task->Aggregate(replica_task);
+      orig_task->AggregateOut(replica_task);
       break;
     }
   }

--- a/context-transfer-engine/compressor/src/compressor_runtime.cc
+++ b/context-transfer-engine/compressor/src/compressor_runtime.cc
@@ -1095,7 +1095,7 @@ chi::TaskResume Runtime::PollNodeLoad(ctp::ipc::FullPtr<PollNodeLoadTask> task,
     prev_cpu_times_ = cur;
   }
 
-  // Aggregate worker load across all workers on this node.
+  // AggregateOut worker load across all workers on this node.
   auto* orchestrator = CLIO_WORK_ORCHESTRATOR;
   if (orchestrator) {
     std::size_t num_workers = orchestrator->GetWorkerCount();

--- a/context-transfer-engine/compressor/test/clio_cte_compress_bench.cc
+++ b/context-transfer-engine/compressor/test/clio_cte_compress_bench.cc
@@ -899,7 +899,7 @@ class CTECompressBenchmark {
     HLOG(kInfo, "Bandwidth per thread (min): {} MB/s", min_bw);
     HLOG(kInfo, "Bandwidth per thread (max): {} MB/s", max_bw);
     HLOG(kInfo, "Bandwidth per thread (avg): {} MB/s", avg_bw);
-    HLOG(kInfo, "Aggregate bandwidth: {} MB/s", agg_bw);
+    HLOG(kInfo, "AggregateOut bandwidth: {} MB/s", agg_bw);
     HLOG(kInfo, "");
     HLOG(kInfo, "Compression ratio (avg): {}:1", avg_ratio);
     HLOG(kInfo, "=============================================");

--- a/context-transfer-engine/core/include/clio_cte/core/core_runtime.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_runtime.h
@@ -201,7 +201,7 @@ public:
   ctp::ipc::FullPtr<chi::Task> NewCopyTask(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task_ptr,
                                         bool deep) override;
   ctp::ipc::FullPtr<chi::Task> NewTask(chi::u32 method) override;
-  void Aggregate(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
+  void AggregateOut(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
                  const ctp::ipc::FullPtr<chi::Task>& replica_task) override;
   void DelTask(chi::u32 method, ctp::ipc::FullPtr<chi::Task> task_ptr) override;
   void LocalLoadTask(chi::u32 method, chi::DefaultLoadArchive &archive,

--- a/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
@@ -361,11 +361,11 @@ struct RegisterTargetTask : public chi::Task {
   }
 
   /**
-   * Aggregate replica results into this task
+   * AggregateOut replica results into this task
    * @param other Pointer to the replica task to aggregate from
    */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<RegisterTargetTask>());
   }
 };
@@ -422,11 +422,11 @@ struct UnregisterTargetTask : public chi::Task {
   }
 
   /**
-   * Aggregate replica results into this task
+   * AggregateOut replica results into this task
    * @param other Pointer to the replica task to aggregate from
    */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<UnregisterTargetTask>());
   }
 };
@@ -481,11 +481,11 @@ struct ListTargetsTask : public chi::Task {
   }
 
   /**
-   * Aggregate entries from another ListTargetsTask
+   * AggregateOut entries from another ListTargetsTask
    * Appends all target names from the other task to this one
    */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     auto other = other_base.template Cast<ListTargetsTask>();
     for (const auto &target_name : other->target_names_) {
       target_names_.push_back(target_name);
@@ -541,11 +541,11 @@ struct StatTargetsTask : public chi::Task {
   }
 
   /**
-   * Aggregate replica results into this task
+   * AggregateOut replica results into this task
    * @param other Pointer to the replica task to aggregate from
    */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<StatTargetsTask>());
   }
 };
@@ -628,10 +628,10 @@ struct GetTargetInfoTask : public chi::Task {
   }
 
   /**
-   * Aggregate replica results
+   * AggregateOut replica results
    */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     // For target info, just copy (should be same across replicas)
     Copy(other_base.template Cast<GetTargetInfoTask>());
   }
@@ -1026,11 +1026,11 @@ struct GetOrCreateTagTask : public chi::Task {
   }
 
   /**
-   * Aggregate replica results into this task
+   * AggregateOut replica results into this task
    * @param other Pointer to the replica task to aggregate from
    */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<GetOrCreateTagTask>());
   }
 };
@@ -1189,7 +1189,7 @@ struct PutBlobTask : public chi::Task {
     // crucially blob_data_ — must NOT be serialized here: blob_data_ is the
     // CLIENT's SHM buffer pointer, but the receiver runs with its own
     // (daemon-allocated) buffer. Echoing the receiver's blob_data_ back would
-    // clobber the origin task's blob_data_ during Aggregate, so a later
+    // clobber the origin task's blob_data_ during AggregateOut, so a later
     // FreeBuffer(task->blob_data_) frees a foreign/already-freed buffer and
     // corrupts the allocator — observed as a hang in CAE assimilators under
     // CLIO_FORCE_NET (issue #500).
@@ -1221,11 +1221,11 @@ struct PutBlobTask : public chi::Task {
   }
 
   /**
-   * Aggregate replica results into this task
+   * AggregateOut replica results into this task
    * @param other Pointer to the replica task to aggregate from
    */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<PutBlobTask>());
   }
 };
@@ -1378,11 +1378,11 @@ struct GetBlobTask : public chi::Task {
   }
 
   /**
-   * Aggregate replica results into this task
+   * AggregateOut replica results into this task
    * @param other Pointer to the replica task to aggregate from
    */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<GetBlobTask>());
   }
 };
@@ -1450,11 +1450,11 @@ struct ReorganizeBlobTask : public chi::Task {
   }
 
   /**
-   * Aggregate replica results into this task
+   * AggregateOut replica results into this task
    * @param other Pointer to the replica task to aggregate from
    */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<ReorganizeBlobTask>());
   }
 };
@@ -1515,11 +1515,11 @@ struct DelBlobTask : public chi::Task {
   }
 
   /**
-   * Aggregate replica results into this task
+   * AggregateOut replica results into this task
    * @param other Pointer to the replica task to aggregate from
    */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<DelBlobTask>());
   }
 };
@@ -1595,11 +1595,11 @@ struct DelTagTask : public chi::Task {
   }
 
   /**
-   * Aggregate replica results into this task
+   * AggregateOut replica results into this task
    * @param other Pointer to the replica task to aggregate from
    */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<DelTagTask>());
   }
 };
@@ -1658,11 +1658,11 @@ struct GetTagSizeTask : public chi::Task {
   }
 
   /**
-   * Aggregate results from a replica task
+   * AggregateOut results from a replica task
    * Sums the tag_size_ values from multiple nodes
    */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     auto replica = other_base.template Cast<GetTagSizeTask>();
     tag_size_ += replica->tag_size_;
   }
@@ -1728,11 +1728,11 @@ struct PollTelemetryLogTask : public chi::Task {
   }
 
   /**
-   * Aggregate replica results into this task
+   * AggregateOut replica results into this task
    * @param other Pointer to the replica task to aggregate from
    */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<PollTelemetryLogTask>());
   }
 };
@@ -1799,11 +1799,11 @@ struct GetBlobScoreTask : public chi::Task {
   }
 
   /**
-   * Aggregate replica results into this task
+   * AggregateOut replica results into this task
    * @param other Pointer to the replica task to aggregate from
    */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<GetBlobScoreTask>());
   }
 };
@@ -1870,11 +1870,11 @@ struct GetBlobSizeTask : public chi::Task {
   }
 
   /**
-   * Aggregate replica results into this task
+   * AggregateOut replica results into this task
    * @param other Pointer to the replica task to aggregate from
    */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<GetBlobSizeTask>());
   }
 };
@@ -1973,10 +1973,10 @@ struct GetBlobInfoTask : public chi::Task {
   }
 
   /**
-   * Aggregate replica results into this task
+   * AggregateOut replica results into this task
    */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<GetBlobInfoTask>());
   }
 };
@@ -2033,11 +2033,11 @@ struct GetContainedBlobsTask : public chi::Task {
   }
 
   /**
-   * Aggregate results from a replica task
+   * AggregateOut results from a replica task
    * Merges the blob_names_ vectors from multiple nodes
    */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     auto replica = other_base.template Cast<GetContainedBlobsTask>();
     // Merge blob names from replica into this task's blob_names_
     for (size_t i = 0; i < replica->blob_names_.size(); ++i) {
@@ -2053,7 +2053,7 @@ struct GetContainedBlobsTask : public chi::Task {
  *   limit.
  * - Returns a vector of tag names matching the query.
  * - total_tags_matched_ sums the total number of tags that matched the
- *   pattern across replicas during Aggregate.
+ *   pattern across replicas during AggregateOut.
  */
 struct TagQueryTask : public chi::Task {
   IN chi::priv::string tag_regex_;
@@ -2116,10 +2116,10 @@ struct TagQueryTask : public chi::Task {
   }
 
   /**
-   * Aggregate results from multiple nodes
+   * AggregateOut results from multiple nodes
    */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     auto other = other_base.template Cast<TagQueryTask>();
     // Sum total matched tags across replicas
     total_tags_matched_ += other->total_tags_matched_;
@@ -2141,7 +2141,7 @@ struct TagQueryTask : public chi::Task {
  * - Returns a vector of pairs where each pair contains (tag_name, blob_name)
  *   for blobs matching the query.
  * - total_blobs_matched_ sums the total number of blobs that matched across
- *   replicas during Aggregate.
+ *   replicas during AggregateOut.
  */
 struct BlobQueryTask : public chi::Task {
   IN chi::priv::string tag_regex_;
@@ -2211,10 +2211,10 @@ struct BlobQueryTask : public chi::Task {
   }
 
   /**
-   * Aggregate results from multiple nodes
+   * AggregateOut results from multiple nodes
    */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     auto other = other_base.template Cast<BlobQueryTask>();
     // Sum total matched blobs across replicas
     total_blobs_matched_ += other->total_blobs_matched_;
@@ -2269,8 +2269,8 @@ struct FlushMetadataTask : public chi::Task {
     entries_flushed_ = other->entries_flushed_;
   }
 
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<FlushMetadataTask>());
   }
 };
@@ -2326,8 +2326,8 @@ struct FlushDataTask : public chi::Task {
     blobs_flushed_ = other->blobs_flushed_;
   }
 
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<FlushDataTask>());
   }
 };
@@ -2428,18 +2428,18 @@ struct SemanticSearchTask : public chi::Task {
   }
 
   /**
-   * Aggregate one replica's results into this (origin) task.
+   * AggregateOut one replica's results into this (origin) task.
    *
    * SemanticSearch defaults to a Broadcast query, so every tag-owning
    * container runs BM25 over its own slice and returns its local top-k
-   * (already sorted descending by score). Aggregate is called once per
+   * (already sorted descending by score). AggregateOut is called once per
    * replica; it must MERGE those partial result sets and keep the global
    * top-k by score — not overwrite (the previous Copy() dropped every
    * replica but the last). Merge → sort descending by BM25 score → trim
    * to k_ (k_ == 0 means "no cap", keep all).
    */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     auto other = other_base.template Cast<SemanticSearchTask>();
     if (other->results_.empty()) {
       return;
@@ -2548,18 +2548,18 @@ struct TemporalSearchTask : public chi::Task {
   }
 
   /**
-   * Aggregate one replica's results into this (origin) task.
+   * AggregateOut one replica's results into this (origin) task.
    *
    * Like SemanticSearch, TemporalSearch defaults to a Broadcast query: every
    * tag-owning container returns its own oldest `max_entries_` blobs (sorted
-   * ascending by last-modified timestamp). Aggregate is called once per
+   * ascending by last-modified timestamp). AggregateOut is called once per
    * replica; it must MERGE those partial sets and keep the global oldest
    * `max_entries_` — not overwrite (the previous Copy() dropped every replica
    * but the last). Merge → sort ascending by timestamp → trim to max_entries_
    * (max_entries_ == 0 means "no cap", keep all).
    */
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     auto other = other_base.template Cast<TemporalSearchTask>();
     if (other->results_.empty()) {
       return;

--- a/context-transfer-engine/core/src/autogen/core_lib_exec.cc
+++ b/context-transfer-engine/core/src/autogen/core_lib_exec.cc
@@ -1251,141 +1251,141 @@ ctp::ipc::FullPtr<chi::Task> Runtime::NewTask(chi::u32 method) {
   }
 }
 
-void Runtime::Aggregate(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
+void Runtime::AggregateOut(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
                         const ctp::ipc::FullPtr<chi::Task>& replica_task) {
   switch (method) {
     case Method::kCreate: {
       auto typed_task = orig_task.template Cast<CreateTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kDestroy: {
       auto typed_task = orig_task.template Cast<DestroyTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kMonitor: {
       auto typed_task = orig_task.template Cast<MonitorTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kRegisterTarget: {
       auto typed_task = orig_task.template Cast<RegisterTargetTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kUnregisterTarget: {
       auto typed_task = orig_task.template Cast<UnregisterTargetTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kListTargets: {
       auto typed_task = orig_task.template Cast<ListTargetsTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kStatTargets: {
       auto typed_task = orig_task.template Cast<StatTargetsTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kGetOrCreateTag: {
       auto typed_task = orig_task.template Cast<core::GetOrCreateTagTask<core::CreateParams>>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kPutBlob: {
       auto typed_task = orig_task.template Cast<PutBlobTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kGetBlob: {
       auto typed_task = orig_task.template Cast<GetBlobTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kReorganizeBlob: {
       auto typed_task = orig_task.template Cast<ReorganizeBlobTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kDelBlob: {
       auto typed_task = orig_task.template Cast<DelBlobTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kDelTag: {
       auto typed_task = orig_task.template Cast<DelTagTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kGetTagSize: {
       auto typed_task = orig_task.template Cast<GetTagSizeTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kPollTelemetryLog: {
       auto typed_task = orig_task.template Cast<PollTelemetryLogTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kGetBlobScore: {
       auto typed_task = orig_task.template Cast<GetBlobScoreTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kGetBlobSize: {
       auto typed_task = orig_task.template Cast<GetBlobSizeTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kGetContainedBlobs: {
       auto typed_task = orig_task.template Cast<GetContainedBlobsTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kGetBlobInfo: {
       auto typed_task = orig_task.template Cast<GetBlobInfoTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kTagQuery: {
       auto typed_task = orig_task.template Cast<TagQueryTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kBlobQuery: {
       auto typed_task = orig_task.template Cast<BlobQueryTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kGetTargetInfo: {
       auto typed_task = orig_task.template Cast<GetTargetInfoTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kFlushMetadata: {
       auto typed_task = orig_task.template Cast<FlushMetadataTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kFlushData: {
       auto typed_task = orig_task.template Cast<FlushDataTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kSemanticSearch: {
       auto typed_task = orig_task.template Cast<SemanticSearchTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kTemporalSearch: {
       auto typed_task = orig_task.template Cast<TemporalSearchTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     default: {
-      orig_task->Aggregate(replica_task);
+      orig_task->AggregateOut(replica_task);
       break;
     }
   }

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -1143,7 +1143,7 @@ chi::TaskResume Runtime::PutBlob(ctp::ipc::FullPtr<PutBlobTask> task,
       // tag's name lives on whichever container `GetOrCreateTag`'s
       // `DirectHash(tag_name)` selected; this container only owns the
       // blobs that `HashBlobToContainer(tag_id, blob_name)` routed
-      // here. To keep the `GetTagSize` broadcast-and-Aggregate sum
+      // here. To keep the `GetTagSize` broadcast-and-AggregateOut sum
       // correct, every container that holds any of the tag's bytes
       // must carry a `TagInfo` whose `total_size_` reflects its share.
       // The silent-skip variant of this block dropped the accounting
@@ -3416,7 +3416,7 @@ chi::TaskResume Runtime::TagQuery(ctp::ipc::FullPtr<TagQueryTask> task,
           }
         });
 
-    // Total matched tags (summed across replicas during Aggregate)
+    // Total matched tags (summed across replicas during AggregateOut)
     task->total_tags_matched_ = matching_tags.size();
 
     // Build results: just tag names matching the query. Respect max_tags_ if

--- a/context-transfer-engine/core/src/tag.cc
+++ b/context-transfer-engine/core/src/tag.cc
@@ -40,7 +40,7 @@
 
 namespace clio::cte::core {
 
-// Aggregate timing for Tag::PutBlob(const char*) — broken down into the
+// AggregateOut timing for Tag::PutBlob(const char*) — broken down into the
 // four steps that path performs per call (alloc shm, memcpy, sync RPC,
 // free). Counters are flushed by FlushPutBlobTiming(); the POSIX adapter
 // calls that at the end of each Filesystem::Write so we get one summary


### PR DESCRIPTION
## Summary

Implements `PoolQuery::ManyToOne(container_hash, batch_key = 0, batch_for = 10us)` — collective task batching + aggregation at the neighborhood leader (closes #587).

A `ManyToOne` request is routed to the **neighborhood leader**, which briefly batches all tasks sharing the same `(pool_id, method, container_hash, batch_key)` for a `batch_for` window, folds them into **one** aggregate task, runs it once, and **broadcasts** the result back to every submitter.

## How it works

1. **API** (`pool_query.{h,cc}`): new `RoutingMode::ManyToOne`; `container_hash` aliases `hash_value_`, plus `batch_key_` / `batch_for_ns_` (default 10µs); getters, `serialize`, `ToString`/`FromString`.
2. **Routing** (`ipc_manager.cc`): `RouteTask` intercepts `ManyToOne` → `RouteManyToOne`. `GetNeighborhoodLeaderNodeId(for_node)` = lowest alive node in `[base, base+N)`. If we are the leader → park in `BatchManager`; else forward via `Physical(leader)` (the task re-enters routing on the leader and parks).
3. **Batching** (`batch_manager.{h,cc}`, new): groups by `(pool_id, method, container_hash, batch_key)`; per-group deadline = first arrival + `batch_for`; worker 0 drives `FlushDue` each loop and stays awake while batches are pending so the short window is honored.
4. **Aggregate**: `agg = NewCopyTask(first member)`; fold each remaining member's **inputs** via `Container::AggregateIn`; run once on the leader (`TASK_BATCH_AGGREGATE`).
5. **Broadcast + completion**: when the aggregate finishes, `Worker::EndTask` detects the flag and calls `OnAggregateComplete`, which serializes the aggregate's OUT once (`LocalSaveTask`, `kSerializeOut`) and loads it into every member (`LocalLoadTask`, `kSerializeOut`) — a 1→N `SerializeOut` copy-back — then completes each member's future (local signal or remote `SendOut`).

## Aggregate split: `AggregateIn` vs `AggregateOut`

Per review feedback, the two collective merges are now distinct:

- **`AggregateOut`** — the existing replica-gather merge (folds a replica's **OUT** fields into an origin, N→1). The original `Aggregate` was renamed to this everywhere (Task base, `Container` virtual, every chimod task, the autogen generator + all generated `*_lib_exec.cc`, and the `RecvOutAggregate` caller).
- **`AggregateIn`** — new: folds batched member **inputs** into the aggregate (ManyToOne). Default no-op (aggregate = copy of first member, i.e. barrier/dedup); chimods override to combine (sum/max/concat). Dispatched per-method by the autogen generator, mirroring `AggregateOut`.
- ManyToOne result distribution uses **`SerializeOut`**, not `AggregateOut`.

## Example / test vehicle

New MOD_NAME method `kManyToOneSum` (`ManyToOneSumTask`: `IN value_`, `OUT sum_`): `AggregateIn` sums each member's `value_`; the handler echoes the total into `sum_`; the engine broadcasts it to all submitters.

## Verification

- **`ManyToOne AggregateIn collective sum`** (MOD_NAME): 5 submitters contribute 1..5 → `AggregateIn` sums to 15 → broadcast to all 5 (each asserts `sum_ == 15`). Passes.
- **`bdev_manytoone_batch`**: 4 batched `AllocateBlocks` members all receive the broadcast result. Passes (runs in the normal bdev suite).
- Full build green.

## Notable fix

The aggregate is a `NewCopyTask` of a batched member; `Task::Copy` copies `task_flags_` but not `host_run_ctx_`, so the aggregate inherited `TASK_RUN_CTX_EXISTS` with a null run ctx and the submit path skipped `BeginTask` → the aggregate never executed and members hung. Fixed by clearing `TASK_ROUTED | TASK_STARTED | TASK_RUN_CTX_EXISTS` on the aggregate so it gets its own RunContext/future.

## Notes / follow-ups

- In-tree chimods have no `chimaera_repo.yaml`, so MOD_NAME's autogen (`methods.h` + `lib_exec.cc`) was regenerated by hand to match the updated generator; future repo-based regens will reproduce it.
- Remote-origin (`ret_node`) completion reuses the existing response path; the single-node / same-neighborhood path is what's exercised by the tests here. Broader multi-node coverage is a follow-up.
- I verified the two ManyToOne tests + clean full builds; I did not run the entire repo suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
