### PR TITLE
fix(devcontainer): recover broken apt state before fuse/boost install (#670)

### DIFF
--- a/.devcontainer/cpu/Dockerfile
+++ b/.devcontainer/cpu/Dockerfile
@@ -12,10 +12,18 @@ RUN userdel -r ubuntu || true
 # so a devcontainer rebuild picks it up immediately; it is also in the base
 # image (docker/iowarp-base.Dockerfile) as the canonical default. The
 # container runs --privileged, so /dev/fuse + SYS_ADMIN are available.
-RUN apt-get update && apt-get install -y --no-install-recommends \
+#
+# deps-cpu has no ROCm, so apt is healthy here — but keep the same self-healing
+# form as the nvidia/ml devcontainers (issue #670) so the three stay in sync.
+# The HIP purge is a harmless no-op on this image.
+RUN set -eux; \
+    dpkg -P --force-all hipcc hip-dev hip-runtime-amd rocm-llvm hsa-rocr-dev rocm-device-libs 2>/dev/null || true; \
+    apt-get update; \
+    DEBIAN_FRONTEND=noninteractive apt-get --fix-broken install -y || true; \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
       fuse3 libfuse3-dev \
-      libboost-context-dev libboost-dev \
-    && rm -rf /var/lib/apt/lists/*
+      libboost-context-dev libboost-dev; \
+    rm -rf /var/lib/apt/lists/*
 
 # Build the Boost.Context stackful coroutine backend by default in the
 # devcontainer so it is exercised during development (issue #620). Build tooling

--- a/.devcontainer/ml-inference/Dockerfile
+++ b/.devcontainer/ml-inference/Dockerfile
@@ -9,10 +9,22 @@ USER root
 # so a devcontainer rebuild picks it up immediately; it is also in the base
 # image (docker/iowarp-base.Dockerfile) as the canonical default. The
 # container runs --privileged, so /dev/fuse + SYS_ADMIN are available.
-RUN apt-get update && apt-get install -y --no-install-recommends \
+#
+# deps-ml inherits deps-nvidia, which force-installs the HIP-NVCC `hip-dev`
+# headers with `dpkg -i --force-depends` and deliberately never installs the
+# AMD-flavored hip-runtime-amd / rocm-llvm / hsa-rocr-dev / hipcc, leaving apt
+# in a broken-deps state (deps-nvidia.Dockerfile:196-199). apt refuses to run
+# ANY install while those phantom deps are unmet, which aborts this layer with
+# exit 100 (issue #670). Purge the unsatisfiable HIP metapackages and repair
+# the dependency tree first so the fuse/boost install can proceed.
+RUN set -eux; \
+    dpkg -P --force-all hipcc hip-dev hip-runtime-amd rocm-llvm hsa-rocr-dev rocm-device-libs 2>/dev/null || true; \
+    apt-get update; \
+    DEBIAN_FRONTEND=noninteractive apt-get --fix-broken install -y || true; \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
       fuse3 libfuse3-dev \
-      libboost-context-dev libboost-dev \
-    && rm -rf /var/lib/apt/lists/*
+      libboost-context-dev libboost-dev; \
+    rm -rf /var/lib/apt/lists/*
 
 # Boost.Context stackful coroutine backend available + on by default (issue #620).
 ENV CLIO_CORE_ENABLE_BOOST_COROUTINES=ON

--- a/.devcontainer/nvidia-gpu/Dockerfile
+++ b/.devcontainer/nvidia-gpu/Dockerfile
@@ -12,10 +12,23 @@ RUN userdel -r ubuntu || true
 # so a devcontainer rebuild picks it up immediately; it is also in the base
 # image (docker/iowarp-base.Dockerfile) as the canonical default. The
 # container runs --privileged, so /dev/fuse + SYS_ADMIN are available.
-RUN apt-get update && apt-get install -y --no-install-recommends \
+#
+# deps-nvidia force-installs the HIP-NVCC `hip-dev` headers with
+# `dpkg -i --force-depends` and deliberately never installs the AMD-flavored
+# hip-runtime-amd / rocm-llvm / hsa-rocr-dev / hipcc, leaving apt in a
+# broken-deps state (deps-nvidia.Dockerfile:196-199). apt refuses to run ANY
+# install while those phantom deps are unmet, which aborts this layer with
+# exit 100 (issue #670). Purge the unsatisfiable HIP metapackages and repair
+# the dependency tree first so the fuse/boost install can proceed. The oneAPI
+# step below re-runs the same purge (a no-op after this).
+RUN set -eux; \
+    dpkg -P --force-all hipcc hip-dev hip-runtime-amd rocm-llvm hsa-rocr-dev rocm-device-libs 2>/dev/null || true; \
+    apt-get update; \
+    DEBIAN_FRONTEND=noninteractive apt-get --fix-broken install -y || true; \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
       fuse3 libfuse3-dev \
-      libboost-context-dev libboost-dev \
-    && rm -rf /var/lib/apt/lists/*
+      libboost-context-dev libboost-dev; \
+    rm -rf /var/lib/apt/lists/*
 
 # Boost.Context stackful coroutine backend available + on by default (issue #620).
 ENV CLIO_CORE_ENABLE_BOOST_COROUTINES=ON


### PR DESCRIPTION
## Recover broken apt state before fuse/boost install (Fixes #670)

Cherry-picked from the `fix-devcontainer-broken-apt-fuse` branch (PR #671) — **just** the devcontainer fix, onto current `dev`. The rest of that branch is a stale re-integration of work already merged to dev via squash (Boost #627, #619, MPSC #652, leak detection #654), so only this one commit is worth bringing over.

The nvidia-gpu and ml-inference devcontainers failed at the first `apt-get install` layer (exit 100) because `deps-nvidia` leaves apt in an intentionally broken-deps state (force-installed HIP-NVCC `hip-dev` without the AMD `hip-runtime-amd`/`rocm-llvm`/`hsa-rocr-dev`/`hipcc`). While broken, apt refuses any install, so the fuse3/boost layer aborts; `deps-ml` inherits the same wall.

Fix: purge the unsatisfiable HIP metapackages and run `apt --fix-broken install` before the fuse/boost install, across all three devcontainers (no-op on deps-cpu). Verified against a reproduction of the exact broken `hip-dev` 6.4 state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
