### PR TITLE
fix(sycl): locate <sycl/sycl.hpp> for host TUs from compiler path

### DIFF
--- a/cmake/ClioCoreCommon.cmake
+++ b/cmake/ClioCoreCommon.cmake
@@ -237,7 +237,41 @@ macro(wrp_core_enable_sycl CXX_STANDARD)
         "Pass -fsycl-allow-virtual-functions to DPC++ (recent compiler only)"
         OFF)
 
-    message(STATUS "SYCL enabled: compiler=${CLIO_SYCL_COMPILER} target=${SYCL_TARGET} device=${SYCL_DEVICE}")
+    # Locate the SYCL headers so HOST translation units -- compiled with
+    # CTP_ENABLE_SYCL=1 but WITHOUT -fsycl (see context-runtime/src and
+    # context-transfer-engine/core) -- can still find <sycl/sycl.hpp>.
+    # icpx only adds this directory to its search path under -fsycl, so for
+    # plain host TUs we must supply it explicitly. Derive it from the compiler
+    # location rather than hardcoding a vendor prefix: on Aurora the headers
+    # live next to icpx (e.g. .../oneapi/compiler/latest/include/sycl), NOT at
+    # /opt/intel/dpcpp. <sycl/sycl.hpp> is plain C++ and parses without the
+    # SYCL frontend (it only warns; we silence that via the compile def below).
+    if(NOT DEFINED CACHE{CLIO_SYCL_INCLUDE_DIR})
+        set(_wrp_sycl_inc "")
+        if(CLIO_SYCL_COMPILER STREQUAL "DPCPP")
+            get_filename_component(_wrp_cxx_bin "${CMAKE_CXX_COMPILER}" DIRECTORY)
+            get_filename_component(_wrp_cmplr_root "${_wrp_cxx_bin}" DIRECTORY)
+            if(EXISTS "${_wrp_cmplr_root}/include/sycl/sycl.hpp")
+                set(_wrp_sycl_inc "${_wrp_cmplr_root}/include")
+            elseif(EXISTS "/opt/intel/dpcpp/include/sycl/sycl.hpp")
+                set(_wrp_sycl_inc "/opt/intel/dpcpp/include")
+            endif()
+        elseif(CLIO_SYCL_COMPILER STREQUAL "ACPP")
+            if(EXISTS "/opt/adaptivecpp/include/AdaptiveCpp/sycl/sycl.hpp")
+                set(_wrp_sycl_inc "/opt/adaptivecpp/include/AdaptiveCpp")
+            endif()
+        endif()
+        set(CLIO_SYCL_INCLUDE_DIR "${_wrp_sycl_inc}" CACHE PATH
+            "SYCL header directory for host TUs compiled without -fsycl")
+    endif()
+    if(NOT CLIO_SYCL_INCLUDE_DIR)
+        message(WARNING
+            "SYCL enabled but <sycl/sycl.hpp> not located next to ${CMAKE_CXX_COMPILER} "
+            "nor at the legacy /opt prefixes. Host TUs that include it will fail to "
+            "compile. Set -DCLIO_SYCL_INCLUDE_DIR=<dir containing sycl/sycl.hpp>.")
+    endif()
+
+    message(STATUS "SYCL enabled: compiler=${CLIO_SYCL_COMPILER} target=${SYCL_TARGET} device=${SYCL_DEVICE} include=${CLIO_SYCL_INCLUDE_DIR}")
 endmacro()
 
 # Apply SYCL compile and link flags to a specific target.

--- a/context-runtime/src/CMakeLists.txt
+++ b/context-runtime/src/CMakeLists.txt
@@ -110,14 +110,14 @@ if(CHIMAERA_GPU_SOURCES)
     # -fsycl, host code uses sycl::malloc_host / sycl::queue / sycl::free
     # as plain runtime API calls. The chimaera_cxx_gpu library compiled by
     # add_sycl_library still gets full -fsycl + device-pass treatment.
