### PR TITLE
chore(#649): move install.sh -> CI/ci-deps.sh

### DIFF
--- a/.claude-plugin/plugins/iowarp-dev-setup/skills/dev-setup/SKILL.md
+++ b/.claude-plugin/plugins/iowarp-dev-setup/skills/dev-setup/SKILL.md
@@ -147,12 +147,12 @@ The devcontainer automatically forwards from the host:
 
 ## Path 2: Native Linux Build
 
-### Using install.sh (Recommended)
+### Using CI/ci-deps.sh (Recommended)
 
 ```bash
 git clone --recurse-submodules https://github.com/iowarp/clio-core.git
 cd clio-core
-bash install.sh release
+bash CI/ci-deps.sh release
 ```
 
 This installs Miniconda, rattler-build, and IOWarp in one script. Variants are stored in `installers/conda/variants/` — create a new one for custom machine configs.

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -41,10 +41,10 @@ jobs:
           submodules: recursive
       - name: Install lcov
         run: sudo apt-get update && sudo apt-get install -y lcov
-      - name: Build and test using install.sh
+      - name: Build and test using CI/ci-deps.sh
         run: |
-          chmod +x install.sh
-          ./install.sh
+          chmod +x CI/ci-deps.sh
+          ./CI/ci-deps.sh
       - name: Calculate coverage
         run: |
           if [ -f "$HOME/miniconda3/etc/profile.d/conda.sh" ]; then
@@ -111,8 +111,8 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libhdf5-dev liburing-dev
       - name: Install dependencies (conda env, incl. Boost.Context)
         run: |
-          chmod +x install.sh
-          ./install.sh --only-deps
+          chmod +x CI/ci-deps.sh
+          ./CI/ci-deps.sh --only-deps
       - name: Build with Boost backend + run ctest
         run: |
           if [ -f "$HOME/miniconda3/etc/profile.d/conda.sh" ]; then
@@ -153,8 +153,8 @@ jobs:
           sudo apt-get install -y clang llvm libhdf5-dev
       - name: Build and test with ${{ matrix.sanitizer }}
         run: |
-          chmod +x install.sh CI/run_sanitizers.sh
-          ./install.sh
+          chmod +x CI/ci-deps.sh CI/run_sanitizers.sh
+          ./CI/ci-deps.sh
           if [ -f "$HOME/miniconda3/etc/profile.d/conda.sh" ]; then
             source "$HOME/miniconda3/etc/profile.d/conda.sh"
           elif [ -f "$HOME/anaconda3/etc/profile.d/conda.sh" ]; then
@@ -184,8 +184,8 @@ jobs:
           sudo apt-get install -y libhdf5-dev liburing-dev
       - name: Install dependencies (conda env)
         run: |
-          chmod +x install.sh
-          ./install.sh --only-deps
+          chmod +x CI/ci-deps.sh
+          ./CI/ci-deps.sh --only-deps
       - name: Build with leak tracking and run leak tests
         run: |
           if [ -f "$HOME/miniconda3/etc/profile.d/conda.sh" ]; then

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -41,13 +41,13 @@ jobs:
 
       - name: Install dependencies (conda)
         run: |
-          chmod +x install.sh
-          ./install.sh --only-deps release
+          chmod +x CI/ci-deps.sh
+          ./CI/ci-deps.sh --only-deps release
 
       - name: Configure and build
         run: |
           set -x
-          # Re-activate the conda env created by install.sh (env vars do
+          # Re-activate the conda env created by CI/ci-deps.sh (env vars do
           # not persist across GitHub Actions steps).
           if [ -f "$HOME/miniconda3/etc/profile.d/conda.sh" ]; then
             source "$HOME/miniconda3/etc/profile.d/conda.sh"
@@ -148,8 +148,8 @@ jobs:
           submodules: recursive
       - name: Install dependencies (conda env, incl. Boost.Context)
         run: |
-          chmod +x install.sh
-          ./install.sh --only-deps release
+          chmod +x CI/ci-deps.sh
+          ./CI/ci-deps.sh --only-deps release
       - name: Build with Boost backend + run ctest
         run: |
           if [ -f "$HOME/miniconda3/etc/profile.d/conda.sh" ]; then

--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -49,7 +49,7 @@ jobs:
         activate-environment: iowarp
 
     # conda-build is a plugin registered against the BASE env's conda CLI and
-    # must be installed there (see installers/conda + install.sh). Without
+    # must be installed there (see installers/conda + CI/ci-deps.sh). Without
     # `-n base` this installs conda-build into the active `iowarp` env, leaving
     # an `iowarp/bin/conda` ahead of base on PATH that can't import the `conda`
     # module — so conda-build's build-env activation crashes the recipe with
@@ -58,12 +58,12 @@ jobs:
       shell: bash -el {0}
       run: conda install -n base -y conda-build -c conda-forge
 
-    # ── Build CUDA conda package via install.sh ──────────────────────
+    # ── Build CUDA conda package via CI/ci-deps.sh ──────────────────────
     - name: Build CUDA conda package
       shell: bash -el {0}
       run: |
-        chmod +x install.sh
-        ./install.sh cuda-release
+        chmod +x CI/ci-deps.sh
+        ./CI/ci-deps.sh cuda-release
 
     # ── Verify installation ──────────────────────────────────────────
     - name: Verify CUDA package installed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,7 +249,7 @@ NEVER DO MOCK CODE OR STUB CODE UNLESS SPECIFICALLY STATED OTHERWISE. ALWAYS IMP
 - Do NOT use conda in the devcontainer — it is not configured there
 
 **Outside the Devcontainer:**
-- Option 1 (Recommended): Run `install.sh` to build dependencies from source
+- Option 1 (Recommended): Run `CI/ci-deps.sh` to build dependencies from source
 - Option 2: Use system packages via apt
 - Option 3: Use conda via `installers/conda/` recipes
 
@@ -939,7 +939,7 @@ export CLIO_X=IPC
 
 ### Building Bundled Wheels
 
-IOWarp Core can be packaged as a self-contained Python wheel that includes all dependencies installed by `install.sh`.
+IOWarp Core can be packaged as a self-contained Python wheel that includes all dependencies installed by `CI/ci-deps.sh`.
 
 **Quick Build:**
 ```bash
@@ -953,7 +953,7 @@ python -m build --wheel
 
 **What Gets Bundled:**
 - All IOWarp libraries (libclio_run_cxx.so, libclio_ctp_host.so, Module libraries)
-- Dependencies from install.sh (Boost, HDF5, ZeroMQ, yaml-cpp, etc.)
+- Dependencies from CI/ci-deps.sh (Boost, HDF5, ZeroMQ, yaml-cpp, etc.)
 - Command-line tools (clio_cte, clio_cae, clio_run, etc.)
 - Headers and CMake configuration files
 - Conda dependencies (if building in a Conda environment)

--- a/CI/ci-deps.sh
+++ b/CI/ci-deps.sh
@@ -1,24 +1,24 @@
 #!/bin/bash
-# install.sh - Install IOWarp Core using conda-build
+# CI/ci-deps.sh - Install IOWarp Core using conda-build
 # This script builds and installs IOWarp Core from source
 # It will automatically install Miniconda if conda is not detected
 #
 # Usage:
-#   ./install.sh                          # Build with default (release) preset
-#   ./install.sh release                  # Build with release preset
-#   ./install.sh release-fuse             # Build with FUSE adapter enabled
-#   ./install.sh debug                    # Build with debug preset
-#   ./install.sh conda                    # Build with conda-optimized preset
-#   ./install.sh cuda                     # Build with CUDA preset
-#   ./install.sh rocm                     # Build with ROCm preset
-#   ./install.sh --only-deps [preset]     # Install ONLY iowarp-core's deps
+#   ./CI/ci-deps.sh                          # Build with default (release) preset
+#   ./CI/ci-deps.sh release                  # Build with release preset
+#   ./CI/ci-deps.sh release-fuse             # Build with FUSE adapter enabled
+#   ./CI/ci-deps.sh debug                    # Build with debug preset
+#   ./CI/ci-deps.sh conda                    # Build with conda-optimized preset
+#   ./CI/ci-deps.sh cuda                     # Build with CUDA preset
+#   ./CI/ci-deps.sh rocm                     # Build with ROCm preset
+#   ./CI/ci-deps.sh --only-deps [preset]     # Install ONLY iowarp-core's deps
 #                                         # (build+host+run from the recipe),
 #                                         # skip conda-build of iowarp-core itself.
 
 set -e  # Exit on error
 
-# Get script directory
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Get the repo root. This script lives in CI/, so the root is its parent dir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$SCRIPT_DIR"
 
 # Parse arguments: --only-deps flag + optional positional preset

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,7 +284,7 @@ if(CLIO_CORE_ENABLE_DOXYGEN)
     message(STATUS "found doxygen at ${DOXYGEN_EXECUTABLE}")
 endif()
 
-# YAML-CPP - find from system or install.sh installation
+# YAML-CPP - find from system or CI/ci-deps.sh installation
 find_package(yaml-cpp REQUIRED)
 if(yaml-cpp_FOUND)
     message(STATUS "found yaml-cpp at ${yaml-cpp_DIR}")
@@ -319,7 +319,7 @@ if(CLIO_CORE_STATIC_DEPS AND NOT WIN32 AND NOT APPLE)
     endif()
 endif()
 
-# Cereal - find from system or install.sh installation
+# Cereal - find from system or CI/ci-deps.sh installation
 find_package(cereal REQUIRED)
 if(cereal_FOUND)
     message(STATUS "found cereal at ${cereal_DIR}")
@@ -670,7 +670,7 @@ if(CLIO_CORE_ENABLE_ZMQ)
         endif()
     endif()
     if(NOT _ZMQ_FOUND)
-        message(FATAL_ERROR "ZeroMQ not found. Please install ZeroMQ or run install.sh to build from submodules.")
+        message(FATAL_ERROR "ZeroMQ not found. Please install ZeroMQ or run CI/ci-deps.sh to build from submodules.")
     endif()
 endif()
 
@@ -733,7 +733,7 @@ if(CLIO_CTE_ENABLE_HDF5_VOL)
             list(APPEND HDF5_LIBRARIES CURL::libcurl)
         endif()
     else()
-        message(FATAL_ERROR "HDF5 not found. Please install HDF5 or run install.sh to build from submodules.")
+        message(FATAL_ERROR "HDF5 not found. Please install HDF5 or run CI/ci-deps.sh to build from submodules.")
     endif()
 else()
     message(STATUS "HDF5 support disabled")
@@ -1209,7 +1209,7 @@ endif()
 
 # yaml-cpp is already found by ClioCoreCommon (line 202)
 if(NOT TARGET yaml-cpp AND NOT TARGET yaml-cpp::yaml-cpp)
-  message(FATAL_ERROR "yaml-cpp was not found. Please run install.sh to install dependencies.")
+  message(FATAL_ERROR "yaml-cpp was not found. Please run CI/ci-deps.sh to install dependencies.")
 endif()
 message(STATUS "yaml-cpp already found by ClioCoreCommon")
 

--- a/docker/install_docker.sh
+++ b/docker/install_docker.sh
@@ -13,7 +13,7 @@
 #   2. Starts a container and runs pip install inside it
 #   3. Installs IOWarp Core to the container's virtual environment (/opt/venv)
 #   4. Verifies the installation by checking for libraries and CMake configs
-#   Note: Dependencies are automatically downloaded/built by install.sh if not found
+#   Note: Dependencies are automatically downloaded/built by CI/ci-deps.sh if not found
 #==============================================================================
 
 set -e  # Exit on error
@@ -39,13 +39,13 @@ if [ ! -f "$PROJECT_ROOT/setup.py" ]; then
     exit 1
 fi
 
-if [ ! -f "$PROJECT_ROOT/install.sh" ]; then
-    echo "ERROR: install.sh not found in $PROJECT_ROOT"
+if [ ! -f "$PROJECT_ROOT/CI/ci-deps.sh" ]; then
+    echo "ERROR: CI/ci-deps.sh not found in $PROJECT_ROOT"
     echo "Please run this script from the docker/ directory"
     exit 1
 fi
 
-echo "✓ Found setup.py and install.sh in project root"
+echo "✓ Found setup.py and CI/ci-deps.sh in project root"
 echo ""
 
 #------------------------------------------------------------------------------
@@ -89,7 +89,7 @@ else
     echo 'Not a git repository'
 fi
 
-echo 'Note: Dependencies will be downloaded/built by install.sh if not found on system'
+echo 'Note: Dependencies will be downloaded/built by CI/ci-deps.sh if not found on system'
 
 echo ''
 echo '==================================================================='
@@ -110,7 +110,7 @@ echo '==================================================================='
 echo 'Step 2: Installing IOWarp Core with pip'
 echo '==================================================================='
 echo 'This will:'
-echo '  - Run setup.py which calls install.sh'
+echo '  - Run setup.py which calls CI/ci-deps.sh'
 echo '  - Download and build missing dependencies from GitHub releases'
 echo '  - Build and install IOWarp Core libraries'
 echo '  - Install to virtual environment at /opt/venv'
@@ -121,7 +121,7 @@ ls -la | head -20
 echo ''
 
 # pip install -v .
-bash install.sh
+bash CI/ci-deps.sh
 
 echo ''
 echo '==================================================================='


### PR DESCRIPTION
## What
Relocates the source-build helper `install.sh` -> `CI/ci-deps.sh`, alongside the other CI scripts, and fixes its `SCRIPT_DIR` to derive the repo root from `CI/`'s parent.

## References updated
Only the callers that invoke the script by path:
- `.github/workflows/ci-linux.yml`, `ci-macos.yml`, `gpu-tests.yml`
- `docker/install_docker.sh`
- `.claude-plugin/.../dev-setup/SKILL.md`
- `AGENTS.md`
- `CMakeLists.txt` (diagnostic messages)

## Left untouched
`dev` already de-emphasized this script in the user-facing docs (README/INSTALL/installers now recommend `conda install -c iowarp -c conda-forge iowarp-core`) and no longer reference it, so those files are unchanged.

Closes #649.

🤖 Generated with [Claude Code](https://claude.com/claude-code)