### PR TITLE
Integrate GPU compressors (#524) + WinFsp FUSE adapter (#474) into dev

### DIFF
--- a/.devcontainer/nvidia-gpu/Dockerfile
+++ b/.devcontainer/nvidia-gpu/Dockerfile
@@ -69,36 +69,44 @@ RUN set -eux; \
     rm -rf /tmp/cusz_src
 
 # ndzip - GPU high-throughput lossless compressor (CUDA backend).
-# NDZIP_WITH_CUDA=ON builds the ndzip-cuda library the ctp::Ndzip wrapper links.
 #
-# NON-FATAL on purpose. ndzip's CUDA device sources currently fail to compile
-# under this image's CUDA 12.6 + GCC 13 toolchain (an nvcc/libstdc++ '__noinline__'
-# expansion clash in ndzip's own .cu files; verified that minimal CUDA TUs and the
-# cuSZ build above are unaffected, so it is specific to ndzip's source on CUDA 12.6,
-# not a defect in the ctp::Ndzip wrapper, which compiles cleanly against ndzip's
-# headers). Building ndzip is gated behind `|| true` so a failure does NOT abort the
-# image build: the root CMake auto-detects ndzip and simply leaves CLIO_CTP_ENABLE_NDZIP
-# OFF when the library is absent, disabling only the "ndzip" factory entry. To enable
-# ndzip, build this image on a CUDA toolkit that compiles ndzip (e.g. CUDA 12.8, the
-# toolkit already used for sm_120/Blackwell GPUs) and the same step will install it.
-RUN { set -x; \
+# Built with CLANG as the CUDA compiler (clang++ -x cuda), per ndzip's own build
+# docs -- NOT nvcc. nvcc's crt/host_defines.h defines __noinline__ as a macro
+# (__attribute__((noinline))) that nests illegally inside libstdc++'s own
+# __attribute__((__noinline__)) when ndzip's device TUs pull in <memory>/<string>,
+# so the nvcc build fails (ndzip ships a single #undef workaround that is mis-
+# ordered for this toolchain). clang-18 (already installed above for CUDA kernels)
+# does not have that macro and compiles ndzip cleanly. Notes:
+#   - libomp (clang OpenMP) is required by ndzip's CPU codec (cpu_codec.inl).
+#   - -march=native is recommended by ndzip's docs (affects the host/CPU codec; the
+#     CUDA kernels are arch-targeted via CMAKE_CUDA_ARCHITECTURES). Relax it if this
+#     image must run on a different CPU than it was built on.
+#   - ndzip ships no install() rules, so the libs + headers are copied manually.
+#   - clang-18 targets up to sm_90; PTX from the highest arch JITs forward to newer
+#     GPUs (e.g. sm_120 / Blackwell) at runtime.
+RUN set -eux; \
+    apt-get update && apt-get install -y --no-install-recommends libomp-18-dev; \
+    rm -rf /var/lib/apt/lists/*; \
     cd /tmp; \
     git clone --depth 1 --recurse-submodules --shallow-submodules \
-      https://github.com/celerity/ndzip.git ndzip_src && \
+      https://github.com/celerity/ndzip.git ndzip_src; \
     cmake -S ndzip_src -B ndzip_src/build \
       -DCMAKE_BUILD_TYPE=Release \
-      -DCMAKE_INSTALL_PREFIX=/usr/local \
+      -DCMAKE_C_COMPILER=clang-18 -DCMAKE_CXX_COMPILER=clang++-18 \
+      -DCMAKE_CUDA_COMPILER=clang++-18 \
       -DCMAKE_CUDA_ARCHITECTURES="${CUDA_ARCHS}" \
+      -DCMAKE_CXX_FLAGS="-march=native" \
+      -DCMAKE_CUDA_FLAGS="--cuda-path=${CUDA_HOME} -Wno-unknown-cuda-version" \
       -DNDZIP_WITH_CUDA=ON \
       -DNDZIP_WITH_MT=OFF \
       -DNDZIP_BUILD_BENCHMARK=OFF \
       -DNDZIP_BUILD_TEST=OFF \
-      -DCMAKE_POLICY_VERSION_MINIMUM=3.5 && \
-    cmake --build ndzip_src/build -j"$(nproc)" && \
-    cmake --install ndzip_src/build && ldconfig && \
-    echo "ndzip: installed"; \
-  } || echo "WARNING: ndzip build failed (likely the CUDA 12.6 + GCC 13 noinline clash) - ndzip GPU compressor will be DISABLED (auto-detected OFF). See comment above."; \
-  rm -rf /tmp/ndzip_src
+      -DCMAKE_POLICY_VERSION_MINIMUM=3.5; \
+    cmake --build ndzip_src/build -j"$(nproc)"; \
+    cp ndzip_src/build/libndzip.so ndzip_src/build/libndzip-cuda.so /usr/local/lib/; \
+    cp -r ndzip_src/include/ndzip /usr/local/include/; \
+    ldconfig; \
+    rm -rf /tmp/ndzip_src
 
 # Intel oneAPI 2024.2 (SYCL/DPC++) toolchain for the GPU compression factory's
 # SYCL backend (zfp's SYCL execution policy, mirroring how nvcomp backs the CUDA

--- a/.devcontainer/nvidia-gpu/Dockerfile
+++ b/.devcontainer/nvidia-gpu/Dockerfile
@@ -36,6 +36,56 @@ RUN set -eux; \
     ldconfig; \
     rm -rf /tmp/nvcomp*
 
+# Scientific-data GPU compressors that back two more entries in the GPU
+# compression factory (ctp::Cusz / ctp::Ndzip), complementing nvcomp's
+# general-purpose byte codecs. Both are built from source against the CUDA 12
+# toolkit and installed into /usr/local so the root CMake auto-detects them
+# (CLIO_CTP_ENABLE_CUSZ / CLIO_CTP_ENABLE_NDZIP):
+#   - cuSZ  (szcompressor/cuSZ)  : error-bounded LOSSY float compression
+#   - ndzip (celerity/ndzip)     : high-throughput LOSSLESS float compression
+# ndzip has no upstream Spack/apt package, so source-building it here is the only
+# option; cuSZ is also a Spack package (see installers/spack) but is source-built
+# here to match the nvcomp/zfp-sycl pattern. Target SM versions are overridable
+# (default spans Volta..Hopper).
+ARG CUDA_ARCHS="70;75;80;86;89;90"
+
+# cuSZ - GPU error-bounded lossy compressor. Pinned to master; the ctp::Cusz
+# wrapper targets cuSZ's psz_* resource-manager C API.
+RUN set -eux; \
+    cd /tmp; \
+    git clone --depth 1 https://github.com/szcompressor/cuSZ.git cusz_src; \
+    cmake -S cusz_src -B cusz_src/build \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_PREFIX=/usr/local \
+      -DCMAKE_CUDA_ARCHITECTURES="${CUDA_ARCHS}" \
+      -DPSZ_BACKEND=cuda \
+      -DPSZ_BUILD_EXAMPLES=off \
+      -DBUILD_TESTING=off \
+      -DCMAKE_POLICY_VERSION_MINIMUM=3.5; \
+    cmake --build cusz_src/build -j"$(nproc)"; \
+    cmake --install cusz_src/build; \
+    ldconfig; \
+    rm -rf /tmp/cusz_src
+
+# ndzip - GPU high-throughput lossless compressor (CUDA backend).
+# NDZIP_WITH_CUDA=ON builds the ndzip-cuda library the ctp::Ndzip wrapper links.
+RUN set -eux; \
+    cd /tmp; \
+    git clone --depth 1 https://github.com/celerity/ndzip.git ndzip_src; \
+    cmake -S ndzip_src -B ndzip_src/build \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_PREFIX=/usr/local \
+      -DCMAKE_CUDA_ARCHITECTURES="${CUDA_ARCHS}" \
+      -DNDZIP_WITH_CUDA=ON \
+      -DNDZIP_WITH_MT=OFF \
+      -DNDZIP_BUILD_BENCHMARK=OFF \
+      -DNDZIP_BUILD_TEST=OFF \
+      -DCMAKE_POLICY_VERSION_MINIMUM=3.5; \
+    cmake --build ndzip_src/build -j"$(nproc)"; \
+    cmake --install ndzip_src/build; \
+    ldconfig; \
+    rm -rf /tmp/ndzip_src
+
 # Intel oneAPI 2024.2 (SYCL/DPC++) toolchain for the GPU compression factory's
 # SYCL backend (zfp's SYCL execution policy, mirroring how nvcomp backs the CUDA
 # path). Pinned to 2024.2 on purpose: the zfp SYCL port

--- a/.devcontainer/nvidia-gpu/Dockerfile
+++ b/.devcontainer/nvidia-gpu/Dockerfile
@@ -36,17 +36,18 @@ RUN set -eux; \
     ldconfig; \
     rm -rf /tmp/nvcomp*
 
-# Scientific-data GPU compressors that back two more entries in the GPU
-# compression factory (ctp::Cusz / ctp::Ndzip), complementing nvcomp's
-# general-purpose byte codecs. Both are built from source against the CUDA 12
-# toolkit and installed into /usr/local so the root CMake auto-detects them
-# (CLIO_CTP_ENABLE_CUSZ / CLIO_CTP_ENABLE_NDZIP):
+# Scientific-data GPU compressors that back three more entries in the GPU
+# compression factory (ctp::Cusz / ctp::Ndzip / ctp::Cuszp), complementing
+# nvcomp's general-purpose byte codecs. All are built from source against the
+# CUDA 12 toolkit and installed into /usr/local so the root CMake auto-detects
+# them (CLIO_CTP_ENABLE_CUSZ / CLIO_CTP_ENABLE_NDZIP / CLIO_CTP_ENABLE_CUSZP):
 #   - cuSZ  (szcompressor/cuSZ)  : error-bounded LOSSY float compression
 #   - ndzip (celerity/ndzip)     : high-throughput LOSSLESS float compression
-# ndzip has no upstream Spack/apt package, so source-building it here is the only
-# option; cuSZ is also a Spack package (see installers/spack) but is source-built
-# here to match the nvcomp/zfp-sycl pattern. Target SM versions are overridable
-# (default spans Volta..Hopper).
+#   - cuSZp (szcompressor/cuSZp) : ultra-fast single-kernel LOSSY float compression
+# ndzip and cuSZp have no upstream Spack/apt package, so source-building them here
+# is the only option; cuSZ is also a Spack package (see installers/spack) but is
+# source-built here to match the nvcomp/zfp-sycl pattern. Target SM versions are
+# overridable (default spans Volta..Hopper).
 ARG CUDA_ARCHS="70;75;80;86;89;90"
 
 # cuSZ - GPU error-bounded lossy compressor. Pinned to master; the ctp::Cusz
@@ -67,6 +68,24 @@ RUN set -eux; \
     cmake --install cusz_src/build; \
     ldconfig; \
     rm -rf /tmp/cusz_src
+
+# cuSZp - GPU ultra-fast single-kernel error-bounded lossy compressor. Pinned to
+# cuSZp-V3.0.0; the ctp::Cuszp wrapper targets the cuSZp v3 C API
+# (cuSZp_compress / cuSZp_decompress, header <cuSZp.h>, library -lcuSZp).
+RUN set -eux; \
+    cd /tmp; \
+    git clone --depth 1 --branch cuSZp-V3.0.0 \
+      https://github.com/szcompressor/cuSZp.git cuszp_src; \
+    cmake -S cuszp_src -B cuszp_src/build \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_PREFIX=/usr/local \
+      -DCMAKE_CUDA_ARCHITECTURES="${CUDA_ARCHS}" \
+      -DcuSZp_BUILD_EXAMPLES=off \
+      -DCMAKE_POLICY_VERSION_MINIMUM=3.5; \
+    cmake --build cuszp_src/build -j"$(nproc)"; \
+    cmake --install cuszp_src/build; \
+    ldconfig; \
+    rm -rf /tmp/cuszp_src
 
 # ndzip - GPU high-throughput lossless compressor (CUDA backend).
 #

--- a/.devcontainer/nvidia-gpu/Dockerfile
+++ b/.devcontainer/nvidia-gpu/Dockerfile
@@ -70,10 +70,21 @@ RUN set -eux; \
 
 # ndzip - GPU high-throughput lossless compressor (CUDA backend).
 # NDZIP_WITH_CUDA=ON builds the ndzip-cuda library the ctp::Ndzip wrapper links.
-RUN set -eux; \
+#
+# NON-FATAL on purpose. ndzip's CUDA device sources currently fail to compile
+# under this image's CUDA 12.6 + GCC 13 toolchain (an nvcc/libstdc++ '__noinline__'
+# expansion clash in ndzip's own .cu files; verified that minimal CUDA TUs and the
+# cuSZ build above are unaffected, so it is specific to ndzip's source on CUDA 12.6,
+# not a defect in the ctp::Ndzip wrapper, which compiles cleanly against ndzip's
+# headers). Building ndzip is gated behind `|| true` so a failure does NOT abort the
+# image build: the root CMake auto-detects ndzip and simply leaves CLIO_CTP_ENABLE_NDZIP
+# OFF when the library is absent, disabling only the "ndzip" factory entry. To enable
+# ndzip, build this image on a CUDA toolkit that compiles ndzip (e.g. CUDA 12.8, the
+# toolkit already used for sm_120/Blackwell GPUs) and the same step will install it.
+RUN { set -x; \
     cd /tmp; \
     git clone --depth 1 --recurse-submodules --shallow-submodules \
-      https://github.com/celerity/ndzip.git ndzip_src; \
+      https://github.com/celerity/ndzip.git ndzip_src && \
     cmake -S ndzip_src -B ndzip_src/build \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_INSTALL_PREFIX=/usr/local \
@@ -82,11 +93,12 @@ RUN set -eux; \
       -DNDZIP_WITH_MT=OFF \
       -DNDZIP_BUILD_BENCHMARK=OFF \
       -DNDZIP_BUILD_TEST=OFF \
-      -DCMAKE_POLICY_VERSION_MINIMUM=3.5; \
-    cmake --build ndzip_src/build -j"$(nproc)"; \
-    cmake --install ndzip_src/build; \
-    ldconfig; \
-    rm -rf /tmp/ndzip_src
+      -DCMAKE_POLICY_VERSION_MINIMUM=3.5 && \
+    cmake --build ndzip_src/build -j"$(nproc)" && \
+    cmake --install ndzip_src/build && ldconfig && \
+    echo "ndzip: installed"; \
+  } || echo "WARNING: ndzip build failed (likely the CUDA 12.6 + GCC 13 noinline clash) - ndzip GPU compressor will be DISABLED (auto-detected OFF). See comment above."; \
+  rm -rf /tmp/ndzip_src
 
 # Intel oneAPI 2024.2 (SYCL/DPC++) toolchain for the GPU compression factory's
 # SYCL backend (zfp's SYCL execution policy, mirroring how nvcomp backs the CUDA

--- a/.devcontainer/nvidia-gpu/Dockerfile
+++ b/.devcontainer/nvidia-gpu/Dockerfile
@@ -53,7 +53,8 @@ ARG CUDA_ARCHS="70;75;80;86;89;90"
 # wrapper targets cuSZ's psz_* resource-manager C API.
 RUN set -eux; \
     cd /tmp; \
-    git clone --depth 1 https://github.com/szcompressor/cuSZ.git cusz_src; \
+    git clone --depth 1 --recurse-submodules --shallow-submodules \
+      https://github.com/szcompressor/cuSZ.git cusz_src; \
     cmake -S cusz_src -B cusz_src/build \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_INSTALL_PREFIX=/usr/local \
@@ -71,7 +72,8 @@ RUN set -eux; \
 # NDZIP_WITH_CUDA=ON builds the ndzip-cuda library the ctp::Ndzip wrapper links.
 RUN set -eux; \
     cd /tmp; \
-    git clone --depth 1 https://github.com/celerity/ndzip.git ndzip_src; \
+    git clone --depth 1 --recurse-submodules --shallow-submodules \
+      https://github.com/celerity/ndzip.git ndzip_src; \
     cmake -S ndzip_src -B ndzip_src/build \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_INSTALL_PREFIX=/usr/local \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -576,6 +576,33 @@ if(CLIO_CTE_ENABLE_COMPRESS)
         message(STATUS "CLIO_CORE_ENABLE_CUDA is OFF - ndzip GPU compression disabled")
     endif()
 
+    # cuSZp (https://github.com/szcompressor/cuSZp) - GPU ultra-fast error-bounded
+    # lossy compressor for floating-point data. Optional, requires CUDA. Auto-
+    # detected via its CMake config (cuSZp::cuSZp) with a find_library fallback.
+    set(CLIO_CTP_ENABLE_CUSZP OFF)
+    if(CLIO_CORE_ENABLE_CUDA)
+        find_package(cuSZp QUIET)
+        if(cuSZp_FOUND AND TARGET cuSZp::cuSZp)
+            set(cuszp_LIBRARIES cuSZp::cuSZp)
+            set(cuszp_INCLUDE_DIRS "")
+            set(CLIO_CTP_ENABLE_CUSZP ON)
+            message(STATUS "found cuSZp via CMake config (GPU lossy compression)")
+        else()
+            find_path(cuszp_INCLUDE_DIR cuSZp.h)
+            find_library(cuszp_LIBRARY NAMES cuSZp)
+            if(cuszp_INCLUDE_DIR AND cuszp_LIBRARY)
+                set(cuszp_LIBRARIES ${cuszp_LIBRARY})
+                set(cuszp_INCLUDE_DIRS ${cuszp_INCLUDE_DIR})
+                set(CLIO_CTP_ENABLE_CUSZP ON)
+                message(STATUS "found cuSZp.h at ${cuszp_INCLUDE_DIRS}")
+            else()
+                message(STATUS "cuSZp not found - cuSZp GPU compression disabled")
+            endif()
+        endif()
+    else()
+        message(STATUS "CLIO_CORE_ENABLE_CUDA is OFF - cuSZp GPU compression disabled")
+    endif()
+
     set(COMPRESS_LIBS
         bz2
         ${lzo2_LIBRARIES}
@@ -639,6 +666,12 @@ if(CLIO_CTE_ENABLE_COMPRESS)
         list(APPEND COMPRESS_INCLUDES ${ndzip_INCLUDE_DIRS})
     endif()
 
+    # Only add cuSZp if found
+    if(CLIO_CTP_ENABLE_CUSZP)
+        list(APPEND COMPRESS_LIBS ${cuszp_LIBRARIES})
+        list(APPEND COMPRESS_INCLUDES ${cuszp_INCLUDE_DIRS})
+    endif()
+
     # Make CTP_ENABLE_LIBPRESSIO available to subdirectories (CTP)
     set(CLIO_CTP_ENABLE_LIBPRESSIO ${CLIO_CTP_ENABLE_LIBPRESSIO} CACHE BOOL "Enable LibPressio wrapper (auto-detected)" FORCE)
     # Make CTP_ENABLE_NVCOMP available to subdirectories (CTP)
@@ -649,6 +682,7 @@ if(CLIO_CTE_ENABLE_COMPRESS)
     # Make CLIO_CTP_ENABLE_CUSZ / CLIO_CTP_ENABLE_NDZIP available to subdirs (CTP)
     set(CLIO_CTP_ENABLE_CUSZ ${CLIO_CTP_ENABLE_CUSZ} CACHE BOOL "Enable cuSZ GPU compression (auto-detected)" FORCE)
     set(CLIO_CTP_ENABLE_NDZIP ${CLIO_CTP_ENABLE_NDZIP} CACHE BOOL "Enable ndzip GPU compression (auto-detected)" FORCE)
+    set(CLIO_CTP_ENABLE_CUSZP ${CLIO_CTP_ENABLE_CUSZP} CACHE BOOL "Enable cuSZp GPU compression (auto-detected)" FORCE)
 endif()
 
 # Encryption libraries (conditional)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -519,6 +519,63 @@ if(CLIO_CTE_ENABLE_COMPRESS)
         message(STATUS "SYCL libzfp not found under ${CLIO_ZFP_SYCL_ROOT} - zfp-sycl compression disabled")
     endif()
 
+    # cuSZ (https://github.com/szcompressor/cuSZ) - GPU error-bounded lossy
+    # compressor for floating-point data. Optional, requires CUDA. Auto-detected
+    # via its CMake config (target CUSZ::cusz) with a raw find_library fallback.
+    set(CLIO_CTP_ENABLE_CUSZ OFF)
+    if(CLIO_CORE_ENABLE_CUDA)
+        find_package(CUSZ QUIET)
+        if(CUSZ_FOUND)
+            set(cusz_LIBRARIES CUSZ::cusz)
+            set(cusz_INCLUDE_DIRS ${CUSZ_INCLUDE_DIRS})
+            set(CLIO_CTP_ENABLE_CUSZ ON)
+            message(STATUS "found cuSZ via CMake config (GPU lossy compression)")
+        else()
+            find_path(cusz_INCLUDE_DIR cusz.h PATH_SUFFIXES cusz)
+            find_library(cusz_LIBRARY NAMES cusz pszcuda cuszapi)
+            if(cusz_INCLUDE_DIR AND cusz_LIBRARY)
+                set(cusz_LIBRARIES ${cusz_LIBRARY})
+                set(cusz_INCLUDE_DIRS ${cusz_INCLUDE_DIR})
+                set(CLIO_CTP_ENABLE_CUSZ ON)
+                message(STATUS "found cusz.h at ${cusz_INCLUDE_DIRS}")
+            else()
+                message(STATUS "cuSZ not found - cuSZ GPU compression disabled")
+            endif()
+        endif()
+    else()
+        message(STATUS "CLIO_CORE_ENABLE_CUDA is OFF - cuSZ GPU compression disabled")
+    endif()
+
+    # ndzip (https://github.com/celerity/ndzip) - GPU high-throughput lossless
+    # compressor for floating-point data. Optional, requires CUDA and an ndzip
+    # built with NDZIP_WITH_CUDA=ON (provides the ndzip-cuda library). Auto-
+    # detected via its CMake config (ndzip::ndzip-cuda) with a find_library
+    # fallback.
+    set(CLIO_CTP_ENABLE_NDZIP OFF)
+    if(CLIO_CORE_ENABLE_CUDA)
+        find_package(ndzip QUIET)
+        if(ndzip_FOUND AND TARGET ndzip::ndzip-cuda)
+            set(ndzip_LIBRARIES ndzip::ndzip ndzip::ndzip-cuda)
+            set(ndzip_INCLUDE_DIRS "")
+            set(CLIO_CTP_ENABLE_NDZIP ON)
+            message(STATUS "found ndzip via CMake config (GPU lossless compression)")
+        else()
+            find_path(ndzip_INCLUDE_DIR ndzip/ndzip.hh)
+            find_library(ndzip_LIBRARY NAMES ndzip)
+            find_library(ndzip_cuda_LIBRARY NAMES ndzip-cuda)
+            if(ndzip_INCLUDE_DIR AND ndzip_LIBRARY AND ndzip_cuda_LIBRARY)
+                set(ndzip_LIBRARIES ${ndzip_cuda_LIBRARY} ${ndzip_LIBRARY})
+                set(ndzip_INCLUDE_DIRS ${ndzip_INCLUDE_DIR})
+                set(CLIO_CTP_ENABLE_NDZIP ON)
+                message(STATUS "found ndzip.hh at ${ndzip_INCLUDE_DIRS}")
+            else()
+                message(STATUS "ndzip not found - ndzip GPU compression disabled")
+            endif()
+        endif()
+    else()
+        message(STATUS "CLIO_CORE_ENABLE_CUDA is OFF - ndzip GPU compression disabled")
+    endif()
+
     set(COMPRESS_LIBS
         bz2
         ${lzo2_LIBRARIES}
@@ -570,6 +627,18 @@ if(CLIO_CTE_ENABLE_COMPRESS)
         list(APPEND COMPRESS_INCLUDES ${ZFP_SYCL_INCLUDE_DIR})
     endif()
 
+    # Only add cuSZ if found
+    if(CLIO_CTP_ENABLE_CUSZ)
+        list(APPEND COMPRESS_LIBS ${cusz_LIBRARIES})
+        list(APPEND COMPRESS_INCLUDES ${cusz_INCLUDE_DIRS})
+    endif()
+
+    # Only add ndzip if found
+    if(CLIO_CTP_ENABLE_NDZIP)
+        list(APPEND COMPRESS_LIBS ${ndzip_LIBRARIES})
+        list(APPEND COMPRESS_INCLUDES ${ndzip_INCLUDE_DIRS})
+    endif()
+
     # Make CTP_ENABLE_LIBPRESSIO available to subdirectories (CTP)
     set(CLIO_CTP_ENABLE_LIBPRESSIO ${CLIO_CTP_ENABLE_LIBPRESSIO} CACHE BOOL "Enable LibPressio wrapper (auto-detected)" FORCE)
     # Make CTP_ENABLE_NVCOMP available to subdirectories (CTP)
@@ -577,6 +646,9 @@ if(CLIO_CTE_ENABLE_COMPRESS)
     # Make CLIO_CTP_ENABLE_ZFP_SYCL available to subdirectories (CTP). Distinct
     # from CLIO_CTP_ENABLE_SYCL (the SYCL-language switch) -- do not conflate.
     set(CLIO_CTP_ENABLE_ZFP_SYCL ${CLIO_CTP_ENABLE_ZFP_SYCL} CACHE BOOL "Enable zfp-sycl GPU compression (auto-detected)" FORCE)
+    # Make CLIO_CTP_ENABLE_CUSZ / CLIO_CTP_ENABLE_NDZIP available to subdirs (CTP)
+    set(CLIO_CTP_ENABLE_CUSZ ${CLIO_CTP_ENABLE_CUSZ} CACHE BOOL "Enable cuSZ GPU compression (auto-detected)" FORCE)
+    set(CLIO_CTP_ENABLE_NDZIP ${CLIO_CTP_ENABLE_NDZIP} CACHE BOOL "Enable ndzip GPU compression (auto-detected)" FORCE)
 endif()
 
 # Encryption libraries (conditional)

--- a/context-transfer-engine/adapter/libfuse/CMakeLists.txt
+++ b/context-transfer-engine/adapter/libfuse/CMakeLists.txt
@@ -1,10 +1,43 @@
-# Find FUSE3
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(FUSE3 QUIET fuse3)
+# Find FUSE3.
+#   Linux:   libfuse3, discovered via pkg-config.
+#   Windows: WinFsp ships a FUSE3-compatible header (inc/fuse3/fuse.h) and an
+#            import library (lib/winfsp-x64.lib) but NO pkg-config file, so
+#            locate it directly. Default install dir is "%ProgramFiles(x86)%\
+#            WinFsp"; override with -DWINFSP_ROOT=... if installed elsewhere.
+# Both branches set FUSE3_FOUND, FUSE3_INCLUDEDIR and FUSE3_LIBRARIES so the
+# target wiring below is identical on either platform.
+if(WIN32)
+  if(NOT WINFSP_ROOT)
+    set(WINFSP_ROOT "$ENV{ProgramFiles\(x86\)}/WinFsp")
+  endif()
+  find_path(FUSE3_INCLUDEDIR
+    NAMES fuse3/fuse.h
+    HINTS "${WINFSP_ROOT}/inc")
+  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(_winfsp_lib_names winfsp-x64)
+  else()
+    set(_winfsp_lib_names winfsp-x86)
+  endif()
+  find_library(FUSE3_LIBRARIES
+    NAMES ${_winfsp_lib_names} winfsp
+    HINTS "${WINFSP_ROOT}/lib")
+  if(FUSE3_INCLUDEDIR AND FUSE3_LIBRARIES)
+    set(FUSE3_FOUND TRUE)
+    set(FUSE3_VERSION "WinFsp")
+  endif()
+else()
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(FUSE3 QUIET fuse3)
+endif()
 
 if(NOT FUSE3_FOUND)
-  message(WARNING "FUSE3 not found. FUSE adapter will not be built.")
-  message(STATUS "To install FUSE3: sudo apt install libfuse3-dev")
+  if(WIN32)
+    message(WARNING "WinFsp not found. FUSE adapter will not be built.")
+    message(STATUS "Install WinFsp (https://winfsp.dev) or pass -DWINFSP_ROOT=<dir>")
+  else()
+    message(WARNING "FUSE3 not found. FUSE adapter will not be built.")
+    message(STATUS "To install FUSE3: sudo apt install libfuse3-dev")
+  endif()
   return()
 endif()
 

--- a/context-transfer-engine/adapter/libfuse/fuse_cte.cc
+++ b/context-transfer-engine/adapter/libfuse/fuse_cte.cc
@@ -37,7 +37,10 @@
 #include <cstring>
 #include <string>
 #include <vector>
+#include <cerrno>                 // errno
+#include <cstdio>                 // snprintf, fprintf
 
+#ifndef _WIN32
 #include <fuse3/fuse_lowlevel.h>  // fuse_session_custom_io, struct fuse_custom_io
 #include <dlfcn.h>                // dlsym (resolve fuse_session_custom_io at runtime
                                   // so we can link against system libfuse 3.10.5
@@ -46,11 +49,23 @@
 #include <sys/uio.h>              // struct iovec, writev
 #include <sys/mount.h>            // mount syscall
 #include <unistd.h>               // read, getuid, getgid
-#include <cerrno>                 // errno
-#include <cstdio>                 // snprintf, fprintf
+#endif
 
 #include "clio_runtime/clio_runtime.h"
 #include "clio_cte/core/content_transfer_engine.h"
+
+// Bridge the POSIX type spellings the callbacks use to the concrete types
+// each platform's FUSE layer expects in `struct fuse_operations`. On Linux
+// (libfuse) the high-level API uses the POSIX types directly; on Windows the
+// shim maps them to WinFsp's fuse_* types and supplies getuid/getgid/S_IF*.
+#ifdef _WIN32
+#include "fuse_win_compat.h"
+#else
+using cte_stat_t = struct stat;
+using cte_off_t = off_t;
+using cte_mode_t = mode_t;
+using cte_timespec_t = struct timespec;
+#endif
 
 using namespace clio::cae::fuse;
 
@@ -90,10 +105,10 @@ static void cte_fuse_destroy(void *private_data) {
 // Metadata
 // ============================================================================
 
-static int cte_fuse_getattr(const char *path, struct stat *stbuf,
+static int cte_fuse_getattr(const char *path, cte_stat_t *stbuf,
                             struct fuse_file_info *fi) {
   (void)fi;
-  memset(stbuf, 0, sizeof(struct stat));
+  memset(stbuf, 0, sizeof(*stbuf));
 
   std::string p(path);
 
@@ -125,14 +140,14 @@ static int cte_fuse_getattr(const char *path, struct stat *stbuf,
     stbuf->st_nlink = 1;
     stbuf->st_uid = getuid();
     stbuf->st_gid = getgid();
-    stbuf->st_size = static_cast<off_t>(CteGetTagSize(tag_id));
+    stbuf->st_size = static_cast<cte_off_t>(CteGetTagSize(tag_id));
     return 0;
   }
 
   return -ENOENT;
 }
 
-static int cte_fuse_utimens(const char *path, const struct timespec tv[2],
+static int cte_fuse_utimens(const char *path, const cte_timespec_t tv[2],
                             struct fuse_file_info *fi) {
   (void)path;
   (void)tv;
@@ -146,7 +161,7 @@ static int cte_fuse_utimens(const char *path, const struct timespec tv[2],
 // ============================================================================
 
 static int cte_fuse_readdir(const char *path, void *buf,
-                            fuse_fill_dir_t filler, off_t offset,
+                            fuse_fill_dir_t filler, cte_off_t offset,
                             struct fuse_file_info *fi,
                             enum fuse_readdir_flags flags) {
   (void)offset;
@@ -204,7 +219,7 @@ static int cte_fuse_readdir(const char *path, void *buf,
   return 0;
 }
 
-static int cte_fuse_mkdir(const char *path, mode_t mode) {
+static int cte_fuse_mkdir(const char *path, cte_mode_t mode) {
   (void)mode;
   std::string p(path);
   // Create a sentinel tag with a trailing "/" to mark an explicit directory.
@@ -233,7 +248,7 @@ static int cte_fuse_rmdir(const char *path) {
 // File lifecycle
 // ============================================================================
 
-static int cte_fuse_create(const char *path, mode_t mode,
+static int cte_fuse_create(const char *path, cte_mode_t mode,
                            struct fuse_file_info *fi) {
   (void)mode;
   std::string p(path);
@@ -305,7 +320,7 @@ static int cte_fuse_release(const char *path, struct fuse_file_info *fi) {
 // ============================================================================
 
 static int cte_fuse_read(const char *path, char *buf, size_t size,
-                         off_t offset, struct fuse_file_info *fi) {
+                         cte_off_t offset, struct fuse_file_info *fi) {
   (void)path;
   auto *handle = GetHandle(fi);
 
@@ -345,7 +360,7 @@ static int cte_fuse_read(const char *path, char *buf, size_t size,
 }
 
 static int cte_fuse_write(const char *path, const char *buf, size_t size,
-                          off_t offset, struct fuse_file_info *fi) {
+                          cte_off_t offset, struct fuse_file_info *fi) {
   (void)path;
   auto *handle = GetHandle(fi);
 
@@ -386,7 +401,7 @@ static int cte_fuse_unlink(const char *path) {
   return 0;
 }
 
-static int cte_fuse_truncate(const char *path, off_t size,
+static int cte_fuse_truncate(const char *path, cte_off_t size,
                              struct fuse_file_info *fi) {
   (void)fi;
   (void)size;
@@ -419,6 +434,7 @@ static const struct fuse_operations cte_fuse_ops = {
     .utimens = cte_fuse_utimens,
 };
 
+#ifndef _WIN32
 // custom_io callbacks: when apptainer hands us an already-mounted
 // /dev/fuse fd, we need to drive the FUSE protocol on that fd directly
 // instead of having libfuse mount its own. Plain read/writev syscalls
@@ -431,8 +447,17 @@ static ssize_t cte_custom_read(int fd, void *buf, size_t buf_len,
                                void * /*userdata*/) {
   return read(fd, buf, buf_len);
 }
+#endif  // _WIN32
 
 int main(int argc, char *argv[]) {
+#ifdef _WIN32
+  // Native Windows (WinFsp): there is no Apptainer-style /dev/fuse fd
+  // injection. WinFsp's fuse_main() parses argv (the mountpoint is a
+  // drive letter like "Z:" or a host directory) and drives the FUSE
+  // protocol through winfsp.sys. The 16 callbacks and the entire CTE
+  // data path below them are byte-for-byte identical to the Linux build.
+  return fuse_main(argc, argv, &cte_fuse_ops, nullptr);
+#else
   // Apptainer's --fusemount opens /dev/fuse on the host, performs the
   // kernel mount, and passes the fd to the FUSE binary as the last
   // argv ("/dev/fd/<N>"). libfuse 3's high-level argv parser doesn't
@@ -562,4 +587,5 @@ int main(int argc, char *argv[]) {
   fuse_destroy(fuse);
   fuse_opt_free_args(&args);
   return ret;
+#endif  // _WIN32
 }

--- a/context-transfer-engine/adapter/libfuse/fuse_cte.h
+++ b/context-transfer-engine/adapter/libfuse/fuse_cte.h
@@ -47,9 +47,12 @@
 #include <list>
 #include <mutex>
 #include <string>
-#include <sys/stat.h>
-#include <unistd.h>
 #include <vector>
+
+#ifndef _WIN32
+#include <sys/stat.h>  // struct stat + S_IF* for fuse_cte.cc's getattr (Linux)
+#include <unistd.h>    // getuid/getgid/read used by fuse_cte.cc on Linux
+#endif
 
 #include "clio_cte/core/core_client.h"
 #include "clio_cte/core/core_tasks.h"

--- a/context-transfer-engine/adapter/libfuse/fuse_win_compat.h
+++ b/context-transfer-engine/adapter/libfuse/fuse_win_compat.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CLIO_CTE_ADAPTER_LIBFUSE_FUSE_WIN_COMPAT_H_
+#define CLIO_CTE_ADAPTER_LIBFUSE_FUSE_WIN_COMPAT_H_
+
+#ifdef _WIN32
+
+// Windows (WinFsp) compatibility shim for the cross-platform FUSE adapter.
+//
+// This header is included by fuse_cte.cc *after* <fuse3/fuse.h> (WinFsp's
+// FUSE3-compatibility header, pulled in transitively via fuse_cte.h). On
+// MSVC, WinFsp exposes the FUSE data types under fuse_-prefixed names
+// (fuse_stat, fuse_off_t, fuse_mode_t, fuse_timespec) and does NOT remap the
+// bare POSIX spellings the way it does for Cygwin/MinGW. It also does not
+// provide getuid()/getgid() or the S_IF* mode-bit macros, and <unistd.h> /
+// <sys/stat.h> are not available. This header bridges exactly those gaps so
+// the platform-agnostic callback bodies in fuse_cte.cc compile unchanged.
+//
+// Nothing here changes the CTE data path: it only makes the FUSE frontend's
+// type names and helpers resolve on Windows. The matching Linux definitions
+// (the bare POSIX types) live inline in fuse_cte.cc.
+
+// --- Type bridge -----------------------------------------------------------
+// The shared callback signatures must match the function-pointer types in
+// WinFsp's `struct fuse_operations` exactly, so each POSIX spelling maps to
+// the corresponding fuse_* type. The callback bodies only touch fields that
+// fuse_stat shares with POSIX struct stat (st_mode/st_nlink/st_uid/st_gid/
+// st_size), so they need no further change.
+using cte_stat_t = struct fuse_stat;
+using cte_off_t = fuse_off_t;
+using cte_mode_t = fuse_mode_t;
+using cte_timespec_t = struct fuse_timespec;
+
+// --- File mode bits --------------------------------------------------------
+// POSIX octal values; fuse_stat::st_mode uses the same encoding. Guarded in
+// case a future WinFsp header begins providing them.
+#ifndef S_IFMT
+#define S_IFMT 0170000
+#endif
+#ifndef S_IFDIR
+#define S_IFDIR 0040000
+#endif
+#ifndef S_IFREG
+#define S_IFREG 0100000
+#endif
+
+// --- Owner identity --------------------------------------------------------
+// Windows has no POSIX uid/gid; WinFsp fabricates a mapping per request.
+// getattr only uses these to populate st_uid/st_gid for display, so report
+// the WinFsp-supplied context identity when a request is in flight, else 0.
+static inline unsigned cte_fuse_getuid() {
+  struct fuse_context *ctx = fuse_get_context();
+  return ctx ? static_cast<unsigned>(ctx->uid) : 0u;
+}
+static inline unsigned cte_fuse_getgid() {
+  struct fuse_context *ctx = fuse_get_context();
+  return ctx ? static_cast<unsigned>(ctx->gid) : 0u;
+}
+#ifndef getuid
+#define getuid cte_fuse_getuid
+#endif
+#ifndef getgid
+#define getgid cte_fuse_getgid
+#endif
+
+#endif  // _WIN32
+#endif  // CLIO_CTE_ADAPTER_LIBFUSE_FUSE_WIN_COMPAT_H_

--- a/context-transport-primitives/CMakeLists.txt
+++ b/context-transport-primitives/CMakeLists.txt
@@ -320,7 +320,8 @@ if(CLIO_CTE_ENABLE_COMPRESS)
     # imported targets do not all propagate the CUDA toolkit include dir, so link
     # CUDA::cudart to provide it to every consumer of ctp::compress (test + CTE
     # compressor module) whenever any CUDA-backed compressor is enabled.
-    if((CLIO_CTP_ENABLE_NVCOMP OR CLIO_CTP_ENABLE_CUSZ OR CLIO_CTP_ENABLE_NDZIP)
+    if((CLIO_CTP_ENABLE_NVCOMP OR CLIO_CTP_ENABLE_CUSZ OR CLIO_CTP_ENABLE_NDZIP
+        OR CLIO_CTP_ENABLE_CUSZP)
        AND TARGET CUDA::cudart)
         target_link_libraries(compress INTERFACE CUDA::cudart)
     endif()
@@ -332,6 +333,7 @@ target_compile_definitions(compress INTERFACE
     CTP_ENABLE_ZFP_SYCL=$<BOOL:${CLIO_CTP_ENABLE_ZFP_SYCL}>
     CTP_ENABLE_CUSZ=$<BOOL:${CLIO_CTP_ENABLE_CUSZ}>
     CTP_ENABLE_NDZIP=$<BOOL:${CLIO_CTP_ENABLE_NDZIP}>
+    CTP_ENABLE_CUSZP=$<BOOL:${CLIO_CTP_ENABLE_CUSZP}>
 )
 add_library(ctp::compress ALIAS compress)
 

--- a/context-transport-primitives/CMakeLists.txt
+++ b/context-transport-primitives/CMakeLists.txt
@@ -316,10 +316,12 @@ if(CLIO_CTE_ENABLE_COMPRESS)
     if(TARGET dense_nn_predictor)
         target_link_libraries(compress INTERFACE dense_nn_predictor)
     endif()
-    # nvcomp.h includes <cuda_runtime.h>; the nvcomp imported target does not
-    # propagate the CUDA toolkit include dir, so link CUDA::cudart to provide it
-    # to every consumer of ctp::compress (test + CTE compressor module).
-    if(CLIO_CTP_ENABLE_NVCOMP AND TARGET CUDA::cudart)
+    # nvcomp.h / cusz.h / ndzip.h include <cuda_runtime.h>; the GPU compressor
+    # imported targets do not all propagate the CUDA toolkit include dir, so link
+    # CUDA::cudart to provide it to every consumer of ctp::compress (test + CTE
+    # compressor module) whenever any CUDA-backed compressor is enabled.
+    if((CLIO_CTP_ENABLE_NVCOMP OR CLIO_CTP_ENABLE_CUSZ OR CLIO_CTP_ENABLE_NDZIP)
+       AND TARGET CUDA::cudart)
         target_link_libraries(compress INTERFACE CUDA::cudart)
     endif()
 endif()
@@ -328,6 +330,8 @@ target_compile_definitions(compress INTERFACE
     CTP_ENABLE_LIBPRESSIO=$<BOOL:${CLIO_CTP_ENABLE_LIBPRESSIO}>
     CTP_ENABLE_NVCOMP=$<BOOL:${CLIO_CTP_ENABLE_NVCOMP}>
     CTP_ENABLE_ZFP_SYCL=$<BOOL:${CLIO_CTP_ENABLE_ZFP_SYCL}>
+    CTP_ENABLE_CUSZ=$<BOOL:${CLIO_CTP_ENABLE_CUSZ}>
+    CTP_ENABLE_NDZIP=$<BOOL:${CLIO_CTP_ENABLE_NDZIP}>
 )
 add_library(ctp::compress ALIAS compress)
 

--- a/context-transport-primitives/include/clio_ctp/compress/compress_factory.h
+++ b/context-transport-primitives/include/clio_ctp/compress/compress_factory.h
@@ -65,6 +65,10 @@
 #include "ndzip.h"
 #endif
 
+#if CTP_ENABLE_CUSZP
+#include "cuszp.h"
+#endif
+
 namespace ctp {
 
 /**
@@ -99,6 +103,7 @@ class CompressionFactory {
    *                                "zfp-sycl" (lossy fixed-rate, if SYCL enabled)
    *                                "cusz" (GPU lossy float, if cuSZ enabled)
    *                                "ndzip" (GPU lossless float, if ndzip enabled)
+   *                                "cuszp" (GPU lossy float, if cuSZp enabled)
    * @param preset Compression preset level (FAST/BALANCED/BEST/DEFAULT)
    * @return Unique pointer to configured compressor instance,
    *         or nullptr if library not found
@@ -365,6 +370,26 @@ class CompressionFactory {
     return nullptr;
 #endif
   }
+  // cuSZp: GPU ultra-fast error-bounded LOSSY float compressor (single-kernel).
+  // Multi-mode like cusz/the lossy CPU entries -- presets map to ABSOLUTE error
+  // bounds (FAST=1e-2 loose, BALANCED=1e-3, BEST=1e-4 tight). Returns nullptr
+  // when cuSZp is not available in this build.
+  static std::unique_ptr<Compressor> MakeCuszp(CompressionPreset preset) {
+#if CTP_ENABLE_CUSZP
+    float eb;
+    switch (preset) {
+      case CompressionPreset::FAST: eb = 1e-2f; break;
+      case CompressionPreset::BEST: eb = 1e-4f; break;
+      case CompressionPreset::BALANCED:
+      case CompressionPreset::DEFAULT:
+      default: eb = 1e-3f; break;
+    }
+    return std::make_unique<Cuszp>(eb);
+#else
+    (void)preset;
+    return nullptr;
+#endif
+  }
 
   /**
    * The compressor registry: the single source of truth (see CompressorInfo).
@@ -396,6 +421,7 @@ class CompressionFactory {
         CompressorInfo{"zfp-sycl",        17, 19, false, &MakeSyclZfp},
         CompressorInfo{"cusz",            18, 20, false, &MakeCusz},
         CompressorInfo{"ndzip",           19, 21, true,  &MakeNdzip},
+        CompressorInfo{"cuszp",           20, 22, false, &MakeCuszp},
     };
     return kRegistry;
   }

--- a/context-transport-primitives/include/clio_ctp/compress/compress_factory.h
+++ b/context-transport-primitives/include/clio_ctp/compress/compress_factory.h
@@ -57,6 +57,14 @@
 #include "sycl_zfp.h"
 #endif
 
+#if CTP_ENABLE_CUSZ
+#include "cusz.h"
+#endif
+
+#if CTP_ENABLE_NDZIP
+#include "ndzip.h"
+#endif
+
 namespace ctp {
 
 /**
@@ -89,6 +97,8 @@ class CompressionFactory {
    *                                "nvcomp-gdeflate", "nvcomp-deflate",
    *                                "nvcomp-ans" (if nvcomp enabled)
    *                                "zfp-sycl" (lossy fixed-rate, if SYCL enabled)
+   *                                "cusz" (GPU lossy float, if cuSZ enabled)
+   *                                "ndzip" (GPU lossless float, if ndzip enabled)
    * @param preset Compression preset level (FAST/BALANCED/BEST/DEFAULT)
    * @return Unique pointer to configured compressor instance,
    *         or nullptr if library not found
@@ -326,6 +336,35 @@ class CompressionFactory {
     return nullptr;
 #endif
   }
+  // cuSZ: GPU error-bounded LOSSY float compressor. Multi-mode like the lossy
+  // CPU entries -- presets map to error bounds (FAST=1e-2 loose, BALANCED=1e-3,
+  // BEST=1e-4 tight); higher fidelity -> lower compression. Returns nullptr when
+  // cuSZ is not available in this build.
+  static std::unique_ptr<Compressor> MakeCusz(CompressionPreset preset) {
+#if CTP_ENABLE_CUSZ
+    double eb;
+    switch (preset) {
+      case CompressionPreset::FAST: eb = 1e-2; break;
+      case CompressionPreset::BEST: eb = 1e-4; break;
+      case CompressionPreset::BALANCED:
+      case CompressionPreset::DEFAULT:
+      default: eb = 1e-3; break;
+    }
+    return std::make_unique<Cusz>(eb);
+#else
+    (void)preset;
+    return nullptr;
+#endif
+  }
+  // ndzip: GPU high-throughput LOSSLESS float compressor. Single-mode (no preset
+  // levels), like snappy/blosc2. Returns nullptr when ndzip is not available.
+  static std::unique_ptr<Compressor> MakeNdzip(CompressionPreset) {
+#if CTP_ENABLE_NDZIP
+    return std::make_unique<Ndzip>();
+#else
+    return nullptr;
+#endif
+  }
 
   /**
    * The compressor registry: the single source of truth (see CompressorInfo).
@@ -355,6 +394,8 @@ class CompressionFactory {
         CompressorInfo{"nvcomp-deflate",  15, 17, true, &MakeNvCompDeflate},
         CompressorInfo{"nvcomp-ans",      16, 18, true, &MakeNvCompAns},
         CompressorInfo{"zfp-sycl",        17, 19, false, &MakeSyclZfp},
+        CompressorInfo{"cusz",            18, 20, false, &MakeCusz},
+        CompressorInfo{"ndzip",           19, 21, true,  &MakeNdzip},
     };
     return kRegistry;
   }

--- a/context-transport-primitives/include/clio_ctp/compress/cusz.h
+++ b/context-transport-primitives/include/clio_ctp/compress/cusz.h
@@ -1,0 +1,309 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CTP_SHM_INCLUDE_HSHM_SHM_COMPRESS_CUSZ_H_
+#define CTP_SHM_INCLUDE_HSHM_SHM_COMPRESS_CUSZ_H_
+
+#if CTP_ENABLE_COMPRESS && CTP_ENABLE_CUSZ
+
+#include <cuda_runtime.h>
+#include <cusz.h>
+
+#include <cstdint>
+#include <cstring>
+
+#include "compress.h"
+
+namespace ctp {
+
+/**
+ * cuSZ GPU error-bounded LOSSY compressor for floating-point scientific data --
+ * the GPU lossy analog of the LibPressio sz3/zfp entries, the way NvComp is the
+ * GPU lossless analog of the CPU codecs.
+ *
+ * https://github.com/szcompressor/cuSZ
+ *
+ * cuSZ operates directly on GPU device memory. Like NvComp, this wrapper is
+ * adaptive: a pointer that already refers to GPU-accessible memory is used in
+ * place (zero-copy); otherwise the data is staged through a temporary device
+ * buffer (H2D for inputs, D2H for outputs), so host callers (and the unit test
+ * harness) work too while device callers get the zero-copy path automatically.
+ *
+ * Like the existing zfp/sz3/fpzip/zfp-sycl entries, and constrained by the
+ * byte-stream Compressor interface (which carries neither type nor shape), the
+ * input buffer is interpreted as a 1D array of 32-bit floats. Compress requires
+ * input_size to be a multiple of sizeof(float).
+ *
+ * Self-describing framing: the output blob is laid out as
+ *   [ Prefix (magic + elem count + psz_header) ][ cuSZ compressed byte-stream ]
+ * so Decompress rebuilds the cuSZ resource manager from the embedded header
+ * without any out-of-band metadata (cuSZ's compressed stream alone does not
+ * carry its decode metadata).
+ *
+ * IMPORTANT -- LOSSY. Each value is reconstructed within the configured error
+ * bound (relative by default), not bit-exact. Presets map to error bounds:
+ * FAST=1e-2 (loose), BALANCED=1e-3, BEST=1e-4 (tight).
+ *
+ * Tested against the cuSZ master / 0.14 C API (psz_create_resource_manager,
+ * psz_compress_float, psz_decompress_float, psz_release_resource). The NVIDIA
+ * devcontainer pins a matching cuSZ revision.
+ */
+class Cusz : public Compressor {
+ public:
+  /**
+   * @param eb error bound (default 1e-3).
+   * @param mode error-bound mode: Rel (relative) or Abs (absolute).
+   */
+  explicit Cusz(double eb = 1e-3, psz_mode mode = Rel)
+      : eb_(eb), mode_(mode) {}
+
+  bool Compress(void *output, size_t &output_size, void *input,
+                size_t input_size) override {
+    if (input == nullptr || (input_size % sizeof(float)) != 0) {
+      return false;  // float codec; need whole 32-bit floats
+    }
+    if (output_size < sizeof(Prefix)) {
+      return false;
+    }
+    const size_t n = input_size / sizeof(float);
+
+    cudaStream_t stream = nullptr;
+    if (cudaStreamCreate(&stream) != cudaSuccess) {
+      return false;
+    }
+    float *d_in = nullptr;
+    bool free_in = false;
+    psz_resource *mgr = nullptr;
+    bool ok = false;
+    do {
+      d_in = static_cast<float *>(
+          ToDeviceInput(input, input_size, stream, &free_in));
+      if (d_in == nullptr) break;
+
+      psz_len len = {n, 1, 1};  // x, y, z (1D)
+      psz_pipeline pipeline = {Lorenzo, HistGeneric, HF, CodecNull};
+      mgr = psz_create_resource_manager(F4, len, pipeline, stream);
+      if (mgr == nullptr) break;
+
+      Prefix prefix;
+      std::memset(&prefix, 0, sizeof(prefix));
+      prefix.magic = kMagic;
+      prefix.elems = static_cast<uint64_t>(n);
+
+      uint8_t *d_comp = nullptr;  // device buffer owned by the manager
+      size_t comp_bytes = 0;
+      psz_rc2 rc = {mode_, eb_, kRadius};
+      if (psz_compress_float(mgr, rc, d_in, &prefix.header, &d_comp,
+                             &comp_bytes) != 0 ||
+          d_comp == nullptr) {
+        break;
+      }
+
+      const size_t total = sizeof(Prefix) + comp_bytes;
+      if (total > output_size) break;  // caller buffer too small
+
+      // Frame: [prefix][compressed stream]. d_comp lives in the manager's
+      // internal device buffer, so it must be copied out before release.
+      const bool out_is_device = IsDeviceAccessible(output);
+      uint8_t *out = static_cast<uint8_t *>(output);
+      const cudaMemcpyKind kind =
+          out_is_device ? cudaMemcpyDeviceToDevice : cudaMemcpyDeviceToHost;
+      if (out_is_device) {
+        if (cudaMemcpyAsync(out, &prefix, sizeof(Prefix),
+                            cudaMemcpyHostToDevice, stream) != cudaSuccess) {
+          break;
+        }
+      } else {
+        std::memcpy(out, &prefix, sizeof(Prefix));
+      }
+      if (cudaMemcpyAsync(out + sizeof(Prefix), d_comp, comp_bytes, kind,
+                          stream) != cudaSuccess) {
+        break;
+      }
+      if (cudaStreamSynchronize(stream) != cudaSuccess) break;
+      output_size = total;
+      ok = true;
+    } while (false);
+
+    if (mgr != nullptr) psz_release_resource(mgr);
+    if (free_in) cudaFree(d_in);
+    cudaStreamDestroy(stream);
+    return ok;
+  }
+
+  bool Decompress(void *output, size_t &output_size, void *input,
+                  size_t input_size) override {
+    if (output == nullptr || input == nullptr || input_size < sizeof(Prefix)) {
+      return false;
+    }
+
+    cudaStream_t stream = nullptr;
+    if (cudaStreamCreate(&stream) != cudaSuccess) {
+      return false;
+    }
+    float *d_out = nullptr;
+    bool free_out = false;
+    psz_resource *mgr = nullptr;
+    bool ok = false;
+    do {
+      // Pull the prefix (magic + header) back to the host.
+      Prefix prefix;
+      if (IsDeviceAccessible(input)) {
+        if (cudaMemcpy(&prefix, input, sizeof(Prefix),
+                       cudaMemcpyDeviceToHost) != cudaSuccess) {
+          break;
+        }
+      } else {
+        std::memcpy(&prefix, input, sizeof(Prefix));
+      }
+      if (prefix.magic != kMagic) break;  // not one of our blobs
+
+      const size_t n = static_cast<size_t>(prefix.elems);
+      if (n * sizeof(float) > output_size) break;  // caller buffer too small
+
+      // cuSZ writes into device memory; use the caller's buffer if it is a GPU
+      // buffer, else decode into a temp and copy D2H.
+      const bool out_is_device = IsDeviceAccessible(output);
+      if (out_is_device) {
+        d_out = static_cast<float *>(output);
+      } else {
+        if (cudaMalloc(&d_out, n * sizeof(float)) != cudaSuccess) break;
+        free_out = true;
+      }
+
+      // The compressed stream must be device-resident for cuSZ.
+      uint8_t *d_stream = nullptr;
+      bool free_stream = false;
+      const size_t comp_bytes = pszheader_compressed_bytes(&prefix.header);
+      uint8_t *stream_src = static_cast<uint8_t *>(input) + sizeof(Prefix);
+      if (IsDeviceAccessible(input)) {
+        d_stream = stream_src;
+      } else {
+        if (cudaMalloc(&d_stream, comp_bytes) != cudaSuccess) break;
+        free_stream = true;
+        if (cudaMemcpyAsync(d_stream, stream_src, comp_bytes,
+                            cudaMemcpyHostToDevice, stream) != cudaSuccess) {
+          cudaFree(d_stream);
+          break;
+        }
+      }
+
+      mgr = psz_create_resource_manager_from_header(&prefix.header, stream);
+      bool decoded = mgr != nullptr &&
+                     psz_decompress_float(mgr, d_stream, comp_bytes, d_out) == 0;
+      if (decoded && cudaStreamSynchronize(stream) == cudaSuccess) {
+        if (!out_is_device) {
+          decoded = cudaMemcpy(output, d_out, n * sizeof(float),
+                               cudaMemcpyDeviceToHost) == cudaSuccess;
+        }
+        if (decoded) {
+          output_size = n * sizeof(float);
+          ok = true;
+        }
+      }
+      if (free_stream) cudaFree(d_stream);
+    } while (false);
+
+    if (mgr != nullptr) psz_release_resource(mgr);
+    if (free_out) cudaFree(d_out);
+    cudaStreamDestroy(stream);
+    return ok;
+  }
+
+  /** Set the error bound. */
+  void SetErrorBound(double eb) { eb_ = eb; }
+  /** Get the error bound. */
+  double GetErrorBound() const { return eb_; }
+
+ private:
+  /** cuSZ quantization radius (cuSZ's historical default). */
+  static constexpr uint16_t kRadius = 512;
+  static constexpr uint32_t kMagic = 0x5A535543u;  // "CUSZ"
+
+  // Self-describing prefix carried ahead of the cuSZ codestream. Embeds the
+  // psz_header so Decompress can rebuild the resource manager from the bytes.
+  struct Prefix {
+    uint32_t magic;
+    uint32_t pad;       // keep `elems` 8-aligned
+    uint64_t elems;     // float element count
+    psz_header header;  // cuSZ metadata needed to decode
+  };
+
+  /**
+   * True if `ptr` is dereferenceable by the GPU directly (device or UVM/managed
+   * memory). Plain/pinned host pointers return false so the caller stages a
+   * copy. A failed query is treated as "not device".
+   */
+  static bool IsDeviceAccessible(const void *ptr) {
+    cudaPointerAttributes attr;
+    if (cudaPointerGetAttributes(&attr, ptr) != cudaSuccess) {
+      cudaGetLastError();  // reset the sticky error from the failed query
+      return false;
+    }
+    return attr.type == cudaMemoryTypeDevice ||
+           attr.type == cudaMemoryTypeManaged;
+  }
+
+  /**
+   * Return a device pointer holding `size` bytes of `input`: used in place if
+   * already GPU-accessible (*owned=false), else copied H2D on `stream`
+   * (*owned=true). Returns nullptr on failure.
+   */
+  static void *ToDeviceInput(void *input, size_t size, cudaStream_t stream,
+                             bool *owned) {
+    *owned = false;
+    if (IsDeviceAccessible(input)) {
+      return input;
+    }
+    void *d = nullptr;
+    if (cudaMalloc(&d, size) != cudaSuccess) {
+      return nullptr;
+    }
+    if (cudaMemcpyAsync(d, input, size, cudaMemcpyHostToDevice, stream) !=
+        cudaSuccess) {
+      cudaFree(d);
+      return nullptr;
+    }
+    *owned = true;
+    return d;
+  }
+
+  double eb_;       // error bound
+  psz_mode mode_;   // error-bound mode (Rel / Abs)
+};
+
+}  // namespace ctp
+
+#endif  // CTP_ENABLE_COMPRESS && CTP_ENABLE_CUSZ
+
+#endif  // CTP_SHM_INCLUDE_HSHM_SHM_COMPRESS_CUSZ_H_

--- a/context-transport-primitives/include/clio_ctp/compress/cuszp.h
+++ b/context-transport-primitives/include/clio_ctp/compress/cuszp.h
@@ -1,0 +1,329 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CTP_SHM_INCLUDE_HSHM_SHM_COMPRESS_CUSZP_H_
+#define CTP_SHM_INCLUDE_HSHM_SHM_COMPRESS_CUSZP_H_
+
+#if CTP_ENABLE_COMPRESS && CTP_ENABLE_CUSZP
+
+#include <cuda_runtime.h>
+#include <cuSZp.h>
+
+#include <cstdint>
+#include <cstring>
+
+#include "compress.h"
+
+namespace ctp {
+
+/**
+ * cuSZp GPU error-bounded LOSSY compressor for floating-point data -- the
+ * ultra-fast single-kernel sibling of cuSZ from the same szcompressor family.
+ * cuSZp fuses the whole compress/decompress pipeline into one CUDA kernel for
+ * very high end-to-end throughput.
+ *
+ * https://github.com/szcompressor/cuSZp  (cuSZp v3 API)
+ *
+ * cuSZp operates directly on GPU device memory. Like NvComp/Cusz, this wrapper
+ * is adaptive: a GPU-accessible pointer is used in place (zero-copy); otherwise
+ * data is staged through a temporary device buffer (H2D for inputs, D2H for
+ * outputs), so host callers (and the unit test harness) work too.
+ *
+ * Constrained by the byte-stream Compressor interface (no type/shape), the input
+ * is interpreted as a 1D array of 32-bit floats; Compress requires input_size to
+ * be a multiple of sizeof(float).
+ *
+ * Self-describing framing: the output blob is laid out as
+ *   [ Prefix (magic + mode + error bound + elem count + cmp_size) ][ stream ]
+ * so Decompress reconstructs with the exact error bound and mode used at
+ * compression (cuSZp's decompress requires both), independent of the preset this
+ * object was built with.
+ *
+ * cuSZp quirk: its reported cmp_size only covers the full compressed payload for
+ * MULTI-block inputs (> 32768 elements); for a single-block input it omits the
+ * payload, so this wrapper retains the whole compress buffer in that case (still
+ * a correct round-trip, but uncompressed). Real GPU-resident blobs are larger
+ * than 128 KB and hit the multi-block, fully-compressed path. See Compress.
+ *
+ * IMPORTANT -- LOSSY. Each value is reconstructed within the configured ABSOLUTE
+ * error bound, not bit-exact. Presets map to error bounds: FAST=1e-2 (loose),
+ * BALANCED=1e-3, BEST=1e-4 (tight).
+ *
+ * NOTE on GPU arch: cuSZp (like cuSZ) currently builds for compute capabilities
+ * up to ~sm_86. On a newer GPU only reachable via forward-compat PTX-JIT (e.g.
+ * Blackwell sm_120), its JIT'd kernels can be clobbered by other CUDA modules in
+ * the same process and return wrong results -- use a natively-supported GPU until
+ * upstream adds the newer arch.
+ *
+ * Tested against the cuSZp v3 C API (cuSZp_compress / cuSZp_decompress). The
+ * NVIDIA devcontainer pins cuSZp-V3.0.0.
+ */
+class Cuszp : public Compressor {
+ public:
+  /**
+   * @param eb absolute error bound (default 1e-3).
+   * @param mode cuSZp encoding mode (default CUSZP_MODE_OUTLIER).
+   */
+  explicit Cuszp(float eb = 1e-3f, cuszp_mode_t mode = CUSZP_MODE_OUTLIER)
+      : eb_(eb), mode_(mode) {}
+
+  bool Compress(void *output, size_t &output_size, void *input,
+                size_t input_size) override {
+    if (input == nullptr || (input_size % sizeof(float)) != 0) {
+      return false;  // float codec; need whole 32-bit floats
+    }
+    if (output_size < sizeof(Prefix)) {
+      return false;
+    }
+    const size_t n = input_size / sizeof(float);
+
+    cudaStream_t stream = nullptr;
+    if (cudaStreamCreate(&stream) != cudaSuccess) {
+      return false;
+    }
+    float *d_in = nullptr;
+    bool free_in = false;
+    unsigned char *d_cmp = nullptr;  // temp worst-case device output buffer
+    bool ok = false;
+    do {
+      d_in = static_cast<float *>(
+          ToDeviceInput(input, input_size, stream, &free_in));
+      if (d_in == nullptr) break;
+
+      // cuSZp writes into a caller-provided device buffer; size it for the
+      // worst case (no larger than the original data).
+      if (cudaMalloc(&d_cmp, input_size) != cudaSuccess) break;
+
+      size_t cmp_size = 0;
+      uint3 dims = {0, 0, 0};  // ignored for 1D
+      cuSZp_compress(d_in, d_cmp, n, &cmp_size, eb_, CUSZP_DIM_1D, dims,
+                     CUSZP_TYPE_FLOAT, mode_, stream);
+      if (cudaStreamSynchronize(stream) != cudaSuccess) break;
+      if (cudaGetLastError() != cudaSuccess || cmp_size == 0) break;
+
+      // How many bytes of the compressed buffer must be retained so that
+      // Decompress can read everything cuSZp's decompressor touches. cuSZp's
+      // reported cmp_size is the meaningful compressed size for MULTI-block
+      // inputs, but for a SINGLE-block input (nbEle <= kBlockElems) cuSZp's
+      // cross-block offset sync degenerates and cmp_size omits the payload
+      // (it reports only the fixed per-group "rate" region). The decompressor
+      // still reads the payload that physically follows, which cuSZp does not
+      // expose a size for -- so for the single-block case we conservatively
+      // retain the whole compress buffer (<= the original size). Net effect:
+      // full compression for blobs > kBlockElems*4 bytes (the common case for
+      // GPU-resident data); small blobs round-trip correctly but uncompressed.
+      const size_t retain = (n > kBlockElems) ? cmp_size : input_size;
+
+      const size_t total = sizeof(Prefix) + retain;
+      if (total > output_size) break;  // caller buffer too small
+
+      Prefix prefix;
+      std::memset(&prefix, 0, sizeof(prefix));
+      prefix.magic = kMagic;
+      prefix.mode = static_cast<uint32_t>(mode_);
+      prefix.eb = eb_;
+      prefix.elems = static_cast<uint64_t>(n);
+      prefix.cmp_size = static_cast<uint64_t>(cmp_size);  // decompress arg
+
+      // Frame: [prefix][cuSZp stream].
+      const bool out_is_device = IsDeviceAccessible(output);
+      uint8_t *out = static_cast<uint8_t *>(output);
+      const cudaMemcpyKind kind =
+          out_is_device ? cudaMemcpyDeviceToDevice : cudaMemcpyDeviceToHost;
+      if (out_is_device) {
+        if (cudaMemcpyAsync(out, &prefix, sizeof(Prefix),
+                            cudaMemcpyHostToDevice, stream) != cudaSuccess) {
+          break;
+        }
+      } else {
+        std::memcpy(out, &prefix, sizeof(Prefix));
+      }
+      if (cudaMemcpyAsync(out + sizeof(Prefix), d_cmp, retain, kind, stream) !=
+          cudaSuccess) {
+        break;
+      }
+      if (cudaStreamSynchronize(stream) != cudaSuccess) break;
+      output_size = total;
+      ok = true;
+    } while (false);
+
+    if (d_cmp != nullptr) cudaFree(d_cmp);
+    if (free_in) cudaFree(d_in);
+    cudaStreamDestroy(stream);
+    return ok;
+  }
+
+  bool Decompress(void *output, size_t &output_size, void *input,
+                  size_t input_size) override {
+    if (output == nullptr || input == nullptr || input_size < sizeof(Prefix)) {
+      return false;
+    }
+
+    cudaStream_t stream = nullptr;
+    if (cudaStreamCreate(&stream) != cudaSuccess) {
+      return false;
+    }
+    float *d_out = nullptr;
+    bool free_out = false;
+    unsigned char *d_stream = nullptr;
+    bool free_stream = false;
+    bool ok = false;
+    do {
+      Prefix prefix;
+      if (IsDeviceAccessible(input)) {
+        if (cudaMemcpy(&prefix, input, sizeof(Prefix),
+                       cudaMemcpyDeviceToHost) != cudaSuccess) {
+          break;
+        }
+      } else {
+        std::memcpy(&prefix, input, sizeof(Prefix));
+      }
+      if (prefix.magic != kMagic) break;  // not one of our blobs
+
+      const size_t n = static_cast<size_t>(prefix.elems);
+      if (n * sizeof(float) > output_size) break;  // caller buffer too small
+      // `avail` = compressed bytes physically present in the blob (what Compress
+      // retained: cuSZp's cmp_size for multi-block, or the full buffer for the
+      // single-block case). `cmp_arg` = the cmp_size value cuSZp itself reported,
+      // which is what its decompressor expects as the size argument.
+      const size_t avail = input_size - sizeof(Prefix);
+      const size_t cmp_arg = static_cast<size_t>(prefix.cmp_size);
+
+      const bool out_is_device = IsDeviceAccessible(output);
+      if (out_is_device) {
+        d_out = static_cast<float *>(output);
+      } else {
+        if (cudaMalloc(&d_out, n * sizeof(float)) != cudaSuccess) break;
+        free_out = true;
+      }
+
+      // The compressed stream must be device-resident for cuSZp.
+      uint8_t *stream_src = static_cast<uint8_t *>(input) + sizeof(Prefix);
+      if (IsDeviceAccessible(input)) {
+        d_stream = stream_src;
+      } else {
+        if (cudaMalloc(&d_stream, avail) != cudaSuccess) break;
+        free_stream = true;
+        if (cudaMemcpyAsync(d_stream, stream_src, avail,
+                            cudaMemcpyHostToDevice, stream) != cudaSuccess) {
+          break;
+        }
+      }
+
+      uint3 dims = {0, 0, 0};
+      cuSZp_decompress(d_out, d_stream, n, cmp_arg, prefix.eb, CUSZP_DIM_1D,
+                       dims, CUSZP_TYPE_FLOAT,
+                       static_cast<cuszp_mode_t>(prefix.mode), stream);
+      bool decoded = cudaStreamSynchronize(stream) == cudaSuccess &&
+                     cudaGetLastError() == cudaSuccess;
+      if (decoded) {
+        if (!out_is_device) {
+          decoded = cudaMemcpy(output, d_out, n * sizeof(float),
+                               cudaMemcpyDeviceToHost) == cudaSuccess;
+        }
+        if (decoded) {
+          output_size = n * sizeof(float);
+          ok = true;
+        }
+      }
+    } while (false);
+
+    if (free_stream) cudaFree(d_stream);
+    if (free_out) cudaFree(d_out);
+    cudaStreamDestroy(stream);
+    return ok;
+  }
+
+  /** Set the absolute error bound. */
+  void SetErrorBound(float eb) { eb_ = eb; }
+  /** Get the absolute error bound. */
+  float GetErrorBound() const { return eb_; }
+
+ private:
+  static constexpr uint32_t kMagic = 0x435A5370u;  // "pSZC"
+  // Elements processed per cuSZp thread block (tblock_size 32 * thread_chunk
+  // 1024). Inputs with nbEle <= this are single-block; see the retain logic in
+  // Compress for why that case is handled specially.
+  static constexpr size_t kBlockElems = 32 * 1024;
+
+  // Self-describing prefix carried ahead of the cuSZp codestream. 32 bytes,
+  // 8-aligned so the codestream that follows stays aligned for cuSZp.
+  struct Prefix {
+    uint32_t magic;
+    uint32_t mode;      // cuszp_mode_t used at compression
+    float eb;           // absolute error bound used at compression
+    uint32_t pad;       // keep the 64-bit fields 8-aligned
+    uint64_t elems;     // float element count
+    uint64_t cmp_size;  // cuSZp's reported cmp_size (decompress size argument)
+  };
+
+  /** See ctp::Cusz::IsDeviceAccessible. */
+  static bool IsDeviceAccessible(const void *ptr) {
+    cudaPointerAttributes attr;
+    if (cudaPointerGetAttributes(&attr, ptr) != cudaSuccess) {
+      cudaGetLastError();  // reset the sticky error from the failed query
+      return false;
+    }
+    return attr.type == cudaMemoryTypeDevice ||
+           attr.type == cudaMemoryTypeManaged;
+  }
+
+  /** See ctp::Cusz::ToDeviceInput. */
+  static void *ToDeviceInput(void *input, size_t size, cudaStream_t stream,
+                             bool *owned) {
+    *owned = false;
+    if (IsDeviceAccessible(input)) {
+      return input;
+    }
+    void *d = nullptr;
+    if (cudaMalloc(&d, size) != cudaSuccess) {
+      return nullptr;
+    }
+    if (cudaMemcpyAsync(d, input, size, cudaMemcpyHostToDevice, stream) !=
+        cudaSuccess) {
+      cudaFree(d);
+      return nullptr;
+    }
+    *owned = true;
+    return d;
+  }
+
+  float eb_;          // absolute error bound
+  cuszp_mode_t mode_;  // cuSZp encoding mode
+};
+
+}  // namespace ctp
+
+#endif  // CTP_ENABLE_COMPRESS && CTP_ENABLE_CUSZP
+
+#endif  // CTP_SHM_INCLUDE_HSHM_SHM_COMPRESS_CUSZP_H_

--- a/context-transport-primitives/include/clio_ctp/compress/ndzip.h
+++ b/context-transport-primitives/include/clio_ctp/compress/ndzip.h
@@ -37,12 +37,15 @@
 #if CTP_ENABLE_COMPRESS && CTP_ENABLE_NDZIP
 
 #include <cuda_runtime.h>
+
+// These MUST precede the ndzip headers: ndzip/ndzip.hh uses assert() and
+// unqualified size()/data() (std::) but relies on its includer for them.
+#include <cassert>
+#include <cstdint>
+#include <iterator>
+
 #include <ndzip/cuda.hh>
 #include <ndzip/ndzip.hh>
-
-#include <cassert>   // ndzip/ndzip.hh uses assert() without including <cassert>
-#include <cstdint>
-#include <iterator>  // ndzip/ndzip.hh uses unqualified size()/data() (std::)
 
 #include "compress.h"
 

--- a/context-transport-primitives/include/clio_ctp/compress/ndzip.h
+++ b/context-transport-primitives/include/clio_ctp/compress/ndzip.h
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CTP_SHM_INCLUDE_HSHM_SHM_COMPRESS_NDZIP_H_
+#define CTP_SHM_INCLUDE_HSHM_SHM_COMPRESS_NDZIP_H_
+
+#if CTP_ENABLE_COMPRESS && CTP_ENABLE_NDZIP
+
+#include <cuda_runtime.h>
+#include <ndzip/cuda.hh>
+#include <ndzip/ndzip.hh>
+
+#include <cstdint>
+
+#include "compress.h"
+
+namespace ctp {
+
+/**
+ * ndzip GPU high-throughput, LOSSLESS compressor for floating-point data -- the
+ * GPU lossless analog of the CPU codecs, complementing NvComp's general-purpose
+ * byte codecs with a predictor designed specifically for scientific float data.
+ *
+ * https://github.com/celerity/ndzip
+ *
+ * ndzip's cuda_compressor reads and writes GPU device memory. Like NvComp, this
+ * wrapper is adaptive: a GPU-accessible pointer is used in place (zero-copy);
+ * otherwise data is staged through a temporary device buffer (H2D for inputs,
+ * D2H for outputs), so host callers (and the unit test harness) work too.
+ *
+ * Constrained by the byte-stream Compressor interface (no type/shape), the input
+ * is interpreted as a 1D array of 32-bit floats; Compress requires input_size to
+ * be a multiple of sizeof(float). ndzip is LOSSLESS, so Decompress reconstructs
+ * the input bit-exactly. The original element count is taken from the caller-
+ * supplied output_size (decompressed bytes), since the ndzip stream does not
+ * self-describe its extent -- mirroring how the byte interface already carries
+ * the decompressed length out-of-band for the other codecs.
+ *
+ * Tested against the ndzip master CUDA C++ API (make_cuda_compressor /
+ * make_cuda_decompressor, extent, compressor_requirements). The NVIDIA
+ * devcontainer builds a matching ndzip revision (with NDZIP_WITH_CUDA=ON).
+ */
+class Ndzip : public Compressor {
+ public:
+  Ndzip() = default;
+
+  bool Compress(void *output, size_t &output_size, void *input,
+                size_t input_size) override {
+    if (input == nullptr || (input_size % sizeof(value_t)) != 0) {
+      return false;  // float codec; need whole 32-bit floats
+    }
+    const size_t n = input_size / sizeof(value_t);
+
+    ndzip::extent ext(1);  // 1D
+    ext[0] = n;
+    const size_t bound_bytes =
+        ndzip::compressed_length_bound<value_t>(ext) * sizeof(compressed_t);
+
+    cudaStream_t stream = nullptr;
+    if (cudaStreamCreate(&stream) != cudaSuccess) {
+      return false;
+    }
+    value_t *d_in = nullptr;
+    compressed_t *d_out = nullptr;
+    ndzip::index_type *d_len = nullptr;
+    bool free_in = false;
+    bool free_out = false;
+    bool ok = false;
+    do {
+      d_in = static_cast<value_t *>(
+          ToDeviceInput(input, input_size, stream, &free_in));
+      if (d_in == nullptr) break;
+
+      // Output: write straight into the caller's buffer only if it is a GPU
+      // buffer large enough for ndzip's worst case; else use a device temp.
+      const bool out_is_device = IsDeviceAccessible(output);
+      if (out_is_device && output_size >= bound_bytes) {
+        d_out = static_cast<compressed_t *>(output);
+      } else {
+        if (cudaMalloc(&d_out, bound_bytes) != cudaSuccess) break;
+        free_out = true;
+      }
+
+      if (cudaMalloc(&d_len, sizeof(ndzip::index_type)) != cudaSuccess) break;
+
+      auto compressor = ndzip::make_cuda_compressor<value_t>(
+          ndzip::compressor_requirements{ext}, stream);
+      compressor->compress(d_in, ext, d_out, d_len);
+
+      ndzip::index_type len_words = 0;
+      if (cudaMemcpyAsync(&len_words, d_len, sizeof(ndzip::index_type),
+                          cudaMemcpyDeviceToHost, stream) != cudaSuccess) {
+        break;
+      }
+      if (cudaStreamSynchronize(stream) != cudaSuccess) break;
+      const size_t comp_bytes =
+          static_cast<size_t>(len_words) * sizeof(compressed_t);
+      if (comp_bytes == 0 || comp_bytes > output_size) break;
+
+      // Deliver to the caller's buffer if we compressed into a temp.
+      if (static_cast<void *>(d_out) != output) {
+        const cudaMemcpyKind kind =
+            out_is_device ? cudaMemcpyDeviceToDevice : cudaMemcpyDeviceToHost;
+        if (cudaMemcpy(output, d_out, comp_bytes, kind) != cudaSuccess) break;
+      }
+      output_size = comp_bytes;
+      ok = true;
+    } while (false);
+
+    if (d_len != nullptr) cudaFree(d_len);
+    if (free_out) cudaFree(d_out);
+    if (free_in) cudaFree(d_in);
+    cudaStreamDestroy(stream);
+    return ok;
+  }
+
+  bool Decompress(void *output, size_t &output_size, void *input,
+                  size_t input_size) override {
+    if (output == nullptr || input == nullptr ||
+        (output_size % sizeof(value_t)) != 0) {
+      return false;
+    }
+    const size_t n = output_size / sizeof(value_t);
+
+    ndzip::extent ext(1);  // 1D
+    ext[0] = n;
+
+    cudaStream_t stream = nullptr;
+    if (cudaStreamCreate(&stream) != cudaSuccess) {
+      return false;
+    }
+    compressed_t *d_in = nullptr;
+    value_t *d_out = nullptr;
+    bool free_in = false;
+    bool free_out = false;
+    bool ok = false;
+    do {
+      d_in = static_cast<compressed_t *>(
+          ToDeviceInput(input, input_size, stream, &free_in));
+      if (d_in == nullptr) break;
+
+      const bool out_is_device = IsDeviceAccessible(output);
+      if (out_is_device) {
+        d_out = static_cast<value_t *>(output);
+      } else {
+        if (cudaMalloc(&d_out, n * sizeof(value_t)) != cudaSuccess) break;
+        free_out = true;
+      }
+
+      auto decompressor =
+          ndzip::make_cuda_decompressor<value_t>(/*dims=*/1, stream);
+      decompressor->decompress(d_in, d_out, ext);
+      if (cudaStreamSynchronize(stream) != cudaSuccess) break;
+
+      if (static_cast<void *>(d_out) != output) {
+        if (cudaMemcpy(output, d_out, n * sizeof(value_t),
+                       cudaMemcpyDeviceToHost) != cudaSuccess) {
+          break;
+        }
+      }
+      output_size = n * sizeof(value_t);
+      ok = true;
+    } while (false);
+
+    if (free_out) cudaFree(d_out);
+    if (free_in) cudaFree(d_in);
+    cudaStreamDestroy(stream);
+    return ok;
+  }
+
+ private:
+  using value_t = float;
+  using compressed_t = ndzip::compressed_type<value_t>;  // 4 bytes for float
+
+  /** See ctp::NvComp::IsDeviceAccessible. */
+  static bool IsDeviceAccessible(const void *ptr) {
+    cudaPointerAttributes attr;
+    if (cudaPointerGetAttributes(&attr, ptr) != cudaSuccess) {
+      cudaGetLastError();  // reset the sticky error from the failed query
+      return false;
+    }
+    return attr.type == cudaMemoryTypeDevice ||
+           attr.type == cudaMemoryTypeManaged;
+  }
+
+  /** See ctp::NvComp::ToDeviceInput. */
+  static void *ToDeviceInput(void *input, size_t size, cudaStream_t stream,
+                             bool *owned) {
+    *owned = false;
+    if (IsDeviceAccessible(input)) {
+      return input;
+    }
+    void *d = nullptr;
+    if (cudaMalloc(&d, size) != cudaSuccess) {
+      return nullptr;
+    }
+    if (cudaMemcpyAsync(d, input, size, cudaMemcpyHostToDevice, stream) !=
+        cudaSuccess) {
+      cudaFree(d);
+      return nullptr;
+    }
+    *owned = true;
+    return d;
+  }
+};
+
+}  // namespace ctp
+
+#endif  // CTP_ENABLE_COMPRESS && CTP_ENABLE_NDZIP
+
+#endif  // CTP_SHM_INCLUDE_HSHM_SHM_COMPRESS_NDZIP_H_

--- a/context-transport-primitives/include/clio_ctp/compress/ndzip.h
+++ b/context-transport-primitives/include/clio_ctp/compress/ndzip.h
@@ -40,7 +40,9 @@
 #include <ndzip/cuda.hh>
 #include <ndzip/ndzip.hh>
 
+#include <cassert>   // ndzip/ndzip.hh uses assert() without including <cassert>
 #include <cstdint>
+#include <iterator>  // ndzip/ndzip.hh uses unqualified size()/data() (std::)
 
 #include "compress.h"
 

--- a/context-transport-primitives/test/unit/compress/test_compress.cc
+++ b/context-transport-primitives/test/unit/compress/test_compress.cc
@@ -46,6 +46,14 @@
 #include <vector>
 #endif
 
+#if CTP_ENABLE_CUSZ || CTP_ENABLE_NDZIP
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+#endif
+
 TEST_CASE("TestCompress") {
   std::string raw = "Hello, World!";
   std::vector<char> compressed(1024);
@@ -218,10 +226,12 @@ TEST_CASE("CompressorRegistryMappings") {
     REQUIRE(CompressionFactory::NameForWireId(15) == "nvcomp-deflate");
     REQUIRE(CompressionFactory::NameForWireId(16) == "nvcomp-ans");
     REQUIRE(CompressionFactory::NameForWireId(17) == "zfp-sycl");
+    REQUIRE(CompressionFactory::NameForWireId(18) == "cusz");
+    REQUIRE(CompressionFactory::NameForWireId(19) == "ndzip");
     // Out-of-range falls back to the historical default. (Registry rows are
     // build-independent, so the GPU names above resolve even without nvcomp.)
     REQUIRE(CompressionFactory::NameForWireId(-1) == "zstd");
-    REQUIRE(CompressionFactory::NameForWireId(18) == "zstd");
+    REQUIRE(CompressionFactory::NameForWireId(20) == "zstd");
     REQUIRE(CompressionFactory::NameForWireId(9999) == "zstd");
   }
 
@@ -255,8 +265,9 @@ TEST_CASE("CompressorRegistryMappings") {
     // Unknown library -> 0.
     REQUIRE(CompressionFactory::GetLibraryId("does-not-exist", BAL) == 0);
 
-    // GPU compressors: single-mode (preset forced to 2), base_ids 13-19. These
-    // are build-independent -- the registry rows resolve even without nvcomp.
+    // GPU compressors: base_ids 13-21. The nvcomp/ndzip rows are single-mode
+    // (preset forced to 2); zfp-sycl/cusz are multi-mode. All are build-
+    // independent -- the registry rows resolve even without the backend.
     REQUIRE(CompressionFactory::GetLibraryId("nvcomp-lz4", FAST) == 132);
     REQUIRE(CompressionFactory::GetLibraryId("nvcomp-lz4", BEST) == 132);
     REQUIRE(CompressionFactory::GetLibraryId("nvcomp-snappy", BAL) == 142);
@@ -269,6 +280,15 @@ TEST_CASE("CompressorRegistryMappings") {
     REQUIRE(CompressionFactory::GetLibraryId("zfp-sycl", FAST) == 191);
     REQUIRE(CompressionFactory::GetLibraryId("zfp-sycl", BAL) == 192);
     REQUIRE(CompressionFactory::GetLibraryId("zfp-sycl", BEST) == 193);
+
+    // cusz: multi-mode lossy GPU (base_id 20), preset varies the error bound.
+    REQUIRE(CompressionFactory::GetLibraryId("cusz", FAST) == 201);
+    REQUIRE(CompressionFactory::GetLibraryId("cusz", BAL) == 202);
+    REQUIRE(CompressionFactory::GetLibraryId("cusz", BEST) == 203);
+
+    // ndzip: single-mode lossless GPU (base_id 21), preset forced to 2.
+    REQUIRE(CompressionFactory::GetLibraryId("ndzip", FAST) == 212);
+    REQUIRE(CompressionFactory::GetLibraryId("ndzip", BEST) == 212);
   }
 
   PAGE_DIVIDE("ML library id -> name + preset (reverse)") {
@@ -294,6 +314,10 @@ TEST_CASE("CompressorRegistryMappings") {
     REQUIRE(CompressionFactory::GetLibraryInfo(172).first == "nvcomp-deflate");
     REQUIRE(CompressionFactory::GetLibraryInfo(182).first == "nvcomp-ans");
     REQUIRE(CompressionFactory::GetLibraryInfo(192).first == "zfp-sycl");
+    REQUIRE(CompressionFactory::GetLibraryInfo(202).first == "cusz");
+    REQUIRE(CompressionFactory::GetLibraryInfo(201).second ==
+            CompressionPreset::FAST);
+    REQUIRE(CompressionFactory::GetLibraryInfo(212).first == "ndzip");
   }
 
   PAGE_DIVIDE("GetPreset constructs known CPU compressors (incl. alias)") {
@@ -489,3 +513,109 @@ TEST_CASE("TestNvCompGpu") {
   }
 }
 #endif  // CTP_ENABLE_NVCOMP
+
+#if CTP_ENABLE_CUSZ
+// cuSZ is GPU error-bounded LOSSY float compression. Needs a real GPU; skip
+// gracefully where none is present so the suite stays green everywhere.
+TEST_CASE("TestCuszGpu") {
+  int device_count = 0;
+  if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+    WARN("No CUDA device available; skipping cuSZ GPU compression test");
+    return;
+  }
+
+  // 8192 floats of a smooth signal -- the regime cuSZ's Lorenzo predictor wins.
+  const size_t n = 8192;
+  std::vector<float> orig(n), deco(n, 0.0f);
+  for (size_t i = 0; i < n; ++i) {
+    orig[i] = std::sin(static_cast<float>(i) * 0.01f) * 100.0f;
+  }
+  const size_t raw_bytes = n * sizeof(float);
+
+  // Device-pointer (zero-copy) round-trip with a fixed error bound.
+  PAGE_DIVIDE("cusz (device pointers, BALANCED) round-trips within eb") {
+    void *d_in = nullptr, *d_comp = nullptr, *d_out = nullptr;
+    REQUIRE(cudaMalloc(&d_in, raw_bytes) == cudaSuccess);
+    REQUIRE(cudaMalloc(&d_comp, raw_bytes + 4096) == cudaSuccess);
+    REQUIRE(cudaMalloc(&d_out, raw_bytes) == cudaSuccess);
+    REQUIRE(cudaMemcpy(d_in, orig.data(), raw_bytes,
+                       cudaMemcpyHostToDevice) == cudaSuccess);
+
+    auto comp = ctp::CompressionFactory::GetPreset(
+        "cusz", ctp::CompressionPreset::BALANCED);
+    REQUIRE(comp != nullptr);
+    size_t cmpr_size = raw_bytes + 4096;
+    REQUIRE(comp->Compress(d_comp, cmpr_size, d_in, raw_bytes));
+    REQUIRE(cmpr_size > 0);
+
+    auto dcmp = ctp::CompressionFactory::GetPreset("cusz");
+    REQUIRE(dcmp != nullptr);
+    size_t deco_size = raw_bytes;
+    REQUIRE(dcmp->Decompress(d_out, deco_size, d_comp, cmpr_size));
+    REQUIRE(deco_size == raw_bytes);
+
+    REQUIRE(cudaMemcpy(deco.data(), d_out, raw_bytes,
+                       cudaMemcpyDeviceToHost) == cudaSuccess);
+    // Lossy within the BALANCED relative error bound (1e-3) on a [-100,100]
+    // signal -> generous absolute slack.
+    double max_err = 0.0;
+    for (size_t i = 0; i < n; ++i) {
+      max_err = std::max(max_err,
+                         std::abs(static_cast<double>(orig[i] - deco[i])));
+    }
+    REQUIRE(max_err < 1.0);
+
+    cudaFree(d_in);
+    cudaFree(d_comp);
+    cudaFree(d_out);
+  }
+}
+#endif  // CTP_ENABLE_CUSZ
+
+#if CTP_ENABLE_NDZIP
+// ndzip is GPU high-throughput LOSSLESS float compression. Needs a real GPU;
+// skip gracefully where none is present.
+TEST_CASE("TestNdzipGpu") {
+  int device_count = 0;
+  if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+    WARN("No CUDA device available; skipping ndzip GPU compression test");
+    return;
+  }
+
+  const size_t n = 8192;
+  std::vector<float> orig(n), deco(n, 0.0f);
+  for (size_t i = 0; i < n; ++i) {
+    orig[i] = std::sin(static_cast<float>(i) * 0.01f) * 100.0f;
+  }
+  const size_t raw_bytes = n * sizeof(float);
+
+  // Lossless: device round-trip must reconstruct the input bit-exactly.
+  PAGE_DIVIDE("ndzip (device pointers) round-trips bit-exactly") {
+    void *d_in = nullptr, *d_comp = nullptr, *d_out = nullptr;
+    REQUIRE(cudaMalloc(&d_in, raw_bytes) == cudaSuccess);
+    REQUIRE(cudaMalloc(&d_comp, raw_bytes * 2 + 4096) == cudaSuccess);
+    REQUIRE(cudaMalloc(&d_out, raw_bytes) == cudaSuccess);
+    REQUIRE(cudaMemcpy(d_in, orig.data(), raw_bytes,
+                       cudaMemcpyHostToDevice) == cudaSuccess);
+
+    auto comp = ctp::CompressionFactory::GetPreset("ndzip");
+    REQUIRE(comp != nullptr);
+    size_t cmpr_size = raw_bytes * 2 + 4096;
+    REQUIRE(comp->Compress(d_comp, cmpr_size, d_in, raw_bytes));
+    REQUIRE(cmpr_size > 0);
+
+    auto dcmp = ctp::CompressionFactory::GetPreset("ndzip");
+    REQUIRE(dcmp != nullptr);
+    size_t deco_size = raw_bytes;
+    REQUIRE(dcmp->Decompress(d_out, deco_size, d_comp, cmpr_size));
+    REQUIRE(deco_size == raw_bytes);
+
+    REQUIRE(cudaMemcpy(deco.data(), d_out, raw_bytes,
+                       cudaMemcpyDeviceToHost) == cudaSuccess);
+    REQUIRE(orig == deco);  // lossless: exact
+    cudaFree(d_in);
+    cudaFree(d_comp);
+    cudaFree(d_out);
+  }
+}
+#endif  // CTP_ENABLE_NDZIP

--- a/context-transport-primitives/test/unit/compress/test_compress.cc
+++ b/context-transport-primitives/test/unit/compress/test_compress.cc
@@ -46,7 +46,7 @@
 #include <vector>
 #endif
 
-#if CTP_ENABLE_CUSZ || CTP_ENABLE_NDZIP
+#if CTP_ENABLE_CUSZ || CTP_ENABLE_NDZIP || CTP_ENABLE_CUSZP
 #include <cuda_runtime.h>
 
 #include <algorithm>
@@ -228,10 +228,11 @@ TEST_CASE("CompressorRegistryMappings") {
     REQUIRE(CompressionFactory::NameForWireId(17) == "zfp-sycl");
     REQUIRE(CompressionFactory::NameForWireId(18) == "cusz");
     REQUIRE(CompressionFactory::NameForWireId(19) == "ndzip");
+    REQUIRE(CompressionFactory::NameForWireId(20) == "cuszp");
     // Out-of-range falls back to the historical default. (Registry rows are
     // build-independent, so the GPU names above resolve even without nvcomp.)
     REQUIRE(CompressionFactory::NameForWireId(-1) == "zstd");
-    REQUIRE(CompressionFactory::NameForWireId(20) == "zstd");
+    REQUIRE(CompressionFactory::NameForWireId(21) == "zstd");
     REQUIRE(CompressionFactory::NameForWireId(9999) == "zstd");
   }
 
@@ -289,6 +290,11 @@ TEST_CASE("CompressorRegistryMappings") {
     // ndzip: single-mode lossless GPU (base_id 21), preset forced to 2.
     REQUIRE(CompressionFactory::GetLibraryId("ndzip", FAST) == 212);
     REQUIRE(CompressionFactory::GetLibraryId("ndzip", BEST) == 212);
+
+    // cuszp: multi-mode lossy GPU (base_id 22), preset varies the error bound.
+    REQUIRE(CompressionFactory::GetLibraryId("cuszp", FAST) == 221);
+    REQUIRE(CompressionFactory::GetLibraryId("cuszp", BAL) == 222);
+    REQUIRE(CompressionFactory::GetLibraryId("cuszp", BEST) == 223);
   }
 
   PAGE_DIVIDE("ML library id -> name + preset (reverse)") {
@@ -315,6 +321,7 @@ TEST_CASE("CompressorRegistryMappings") {
     REQUIRE(CompressionFactory::GetLibraryInfo(182).first == "nvcomp-ans");
     REQUIRE(CompressionFactory::GetLibraryInfo(192).first == "zfp-sycl");
     REQUIRE(CompressionFactory::GetLibraryInfo(202).first == "cusz");
+    REQUIRE(CompressionFactory::GetLibraryInfo(222).first == "cuszp");
     REQUIRE(CompressionFactory::GetLibraryInfo(201).second ==
             CompressionPreset::FAST);
     REQUIRE(CompressionFactory::GetLibraryInfo(212).first == "ndzip");
@@ -619,3 +626,64 @@ TEST_CASE("TestNdzipGpu") {
   }
 }
 #endif  // CTP_ENABLE_NDZIP
+
+#if CTP_ENABLE_CUSZP
+// cuSZp is GPU ultra-fast error-bounded LOSSY float compression. Needs a real
+// GPU; skip gracefully where none is present.
+TEST_CASE("TestCuszpGpu") {
+  int device_count = 0;
+  if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+    WARN("No CUDA device available; skipping cuSZp GPU compression test");
+    return;
+  }
+
+  // Use a multi-block input (> 32768 elements). cuSZp only reports a complete
+  // compressed size for multi-block inputs; smaller single-block inputs still
+  // round-trip correctly but are stored uncompressed (see ctp::Cuszp), so a
+  // multi-block size exercises the real, compressing path.
+  const size_t n = 65536;
+  std::vector<float> orig(n), deco(n, 0.0f);
+  for (size_t i = 0; i < n; ++i) {
+    orig[i] = std::sin(static_cast<float>(i) * 0.01f) * 100.0f;
+  }
+  const size_t raw_bytes = n * sizeof(float);
+
+  // Device-pointer (zero-copy) round-trip within the absolute error bound.
+  PAGE_DIVIDE("cuszp (device pointers, BALANCED) round-trips within eb") {
+    void *d_in = nullptr, *d_comp = nullptr, *d_out = nullptr;
+    REQUIRE(cudaMalloc(&d_in, raw_bytes) == cudaSuccess);
+    REQUIRE(cudaMalloc(&d_comp, raw_bytes + 4096) == cudaSuccess);
+    REQUIRE(cudaMalloc(&d_out, raw_bytes) == cudaSuccess);
+    REQUIRE(cudaMemcpy(d_in, orig.data(), raw_bytes,
+                       cudaMemcpyHostToDevice) == cudaSuccess);
+
+    auto comp = ctp::CompressionFactory::GetPreset(
+        "cuszp", ctp::CompressionPreset::BALANCED);
+    REQUIRE(comp != nullptr);
+    size_t cmpr_size = raw_bytes + 4096;
+    REQUIRE(comp->Compress(d_comp, cmpr_size, d_in, raw_bytes));
+    REQUIRE(cmpr_size > 0);
+    REQUIRE(cmpr_size < raw_bytes);  // multi-block -> actually compresses
+
+    auto dcmp = ctp::CompressionFactory::GetPreset("cuszp");
+    REQUIRE(dcmp != nullptr);
+    size_t deco_size = raw_bytes;
+    REQUIRE(dcmp->Decompress(d_out, deco_size, d_comp, cmpr_size));
+    REQUIRE(deco_size == raw_bytes);
+
+    REQUIRE(cudaMemcpy(deco.data(), d_out, raw_bytes,
+                       cudaMemcpyDeviceToHost) == cudaSuccess);
+    // Lossy within the BALANCED absolute error bound (1e-3) -> generous slack.
+    double max_err = 0.0;
+    for (size_t i = 0; i < n; ++i) {
+      max_err = std::max(max_err,
+                         std::abs(static_cast<double>(orig[i] - deco[i])));
+    }
+    REQUIRE(max_err < 1.0);
+
+    cudaFree(d_in);
+    cudaFree(d_comp);
+    cudaFree(d_out);
+  }
+}
+#endif  // CTP_ENABLE_CUSZP

--- a/installers/spack/packages/iowarp/package.py
+++ b/installers/spack/packages/iowarp/package.py
@@ -96,6 +96,14 @@ class Iowarp(CMakePackage):
     depends_on('snappy', when='+compress')
     depends_on('c-blosc2', when='+compress')
 
+    # GPU compression libraries (conditional on +compress +cuda). These operate
+    # on device pointers and back the ctp::Cusz / ctp::Ndzip wrappers.
+    #   - cuSZ has an upstream Spack package.
+    #   - ndzip has NO upstream Spack package; it is source-built in the NVIDIA
+    #     devcontainer (docker/deps-nvidia.Dockerfile) instead. Add a depends_on
+    #     here if/when an ndzip Spack package becomes available.
+    depends_on('cusz', when='+compress +cuda')
+
     # Encryption libraries (conditional on +encrypt)
     depends_on('openssl', when='+encrypt')
 

--- a/installers/spack/packages/iowarp/package.py
+++ b/installers/spack/packages/iowarp/package.py
@@ -97,11 +97,11 @@ class Iowarp(CMakePackage):
     depends_on('c-blosc2', when='+compress')
 
     # GPU compression libraries (conditional on +compress +cuda). These operate
-    # on device pointers and back the ctp::Cusz / ctp::Ndzip wrappers.
+    # on device pointers and back the ctp::Cusz / ctp::Ndzip / ctp::Cuszp wrappers.
     #   - cuSZ has an upstream Spack package.
-    #   - ndzip has NO upstream Spack package; it is source-built in the NVIDIA
-    #     devcontainer (docker/deps-nvidia.Dockerfile) instead. Add a depends_on
-    #     here if/when an ndzip Spack package becomes available.
+    #   - ndzip and cuSZp have NO upstream Spack package; they are source-built in
+    #     the NVIDIA devcontainer (.devcontainer/nvidia-gpu/Dockerfile) instead.
+    #     Add a depends_on here if/when a Spack package becomes available.
     depends_on('cusz', when='+compress +cuda')
 
     # Encryption libraries (conditional on +encrypt)


### PR DESCRIPTION
**Draft** — integrates two previously-unmerged feature branches onto `dev`. Safe-bdev erasure coding (#543) is tracked separately (it's a much larger re-port and gets its own PR).

## What's here
- **#524 — GPU compressors (cuSZ / cuSZp / ndzip)** — merged clean off `dev` (new `clio_ctp/compress/{cusz,cuszp,ndzip}.h` + `compress_factory.h`, tests, nvidia devcontainer + CMake wiring).
- **#474 / feat/winscp — native-Windows FUSE via WinFsp** — merged with 2 conflict resolutions, since `dev` rewrote the libfuse adapter (#552 filesystem-chimod shim, #637 hard-link aliases) after this branch forked:
  - `libfuse/CMakeLists.txt`: took the cross-platform version (WinFsp on Windows via `WINFSP_ROOT`, pkg-config on Linux; warn+skip instead of fatal when FUSE not found).
  - `libfuse/fuse_cte.cc`: kept `dev`'s current `getattr` logic (alias-based `st_nlink`, `t->size_`) and applied the WinFsp portability layer (`cte_off_t`, `#ifndef _WIN32` header guards, `fuse_win_compat.h`).

## Validation status
- GPU-compressor build: covered by the CUDA CI job.
- **WinFsp `_WIN32` path is not verified locally** — `nlink_t`, `fcntl.h`/`O_CREAT`, and `getuid`/`getgid` resolve through the WinFsp compat shim; the Windows CI matrix is the check. The Linux libfuse path is unchanged in behavior.

## Not included
- **#543 safe-bdev erasure coding** — 22 conflicts / 58 files against `dev`'s rewritten bdev/admin/runtime + autogen, and it pulls in #548. Being re-ported on its own branch; separate draft PR to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)