### PR TITLE
test(python): enable Python bindings under coverage + runtime-free type test

### DIFF
--- a/context-transfer-engine/wrapper/python/CMakeLists.txt
+++ b/context-transfer-engine/wrapper/python/CMakeLists.txt
@@ -82,6 +82,21 @@ if(BUILD_TESTING)
         DEPENDS clio_cte_core_ext
     )
 
+    # Runtime-free coverage of the CTE binding value types (UniqueId,
+    # PoolQuery, search-result repr, CteTelemetry, enums). No runtime needed.
+    add_test(
+        NAME python_types_test
+        COMMAND ${Python_EXECUTABLE} -I ${CMAKE_CURRENT_SOURCE_DIR}/test_cte_types.py
+        WORKING_DIRECTORY $<TARGET_FILE_DIR:clio_cte_core_ext>
+    )
+    set_tests_properties(
+        python_types_test
+        PROPERTIES
+        LABELS "python;bindings"
+        TIMEOUT 60
+        DEPENDS clio_cte_core_ext
+    )
+
     # PollTelemetryLog focused test (requires runtime initialization).
     # Requires CLIO_WITH_RUNTIME=1 and CLIO_SERVER_CONF set.
     # NOTE: test reads the CLIO_-prefixed names verbatim (not GetCompat),

--- a/context-transfer-engine/wrapper/python/test_cte_types.py
+++ b/context-transfer-engine/wrapper/python/test_cte_types.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""
+Runtime-free coverage for the CTE Python binding *types*.
+
+The existing test_bindings.py focuses on the runtime-dependent Tag/Client
+data path and skips most assertions when no runtime is available. This test
+exercises the pure value types and their bound methods — UniqueId/TagId,
+PoolQuery factory methods, the search-result repr lambdas, the CteTelemetry
+constructors/fields, and the enums — none of which need a running runtime.
+That covers the binding definitions and lambda bodies (e.g. the __repr__
+implementations) deterministically.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.getcwd())
+# Make sure no runtime is spun up for this pure-types test.
+os.environ.pop("CHI_WITH_RUNTIME", None)
+os.environ.pop("CLIO_WITH_RUNTIME", None)
+
+import clio_cte_core_ext as cte
+
+
+def test_unique_id():
+    # Default + (major, minor) constructors, accessors, field read/write.
+    a = cte.UniqueId()
+    b = cte.UniqueId(major=7, minor=3)
+    assert b.major_ == 7
+    assert b.minor_ == 3
+    assert b.ToU64() != 0
+    null = cte.UniqueId.GetNull()
+    assert null.IsNull()
+    assert not b.IsNull()
+    b.major_ = 11
+    assert b.major_ == 11
+    # TagId / BlobId / PoolId are aliases of the same class.
+    assert cte.TagId is cte.UniqueId
+    assert cte.BlobId is cte.UniqueId
+    assert cte.PoolId is cte.UniqueId
+    print("PASSED: test_unique_id")
+
+
+def test_pool_query():
+    # All three factory methods + their default/explicit args.
+    assert cte.PoolQuery.Broadcast() is not None
+    assert cte.PoolQuery.Broadcast(net_timeout=1.5) is not None
+    assert cte.PoolQuery.Dynamic() is not None
+    assert cte.PoolQuery.Dynamic(net_timeout=2.0) is not None
+    assert cte.PoolQuery.Local() is not None
+    assert cte.PoolQuery.Local(parallelism=8) is not None
+    assert cte.PoolQuery() is not None
+    print("PASSED: test_pool_query")
+
+
+def test_search_result_repr():
+    s = cte.SemanticSearchResult()
+    s.tag_id = cte.UniqueId(major=2, minor=5)
+    s.blob_name = "blobA"
+    s.score = 0.875
+    assert s.blob_name == "blobA"
+    assert abs(s.score - 0.875) < 1e-6
+    rep = repr(s)  # exercises the __repr__ lambda body
+    assert "SemanticSearchResult" in rep
+    assert "blobA" in rep
+
+    t = cte.TemporalSearchResult()
+    t.tag_id = cte.UniqueId(major=4, minor=9)
+    t.blob_name = "blobB"
+    t.last_modified = 12345
+    rep = repr(t)
+    assert "TemporalSearchResult" in rep
+    assert "blobB" in rep
+    print("PASSED: test_search_result_repr")
+
+
+def test_telemetry_and_enums():
+    # Enum values are bound.
+    assert cte.CteOp.kPutBlob is not None
+    assert cte.CteOp.kGetBlob is not None
+    assert cte.CteOp.kDelBlob is not None
+
+    # Default-constructed telemetry + field read/write.
+    tel = cte.CteTelemetry()
+    tel.off_ = 64
+    tel.size_ = 4096
+    tel.logical_time_ = 7
+    tel.op_ = cte.CteOp.kPutBlob
+    tel.tag_id_ = cte.UniqueId(major=1, minor=2)
+    assert tel.off_ == 64
+    assert tel.size_ == 4096
+    assert tel.logical_time_ == 7
+    print("PASSED: test_telemetry_and_enums")
+
+
+if __name__ == "__main__":
+    test_unique_id()
+    test_pool_query()
+    test_search_result_repr()
+    test_telemetry_and_enums()
+    print("\nAll CTE type-binding tests PASSED")


### PR DESCRIPTION
## What

Building with `-DCLIO_CORE_ENABLE_PYTHON=ON` compiles the nanobind extension modules (`clio_cte_core_ext`, `chimaera_runtime_ext`, `clio_cee`) and runs the existing Python test suite (`python_bindings_test`, `python_telemetry_test`, semantic/temporal search, `python_getblob_bytes_test`, `test_monitor_python`, `cee_python_*`) under coverage instrumentation. All 11 Python tests pass.

This raises overall line coverage **85.4% → 86.6%** (full ctest, all green): the binding `.cc` files go from compiled-but-untested to covered (`core_bindings.cc` ~85%, `runtime_bindings.cc` ~65% by direct gcov — lcov undercounts them due to a known nanobind generated-code line-mapping quirk).

## Added

`test_cte_types.py` — a deterministic, **runtime-free** test of the CTE binding value types: `UniqueId`/`TagId`/`BlobId`/`PoolId` aliases, `PoolQuery` factory methods, `SemanticSearchResult`/`TemporalSearchResult` `__repr__`, `CteTelemetry` constructors/fields, and the `CteOp` enum. The existing runtime-dependent tests skip these when no runtime is available; this guarantees a coverage floor for the binding type surface in runtime-less CI.

## Notes
- The remaining uncovered binding lines are runtime-dependent Client method success-returns (`TagQuery`/`BlobQuery`/`ReorganizeBlob`) — covered only when those ops run against a live runtime.
- To capture this gain in CI, the coverage build must pass `-DCLIO_CORE_ENABLE_PYTHON=ON` (Python bindings default OFF for packaging).

Refs #614

🤖 Generated with [Claude Code](https://claude.com/claude-code)