### PR TITLE
config: compose the filesystem chimod by default

### DIFF
--- a/context-runtime/config/chimaera_default.yaml
+++ b/context-runtime/config/chimaera_default.yaml
@@ -144,3 +144,18 @@ compose:
     #   flush_data_period_ms: 10000      # Data flush interval (ms)
     #   flush_data_min_persistence: 1    # Min persistence level (1=temp-nonvolatile)
     #   transaction_log_capacity: "32MB" # Write-ahead log capacity
+
+  # === Context Filesystem (CFS) ===
+  # POSIX-style filesystem chimod that the libfuse / POSIX adapters drive. It
+  # sits at the canonical filesystem pool 560.0 (clio::cte::filesystem::
+  # kCfsPoolId) over the CTE core at next_pool_id (512.0): paths map to CTE tags
+  # and offsets to 1 MiB page-blobs. Composing it here means a filesystem pool
+  # exists out of the box; the adapters create-or-bind it idempotently, so this
+  # is safe whether or not an adapter is also used. Must come AFTER the CTE core
+  # entry above — its Create resolves tags on the CTE pool (512.0). Remove it if
+  # you do not need the filesystem layer.
+  - mod_name: clio_cte_filesystem
+    pool_name: clio_cte_filesystem
+    pool_query: local
+    pool_id: "560.0"
+    next_pool_id: "512.0"               # CTE core pool — see entry above


### PR DESCRIPTION
Adds `clio_cte_filesystem` to the `compose:` section of the default config (`context-runtime/config/chimaera_default.yaml`), so a filesystem pool is created with the runtime out of the box.

```yaml
- mod_name: clio_cte_filesystem
  pool_name: clio_cte_filesystem
  pool_query: local
  pool_id: "560.0"
  next_pool_id: "512.0"   # CTE core pool
```

- Pool **560.0** is the canonical filesystem pool (`clio::cte::filesystem::kCfsPoolId`); `next_pool_id: 512.0` points it at the CTE core (`FilesystemConfig::LoadConfig` reads `next_pool_id`, and the compose parser passes the whole node through).
- Placed **after** the CTE core entry: compose runs entries in list order, and the filesystem's `Create` resolves tags on the CTE pool, so CTE (512.0) must exist first.
- Idempotent with the libfuse/POSIX adapters, which `create-or-bind` the same pool — safe whether or not an adapter is also used.

**Verified:** `clio_run start` with the default config composes all four pools; the filesystem pool 560.0 is created over CTE core 512.0:
```
Loaded ChiMod: clio_cte_filesystem
filesystem: Create over CTE core pool 512.0
Compose: Successfully created pool clio_cte_filesystem
Compose: All 4 pools created successfully
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)