### PR TITLE
fix(ctp): expand ${HOME} via GetHomeDir() for Windows consistency

### DIFF
--- a/context-transport-primitives/include/clio_ctp/util/config_parse.h
+++ b/context-transport-primitives/include/clio_ctp/util/config_parse.h
@@ -275,10 +275,16 @@ class ConfigParse {
       size_t end = path.find("}", pos + 2);
       if (end == std::string::npos) break;
       std::string env_name = path.substr(pos + 2, end - pos - 2);
-      std::string env_val = ctp::SystemInfo::Getenv(
-          env_name.c_str(), ctp::Unit<size_t>::Megabytes(1));
-      if (env_val.empty() && env_name == "HOME") {
+      std::string env_val;
+      // Expand ${HOME} via GetHomeDir() so it stays consistent with the
+      // canonical home directory. On Windows GetHomeDir() prefers USERPROFILE
+      // over a stray HOME (e.g. set by MSYS/git), which the raw HOME env var
+      // would otherwise contradict.
+      if (env_name == "HOME") {
         env_val = ctp::SystemInfo::GetHomeDir();
+      } else {
+        env_val = ctp::SystemInfo::Getenv(
+            env_name.c_str(), ctp::Unit<size_t>::Megabytes(1));
       }
       path.replace(pos, end - pos + 1, env_val);
       pos += env_val.size();


### PR DESCRIPTION
## Summary

Fixes the two ctest failures `cr_autogen_coverage_tests` and `cr_autogen_coverage_force_net` on Windows.

`ConfigParse::ExpandPath` expanded `${HOME}` by reading the raw `HOME` env var, while `SystemInfo::GetHomeDir()` deliberately prefers `USERPROFILE` over `HOME` on Windows. On machines where `HOME != USERPROFILE` (e.g. `HOME` set by MSYS/git), the two disagreed and the `Autogen - ConfigParse ExpandPath` assertion failed:

```cpp
REQUIRE(ExpandPath("${HOME}/test") == GetHomeDir() + "/test");
```

This change expands `${HOME}` through `GetHomeDir()` so both code paths stay consistent. No-op on POSIX (`GetHomeDir()` returns `$HOME`); on Windows it honors the canonical `USERPROFILE`-preferred home.

## Test plan

Rebuilt `chimaera_autogen_coverage_tests` with the icx toolchain and ran it directly:

- Before: 248/249 passed (1 failure in `ConfigParse ExpandPath`)
- After: **249/249 passed (100%)**, exit 0

Closes #592

?? Generated with [Claude Code](https://claude.com/claude-code)