### PR TITLE
feat(ctp): batched-fair RwLock + parallel-reader CvRwLock + tests

### DIFF
--- a/context-transport-primitives/include/clio_ctp/thread/lock.h
+++ b/context-transport-primitives/include/clio_ctp/thread/lock.h
@@ -34,6 +34,7 @@
 #ifndef CTP_THREAD_LOCK_H_
 #define CTP_THREAD_LOCK_H_
 
+#include "lock/cvrwlock.h"
 #include "lock/mutex.h"
 #include "lock/rwlock.h"
 #include "thread_model_manager.h"

--- a/context-transport-primitives/include/clio_ctp/thread/lock/cvrwlock.h
+++ b/context-transport-primitives/include/clio_ctp/thread/lock/cvrwlock.h
@@ -34,34 +34,41 @@
 #ifndef CTP_THREAD_CVRWLOCK_H_
 #define CTP_THREAD_CVRWLOCK_H_
 
-// `CvRwLock` -- a fair reader/writer lock built on std::mutex +
-// std::condition_variable, as an alternative to the spin-based ctp::RwLock.
+// `CvRwLock` -- a writer-preferring reader/writer lock that blocks (parks) on a
+// condition variable instead of spinning, as a sleep-friendly alternative to
+// the spin-based ctp::RwLock.
 //
-// It is writer-fair: an arriving writer announces itself (waiting_writers_)
-// which blocks NEW readers from entering, so a steady reader stream cannot
-// starve writers. Threads block on the condition variable instead of spinning,
-// so it trades the spin lock's low uncontended latency for zero CPU burn while
-// waiting. This header exists primarily so the lock-latency benchmark can
-// compare the two approaches head-to-head.
+// Readers are PARALLEL: the common no-writer read path is lock-free (a single
+// atomic increment on `readers_` guarded by an optimistic re-check of the
+// writer-intent counter) and never touches the mutex, so concurrent readers do
+// not serialize on it. The mutex + condition variable are used only on the slow
+// path -- when a reader must park behind a writer, or when a writer must wait
+// for readers to drain. (The earlier version took the mutex on every
+// ReadLock/ReadUnlock, which serialized readers and defeated the point of a
+// shared lock.)
 //
-// HOST ONLY: std::mutex / std::condition_variable are not device-safe, so the
-// class is compiled only on the host pass (mirrors mutex.h's <thread> guard).
+// Writer preference: a writer bumps `write_intent_` on arrival, which makes new
+// readers back off, so a steady reader stream cannot starve writers.
+//
+// HOST ONLY: std::atomic is fine on device, but std::mutex / condition_variable
+// are not, so the class is compiled only on the host pass (mirrors mutex.h).
 
 #include "clio_ctp/constants/macros.h"
 
 #if !CTP_IS_DEVICE_PASS
+#include <atomic>
 #include <condition_variable>
