### PR TITLE
test(coverage): capture multi-node failover coverage via reconnect/recovery tests

### DIFF
--- a/context-runtime/test/integration/reconnect/docker-compose.override.yml
+++ b/context-runtime/test/integration/reconnect/docker-compose.override.yml
@@ -1,0 +1,20 @@
+# Coverage support for builds made OUTSIDE /workspace (e.g. a native
+# checkout at $HOME/clio-core): gcov bakes absolute .gcda paths into the
+# objects at compile time, so the workspace must also be visible inside
+# the container at its real host path or daemon-side counters are
+# silently dropped. Mounting the same source twice (here and at
+# /workspace in docker-compose.yml) is harmless; when the host workspace
+# IS /workspace the two mounts coincide.
+services:
+  iowarp-node1:
+    volumes:
+      - ${HOST_WORKSPACE:-${IOWARP_CORE_ROOT:-/workspace}}:${HOST_WORKSPACE:-${IOWARP_CORE_ROOT:-/workspace}}:rw
+  iowarp-node2:
+    volumes:
+      - ${HOST_WORKSPACE:-${IOWARP_CORE_ROOT:-/workspace}}:${HOST_WORKSPACE:-${IOWARP_CORE_ROOT:-/workspace}}:rw
+  iowarp-node3:
+    volumes:
+      - ${HOST_WORKSPACE:-${IOWARP_CORE_ROOT:-/workspace}}:${HOST_WORKSPACE:-${IOWARP_CORE_ROOT:-/workspace}}:rw
+  iowarp-node4:
+    volumes:
+      - ${HOST_WORKSPACE:-${IOWARP_CORE_ROOT:-/workspace}}:${HOST_WORKSPACE:-${IOWARP_CORE_ROOT:-/workspace}}:rw

--- a/context-runtime/test/integration/recovery/docker-compose.override.yml
+++ b/context-runtime/test/integration/recovery/docker-compose.override.yml
@@ -1,0 +1,20 @@
+# Coverage support for builds made OUTSIDE /workspace (e.g. a native
+# checkout at $HOME/clio-core): gcov bakes absolute .gcda paths into the
+# objects at compile time, so the workspace must also be visible inside
+# the container at its real host path or daemon-side counters are
+# silently dropped. Mounting the same source twice (here and at
+# /workspace in docker-compose.yml) is harmless; when the host workspace
+# IS /workspace the two mounts coincide.
+services:
+  iowarp-node1:
+    volumes:
+      - ${HOST_WORKSPACE:-${IOWARP_CORE_ROOT:-/workspace}}:${HOST_WORKSPACE:-${IOWARP_CORE_ROOT:-/workspace}}:rw
+  iowarp-node2:
+    volumes:
+      - ${HOST_WORKSPACE:-${IOWARP_CORE_ROOT:-/workspace}}:${HOST_WORKSPACE:-${IOWARP_CORE_ROOT:-/workspace}}:rw
+  iowarp-node3:
+    volumes:
+      - ${HOST_WORKSPACE:-${IOWARP_CORE_ROOT:-/workspace}}:${HOST_WORKSPACE:-${IOWARP_CORE_ROOT:-/workspace}}:rw
+  iowarp-node4:
+    volumes:
+      - ${HOST_WORKSPACE:-${IOWARP_CORE_ROOT:-/workspace}}:${HOST_WORKSPACE:-${IOWARP_CORE_ROOT:-/workspace}}:rw


### PR DESCRIPTION
## What

Adds `docker-compose.override.yml` to the `reconnect` and `recovery` distributed integration tests so their **daemon-side gcov counters** are captured (the workspace is mounted at its real host path, matching the CTE distributed test's existing override).

These tests exercise the multi-node failover code that single-node unit tests and the existing (local-pool) distributed test cannot reach:
- `IpcManager::ReconnectToNewHost`, `SetDead`
- `IpcManagerRun2Run::RerouteRetryEntry`, `ProcessRetryQueues` retry branch, `ScanSendMapTimeouts`

## Coverage impact
Running these tests and doing a graceful `docker compose stop` (daemons flush gcov via `__gcov_dump` in admin `InitiateShutdown`):
- Overall **85.7% → 86.5%**
- Context Runtime **81.4% → 83.4%**
- `ipc_run2run.cc` **49% → 64%**

## Important finding (separate product bug)

Both tests currently **hang** after the failure is injected, which is why they are known-flaky (the daemons still produce the failover coverage, hence the graceful-stop capture above). Root cause:

- **reconnect**: after node 1 is stopped, `AsyncCreate(PoolQuery::Dynamic())` creates "one container per node" — including the dead node 0. `ProcessRetryQueues` retries `SendIn` to node 0 forever (`SendIn task timed out after 30s for node 0`) and the create never completes.
- **recovery**: node 4 is hard-killed and `SetDead` *does* fire, but the post-failure `DirectHash`/broadcast to the killed node still hangs — the reroute to a recovered/surviving container doesn't complete.

i.e. operations targeting a dead node retry indefinitely instead of being rerouted. Fixing this would make the tests pass cleanly (and let the coverage be captured automatically), and is the prerequisite for covering the remaining `RetrySendToNode`/`FlushStaleStateForNode` paths.

Refs #614

🤖 Generated with [Claude Code](https://claude.com/claude-code)