### PR TITLE
feat(scripts): add Windows firewall helper to open the cluster RPC port

### DIFF
--- a/scripts/windows/allow_clio_port.ps1
+++ b/scripts/windows/allow_clio_port.ps1
@@ -1,0 +1,49 @@
+# Open the CLIO Core RPC port (ZMQ TCP) on Windows Defender Firewall so peer
+# nodes in the cluster (e.g. jelly, nene) can establish inbound TCP connections
+# to this node (raven). Binding a listening socket on a high port does NOT need
+# Administrator, but accepting INBOUND connections from other hosts does -- the
+# default firewall posture drops them. Adding the allow rule requires elevation.
+#
+# Usage (from a normal PowerShell prompt; this script auto-elevates):
+#   powershell -ExecutionPolicy Bypass -File scripts\windows\allow_clio_port.ps1
+#   powershell -ExecutionPolicy Bypass -File scripts\windows\allow_clio_port.ps1 -Port 9413
+#
+# Idempotent: re-running skips a rule that is already present.
+
+param(
+    [int]$Port = 9413
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Re-elevate if not already running as Administrator.
+$principal = New-Object Security.Principal.WindowsPrincipal(
+    [Security.Principal.WindowsIdentity]::GetCurrent())
+if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Write-Host 'Not elevated; relaunching as Administrator...'
+    $shell = if (Get-Command pwsh -ErrorAction SilentlyContinue) { 'pwsh' } else { 'powershell' }
+    Start-Process $shell -Verb RunAs -ArgumentList @(
+        '-NoProfile',
+        '-ExecutionPolicy', 'Bypass',
+        '-File', $MyInvocation.MyCommand.Path,
+        '-Port', $Port
+    )
+    exit
+}
+
+$ruleName = "CLIO Core RPC (TCP $Port) inbound"
+
+# Skip if the rule already exists (idempotent re-runs).
+netsh advfirewall firewall show rule name="$ruleName" *> $null
+if ($LASTEXITCODE -eq 0) {
+    Write-Host "Rule '$ruleName' already present; nothing to do."
+    exit 0
+}
+
+# Inbound allow for the RPC port on all profiles (domain/private/public) so the
+# cluster works regardless of which network profile the cluster NIC is on.
+netsh advfirewall firewall add rule name="$ruleName" dir=in action=allow `
+    protocol=TCP localport=$Port profile=any enable=yes | Out-Null
+
+Write-Host "Opened inbound TCP $Port for the CLIO Core cluster RPC listener."
+Write-Host "Peers (jelly, nene) can now connect to this node on port $Port."


### PR DESCRIPTION
## What

Adds `scripts/windows/allow_clio_port.ps1` — an idempotent, auto-elevating PowerShell helper that opens **inbound TCP on the runtime RPC port** (default `9413`, ZMQ TCP) on all Windows Defender Firewall profiles, so peer nodes can connect to this node when joining a multi-node cluster.

```powershell
powershell -ExecutionPolicy Bypass -File scripts\windows\allow_clio_port.ps1
powershell -ExecutionPolicy Bypass -File scripts\windows\allow_clio_port.ps1 -Port 9413
```

## Why

Joining a multi-node CLIO Core cluster on Windows requires peers to open inbound connections to the RPC port. Binding the listener (`0.0.0.0:<port>`) needs no elevation, but the default firewall posture drops unsolicited inbound from peers, so the mesh never forms (connections sit in `SYN_SENT`) until an allow rule is added — which requires Administrator.

The existing `allow_firewall.ps1` adds **per-binary** rules for every `*.exe` under `build*/bin` (for silencing the Defender prompt during `ctest`). That only covers already-built binaries and is program-scoped, so it does not fit a cluster deployment. This new helper is **port-scoped** and works before any binary exists.

## Behavior

- Auto-elevates (relaunches via `Start-Process -Verb RunAs`, preferring `pwsh` then `powershell`).
- Idempotent: skips the rule if it already exists.
- `-Port <int>` parameter (default `9413`); rule applied to `profile=any`.

## Testing

- Verified the bound listener comes up on `10.10.10.237:9413` without elevation.
- Confirmed the rule name is skipped on re-run (idempotent).

Closes #622