-    target_compile_definitions(${CHIMAERA_LIB_NAME} PRIVATE CTP_ENABLE_SYCL=1)
-    if(EXISTS "/opt/intel/dpcpp/include/sycl/sycl.hpp")
-      target_include_directories(${CHIMAERA_LIB_NAME} PRIVATE
-          /opt/intel/dpcpp/include
-          /opt/intel/dpcpp/include/sycl)
-    elseif(EXISTS "/opt/adaptivecpp/include/AdaptiveCpp/sycl/sycl.hpp")
-      target_include_directories(${CHIMAERA_LIB_NAME} PRIVATE
-          /opt/adaptivecpp/include/AdaptiveCpp)
+    # SYCL_DISABLE_FSYCL_SYCLHPP_WARNING silences the "including <sycl/sycl.hpp>
+    # without -fsycl" pragma warning that <sycl/sycl.hpp> emits in host TUs.
+    target_compile_definitions(${CHIMAERA_LIB_NAME} PRIVATE
+        CTP_ENABLE_SYCL=1 SYCL_DISABLE_FSYCL_SYCLHPP_WARNING=1)
+    # CLIO_SYCL_INCLUDE_DIR is discovered in wrp_core_enable_sycl() from the
+    # actual compiler location (works on Aurora oneAPI, not just /opt/intel).
+    if(CLIO_SYCL_INCLUDE_DIR)
+      target_include_directories(${CHIMAERA_LIB_NAME} PRIVATE ${CLIO_SYCL_INCLUDE_DIR})
     endif()
   elseif(CLIO_CORE_ENABLE_ROCM)
     add_rocm_gpu_library(${CHIMAERA_LIB_NAME}_gpu SHARED FALSE ${CHIMAERA_GPU_SOURCES})

--- a/context-transfer-engine/core/CMakeLists.txt
+++ b/context-transfer-engine/core/CMakeLists.txt
@@ -17,14 +17,12 @@ add_clio_module_runtime(
 # see the matching #if CTP_ENABLE_{CUDA,ROCM,SYCL} branches. Without
 # these the GPU code paths in core_runtime.cc are no-ops.
 if(CLIO_CORE_ENABLE_SYCL)
-  target_compile_definitions(clio_cte_core_runtime PRIVATE CTP_ENABLE_SYCL=1)
-  if(EXISTS "/opt/intel/dpcpp/include/sycl/sycl.hpp")
-    target_include_directories(clio_cte_core_runtime PRIVATE
-      /opt/intel/dpcpp/include
-      /opt/intel/dpcpp/include/sycl)
-  elseif(EXISTS "/opt/adaptivecpp/include/AdaptiveCpp/sycl/sycl.hpp")
-    target_include_directories(clio_cte_core_runtime PRIVATE
-      /opt/adaptivecpp/include/AdaptiveCpp)
+  # Host TU: CTP_ENABLE_SYCL=1 without -fsycl. See context-runtime/src for the
+  # rationale; CLIO_SYCL_INCLUDE_DIR is discovered in wrp_core_enable_sycl().
+  target_compile_definitions(clio_cte_core_runtime PRIVATE
+    CTP_ENABLE_SYCL=1 SYCL_DISABLE_FSYCL_SYCLHPP_WARNING=1)
+  if(CLIO_SYCL_INCLUDE_DIR)
+    target_include_directories(clio_cte_core_runtime PRIVATE ${CLIO_SYCL_INCLUDE_DIR})
   endif()
 endif()
 if(CLIO_CORE_ENABLE_CUDA)


### PR DESCRIPTION
Fixes #589.

## Problem

A SYCL build on Aurora oneAPI fails with `sycl/sycl.hpp file not found`. `macros.h` includes `<sycl/sycl.hpp>` whenever `CTP_ENABLE_SYCL=1` (set on all targets), but `-fsycl` — which is what makes `icpx` add the SYCL header search path — is only applied to device targets. Host TUs in `context-runtime/src` and `context-transfer-engine/core` are compiled with `CTP_ENABLE_SYCL=1` and **no** `-fsycl`, so they can't find the header.

The CMake meant to supply the path to those host targets hardcoded `/opt/intel/dpcpp/include` and `/opt/adaptivecpp/...`, which don't exist on Aurora (headers live next to `icpx`, e.g. `.../oneapi/compiler/latest/include`). Neither branch matched, so no include dir was added.

## Fix

- `cmake/ClioCoreCommon.cmake`: `wrp_core_enable_sycl()` now derives `CLIO_SYCL_INCLUDE_DIR` from the actual compiler location (`dirname(dirname(CMAKE_CXX_COMPILER))/include`), with the legacy `/opt` paths kept as fallback, and warns if `sycl/sycl.hpp` can't be located.
- `context-runtime/src/CMakeLists.txt` and `context-transfer-engine/core/CMakeLists.txt`: use `CLIO_SYCL_INCLUDE_DIR` instead of the hardcoded paths, and add `SYCL_DISABLE_FSYCL_SYCLHPP_WARNING=1` to silence the host-include pragma warning.

`<sycl/sycl.hpp>` parses cleanly under `icpx` without `-fsycl` once the path is supplied.

## Verification

On Aurora (`sycl-debug` preset, `icx`/`icpx`):
- Configure prints `SYCL enabled: ... include=/opt/aurora/26.26.0/oneapi/compiler/latest/include`
- Build compiles with **0 errors** (previously blocked by the missing header)
- **187/189 tests pass**. The 2 failures (`test_gpu_sycl`, `cr_gpu_kernel_stress_sycl`) are unrelated — they need an actual GPU device and pass on a GPU compute node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)