+#include <cstdint>
 #include <mutex>
 
 namespace ctp {
 
 /**
- * Fair reader/writer lock using a condition variable.
+ * Writer-preferring reader/writer lock with a lock-free parallel reader path
+ * and condition-variable blocking on the slow path.
  *
  * Method names mirror ctp::RwLock (ReadLock/ReadUnlock/WriteLock/WriteUnlock)
- * so it can be swapped in for comparison. Unlike ctp::RwLock, acquisition
- * blocks on a condition variable rather than spinning, and writers are given
- * priority over newly-arriving readers.
+ * so it can be swapped in for comparison.
  */
 class CvRwLock {
  public:
@@ -76,53 +83,68 @@ class CvRwLock {
 
   // -- reader side ----------------------------------------------------
 
-  /** Acquire the lock in shared (read) mode. Blocks while a writer holds the
-   *  lock or is waiting, so writers are not starved by a reader stream. */
+  /** Acquire the lock in shared (read) mode. Lock-free when no writer is
+   *  waiting/active; otherwise parks on the condition variable. */
   void ReadLock() {
-    std::unique_lock<std::mutex> lock(mtx_);
-    cv_.wait(lock, [this]() {
-      return !writer_active_ && waiting_writers_ == 0;
-    });
-    ++active_readers_;
+    for (;;) {
+      if (write_intent_.load() == 0) {
+        // Optimistically register as a reader, then re-check for a writer that
+        // may have arrived in between. If none, we hold the lock -- no mutex.
+        readers_.fetch_add(1);
+        if (write_intent_.load() == 0) {
+          return;
+        }
+        // A writer appeared; back out. If we were the last reader, wake it.
+        if (readers_.fetch_sub(1) == 1) {
+          std::lock_guard<std::mutex> lk(mtx_);
+          cv_.notify_all();
+        }
+      }
+      // Slow path: park until no writer is waiting/active, then retry.
+      std::unique_lock<std::mutex> lk(mtx_);
+      cv_.wait(lk, [this]() { return write_intent_.load() == 0; });
+    }
   }
 
-  /** Release a shared (read) hold. Wakes waiters once the last reader leaves. */
+  /** Release a shared (read) hold. Lock-free unless we are the last reader and
+   *  a writer is waiting, in which case we wake it. */
   void ReadUnlock() {
-    std::unique_lock<std::mutex> lock(mtx_);
-    --active_readers_;
-    if (active_readers_ == 0) {
+    if (readers_.fetch_sub(1) == 1 && write_intent_.load() > 0) {
+      std::lock_guard<std::mutex> lk(mtx_);
       cv_.notify_all();
     }
   }
 
   // -- writer side ----------------------------------------------------
 
-  /** Acquire the lock in exclusive (write) mode. Announces its arrival so new
-   *  readers back off, then waits until no reader or writer holds the lock. */
+  /** Acquire the lock in exclusive (write) mode. Announces intent so new
+   *  readers back off, then waits until no writer holds it and readers drain. */
   void WriteLock() {
-    std::unique_lock<std::mutex> lock(mtx_);
-    ++waiting_writers_;  // announce arrival to stop new readers
-    cv_.wait(lock, [this]() {
-      return !writer_active_ && active_readers_ == 0;
+    write_intent_.fetch_add(1);  // block new readers (writer preference)
+    std::unique_lock<std::mutex> lk(mtx_);
+    cv_.wait(lk, [this]() {
+      return !writer_active_ && readers_.load() == 0;
     });
-    --waiting_writers_;
     writer_active_ = true;
   }
 
-  /** Release an exclusive (write) hold and wake all waiters. Waiting writers
-   *  win the next round via the reader wait predicate (writer preference). */
+  /** Release an exclusive (write) hold; wake the next writer and/or readers. */
   void WriteUnlock() {
-    std::unique_lock<std::mutex> lock(mtx_);
+    std::lock_guard<std::mutex> lk(mtx_);
     writer_active_ = false;
+    write_intent_.fetch_sub(1);  // re-admit readers if no other writer waits
     cv_.notify_all();
   }
 
  private:
+  // Active readers. Modified lock-free on the reader fast path; read under the
+  // mutex by a waiting writer's predicate.
+  std::atomic<std::int64_t> readers_{0};
+  // Writers waiting OR active. Readers back off (do not enter) while > 0.
+  std::atomic<std::int64_t> write_intent_{0};
   std::mutex mtx_;
   std::condition_variable cv_;
-  int active_readers_ = 0;
-  bool writer_active_ = false;
-  int waiting_writers_ = 0;
+  bool writer_active_ = false;  // guarded by mtx_
 };
 
 }  // namespace ctp

--- a/context-transport-primitives/include/clio_ctp/thread/lock/rwlock.h
+++ b/context-transport-primitives/include/clio_ctp/thread/lock/rwlock.h
@@ -57,6 +57,16 @@ struct RwLock {
   ipc::atomic<ctp::reg_uint> writers_;
   ipc::atomic<ctp::reg_uint> cur_writer_;
   ipc::atomic<ctp::big_uint> ticket_;
+  // Batched-fairness counter: acquisitions granted since the last mode switch
+  // (reset to 0 in UpdateMode when the lock flips to kNone). Once a phase has
+  // served kFairnessBatch ops AND the opposite side is waiting, new same-side
+  // acquirers defer so the phase drains and the lock can flip. This bounds
+  // starvation (the pathology of the plain reader-preferring lock) while
+  // keeping the throughput of batching -- unlike a strict per-op handoff or a
+  // condition-variable lock's per-op mutex cost.
+  ipc::atomic<ctp::reg_uint> ops_since_switch_;
+  /** Ops granted in one phase before yielding to a waiting opposite side. */
+  static constexpr ctp::reg_uint kFairnessBatch = 32;
   /** Default constructor */
   CTP_CROSS_FUN
   RwLock()
@@ -64,7 +74,8 @@ struct RwLock {
         writers_(0),
         ticket_(0),
         mode_(RwLockMode::kNone),
-        cur_writer_(0) {}
+        cur_writer_(0),
+        ops_since_switch_(0) {}
 
   /** Explicit constructor */
   CTP_CROSS_FUN
@@ -74,6 +85,7 @@ struct RwLock {
     ticket_ = 0;
     mode_ = RwLockMode::kNone;
     cur_writer_ = 0;
+    ops_since_switch_ = 0;
   }
 
   /** Copy constructor (no-op, mirrors ctp::Mutex): copying a live
@@ -86,7 +98,8 @@ struct RwLock {
         writers_(0),
         ticket_(0),
         mode_(RwLockMode::kNone),
-        cur_writer_(0) {}
+        cur_writer_(0),
+        ops_since_switch_(0) {}
 
   /** Copy assignment (no-op for state, same rationale as copy ctor). */
   CTP_CROSS_FUN
@@ -96,6 +109,7 @@ struct RwLock {
     ticket_.store(0);
     mode_.store(RwLockMode::kNone);
     cur_writer_.store(0);
+    ops_since_switch_.store(0);
     return *this;
   }
 
@@ -106,7 +120,8 @@ struct RwLock {
         writers_(other.writers_.load()),
         ticket_(other.ticket_.load()),
         mode_(other.mode_.load()),
-        cur_writer_(other.cur_writer_.load()) {}
+        cur_writer_(other.cur_writer_.load()),
+        ops_since_switch_(other.ops_since_switch_.load()) {}
 
   /** Move assignment operator */
   CTP_CROSS_FUN
@@ -117,6 +132,7 @@ struct RwLock {
       ticket_ = other.ticket_.load();
       mode_ = other.mode_.load();
       cur_writer_ = other.cur_writer_.load();
+      ops_since_switch_ = other.ops_since_switch_.load();
     }
     return *this;
   }
@@ -140,7 +156,21 @@ struct RwLock {
    *         reentrant callers (e.g. CoRwLock's read->read nesting) depend on. */
   CTP_CROSS_FUN
   void ReadLock(uint32_t owner, bool writer_priority = false) {
-    RwLockMode::Type mode;
+    RwLockMode::Type mode = mode_.load_device();
+
+    // Batched fairness: if a writer is waiting and this read phase has already
+    // served a full batch, let the current readers drain (readers_ -> 0) so the
+    // waiting writer can take over before we pile on another reader. New readers
+    // gate here too, so readers_ actually reaches 0. Checked once (bounded).
+    if (writers_.load_device() > 0 && mode == RwLockMode::kRead &&
+        ops_since_switch_.load_device() >= kFairnessBatch) {
+      while (readers_.load_device() > 0) {
+#if !CTP_IS_DEVICE_PASS
+        CTP_THREAD_MODEL->Yield();
+#endif
+      }
+    }
+    ops_since_switch_.fetch_add(1);
 
     if (writer_priority) {
       while (writers_.load() > 0) {
@@ -178,8 +208,22 @@ struct RwLock {
   /** Acquire write lock */
   CTP_CROSS_FUN
   void WriteLock(uint32_t owner) {
-    RwLockMode::Type mode;
+    RwLockMode::Type mode = mode_.load_device();
     uint32_t cur_writer;
+
+    // Batched fairness: if readers are waiting and this write phase has served a
+    // full batch, let the current writers drain (writers_ -> 0) so the waiting
+    // readers can take over before we queue another writer. New writers gate
+    // here too, so writers_ actually reaches 0. Checked once (bounded).
+    if (readers_.load_device() > 0 && mode == RwLockMode::kWrite &&
+        ops_since_switch_.load_device() >= kFairnessBatch) {
+      while (writers_.load_device() > 0) {
+#if !CTP_IS_DEVICE_PASS
+        CTP_THREAD_MODEL->Yield();
+#endif
+      }
+    }
+    ops_since_switch_.fetch_add(1);
 
     // Increment # writers & get ticket
     writers_.fetch_add(1);
@@ -229,7 +273,11 @@ struct RwLock {
     mode = mode_.load_device();
     if ((readers_.load_device() == 0 && mode == RwLockMode::kRead) ||
         (writers_.load_device() == 0 && mode == RwLockMode::kWrite)) {
-      mode_.compare_exchange_weak(mode, RwLockMode::kNone);
+      if (mode_.compare_exchange_weak(mode, RwLockMode::kNone)) {
+        // The phase just ended -- restart the batch counter so the next phase
+        // (read or write) gets a fresh kFairnessBatch budget.
+        ops_since_switch_.store(0);
+      }
     }
   }
 };

--- a/context-transport-primitives/test/unit/thread/test_lock.cc
+++ b/context-transport-primitives/test/unit/thread/test_lock.cc
@@ -35,6 +35,7 @@
 #include "clio_ctp/thread/lock.h"
 #include "omp.h"
 
+using ctp::CvRwLock;
 using ctp::Mutex;
 using ctp::RwLock;
 
@@ -99,6 +100,48 @@ TEST_CASE("RwLock") {
   RwLockTest(8, 0, 1000000);
   RwLockTest(7, 1, 1000000);
   RwLockTest(4, 4, 1000000);
+}
+
+void CvRwLockTest(int producers, int consumers, size_t loop_count) {
+  size_t nthreads = producers + consumers;
+  size_t count = 0;
+  CvRwLock lock;
+
+  omp_set_dynamic(0);
+#pragma omp parallel shared(lock, nthreads, producers, consumers, loop_count, \
+                                count) num_threads(nthreads)
+  {  // NOLINT
+    int tid = omp_get_thread_num();
+
+#pragma omp barrier
+    size_t total_size = producers * loop_count;
+    if (tid < consumers) {
+      // Readers observe the shared counter under the (parallel) read lock; it
+      // must never exceed the final total while writers are still running.
+      lock.ReadLock();
+      for (size_t i = 0; i < loop_count; ++i) {
+        REQUIRE(count <= total_size);
+      }
+      lock.ReadUnlock();
+    } else {
+      // Writers increment under the exclusive lock; mutual exclusion means no
+      // increment is lost.
+      lock.WriteLock();
+      for (size_t i = 0; i < loop_count; ++i) {
+        count += 1;
+      }
+      lock.WriteUnlock();
+    }
+
+#pragma omp barrier
+    REQUIRE(count == total_size);
+  }
+}
+
+TEST_CASE("CvRwLock") {
+  CvRwLockTest(8, 0, 1000000);
+  CvRwLockTest(7, 1, 1000000);
+  CvRwLockTest(4, 4, 1000000);
 }
 
 #if CTP_ENABLE_THALLIUM


### PR DESCRIPTION
Builds on the lock benchmark / `CvRwLock` merged via #665 and the `RwLock` `writer_priority` opt-in merged via #660. Two commits:

## 1. Batched fairness for `RwLock`
Adds `ops_since_switch_`: once a phase has served ≥32 ops and the opposite side is waiting, new same-side acquirers defer so the lock flips. Bounds starvation **by default** while keeping batching throughput and the spin lock's low latency. Composes with #660's opt-in `writer_priority` (both live in `ReadLock`). `sizeof(RwLock)` 24→32.

Benchmark impact (vs the plain reader-preferring lock):
- Mostly-writes: lone reader p50 **148 ms → ~2 ms** (~70× better); writers stay fast.
- Mostly-reads: writer p90 **12.8 ms → ~1.5 ms**; readers unchanged (p99 ~400 ns).
- Mixed 2R/2W: goes from writer-skewed to balanced acquire counts.

## 2. Parallel reader path for `CvRwLock` + unit tests
The merged `CvRwLock` took its internal `std::mutex` on every `ReadLock`/`ReadUnlock`, so "shared" readers serialized on it. Rewrite the reader fast path to be lock-free (atomic reader count + optimistic write-intent re-check); the mutex/CV is only touched on the blocking slow path. Readers now scale (4-reader bench: ~10M → ~27M acquires, on par with `RwLock`). Also adds a `CvRwLock` unit test mirroring the `RwLock` test and registers `CvRwLock` in `thread/lock.h`.

**Known tradeoff:** the parallel `CvRwLock` is strictly writer-preferring and **starves readers under sustained writes** (a lone reader can wait a full multi-second run). The batched-fair `RwLock` does not — and is 8 bytes smaller — so `RwLock` is the recommended default; `CvRwLock` suits read-heavy / sleep-friendly workloads.

## Follow-up worth considering
`RwLock`'s batched fairness makes it fair by default, so #660's opt-in `writer_priority` (and the `unordered_map_ll` call sites that pass it) could likely be simplified away later.

## Validation
Locally via the workload benchmark plus a 200-run standalone mutual-exclusion/deadlock stress on `CvRwLock` (all pass). The committed Catch2 `RwLock`/`CvRwLock` tests run in CI (CMake+OpenMP).