### PR TITLE
fix(ci): replace stale chimaera references in adapter tests

### DIFF
--- a/context-transfer-engine/test/unit/adapters/hdf5_vol/CMakeLists.txt
+++ b/context-transfer-engine/test/unit/adapters/hdf5_vol/CMakeLists.txt
@@ -63,7 +63,7 @@ set_tests_properties(
 # End-to-end I/O test: drives real HDF5 file/dataset/group/attr operations
 # through the connector against an in-process Chimaera/CTE runtime. Unlike the
 # registration-only suite above, this links the CTE core + admin + bdev
-# runtimes so CHIMAERA_INIT(kClient, true) stands up an in-process runtime.
+# runtimes so CLIO_INIT(kClient, true) stands up an in-process runtime.
 #------------------------------------------------------------------------------
 add_executable(test_hdf5_vol_io
     test_hdf5_vol_io.cc
@@ -79,10 +79,10 @@ target_link_libraries(test_hdf5_vol_io
     iowarp_hdf5_vol
     clio_cte_core_runtime
     clio_cte_core_client
-    chimaera::admin_runtime
-    chimaera::admin_client
-    chimaera::bdev_runtime
-    chimaera::bdev_client
+    clio::run::admin_runtime
+    clio::run::admin_client
+    clio::run::bdev_runtime
+    clio::run::bdev_client
     ctp::cxx
     ${HDF5_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}

--- a/context-transfer-engine/test/unit/adapters/hdf5_vol/test_hdf5_vol_io.cc
+++ b/context-transfer-engine/test/unit/adapters/hdf5_vol/test_hdf5_vol_io.cc
@@ -57,8 +57,8 @@ hid_t setupVolEnvironment() {
   // a modest dataset (16 KiB / 4 KiB = 4 chunks).
   setenv("IOWARP_VOL_CHUNK_SIZE", "4096", 1);
 
-  REQUIRE(chi::CHIMAERA_INIT(chi::ChimaeraMode::kClient, true));
-  SimpleTest::g_test_finalize = chi::CHIMAERA_FINALIZE;
+  REQUIRE(clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, true));
+  SimpleTest::g_test_finalize = clio::run::CLIO_RUNTIME_FINALIZE;
   REQUIRE(clio::cte::core::CLIO_CTE_CLIENT_INIT());
 
   // Register a file-backed target into the default CTE pool so the connector's
@@ -67,8 +67,8 @@ hid_t setupVolEnvironment() {
   auto *cte_client = CLIO_CTE_CLIENT;
   auto reg_task = cte_client->AsyncRegisterTarget(
       kBackendFile, clio::run::bdev::BdevType::kFile,
-      static_cast<chi::u64>(64) * 1024 * 1024, chi::PoolQuery::Local(),
-      chi::PoolId(600, 0));
+      static_cast<clio::run::u64>(64) * 1024 * 1024, clio::run::PoolQuery::Local(),
+      clio::run::PoolId(600, 0));
   reg_task.Wait();
   REQUIRE(reg_task->GetReturnCode() == 0);
 

--- a/context-transfer-engine/test/unit/adapters/libfuse/test_fuse_copy_workspace.cc
+++ b/context-transfer-engine/test/unit/adapters/libfuse/test_fuse_copy_workspace.cc
@@ -207,14 +207,14 @@ static std::vector<fs::path> CollectFiles() {
 
 class CopyWorkspaceFixture {
  public:
-  static constexpr chi::u64 kCopyTargetSize = 64ULL * 1024 * 1024;
+  static constexpr clio::run::u64 kCopyTargetSize = 64ULL * 1024 * 1024;
   static inline bool g_initialized = false;
 
   CopyWorkspaceFixture() {
     if (!g_initialized) {
       bool success = clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, true);
       REQUIRE(success);
-      SimpleTest::g_test_finalize = chi::CHIMAERA_FINALIZE;
+      SimpleTest::g_test_finalize = clio::run::CLIO_RUNTIME_FINALIZE;
 
       std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
@@ -233,11 +233,11 @@ class CopyWorkspaceFixture {
       create_task.Wait();
       REQUIRE(create_task->GetReturnCode() == 0);
 
-      chi::PoolId bdev_pool_id(951, 0);
+      clio::run::PoolId bdev_pool_id(951, 0);
       std::string target_name = "cte_fuse_copy_workspace_ram";
       auto reg_task = cte_client->AsyncRegisterTarget(
           target_name, clio::run::bdev::BdevType::kRam, kCopyTargetSize,
-          chi::PoolQuery::DirectHash(0), bdev_pool_id);
+          clio::run::PoolQuery::DirectHash(0), bdev_pool_id);
       reg_task.Wait();
       REQUIRE(reg_task->GetReturnCode() == 0);
 


### PR DESCRIPTION
## Problem
Two `dev` CI jobs have been failing due to leftovers from the chimaera removal (#546):
- **CI Adapters** — `context-transfer-engine/test/unit/adapters/hdf5_vol/CMakeLists.txt` linked the removed `chimaera::{admin,bdev}_{runtime,client}` targets → CMake configure error (`target ... not found`) on linux/macOS/windows.
- **Cluster Tests** — `hdf5_vol/test_hdf5_vol_io.cc` and `libfuse/test_fuse_copy_workspace.cc` used the removed `chi::` namespace → compile errors (`'chi' does not name a type`, etc.).

## Fix
Migrate all references to the brand-aligned names already used by the working sibling test `libfuse/test_fuse_adapter.cc`:

| Old (removed) | New |
|---|---|
| `chimaera::{admin,bdev}_{runtime,client}` | `clio::run::{admin,bdev}_{runtime,client}` |
| `chi::CHIMAERA_INIT(chi::ChimaeraMode::kClient, …)` | `clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, …)` |
| `chi::CHIMAERA_FINALIZE` | `clio::run::CLIO_RUNTIME_FINALIZE` |
| `chi::{u64,PoolId,PoolQuery}` | `clio::run::{u64,PoolId,PoolQuery}` |

All replacement symbols verified present (`clio::run::PoolQuery::DirectHash(u32)` static factory, `clio::run::CLIO_RUNTIME_FINALIZE()`), and a repo-wide sweep confirms no `chi::`/`chimaera::` leftovers remain in the adapter tests.

Touches only the two broken test files + one test CMakeLists — no library/runtime code. Verification is via CI (these jobs build in the Linux `deps-cpu` container).

🤖 Generated with [Claude Code](https://claude.com/claude-code)