### PR TITLE
CTE: track ctime on tags and report it via getattr (#603)

### DIFF
--- a/context-transfer-engine/adapter/libfuse/fuse_cte.cc
+++ b/context-transfer-engine/adapter/libfuse/fuse_cte.cc
@@ -171,6 +171,12 @@ static int cte_fuse_getattr(const char *path, struct stat *stbuf,
     stbuf->st_nlink = nlink;
     stbuf->st_size = static_cast<off_t>(t->size_);
   }
+  // Change time (ctime): the tag's last_changed_, in ns since the epoch. Tags
+  // only; 0 means the chimod had no value (leave st_ctim at the epoch).
+  if (t->ctime_ != 0) {
+    stbuf->st_ctim.tv_sec = static_cast<time_t>(t->ctime_ / 1000000000ULL);
+    stbuf->st_ctim.tv_nsec = static_cast<long>(t->ctime_ % 1000000000ULL);
+  }
   return 0;
 }
 

--- a/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
@@ -673,6 +673,10 @@ struct TagInfo {
       total_size_;  // Total size of all blobs in this tag (non-atomic for GPU)
   Timestamp last_modified_;
   Timestamp last_read_;
+  // Change time (ctime): bumped whenever this tag's METADATA changes — create,
+  // rename, hard-link add/remove, or size change. Distinct from last_modified_
+  // (content/mtime) and last_read_ (atime). Tags only; blobs are not tracked.
+  Timestamp last_changed_;
   // Additional names bound to this tag's id (tag-level hard links). The
   // canonical name lives in tag_name_; aliases_ holds every extra name. When
   // the canonical tag is deleted, all of these bindings are removed too.
@@ -684,6 +688,7 @@ struct TagInfo {
         total_size_(0),
         last_modified_(0),
         last_read_(0),
+        last_changed_(0),
         aliases_(CLIO_PRIV_ALLOC) {}
 
   CTP_CROSS_FUN TagInfo(const chi::priv::string &tag_name, const TagId &tag_id)
@@ -692,6 +697,7 @@ struct TagInfo {
         total_size_(0),
         last_modified_(0),
         last_read_(0),
+        last_changed_(0),
         aliases_(CLIO_PRIV_ALLOC) {}
 
 #if CTP_IS_HOST
@@ -701,6 +707,7 @@ struct TagInfo {
         total_size_(0),
         last_modified_(GetCurrentTimeNs()),
         last_read_(GetCurrentTimeNs()),
+        last_changed_(GetCurrentTimeNs()),
         aliases_(CLIO_PRIV_ALLOC) {}
 #endif
 
@@ -710,6 +717,7 @@ struct TagInfo {
         total_size_(other.total_size_),
         last_modified_(other.last_modified_),
         last_read_(other.last_read_),
+        last_changed_(other.last_changed_),
         aliases_(other.aliases_) {}
 
   CTP_CROSS_FUN TagInfo &operator=(const TagInfo &other) {
@@ -719,6 +727,7 @@ struct TagInfo {
       total_size_ = other.total_size_;
       last_modified_ = other.last_modified_;
       last_read_ = other.last_read_;
+      last_changed_ = other.last_changed_;
       aliases_ = other.aliases_;
     }
     return *this;
@@ -1891,9 +1900,11 @@ struct GetTagNameTask : public chi::Task {
 struct GetTagSizeTask : public chi::Task {
   IN TagId tag_id_;      // Tag ID to query
   OUT size_t tag_size_;  // Total size of all blobs in tag
+  OUT chi::u64 ctime_;   // Tag change-time (last_changed_), ns; 0 if unknown
 
   // SHM constructor
-  GetTagSizeTask() : chi::Task(), tag_id_(TagId::GetNull()), tag_size_(0) {}
+  GetTagSizeTask()
+      : chi::Task(), tag_id_(TagId::GetNull()), tag_size_(0), ctime_(0) {}
 
   // Emplace constructor
   CTP_CROSS_FUN explicit GetTagSizeTask(const chi::TaskId &task_id,
@@ -1902,7 +1913,8 @@ struct GetTagSizeTask : public chi::Task {
                                          const TagId &tag_id)
       : chi::Task(task_id, pool_id, pool_query, Method::kGetTagSize),
         tag_id_(tag_id),
-        tag_size_(0) {
+        tag_size_(0),
+        ctime_(0) {
     task_id_ = task_id;
     pool_id_ = pool_id;
     method_ = Method::kGetTagSize;
@@ -1925,7 +1937,7 @@ struct GetTagSizeTask : public chi::Task {
   template <typename Archive>
   CTP_CROSS_FUN void SerializeOut(Archive &ar) {
     Task::SerializeOut(ar);
-    ar(tag_size_);
+    ar(tag_size_, ctime_);
   }
 
   /**
@@ -1936,16 +1948,18 @@ struct GetTagSizeTask : public chi::Task {
     Task::Copy(other.template Cast<Task>());
     tag_id_ = other->tag_id_;
     tag_size_ = other->tag_size_;
+    ctime_ = other->ctime_;
   }
 
   /**
    * AggregateOut results from a replica task
-   * Sums the tag_size_ values from multiple nodes
+   * Sums the tag_size_ values from multiple nodes; keeps the newest ctime.
    */
   void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
     Task::AggregateOut(other_base);
     auto replica = other_base.template Cast<GetTagSizeTask>();
     tag_size_ += replica->tag_size_;
+    if (replica->ctime_ > ctime_) ctime_ = replica->ctime_;
   }
 };
 

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -1302,12 +1302,14 @@ chi::TaskResume Runtime::PutBlob(ctp::ipc::FullPtr<PutBlobTask> task,
         seed.tag_id_ = tag_id;
         seed.last_modified_ = now;
         seed.last_read_ = now;
+        seed.last_changed_ = now;
         seed.total_size_ = 0;
         auto ins = tag_id_to_info_.insert_or_assign(tag_id, seed);
         tag_info_ptr = ins.value;
       }
       if (tag_info_ptr) {
         tag_info_ptr->last_modified_ = now;
+        tag_info_ptr->last_changed_ = now;  // size change => ctime bump
         if (size_change >= 0) {
           tag_info_ptr->total_size_ += static_cast<chi::u64>(size_change);
         } else {
@@ -1575,6 +1577,7 @@ chi::TaskResume Runtime::DelBlob(ctp::ipc::FullPtr<DelBlobTask> task,
         } else {
           tag_info_ptr->total_size_ = 0;
         }
+        tag_info_ptr->last_changed_ = GetCurrentTimeNs();  // size change => ctime
       }
     }
 
@@ -1663,6 +1666,7 @@ chi::TaskResume Runtime::TruncateBlob(ctp::ipc::FullPtr<TruncateBlobTask> task,
               (d <= tag_info_ptr->total_size_) ? tag_info_ptr->total_size_ - d
                                                : 0;
         }
+        tag_info_ptr->last_changed_ = GetCurrentTimeNs();  // truncate => ctime
       }
     }
 
@@ -1778,6 +1782,7 @@ chi::TaskResume Runtime::RenameTag(ctp::ipc::FullPtr<RenameTagTask> task,
         tag_name_to_id_.insert_or_assign(new_rel, tag_id);
         info->tag_name_ = chi::priv::string(CLIO_PRIV_ALLOC, new_rel);
         info->last_modified_ = GetCurrentTimeNs();
+        info->last_changed_ = info->last_modified_;  // rename => ctime bump
 
         // Re-key this tag and its descendants in the search index from old_abs
         // to new_abs (#598). A directory move changes the absolute names of the
@@ -1817,6 +1822,7 @@ chi::TaskResume Runtime::RenameTag(ctp::ipc::FullPtr<RenameTagTask> task,
       if (info != nullptr) {
         info->tag_name_ = chi::priv::string(CLIO_PRIV_ALLOC, new_name);
         info->last_modified_ = GetCurrentTimeNs();
+        info->last_changed_ = info->last_modified_;  // rename => ctime bump
       }
     }
     // Flat tags have no hierarchy, so the index key is the verbatim name; move
@@ -1914,6 +1920,7 @@ chi::TaskResume Runtime::GetOrCreateTagAlias(
                 chi::priv::string(CLIO_PRIV_ALLOC, alias_key));
           }
           info->last_modified_ = GetCurrentTimeNs();
+          info->last_changed_ = info->last_modified_;  // link added => ctime
         }
       }
     }
@@ -2010,6 +2017,7 @@ chi::TaskResume Runtime::DelTag(ctp::ipc::FullPtr<DelTagTask> task,
             break;
           }
         }
+        tag_info_ptr->last_changed_ = GetCurrentTimeNs();  // unlink => ctime
         tag_info_ptr->last_modified_ = GetCurrentTimeNs();
       }
       task->return_code_ = 0;
@@ -2260,6 +2268,7 @@ chi::TaskResume Runtime::GetTagSize(ctp::ipc::FullPtr<GetTagSizeTask> task,
     tag_info_ptr->last_read_ = now;
 
     task->tag_size_ = tag_info_ptr->total_size_;
+    task->ctime_ = tag_info_ptr->last_changed_;  // surface ctime to getattr
     task->return_code_ = 0;
 
     // Log telemetry for GetTagSize operation
@@ -2442,6 +2451,7 @@ TagId Runtime::GetOrAssignTagId(const std::string &tag_name,
   TagInfo tag_info;
   tag_info.tag_name_ = tag_name;
   tag_info.tag_id_ = tag_id;
+  tag_info.last_changed_ = GetCurrentTimeNs();  // ctime at creation
 
   // Store mappings
   tag_name_to_id_.insert_or_assign(tag_name, tag_id);

--- a/context-transfer-engine/filesystem/include/clio_cte/filesystem/filesystem_tasks.h
+++ b/context-transfer-engine/filesystem/include/clio_cte/filesystem/filesystem_tasks.h
@@ -241,21 +241,23 @@ struct GetattrTask : public chi::Task {
   OUT chi::u32 exists_;
   OUT chi::u32 is_dir_;
   OUT chi::u64 size_;
+  OUT chi::u64 ctime_;  // tag change-time (ns); 0 if unknown
   GetattrTask()
-      : chi::Task(), path_(CTP_MALLOC), exists_(0), is_dir_(0), size_(0) {}
+      : chi::Task(), path_(CTP_MALLOC), exists_(0), is_dir_(0), size_(0),
+        ctime_(0) {}
   explicit GetattrTask(const chi::TaskId &task_id, const chi::PoolId &pool_id,
                        const chi::PoolQuery &pool_query, const std::string &path)
       : chi::Task(task_id, pool_id, pool_query, Method::kGetattr),
-        path_(CTP_MALLOC, path), exists_(0), is_dir_(0), size_(0) {}
+        path_(CTP_MALLOC, path), exists_(0), is_dir_(0), size_(0), ctime_(0) {}
   void Copy(const ctp::ipc::FullPtr<GetattrTask>& o) {
     path_ = o->path_; exists_ = o->exists_; is_dir_ = o->is_dir_;
-    size_ = o->size_;
+    size_ = o->size_; ctime_ = o->ctime_;
   }
   template <typename Ar> void SerializeIn(Ar &ar) {
     Task::SerializeIn(ar); ar(path_);
   }
   template <typename Ar> void SerializeOut(Ar &ar) {
-    Task::SerializeOut(ar); ar(exists_, is_dir_, size_);
+    Task::SerializeOut(ar); ar(exists_, is_dir_, size_, ctime_);
   }
 };
 

--- a/context-transfer-engine/filesystem/src/filesystem_runtime.cc
+++ b/context-transfer-engine/filesystem/src/filesystem_runtime.cc
@@ -446,13 +446,11 @@ chi::TaskResume Runtime::Getattr(ctp::ipc::FullPtr<GetattrTask> task,
     CLIO_CO_AWAIT(q);
     if (q->GetReturnCode() == 0 && !q->results_.empty()) {
       task->exists_ = 1; task->is_dir_ = 1; task->size_ = 0;
-      // ctime of the directory tag itself.
-      auto tag = cte_.AsyncGetOrCreateTag(dir, clio::cte::core::TagId::GetNull(),
-                                          chi::PoolQuery::Local());
-      CLIO_CO_AWAIT(tag);
-      auto s = cte_.AsyncGetTagSize(tag->tag_id_, chi::PoolQuery::Local());
-      CLIO_CO_AWAIT(s);
-      task->ctime_ = (s->GetReturnCode() == 0) ? s->ctime_ : 0;
+      // NOTE: deliberately do NOT fetch the directory's ctime here. getattr must
+      // be read-only; resolving the dir tag via GetOrCreateTag would re-create a
+      // concurrently-removed directory (corrupts dirstress/nested-dir tests),
+      // and it adds RPCs to the hot dir-stat path. Directory ctime is left at 0
+      // for now; file ctime (below) is what the ctime xfstests exercise. (#603)
       task->return_code_ = 0;
       CLIO_CO_RETURN;
     }

--- a/context-transfer-engine/filesystem/src/filesystem_runtime.cc
+++ b/context-transfer-engine/filesystem/src/filesystem_runtime.cc
@@ -410,12 +410,28 @@ chi::TaskResume Runtime::Getattr(ctp::ipc::FullPtr<GetattrTask> task,
   // Live logical size wins if the file is currently tracked (open files only;
   // directories are never tracked here).
   {
-    std::lock_guard<std::mutex> g(meta_mu_);
-    auto it = by_path_.find(path);
-    if (it != by_path_.end()) {
+    bool tracked = false;
+    chi::u64 live_size = 0;
+    clio::cte::core::TagId h_tag = clio::cte::core::TagId::GetNull();
+    {
+      std::lock_guard<std::mutex> g(meta_mu_);
+      auto it = by_path_.find(path);
+      if (it != by_path_.end()) {
+        tracked = true;
+        live_size = it->second->size_.load();
+        h_tag = it->second->tag_id_;
+      }
+    }
+    if (tracked) {
       task->exists_ = 1;
       task->is_dir_ = 0;
-      task->size_ = it->second->size_.load();
+      task->size_ = live_size;
+      // ctime from the tag (mutex released before this RPC).
+      if (!h_tag.IsNull()) {
+        auto s = cte_.AsyncGetTagSize(h_tag, chi::PoolQuery::Local());
+        CLIO_CO_AWAIT(s);
+        task->ctime_ = (s->GetReturnCode() == 0) ? s->ctime_ : 0;
+      }
       task->return_code_ = 0;
       CLIO_CO_RETURN;
     }
@@ -430,6 +446,13 @@ chi::TaskResume Runtime::Getattr(ctp::ipc::FullPtr<GetattrTask> task,
     CLIO_CO_AWAIT(q);
     if (q->GetReturnCode() == 0 && !q->results_.empty()) {
       task->exists_ = 1; task->is_dir_ = 1; task->size_ = 0;
+      // ctime of the directory tag itself.
+      auto tag = cte_.AsyncGetOrCreateTag(dir, clio::cte::core::TagId::GetNull(),
+                                          chi::PoolQuery::Local());
+      CLIO_CO_AWAIT(tag);
+      auto s = cte_.AsyncGetTagSize(tag->tag_id_, chi::PoolQuery::Local());
+      CLIO_CO_AWAIT(s);
+      task->ctime_ = (s->GetReturnCode() == 0) ? s->ctime_ : 0;
       task->return_code_ = 0;
       CLIO_CO_RETURN;
     }
@@ -446,6 +469,7 @@ chi::TaskResume Runtime::Getattr(ctp::ipc::FullPtr<GetattrTask> task,
     auto s = cte_.AsyncGetTagSize(tag->tag_id_, chi::PoolQuery::Local());
     CLIO_CO_AWAIT(s);
     task->size_ = (s->GetReturnCode() == 0) ? s->tag_size_ : 0;
+    task->ctime_ = (s->GetReturnCode() == 0) ? s->ctime_ : 0;
   } else {
     task->exists_ = 0; task->is_dir_ = 0; task->size_ = 0;
   }


### PR DESCRIPTION
Adds a change-time (**ctime**) to CTE tags and surfaces it through `stat()`. Tags only — blob ctime is out of scope. Closes #603.

## Changes
- **Core:** new `TagInfo::last_changed_`, bumped on every tag-metadata mutation — create (GetOrAssignTagId), size change (PutBlob/DelBlob/TruncateBlob), rename (hierarchical + flat), and hard-link add/remove (GetOrCreateTagAlias / DelTag alias-unlink).
- **Plumbing:** `GetTagSizeTask` gains an OUT `ctime_`; the filesystem `Getattr` fills `GetattrTask.ctime_` for files (and open files); the libfuse `getattr` sets `st_ctim` (ns → timespec). Uses `steady_clock` (monotonic), consistent with the existing `last_modified_`/`last_read_`, so ctime advances on metadata changes.
- **getattr stays read-only:** directory ctime is intentionally NOT fetched — resolving the dir tag would require the *mutating* `GetOrCreateTag`, which under concurrent mkdir/rmdir+stat can resurrect a just-removed directory (regressed generic/011) and adds RPCs to the hot dir-stat path. Directory `st_ctim` is left at 0 for now; a non-mutating dir→tag-id lookup is a small follow-up.

## Testing
- Manual: ctime is non-zero at create and advances on link + unlink.
- xfstests generic/quick: **generic/236 and generic/755 now pass** (both were failing on ctime). No correctness regressions (generic/011, 007 verified passing). `chimaera_cfs_test` passes.
- generic/313 (truncate c+m time) and 221 (futimens) still fail — they additionally require **mtime**/**utimens**, tracked separately.

Related: #597 (xfstests feature-gap breakdown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)