### PR TITLE
feat(leak): allocator-destructor + IpcManager shutdown leak detection

### DIFF
--- a/context-runtime/include/clio_runtime/ipc_manager.h
+++ b/context-runtime/include/clio_runtime/ipc_manager.h
@@ -232,6 +232,16 @@ class IpcManager {
 
  public:
   /**
+   * Destructor. In leak-tracking builds it scans the runtime-owned allocators
+   * (see ReportRuntimeLeaks). Note the CLIO_IPC global is intentionally leaked
+   * (GetGlobalPtrVar new's it and never deletes), so this rarely runs in
+   * practice — ServerFinalize() is the guaranteed shutdown hook that performs
+   * the same scan. Declared so the scan still fires if the object is ever
+   * explicitly destroyed.
+   */
+  ~IpcManager();
+
+  /**
    * Get the run-to-run IPC manager (cross-node task transfer logic).
    * @return Pointer to the IpcManagerRun2Run instance owned by this IpcManager.
    */
@@ -1566,6 +1576,21 @@ class IpcManager {
    * @return true if successful, false otherwise
    */
   bool IncreaseClientShm(size_t size);
+
+  /**
+   * Leak scan over the runtime-owned allocators, tagged with \a phase. The
+   * per-process SHM segments in alloc_vector_ (where AllocateBuffer draws from)
+   * MUST be empty at shutdown, so any outstanding bytes there are logged as an
+   * ERROR-level leak -- this is the ONLY observation point for those
+   * placement-constructed allocators, whose C++ destructors never run (so the
+   * AllocatorLeakChecker destructor path cannot see them). CTP_MALLOC's private
+   * heap is only reported at INFO (it legitimately holds process-lifetime state
+   * at shutdown; real CTP_MALLOC leaks are caught by the MallocAllocator
+   * destructor at static teardown). Compiles to a no-op unless
+   * CTP_ALLOC_TRACK_SIZE is set (CLIO_CORE_ENABLE_LEAK_CHECK). Returns the total
+   * outstanding SHM bytes (the actionable leak signal).
+   */
+  size_t ReportRuntimeLeaks(const char *phase) const;
 
   /**
    * Vector of allocators owned by this process

--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -622,6 +622,12 @@ void IpcManager::ServerFinalize() {
   // Clear main allocator pointer
   main_allocator_ = nullptr;
 
+  // Leak scan while the SHM segments are still mapped (alloc_vector_ is not
+  // cleared here). This is the reliable trigger for the IpcManager leak scan:
+  // the CLIO_IPC global is intentionally leaked, so ~IpcManager rarely runs.
+  // No-op unless built with CTP_ALLOC_TRACK_SIZE (CLIO_CORE_ENABLE_LEAK_CHECK).
+  ReportRuntimeLeaks("ServerFinalize");
+
   is_initialized_ = false;
 }
 
@@ -1637,6 +1643,66 @@ size_t IpcManager::GetRuntimeHeapAllocatedBytes() const {
   return total;
 #else
   return 0;
+#endif
+}
+
+size_t IpcManager::ReportRuntimeLeaks(const char *phase) const {
+#if defined(CTP_ALLOC_TRACK_SIZE) && CTP_IS_HOST
+  // Private heap (NewTask/NewObj/client-ZMQ buffers). At shutdown this
+  // legitimately still holds process-lifetime runtime state (pools, config,
+  // module manager) that is only released at static teardown -- so report it at
+  // INFO, NOT as a leak, to avoid false positives. Genuinely unfreed CTP_MALLOC
+  // allocations are caught for real by the MallocAllocator destructor
+  // (ctp::ipc::AllocatorLeakChecker) which runs at static teardown, after that
+  // process-lifetime state is gone.
+  const size_t priv = CTP_MALLOC->GetCurrentlyAllocatedSize();
+  if (priv != 0) {
+    HLOG(kInfo,
+         "[leak][runtime] {}: CTP_MALLOC private heap holds {} bytes (may be "
+         "process-lifetime state; verified clean at static teardown)",
+         phase, priv);
+  }
+
+  // Per-process SHM segments the runtime's AllocateBuffer draws from. These
+  // MultiProcessAllocators are placement-constructed in shared memory and never
+  // get a C++ destructor, so this scan is the ONLY place their leaks surface.
+  // Every buffer MUST be freed by shutdown, so any outstanding bytes here are a
+  // real shared-memory leak (reported at ERROR). This is the return value.
+  size_t shm_leaked = 0;
+  {
+    std::lock_guard<std::mutex> lock(shm_mutex_);
+    for (size_t i = 0; i < alloc_vector_.size(); ++i) {
+      auto *alloc = alloc_vector_[i];
+      if (alloc == nullptr) {
+        continue;
+      }
+      const size_t out = alloc->GetCurrentlyAllocatedSize();
+      if (out != 0) {
+        shm_leaked += out;
+        HLOG(kError,
+             "[leak][runtime] {}: SHM allocator #{} leaked {} bytes "
+             "(outstanding at shutdown)",
+             phase, i, out);
+      }
+    }
+  }
+
+  if (shm_leaked == 0) {
+    HLOG(kInfo, "[leak][runtime] {}: no outstanding SHM buffers", phase);
+  } else {
+    HLOG(kError, "[leak][runtime] {}: {} total SHM bytes leaked", phase,
+         shm_leaked);
+  }
+  return shm_leaked;
+#else
+  (void)phase;
+  return 0;
+#endif
+}
+
+IpcManager::~IpcManager() {
+#if defined(CTP_ALLOC_TRACK_SIZE) && CTP_IS_HOST
+  ReportRuntimeLeaks("~IpcManager");
 #endif
 }
 

--- a/context-transfer-engine/test/unit/CMakeLists.txt
+++ b/context-transfer-engine/test/unit/CMakeLists.txt
@@ -74,6 +74,12 @@ add_executable(test_reorganize_blob
     test_reorganize_blob.cc
 )
 
+# BDEV leak stress: PutBlob/DelBlob loop for a wall-clock minute, then assert
+# the bdev used capacity is 0 and the runtime leak-checker heap counter is flat.
+add_executable(test_bdev_leak_stress
+    test_bdev_leak_stress.cc
+)
+
 # GPU-runtime-era CUDA tests were removed when the GPU runtime concept
 # was retired. The kernel→CPU submission path is now exercised by:
 #   - context-runtime/test/unit/gpu/test_gpu_kernel_stress_*
@@ -265,6 +271,18 @@ target_link_libraries(test_blob_block_reuse
 
 # Link test_reorganize_blob - using simple_test.h framework (NOT Catch2)
 target_link_libraries(test_reorganize_blob
+    clio_cte_core_runtime         # CTE core runtime library
+    clio_cte_core_client          # CTE core client library
+    clio::run::admin_runtime      # Admin module runtime (required for runtime mode)
+    clio::run::admin_client       # Admin module client
+    clio::run::bdev_runtime       # Bdev module runtime (required for runtime mode)
+    clio::run::bdev_client        # Bdev client for BdevType enum
+    ctp::cxx                    # ClioCtp library
+    ${CMAKE_THREAD_LIBS_INIT}    # Threading support
+)
+
+# Link test_bdev_leak_stress - using simple_test.h framework (NOT Catch2)
+target_link_libraries(test_bdev_leak_stress
     clio_cte_core_runtime         # CTE core runtime library
     clio_cte_core_client          # CTE core client library
     clio::run::admin_runtime      # Admin module runtime (required for runtime mode)
@@ -491,6 +509,17 @@ set_tests_properties(cte_runtime_coverage_all PROPERTIES
     ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CLIO_TEST_DATA_DIR=${CMAKE_BINARY_DIR};CLIO_BIND_ADDR=127.0.0.1"
 )
 
+# BDEV leak stress: a 1-minute PutBlob/DelBlob churn that asserts the bdev used
+# capacity returns to 0 and the runtime leak-checker heap counter stays flat.
+# Name contains "leak" so the Leak Check CI (-R "leak|...force_net") runs it.
+add_test(NAME cte_bdev_leak_stress
+    COMMAND test_bdev_leak_stress)
+set_tests_properties(cte_bdev_leak_stress PROPERTIES
+    TIMEOUT 180
+    LABELS "unit;cte;bdev;leak;stress;msan_skip"
+    ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CLIO_TEST_DATA_DIR=${CMAKE_BINARY_DIR};CLIO_BIND_ADDR=127.0.0.1;CTE_LEAK_STRESS_SECONDS=60"
+)
+
 # Add tiered storage stress tests
 # NOTE: These tests are chained (Put -> Reorganize -> Integrity -> Cleanup)
 # and share global state via g_fixture, so they must run together in a single
@@ -581,6 +610,12 @@ clio_add_force_net_test(NAME cte_client_config_force_net
     COMMAND test_core_client_config ENVIRONMENT "${_cte_fn_env_basic}" TIMEOUT 600)
 clio_add_force_net_test(NAME cte_config_dpe_force_net
     COMMAND test_cte_config_dpe ENVIRONMENT "${_cte_fn_env_basic}")
+# BDEV leak stress over the loopback net path. Each Put/Del round-trips the net
+# transport (far slower than in-process), so use a shorter window — still enough
+# churn to expose a per-op leak, while keeping the CI job bounded.
+clio_add_force_net_test(NAME cte_bdev_leak_stress_force_net
+    COMMAND test_bdev_leak_stress
+    ENVIRONMENT "${_cte_fn_env_data};CTE_LEAK_STRESS_SECONDS=20" TIMEOUT 180)
 
 # NOTE: the legacy GPU CTE tests cte_gpu_coroutine / cte_gpu_core_all /
 # cte_gpu_create were removed — their executables (test_cte_gpu_coroutine /

--- a/context-transfer-engine/test/unit/test_bdev_leak_stress.cc
+++ b/context-transfer-engine/test/unit/test_bdev_leak_stress.cc
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * BDEV LEAK STRESS TEST
+ *
+ * Hammer PutBlob + DelBlob of the same key in a tight loop for a wall-clock
+ * duration (default 60 s) against a single small RAM tier, then assert that
+ * NOTHING leaked at two independent layers:
+ *
+ *   1. BDEV BLOCK LEVEL — the bdev target's used capacity must be back to zero:
+ *      GetTargetInfo(remaining_space_) after the loop equals the steady-state
+ *      baseline captured after a warm-up cycle. Every PutBlob draws blocks from
+ *      the bdev allocator and every DelBlob must return them, so after tens of
+ *      thousands of balanced cycles the live set is still one blob and the
+ *      allocator's outstanding bytes are 0. A block leak shows up as
+ *      remaining_after < remaining_before.
+ *
+ *   2. RUNTIME ALLOCATOR LEVEL — the runtime leak checker metric
+ *      (IpcManager::GetRuntimeHeapAllocatedBytes = CTP_MALLOC private heap +
+ *      every owned SHM MultiProcessAllocator) must not have grown beyond a
+ *      small tolerance across the loop. Because that counter tracks handed-out
+ *      bytes (balanced alloc/free nets to zero), a per-op runtime leak that the
+ *      coarse per-test gate might tolerate accumulates over the minute and trips
+ *      here. Returns 0 in non-leak builds, so the assertion is a no-op there.
+ *
+ * Both leak checkers added alongside this test run simultaneously: the runtime
+ * scan (IpcManager::ReportRuntimeLeaks) fires at ServerFinalize and the
+ * allocator-destructor checker (ctp::ipc::AllocatorLeakChecker) fires at static
+ * teardown when the process exits — this test simply drives enough churn to make
+ * a leak, if present, unmistakable.
+ *
+ * Duration is overridable via CTE_LEAK_STRESS_SECONDS (the force-net variant
+ * routes every op over the loopback net path, so it uses a shorter window).
+ */
+
+#include <clio_runtime/clio_runtime.h>
+#include <clio_runtime/bdev/bdev_client.h>
+#include <clio_cte/core/core_client.h>
+#include <clio_cte/core/core_tasks.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <thread>
+
+#include "clio_ctp/memory/allocator/leak_checker.h"
+#include "simple_test.h"
+
+// 1 MiB per blob: draws from the bdev's 1 MiB size-class partition, the same
+// path the block-reuse regression exercises.
+static constexpr clio::run::u64 kBlobSize = 1 * 1024 * 1024;
+
+// Explicitly-registered RAM bdev target for this test. GetTargetInfo() matches
+// on this exact name, so registering it ourselves (rather than via a compose
+// config) removes any name-resolution ambiguity.
+static const char *kTargetName = "leak_stress_target";
+static constexpr clio::run::u64 kTargetSize = 256ULL * 1024 * 1024;  // 256 MiB
+
+// Loop duration. Default 60 s (the requested "1 minute" stress); overridable so
+// the loopback force-net variant can use a shorter, still-representative window.
+static int StressSecondsFromEnv() {
+  if (const char *e = std::getenv("CTE_LEAK_STRESS_SECONDS")) {
+    int n = std::atoi(e);
+    if (n > 0) return n;
+  }
+  return 60;
+}
+static const int kStressSeconds = StressSecondsFromEnv();
+
+class BdevLeakStressFixture {
+ public:
+  bool initialized_ = false;
+
+  BdevLeakStressFixture() {
+    bool success = clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, true);
+    REQUIRE(success);
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    success = clio::cte::core::CLIO_CTE_CLIENT_INIT();
+    REQUIRE(success);
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    SetupTarget();
+    initialized_ = true;
+  }
+
+  ~BdevLeakStressFixture() = default;
+
+  // Create a single 256 MiB RAM bdev and register it with the CTE under
+  // kTargetName. Small on purpose: only ~1 blob is ever live, so it is ample for
+  // a clean run but would be exhausted quickly by a block leak.
+  void SetupTarget() {
+    auto *cte = CLIO_CTE_CLIENT;
+
+    clio::run::PoolId bdev_pool_id(901, 0);
+    clio::run::bdev::Client bdev_client(bdev_pool_id);
+    auto create = bdev_client.AsyncCreate(
+        clio::run::PoolQuery::Dynamic(), kTargetName, bdev_pool_id,
+        clio::run::bdev::BdevType::kRam, kTargetSize);
+    create.Wait();
+
+    auto reg = cte->AsyncRegisterTarget(
+        kTargetName, clio::run::bdev::BdevType::kRam, kTargetSize,
+        clio::run::PoolQuery::Local(), bdev_pool_id);
+    reg.Wait();
+    REQUIRE(reg->GetReturnCode() == 0);
+  }
+};
+
+static BdevLeakStressFixture *g_fixture = nullptr;
+
+// Query the bdev target's remaining allocatable bytes via the CTE client.
+static clio::run::u64 TargetRemaining() {
+  auto *cte = CLIO_CTE_CLIENT;
+  auto info = cte->AsyncGetTargetInfo(kTargetName);
+  info.Wait();
+  REQUIRE(info->GetReturnCode() == 0);
+  return info->remaining_space_;
+}
+
+// Poll the runtime-heap counter until it stops changing (so async server-side
+// frees that lag the client's Wait() have settled), or a short bound elapses.
+static size_t StabilizeRuntimeHeap() {
+  auto *ipc = CLIO_IPC;
+  size_t prev = ipc->GetRuntimeHeapAllocatedBytes();
+  for (int i = 0; i < 50; ++i) {  // up to ~1 s
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    size_t cur = ipc->GetRuntimeHeapAllocatedBytes();
+    if (cur == prev) return cur;
+    prev = cur;
+  }
+  return prev;
+}
+
+/**
+ * Put + Del the same key for kStressSeconds, then assert no leak at the bdev
+ * block level (used capacity back to 0) and the runtime allocator level (heap
+ * counter flat).
+ */
+TEST_CASE("BdevLeakStress - PutBlob/DelBlob loop leaves no leaks",
+          "[bdev][leak][stress]") {
+  REQUIRE(g_fixture != nullptr);
+  REQUIRE(g_fixture->initialized_);
+
+  auto *cte = CLIO_CTE_CLIENT;
+  REQUIRE(cte != nullptr);
+
+  clio::cte::core::Tag tag("leak_stress_tag");
+  clio::cte::core::TagId tag_id = tag.GetTagId();
+  const std::string blob_name = "leak_stress_blob";
+
+  auto shm = CLIO_IPC->AllocateBuffer(kBlobSize);
+  REQUIRE(!shm.IsNull());
+  std::memset(shm.ptr_, 0xAB, kBlobSize);
+  ctp::ipc::ShmPtr<> shm_ptr = shm.shm_.template Cast<void>();
+
+  // Warm-up cycle: force first-touch lazy allocations (SHM segment growth,
+  // target metadata) so they are folded into the baseline, not counted as a
+  // leak.
+  {
+    auto put = tag.AsyncPutBlob(blob_name, shm_ptr, kBlobSize, 0, 1.0f);
+    put.Wait();
+    REQUIRE(put->GetReturnCode() == 0);
+    auto del = cte->AsyncDelBlob(tag_id, blob_name);
+    del.Wait();
+    REQUIRE(del->GetReturnCode() == 0);
+  }
+
+  const clio::run::u64 remaining_before = TargetRemaining();
+  const size_t heap_before = StabilizeRuntimeHeap();
+
+  INFO("Baseline: bdev remaining=" << remaining_before
+       << " runtime-heap=" << heap_before
+       << " running Put/Del for " << kStressSeconds << "s");
+
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(kStressSeconds);
+  long iters = 0;
+  int put_fail = 0;
+  int del_fail = 0;
+
+  while (std::chrono::steady_clock::now() < deadline) {
+    auto put = tag.AsyncPutBlob(blob_name, shm_ptr, kBlobSize, 0, 1.0f);
+    put.Wait();
+    if (put->GetReturnCode() != 0) {
+      ++put_fail;
+      INFO("PutBlob failed at iter " << iters
+                                     << " rc=" << put->GetReturnCode());
+      break;
+    }
+
+    auto del = cte->AsyncDelBlob(tag_id, blob_name);
+    del.Wait();
+    if (del->GetReturnCode() != 0) {
+      ++del_fail;
+      INFO("DelBlob failed at iter " << iters
+                                     << " rc=" << del->GetReturnCode());
+      break;
+    }
+    ++iters;
+  }
+
+  CLIO_IPC->FreeBuffer(shm);
+
+  // Let any trailing async frees settle before measuring.
+  const clio::run::u64 remaining_after = TargetRemaining();
+  const size_t heap_after = StabilizeRuntimeHeap();
+
+  const clio::run::u64 bdev_used =
+      (remaining_before > remaining_after) ? (remaining_before - remaining_after)
+                                           : 0;
+  const size_t heap_growth =
+      (heap_after > heap_before) ? (heap_after - heap_before) : 0;
+
+  INFO("Completed " << iters << " Put/Del cycles ("
+       << (static_cast<double>(iters) * kBlobSize / (1024.0 * 1024.0))
+       << " MiB cumulative); bdev_used_after=" << bdev_used
+       << " runtime_heap_growth=" << heap_growth
+       << " allocator_leak_checker_total="
+       << ctp::ipc::AllocatorLeakChecker::Get().TotalLeakedBytes());
+
+  // Every op must have succeeded (a block leak would exhaust the 256 MiB tier).
+  REQUIRE(put_fail == 0);
+  REQUIRE(del_fail == 0);
+  REQUIRE(iters > 0);
+
+  // (1) BDEV BLOCK LEVEL: used capacity back to zero — every DelBlob returned
+  //     its blocks. Exact: block alloc/free is deterministic.
+  REQUIRE(remaining_after == remaining_before);
+
+  // (2) RUNTIME ALLOCATOR LEVEL: the leak-checker heap counter did not grow.
+  //     Allow a couple of in-flight buffers of slack; a real per-op leak dwarfs
+  //     this after tens of thousands of cycles. No-op in non-leak builds
+  //     (counter is a constant 0).
+  const size_t kHeapTolerance = 2 * kBlobSize;
+  REQUIRE(heap_growth <= kHeapTolerance);
+
+  auto del_tag = cte->AsyncDelTag("leak_stress_tag");
+  del_tag.Wait();
+}
+
+int main(int argc, char **argv) {
+  g_fixture = new BdevLeakStressFixture();
+  std::string filter = (argc > 1) ? argv[1] : "";
+  int result = SimpleTest::run_all_tests(filter);
+  delete g_fixture;
+  g_fixture = nullptr;
+  return result;
+}

--- a/context-transport-primitives/include/clio_ctp/memory/allocator/leak_checker.h
+++ b/context-transport-primitives/include/clio_ctp/memory/allocator/leak_checker.h
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CLIO_CTP_MEMORY_ALLOCATOR_LEAK_CHECKER_H_
+#define CLIO_CTP_MEMORY_ALLOCATOR_LEAK_CHECKER_H_
+
+#include "clio_ctp/constants/macros.h"
+
+// Host-only facility: the registry stores std::string/std::vector and logs via
+// HLOG, none of which belong in device code. Device translation units get an
+// empty header; the allocator destructors that call it are themselves guarded
+// by `#if CTP_IS_HOST`, so there are no dangling references on the device pass.
+#if CTP_IS_HOST
+
+#include <cstddef>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "clio_ctp/util/logging.h"
+
+namespace ctp::ipc {
+
+/**
+ * Process-global registry that an allocator's *destructor* reports to when it
+ * is torn down with a non-empty heap (outstanding allocated-but-not-freed
+ * bytes). This is one of two complementary leak facilities:
+ *
+ *   * This checker (destructor driven) catches every allocator whose C++
+ *     destructor actually runs — the process-lifetime singletons such as
+ *     CTP_MALLOC, and any stack/heap allocator. It does NOT observe
+ *     placement-constructed shared-memory allocators, whose destructors are
+ *     never invoked; those are covered by IpcManager's own shutdown scan
+ *     (IpcManager::ReportRuntimeLeaks) instead.
+ *   * IpcManager::ReportRuntimeLeaks (context-runtime) scans the runtime-owned
+ *     allocators (CTP_MALLOC + the per-process SHM segments) at ServerFinalize.
+ *
+ * Reports only carry meaning in leak-tracking builds (CTP_ALLOC_TRACK_SIZE, via
+ * CLIO_CORE_ENABLE_LEAK_CHECK): allocators only call Report() under that macro,
+ * and GetCurrentlyAllocatedSize() is a constant 0 otherwise. The class itself
+ * is always compiled on host so tests can query it unconditionally.
+ *
+ * The singleton is intentionally leaked (heap-allocated, never freed) so that
+ * allocator destructors firing during static teardown can always reach it,
+ * regardless of static destruction order.
+ */
+class AllocatorLeakChecker {
+ public:
+  /** One recorded leak: which allocator, and how many bytes it still held. */
+  struct Entry {
+    std::string label;
+    size_t bytes;
+  };
+
+  /** Access the process-global (leaked) instance. */
+  static AllocatorLeakChecker &Get() {
+    static AllocatorLeakChecker *inst = new AllocatorLeakChecker();
+    return *inst;
+  }
+
+  /**
+   * Record that the allocator identified by \a label was destroyed while still
+   * holding \a bytes. Zero-byte reports are ignored (a clean allocator is not a
+   * leak). Every non-zero report is also emitted immediately to the log.
+   */
+  void Report(const char *label, size_t bytes) {
+    if (bytes == 0) {
+      return;
+    }
+    const char *name = (label != nullptr) ? label : "<unknown>";
+    std::lock_guard<std::mutex> lk(mu_);
+    entries_.push_back(Entry{std::string(name), bytes});
+    total_bytes_ += bytes;
+    HLOG(kError,
+         "[leak][allocator] '{}' destroyed with {} bytes still allocated",
+         name, bytes);
+  }
+
+  /** Total outstanding bytes across all recorded leaks. */
+  size_t TotalLeakedBytes() {
+    std::lock_guard<std::mutex> lk(mu_);
+    return total_bytes_;
+  }
+
+  /** Number of allocators that reported a leak. */
+  size_t LeakCount() {
+    std::lock_guard<std::mutex> lk(mu_);
+    return entries_.size();
+  }
+
+  /** Snapshot of the recorded leaks (copied under lock). */
+  std::vector<Entry> Entries() {
+    std::lock_guard<std::mutex> lk(mu_);
+    return entries_;
+  }
+
+  /** Clear all recorded leaks (mainly for tests that check specific phases). */
+  void Reset() {
+    std::lock_guard<std::mutex> lk(mu_);
+    entries_.clear();
+    total_bytes_ = 0;
+  }
+
+ private:
+  AllocatorLeakChecker() = default;
+
+  std::mutex mu_;
+  std::vector<Entry> entries_;
+  size_t total_bytes_ = 0;
+};
+
+}  // namespace ctp::ipc
+
+#endif  // CTP_IS_HOST
+#endif  // CLIO_CTP_MEMORY_ALLOCATOR_LEAK_CHECKER_H_

--- a/context-transport-primitives/include/clio_ctp/memory/allocator/malloc_allocator.h
+++ b/context-transport-primitives/include/clio_ctp/memory/allocator/malloc_allocator.h
@@ -35,6 +35,7 @@
 #define HERMES_SHM_MEMORY_ALLOCATOR_MALLOC_ALLOCATOR_H_
 
 #include "clio_ctp/memory/allocator/allocator.h"
+#include "clio_ctp/memory/allocator/leak_checker.h"
 #include <memory>
 
 namespace ctp::ipc {
@@ -94,6 +95,25 @@ class _MallocAllocator : public Allocator {
     // Always zero-initialize the tracking counter (atomic's default ctor does
     // not), so GetCurrentlyAllocatedSize() reads 0 even when tracking is off.
     total_alloc_ = 0;
+  }
+
+  /**
+   * Destructor. In leak-tracking builds (CTP_ALLOC_TRACK_SIZE) report to the
+   * process-global AllocatorLeakChecker if this allocator is being torn down
+   * with a non-empty heap — e.g. CTP_MALLOC (MallocAllocatorSingleton) at
+   * static teardown after a task/buffer/NewObj was never freed. A no-op in
+   * normal builds (total_alloc_ is a constant 0) and on the device (no
+   * process-lifetime teardown to observe).
+   */
+  CTP_CROSS_FUN
+  ~_MallocAllocator() {
+#if CTP_IS_HOST && defined(CTP_ALLOC_TRACK_SIZE)
+    size_t outstanding = static_cast<size_t>(total_alloc_.load());
+    if (outstanding != 0) {
+      ::ctp::ipc::AllocatorLeakChecker::Get().Report("MallocAllocator",
+                                                     outstanding);
+    }
+#endif
   }
 
   /**


### PR DESCRIPTION
## Summary

Two complementary, purpose-built leak-detection facilities for leak-tracking builds (`CTP_ALLOC_TRACK_SIZE` / `CLIO_CORE_ENABLE_LEAK_CHECK`), independent of the per-test `simple_test.h` gate. **Both run at the same time** in a leak build; both compile to no-ops in normal builds and on the device.

Stacked on `620-tcp-blocking-recv` (depends on `GetRuntimeHeapAllocatedBytes()` / `alloc_vector_` from that branch), so the base is set accordingly.

### 1. `AllocatorLeakChecker` — singleton, destructor-driven (CTP)
`context-transport-primitives/include/clio_ctp/memory/allocator/leak_checker.h` (new)
- Process-global, intentionally-leaked registry (survives static-destruction ordering).
- An allocator's **destructor** reports to it when torn down with a non-empty heap. `_MallocAllocator`'s new destructor wires **CTP_MALLOC** in, so an unfreed task/buffer/NewObj surfaces at static teardown.
- Catches every allocator whose C++ destructor actually runs.

### 2. `IpcManager::ReportRuntimeLeaks` — shutdown scan (context-runtime)
- Driven from `ServerFinalize()` (the `CLIO_IPC` global is `new`'d and never deleted, so `~IpcManager` rarely runs; the destructor is added too for completeness).
- The per-process **SHM `MultiProcessAllocator`s** are placement-constructed and never get a C++ destructor — this scan is the **only** observation point for their leaks → outstanding SHM bytes logged at **ERROR**.
- CTP_MALLOC's private heap legitimately holds process-lifetime state at finalize → **INFO** only (real CTP_MALLOC leaks are caught by facility #1 at teardown).

## Verification
- Builds clean in both leak (`build-leak`) and normal (`build`) configs; cpplint clean.
- Facility #1: balanced alloc/free → nothing; a leaked 4096 bytes → exactly one report.
- Facility #2: `ipc_allocate_buffer` test 7/7 pass; SHM reported clean at `ServerFinalize`; no shutdown crash.
- Confirmed the `per_process_shm` "medium sizes" per-test-gate failure is **pre-existing** (reproduces with these changes stashed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)