### PR TITLE
feat(cae): S3 and GCS cloud import assimilators (Issue #626)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,6 +181,8 @@ option(CLIO_CTE_ENABLE_HDF5_VOL "Enable HDF5 VOL connector (requires HDF5 >= 1.1
 # CAE (context-assimilation-engine) Options
 #------------------------------------------------------------------------------
 option(CAE_ENABLE_GLOBUS "Enable Globus transfer support in CAE" OFF)
+option(CAE_ENABLE_S3 "Enable Amazon S3 (s3://) import in CAE" OFF)
+option(CAE_ENABLE_GCS "Enable Google Cloud Storage (gs://) import in CAE" OFF)
 # LLM labeling/summary + semantic-search features and their integration tests
 # require a running Ollama service. OFF by default so default builds don't
 # build or run them without Ollama.
@@ -766,6 +768,37 @@ if(CLIO_ENABLE_GOOGLE_CLOUD AND NOT Poco_FOUND)
 endif()
 if(CLIO_ENABLE_GOOGLE_CLOUD)
   message(STATUS "Google Cloud Storage bdev support: ENABLED (Poco found)")
+endif()
+
+# AWS SDK for C++ (optional - for the CAE S3 assimilator, s3://). Reuses the
+# same dependency the bdev S3 transport links (aws-cpp-sdk-s3/-core). If the
+# option is requested but the SDK isn't found, warn and disable rather than
+# fail the configure (mirrors the CAE Globus dependency check).
+if(CAE_ENABLE_S3)
+  find_package(AWSSDK COMPONENTS s3 QUIET)
+  if(AWSSDK_FOUND)
+    message(STATUS "found AWS SDK for C++ (CAE S3 support: ENABLED)")
+  else()
+    message(WARNING "CAE_ENABLE_S3 is ON but the AWS SDK for C++ (component s3) "
+                    "was not found. S3 import will be disabled. "
+                    "Install aws-sdk-cpp to enable it.")
+    set(CAE_ENABLE_S3 OFF)
+  endif()
+endif()
+
+# google-cloud-cpp (optional - for the CAE GCS assimilator, gs://). A new
+# optional dependency (the storage component). If requested but not found,
+# warn and disable rather than fail the configure.
+if(CAE_ENABLE_GCS)
+  find_package(google_cloud_cpp_storage QUIET)
+  if(google_cloud_cpp_storage_FOUND)
+    message(STATUS "found google-cloud-cpp storage (CAE GCS support: ENABLED)")
+  else()
+    message(WARNING "CAE_ENABLE_GCS is ON but google-cloud-cpp (storage "
+                    "component) was not found. GCS import will be disabled. "
+                    "Install google-cloud-cpp to enable it.")
+    set(CAE_ENABLE_GCS OFF)
+  endif()
 endif()
 
 if (CLIO_CTE_ENABLE_ADIOS2_ADAPTER OR CLIO_CORE_ENABLE_GRAY_SCOTT)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -126,6 +126,8 @@ distro repos).
 | Redis bench            | `CLIO_CORE_ENABLE_REDIS=ON`          | Builds the head-to-head Redis comparison benchmark. `libhiredis-dev` / `hiredis-devel`. |
 | LLM hooks (llama.cpp)  | `CLIO_CORE_ENABLE_LLAMA=ON`          | Integrates the bundled `external/llama.cpp` submodule.             |
 | Globus transfer (CAE)  | `CAE_ENABLE_GLOBUS=ON`               | Globus toolkit installed and on PATH.                              |
+| S3 import (CAE)        | `CAE_ENABLE_S3=ON`                   | Imports `s3://bucket/key` into CTE. Requires the AWS SDK for C++ (`aws-sdk-cpp`, component `s3`). OFF by default; self-disables with a warning if the SDK is not found. |
+| GCS import (CAE)       | `CAE_ENABLE_GCS=ON`                  | Imports `gs://bucket/object` into CTE. Requires `google-cloud-cpp` (storage component). OFF by default; self-disables with a warning if the SDK is not found. |
 
 ### Testing + diagnostics
 
@@ -225,6 +227,8 @@ Misc
 [ ] CLIO_CORE_ENABLE_REDIS=ON         Redis comparison benchmark (hiredis)
 [ ] CLIO_CORE_ENABLE_LLAMA=ON         llama.cpp LLM hooks
 [ ] CAE_ENABLE_GLOBUS=ON              Globus transfers in CAE
+[ ] CAE_ENABLE_S3=ON                  S3 (s3://) imports in CAE (aws-sdk-cpp)
+[ ] CAE_ENABLE_GCS=ON                 GCS (gs://) imports in CAE (google-cloud-cpp)
 
 Build profiles (mutually exclusive)
 ─────────────────────────────────

--- a/context-assimilation-engine/README.md
+++ b/context-assimilation-engine/README.md
@@ -2,7 +2,8 @@
 
 A CLIO ChiMod for high-performance data ingestion into the IOWarp ecosystem.
 CAE assimilates data from external sources — local binary files, HDF5
-datasets, and Globus endpoints — into the [Context Transfer
+datasets, Globus endpoints, and cloud object stores (Amazon S3 and Google
+Cloud Storage) — into the [Context Transfer
 Engine](../context-transfer-engine) (CTE) for distributed storage and
 retrieval.
 
@@ -19,6 +20,9 @@ External Source          CAE Module              CTE Module
 ```
 
 **Supported formats:** `binary`, `hdf5`, `globus`
+
+**Supported source schemes:** `file::`, `string::`, `hdf5::`, `globus://`,
+`s3://` (Amazon S3 / MinIO), `gs://` and `gcs://` (Google Cloud Storage)
 
 ## Building
 
@@ -40,6 +44,12 @@ cmake --preset release -DCLIO_CORE_ENABLE_HDF5=ON
 
 Globus ingestion is opt-in via `-DCAE_ENABLE_GLOBUS=ON` and requires the
 Globus toolkit on `PATH`.
+
+S3 ingestion is opt-in via `-DCAE_ENABLE_S3=ON` and requires the AWS SDK for
+C++ (the same dependency the bdev S3 transport uses). GCS ingestion is opt-in
+via `-DCAE_ENABLE_GCS=ON` and requires `google-cloud-cpp` (storage component).
+Both default to OFF and self-disable with a warning if their SDK is not found,
+so a default build is unaffected.
 
 ## Running
 
@@ -103,11 +113,35 @@ transfers:
         - "/sensors/raw/*"
 ```
 
+**Cloud object stores (S3 / GCS):**
+
+```yaml
+transfers:
+  - src: s3://my-bucket/data.bin       # Amazon S3 / MinIO (s3:// or s3::)
+    dst: iowarp::my_tag
+    format: binary
+  - src: gs://my-bucket/data.bin       # Google Cloud Storage (gs:// or gcs://)
+    dst: iowarp::my_other_tag
+    format: binary
+    range_off: 0                       # optional ranged read
+    range_size: 0
+```
+
+Credentials and endpoints are resolved from the standard cloud environment at
+assimilation time (no secrets are placed in the OMNI file):
+
+- **S3:** `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN`
+  (or profiles / instance roles), `AWS_DEFAULT_REGION`, and an optional
+  S3-compatible endpoint via `S3_ENDPOINT` or `AWS_ENDPOINT_URL` (e.g. MinIO).
+- **GCS:** Application Default Credentials (`GOOGLE_APPLICATION_CREDENTIALS`,
+  gcloud ADC, or the GCE/GKE metadata server), and an optional endpoint via
+  `GCS_ENDPOINT` (e.g. fake-gcs-server).
+
 **Key fields:**
 
 | Field | Description |
 |---|---|
-| `src` | Source URL (`file::`, `globus::`) |
+| `src` | Source URL (`file::`, `string::`, `hdf5::`, `globus://`, `s3://`, `gs://`) |
 | `dst` | CTE destination tag (`iowarp::tag_name`) |
 | `format` | `binary`, `hdf5`, or `globus` |
 | `range_off` / `range_size` | Byte range within source (0 = full file) |

--- a/context-assimilation-engine/core/CMakeLists.txt
+++ b/context-assimilation-engine/core/CMakeLists.txt
@@ -121,6 +121,30 @@ if(GLOBUS_ENABLED)
   list(APPEND RUNTIME_LINK_LIBRARIES Poco::Net Poco::NetSSL Poco::Crypto Poco::JSON nlohmann_json::nlohmann_json)
 endif()
 
+# Conditionally add S3 assimilator if enabled (AWS SDK found by root CMakeLists).
+# NOTE: the AWS SDK is intentionally NOT linked into the CAE runtime library.
+# Loading libaws-cpp-sdk-core.so into the CLIO runtime process corrupts runtime
+# startup (its load-time global ctors / static-baked s2n collide with CLIO init).
+# The assimilator instead shells out to the standalone `cae_s3_tool` helper
+# (defined below), which is the only target that links the AWS SDK.
+if(CAE_ENABLE_S3)
+  message(STATUS "CAE S3 support: ENABLED")
+  add_compile_definitions(CAE_ENABLE_S3)
+  list(APPEND RUNTIME_SOURCES src/factory/s3_file_assimilator.cc)
+else()
+  message(STATUS "CAE S3 support: DISABLED")
+endif()
+
+# Conditionally add GCS assimilator if enabled (google-cloud-cpp found by root).
+if(CAE_ENABLE_GCS)
+  message(STATUS "CAE GCS support: ENABLED")
+  add_compile_definitions(CAE_ENABLE_GCS)
+  list(APPEND RUNTIME_SOURCES src/factory/gcs_file_assimilator.cc)
+  list(APPEND RUNTIME_LINK_LIBRARIES google-cloud-cpp::storage)
+else()
+  message(STATUS "CAE GCS support: DISABLED")
+endif()
+
 add_clio_module_runtime(
   SOURCES
     ${RUNTIME_SOURCES}
@@ -142,6 +166,16 @@ endif()
 #------------------------------------------------------------------------------
 # Utilities
 #------------------------------------------------------------------------------
+
+# cae_s3_tool: standalone S3 helper executable. This is the ONLY target that
+# links the AWS SDK; S3FileAssimilator fork+execs it so the SDK never loads into
+# the CLIO runtime process (which would corrupt runtime startup). It links no
+# CLIO libraries. Installed to bin/ alongside the runtime.
+if(CAE_ENABLE_S3)
+  add_executable(cae_s3_tool src/factory/tools/s3_tool_main.cc)
+  target_link_libraries(cae_s3_tool PRIVATE aws-cpp-sdk-s3 aws-cpp-sdk-core)
+  install(TARGETS cae_s3_tool DESTINATION bin)
+endif()
 
 # clio_cae utility (CAE OMNI ingest driver). Installed as `clio_cae`;
 # the legacy `clio_cae_omni` name is preserved as an install-time symlink

--- a/context-assimilation-engine/core/include/clio_cae/core/factory/gcs_file_assimilator.h
+++ b/context-assimilation-engine/core/include/clio_cae/core/factory/gcs_file_assimilator.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CLIO_CAE_CORE_GCS_FILE_ASSIMILATOR_H_
+#define CLIO_CAE_CORE_GCS_FILE_ASSIMILATOR_H_
+
+#include <clio_cae/core/factory/base_assimilator.h>
+#include <string>
+#include <memory>
+
+// Forward declaration
+namespace clio::cte::core {
+class Client;
+}  // namespace clio::cte::core
+
+namespace clio::cae::core {
+
+/**
+ * GcsFileAssimilator - Imports an object straight from Google Cloud Storage
+ * into CTE.
+ *
+ * The source URL is `gs://bucket/object` (the `gcs://bucket/object` form is
+ * also accepted). Object bytes are streamed in chunks into CTE using the same
+ * tag + chunked-blob flow as BinaryFileAssimilator; only the byte source
+ * differs (a GCS ObjectReadStream instead of a local file).
+ *
+ * Credentials are resolved through Google Application Default Credentials
+ * (GOOGLE_APPLICATION_CREDENTIALS, gcloud ADC, or the GCE/GKE metadata
+ * server). An optional GCS-compatible endpoint (e.g. fake-gcs-server) can be
+ * set via GCS_ENDPOINT, in which case anonymous credentials are used.
+ */
+class GcsFileAssimilator : public BaseAssimilator {
+ public:
+  /**
+   * Constructor with CTE client
+   * @param cte_client Shared pointer to initialized CTE client
+   */
+  explicit GcsFileAssimilator(std::shared_ptr<clio::cte::core::Client> cte_client);
+
+  /**
+   * Schedule assimilation tasks for a GCS object
+   * This is a coroutine that uses co_await for async CTE operations.
+   * @param ctx Assimilation context with source, destination, and metadata
+   * @param error_code Output: 0 on success, non-zero error code on failure
+   * @return TaskResume for coroutine suspension/resumption
+   */
+  clio::run::TaskResume Schedule(const AssimilationCtx& ctx, int& error_code) override;
+
+ private:
+  /**
+   * Extract protocol from URL (part before :: or ://)
+   * @param url URL in format protocol::path or protocol://path
+   * @return Protocol string, or empty string if no protocol found
+   */
+  std::string GetUrlProtocol(const std::string& url);
+
+  /**
+   * Extract path from URL (part after :: or ://)
+   * @param url URL in format protocol::path or protocol://path
+   * @return Path string, or empty string if no protocol found
+   */
+  std::string GetUrlPath(const std::string& url);
+
+  /**
+   * Parse a GCS source URL into its bucket and object components.
+   * Accepts `gs://bucket/object`, `gcs://bucket/object`, and the `::` forms.
+   * @param url Source URL
+   * @param bucket Output: bucket name
+   * @param object Output: object name (everything after the first '/')
+   * @return true on success, false if the URL is malformed
+   */
+  bool ParseGcsUrl(const std::string& url, std::string& bucket, std::string& object);
+
+  std::shared_ptr<clio::cte::core::Client> cte_client_;
+};
+
+}  // namespace clio::cae::core
+
+#endif  // CLIO_CAE_CORE_GCS_FILE_ASSIMILATOR_H_

--- a/context-assimilation-engine/core/include/clio_cae/core/factory/s3_file_assimilator.h
+++ b/context-assimilation-engine/core/include/clio_cae/core/factory/s3_file_assimilator.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CLIO_CAE_CORE_S3_FILE_ASSIMILATOR_H_
+#define CLIO_CAE_CORE_S3_FILE_ASSIMILATOR_H_
+
+#include <clio_cae/core/factory/base_assimilator.h>
+#include <string>
+#include <memory>
+
+// Forward declaration
+namespace clio::cte::core {
+class Client;
+}  // namespace clio::cte::core
+
+namespace clio::cae::core {
+
+/**
+ * S3FileAssimilator - Imports an object straight from Amazon S3 (or any
+ * S3-compatible endpoint, e.g. MinIO) into CTE.
+ *
+ * The source URL is `s3://bucket/key` (the `s3::bucket/key` form is also
+ * accepted). Object bytes are streamed in chunks into CTE using the same
+ * tag + chunked-blob flow as BinaryFileAssimilator; only the byte source
+ * differs (an S3 GetObject response stream instead of a local file).
+ *
+ * Credentials, region, and an optional S3-compatible endpoint are resolved
+ * from the standard AWS environment at assimilation time
+ * (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_SESSION_TOKEN, profiles,
+ * instance roles; AWS_DEFAULT_REGION; S3_ENDPOINT or AWS_ENDPOINT_URL).
+ */
+class S3FileAssimilator : public BaseAssimilator {
+ public:
+  /**
+   * Constructor with CTE client
+   * @param cte_client Shared pointer to initialized CTE client
+   */
+  explicit S3FileAssimilator(std::shared_ptr<clio::cte::core::Client> cte_client);
+
+  /**
+   * Schedule assimilation tasks for an S3 object
+   * This is a coroutine that uses co_await for async CTE operations.
+   * @param ctx Assimilation context with source, destination, and metadata
+   * @param error_code Output: 0 on success, non-zero error code on failure
+   * @return TaskResume for coroutine suspension/resumption
+   */
+  clio::run::TaskResume Schedule(const AssimilationCtx& ctx, int& error_code) override;
+
+ private:
+  /**
+   * Extract protocol from URL (part before :: or ://)
+   * @param url URL in format protocol::path or protocol://path
+   * @return Protocol string, or empty string if no protocol found
+   */
+  std::string GetUrlProtocol(const std::string& url);
+
+  /**
+   * Extract path from URL (part after :: or ://)
+   * @param url URL in format protocol::path or protocol://path
+   * @return Path string, or empty string if no protocol found
+   */
+  std::string GetUrlPath(const std::string& url);
+
+  /**
+   * Parse an S3 source URL into its bucket and key components.
+   * Accepts `s3://bucket/key` and `s3::bucket/key`.
+   * @param url Source URL
+   * @param bucket Output: bucket name
+   * @param key Output: object key (everything after the first '/')
+   * @return true on success, false if the URL is malformed
+   */
+  bool ParseS3Url(const std::string& url, std::string& bucket, std::string& key);
+
+  std::shared_ptr<clio::cte::core::Client> cte_client_;
+};
+
+}  // namespace clio::cae::core
+
+#endif  // CLIO_CAE_CORE_S3_FILE_ASSIMILATOR_H_

--- a/context-assimilation-engine/core/include/wrp_cae/core/factory/gcs_file_assimilator.h
+++ b/context-assimilation-engine/core/include/wrp_cae/core/factory/gcs_file_assimilator.h
@@ -1,0 +1,4 @@
+// Backward-compat forwarding shim.
+// Prefer the new path: <clio_cae/core/factory/gcs_file_assimilator.h>.
+// Renamed as part of the WRP_ -> CLIO_ pass.
+#include <clio_cae/core/factory/gcs_file_assimilator.h>

--- a/context-assimilation-engine/core/include/wrp_cae/core/factory/s3_file_assimilator.h
+++ b/context-assimilation-engine/core/include/wrp_cae/core/factory/s3_file_assimilator.h
@@ -1,0 +1,4 @@
+// Backward-compat forwarding shim.
+// Prefer the new path: <clio_cae/core/factory/s3_file_assimilator.h>.
+// Renamed as part of the WRP_ -> CLIO_ pass.
+#include <clio_cae/core/factory/s3_file_assimilator.h>

--- a/context-assimilation-engine/core/src/factory/assimilator_factory.cc
+++ b/context-assimilation-engine/core/src/factory/assimilator_factory.cc
@@ -40,6 +40,12 @@
 #ifdef CAE_ENABLE_GLOBUS
 #include <clio_cae/core/factory/globus_file_assimilator.h>
 #endif
+#ifdef CAE_ENABLE_S3
+#include <clio_cae/core/factory/s3_file_assimilator.h>
+#endif
+#ifdef CAE_ENABLE_GCS
+#include <clio_cae/core/factory/gcs_file_assimilator.h>
+#endif
 #include <clio_runtime/clio_runtime.h>
 
 #include <memory>
@@ -113,6 +119,35 @@ std::unique_ptr<BaseAssimilator> AssimilatorFactory::Get(
          "AssimilatorFactory: Globus protocol requested but Globus support not "
          "compiled in. "
          "Rebuild with -DCAE_ENABLE_GLOBUS=ON to enable Globus support.");
+    return nullptr;
+#endif
+  } else if (protocol == "s3") {
+#ifdef CAE_ENABLE_S3
+    HLOG(kDebug,
+         "AssimilatorFactory: Creating S3FileAssimilator for 's3' protocol");
+    // For s3 protocol, return an S3FileAssimilator
+    return std::make_unique<S3FileAssimilator>(cte_client_);
+#else
+    // S3 support not compiled in
+    HLOG(kError,
+         "AssimilatorFactory: S3 protocol requested but S3 support not compiled "
+         "in. "
+         "Rebuild with -DCAE_ENABLE_S3=ON to enable S3 support.");
+    return nullptr;
+#endif
+  } else if (protocol == "gs" || protocol == "gcs") {
+#ifdef CAE_ENABLE_GCS
+    HLOG(kDebug,
+         "AssimilatorFactory: Creating GcsFileAssimilator for 'gs'/'gcs' "
+         "protocol");
+    // For gs/gcs protocol, return a GcsFileAssimilator
+    return std::make_unique<GcsFileAssimilator>(cte_client_);
+#else
+    // GCS support not compiled in
+    HLOG(kError,
+         "AssimilatorFactory: GCS protocol requested but GCS support not "
+         "compiled in. "
+         "Rebuild with -DCAE_ENABLE_GCS=ON to enable GCS support.");
     return nullptr;
 #endif
   }

--- a/context-assimilation-engine/core/src/factory/gcs_file_assimilator.cc
+++ b/context-assimilation-engine/core/src/factory/gcs_file_assimilator.cc
@@ -1,0 +1,327 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <clio_runtime/clio_runtime.h>
+#include <clio_cae/core/factory/gcs_file_assimilator.h>
+
+// google-cloud-cpp pulls in abseil, whose <absl/base/log_severity.h> declares
+//   enum class LogSeverity : int { kInfo, kWarning, kError, kFatal };
+// CLIO's logging.h defines those same names as object-like macros
+// (kInfo=1, kWarning=3, kError=4, kFatal=5), which textually mangle the enum and
+// produce a cascade of syntax errors. Neutralize the macros across just the
+// google-cloud includes, then restore them so HLOG(kInfo, ...) keeps working in
+// the rest of this translation unit. (S3 never hit this — the AWS SDK has no abseil.)
+#pragma push_macro("kInfo")
+#pragma push_macro("kWarning")
+#pragma push_macro("kError")
+#pragma push_macro("kFatal")
+#undef kInfo
+#undef kWarning
+#undef kError
+#undef kFatal
+#include <google/cloud/credentials.h>
+#include <google/cloud/options.h>
+#include <google/cloud/storage/client.h>
+#include <google/cloud/storage/options.h>
+#pragma pop_macro("kFatal")
+#pragma pop_macro("kError")
+#pragma pop_macro("kWarning")
+#pragma pop_macro("kInfo")
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <istream>
+#include <string>
+#include <vector>
+
+// Include clio_cte headers after the clio_cae includes to avoid Method
+// namespace collision (same ordering as BinaryFileAssimilator).
+#include <clio_cte/core/core_client.h>
+#include <clio_cte/core/core_tasks.h>
+
+namespace gcs = google::cloud::storage;
+namespace gc = google::cloud;
+
+namespace clio::cae::core {
+
+GcsFileAssimilator::GcsFileAssimilator(
+    std::shared_ptr<clio::cte::core::Client> cte_client)
+    : cte_client_(cte_client) {}
+
+clio::run::TaskResume GcsFileAssimilator::Schedule(const AssimilationCtx& ctx,
+                                                   int& error_code) {
+#ifdef __NVCOMPILER
+  thread_local clio::run::RunContext _fb_rctx;
+  clio::run::RunContext* _fp = clio::run::GetCurrentRunContextFromWorker();
+  clio::run::RunContext& rctx = _fp ? *_fp : _fb_rctx;
+#endif
+  CLIO_TASK_BODY_BEGIN
+  HLOG(kDebug,
+       "GcsFileAssimilator::Schedule ENTRY: src='{}', dst='{}', range_off={}, "
+       "range_size={}",
+       ctx.src, ctx.dst, ctx.range_off, ctx.range_size);
+
+  // Validate destination protocol
+  std::string dst_protocol = GetUrlProtocol(ctx.dst);
+  if (dst_protocol != "iowarp") {
+    HLOG(kError,
+         "GcsFileAssimilator: Destination protocol must be 'iowarp', got '{}'",
+         dst_protocol);
+    error_code = -1;
+    CLIO_CO_RETURN;
+  }
+
+  // Extract tag name from destination URL
+  std::string tag_name = GetUrlPath(ctx.dst);
+  if (tag_name.empty()) {
+    HLOG(kError,
+         "GcsFileAssimilator: Invalid destination URL, no tag name found");
+    error_code = -2;
+    CLIO_CO_RETURN;
+  }
+
+  // Get or create the tag in CTE
+  auto tag_task = cte_client_->AsyncGetOrCreateTag(tag_name);
+  CLIO_CO_AWAIT(tag_task);
+  clio::cte::core::TagId tag_id = tag_task->tag_id_;
+  if (tag_id.IsNull()) {
+    HLOG(kError, "GcsFileAssimilator: Failed to get or create tag '{}'",
+         tag_name);
+    error_code = -3;
+    CLIO_CO_RETURN;
+  }
+
+  // Dependency-based scheduling is not yet supported (mirrors binary backend).
+  if (!ctx.depends_on.empty()) {
+    HLOG(kDebug,
+         "GcsFileAssimilator: Dependency handling not yet implemented "
+         "(depends_on: {})",
+         ctx.depends_on);
+    error_code = 0;
+    CLIO_CO_RETURN;
+  }
+
+  // Parse the GCS source URL into bucket + object
+  std::string bucket;
+  std::string object;
+  if (!ParseGcsUrl(ctx.src, bucket, object)) {
+    HLOG(kError, "GcsFileAssimilator: Invalid GCS source URL '{}'", ctx.src);
+    error_code = -4;
+    CLIO_CO_RETURN;
+  }
+
+  // Build a GCS client. Credentials default to Application Default
+  // Credentials; an optional GCS_ENDPOINT (e.g. fake-gcs-server) switches to
+  // that endpoint with anonymous credentials.
+  gc::Options options;
+  const char* endpoint_env = std::getenv("GCS_ENDPOINT");
+  if (endpoint_env && *endpoint_env) {
+    options.set<gcs::RestEndpointOption>(endpoint_env);
+    options.set<gc::UnifiedCredentialsOption>(gc::MakeInsecureCredentials());
+  }
+  auto client = gcs::Client(std::move(options));
+
+  // Open the object stream: ranged when range_size>0, otherwise the whole
+  // object (size resolved from object metadata for the description blob).
+  size_t total_size;
+  size_t chunk_offset;
+  gcs::ObjectReadStream stream;
+  if (ctx.range_size > 0) {
+    chunk_offset = ctx.range_off;
+    total_size = ctx.range_size;
+    stream = client.ReadObject(
+        bucket, object,
+        gcs::ReadRange(static_cast<std::int64_t>(ctx.range_off),
+                       static_cast<std::int64_t>(ctx.range_off + ctx.range_size)));
+  } else {
+    auto metadata = client.GetObjectMetadata(bucket, object);
+    if (!metadata) {
+      HLOG(kError, "GcsFileAssimilator: HEAD gs://{}/{} failed: {}", bucket,
+           object, metadata.status().message());
+      error_code = -5;
+      CLIO_CO_RETURN;
+    }
+    total_size = static_cast<size_t>(metadata->size());
+    chunk_offset = 0;
+    stream = client.ReadObject(bucket, object);
+  }
+  if (!stream.status().ok()) {
+    HLOG(kError, "GcsFileAssimilator: ReadObject gs://{}/{} failed: {}", bucket,
+         object, stream.status().message());
+    error_code = -7;
+    CLIO_CO_RETURN;
+  }
+  HLOG(kDebug, "GcsFileAssimilator: gs://{}/{} -> {} bytes (offset {})", bucket,
+       object, total_size, chunk_offset);
+
+  // Store object metadata as the "description" blob (mirrors binary backend).
+  std::string description = "binary<size=" + std::to_string(total_size) +
+                            ", offset=" + std::to_string(chunk_offset) + ">";
+  size_t desc_size = description.size();
+  auto desc_buffer = CLIO_IPC->AllocateBuffer(desc_size);
+  std::memcpy(desc_buffer.ptr_, description.c_str(), desc_size);
+  auto desc_task =
+      cte_client_->AsyncPutBlob(tag_id, "description", 0, desc_size,
+                                desc_buffer.shm_.template Cast<void>(), 1.0f,
+                                clio::cte::core::Context(), 0);
+  CLIO_CO_AWAIT(desc_task);
+  if (desc_task->return_code_ != 0) {
+    HLOG(kError,
+         "GcsFileAssimilator: Failed to store description for tag '{}' (code {})",
+         tag_name, desc_task->return_code_);
+    error_code = -9;
+    CLIO_CO_RETURN;
+  }
+
+  // Stream the object body into CTE in chunks, keeping up to kMaxParallelTasks
+  // PutBlob tasks in flight (identical wait-and-drain shape to binary backend).
+  static constexpr size_t kMaxChunkSize = 1024 * 1024;  // 1 MB
+  static constexpr size_t kMaxParallelTasks = 32;
+  size_t chunk_idx = 0;
+  size_t bytes_processed = 0;
+  std::vector<clio::run::Future<clio::cte::core::PutBlobTask>> active_tasks;
+
+  while (bytes_processed < total_size) {
+    while (active_tasks.size() < kMaxParallelTasks &&
+           bytes_processed < total_size) {
+      size_t current_chunk_size =
+          std::min(kMaxChunkSize, total_size - bytes_processed);
+      auto buffer_ptr = CLIO_IPC->AllocateBuffer(current_chunk_size);
+      char* buffer = buffer_ptr.ptr_;
+
+      stream.read(buffer, current_chunk_size);
+      std::streamsize bytes_read = stream.gcount();
+      if (bytes_read != static_cast<std::streamsize>(current_chunk_size)) {
+        if (stream.eof() && bytes_read > 0) {
+          current_chunk_size = static_cast<size_t>(bytes_read);
+        } else {
+          HLOG(kError,
+               "GcsFileAssimilator: Short read on chunk {} from gs://{}/{} "
+               "(bytes_read={}, eof={}, fail={})",
+               chunk_idx, bucket, object, bytes_read, stream.eof(),
+               stream.fail());
+          CLIO_IPC->FreeBuffer(buffer_ptr);
+          error_code = -9;
+          CLIO_CO_RETURN;
+        }
+      }
+
+      std::string blob_name = "chunk_" + std::to_string(chunk_idx);
+      auto task =
+          cte_client_->AsyncPutBlob(tag_id, blob_name, 0, current_chunk_size,
+                                    buffer_ptr.shm_.template Cast<void>(), 1.0f,
+                                    clio::cte::core::Context(), 0);
+      active_tasks.push_back(task);
+      bytes_processed += current_chunk_size;
+      chunk_idx++;
+    }
+
+    if (!active_tasks.empty()) {
+      auto& first_task = active_tasks.front();
+      CLIO_CO_AWAIT(first_task);
+      if (first_task->return_code_ != 0) {
+        HLOG(kError, "GcsFileAssimilator: PutBlob task failed with code {}",
+             first_task->return_code_);
+        CLIO_IPC->FreeBuffer(first_task->blob_data_.template Cast<char>());
+        error_code = -10;
+        CLIO_CO_RETURN;
+      }
+      CLIO_IPC->FreeBuffer(first_task->blob_data_.template Cast<char>());
+      active_tasks.erase(active_tasks.begin());
+    }
+  }
+
+  // Drain any remaining in-flight tasks.
+  for (auto& task : active_tasks) {
+    CLIO_CO_AWAIT(task);
+    if (task->return_code_ != 0) {
+      HLOG(kError, "GcsFileAssimilator: PutBlob task failed with code {}",
+           task->return_code_);
+      CLIO_IPC->FreeBuffer(task->blob_data_.template Cast<char>());
+      error_code = -10;
+      CLIO_CO_RETURN;
+    }
+    CLIO_IPC->FreeBuffer(task->blob_data_.template Cast<char>());
+  }
+
+  HLOG(kDebug,
+       "GcsFileAssimilator: Imported gs://{}/{} ({} chunks) into tag '{}'",
+       bucket, object, chunk_idx, tag_name);
+  error_code = 0;
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
+std::string GcsFileAssimilator::GetUrlProtocol(const std::string& url) {
+  size_t pos_standard = url.find("://");
+  if (pos_standard != std::string::npos) {
+    return url.substr(0, pos_standard);
+  }
+  size_t pos_custom = url.find("::");
+  if (pos_custom != std::string::npos) {
+    return url.substr(0, pos_custom);
+  }
+  return "";
+}
+
+std::string GcsFileAssimilator::GetUrlPath(const std::string& url) {
+  size_t pos_standard = url.find("://");
+  if (pos_standard != std::string::npos) {
+    return url.substr(pos_standard + 3);
+  }
+  size_t pos_custom = url.find("::");
+  if (pos_custom != std::string::npos) {
+    return url.substr(pos_custom + 2);
+  }
+  return "";
+}
+
+bool GcsFileAssimilator::ParseGcsUrl(const std::string& url, std::string& bucket,
+                                     std::string& object) {
+  // Strip the scheme (`gs://`, `gcs://`, or the `::` forms) -> "bucket/object".
+  std::string path = GetUrlPath(url);
+  if (path.empty()) {
+    return false;
+  }
+  size_t slash = path.find('/');
+  if (slash == std::string::npos || slash == 0 || slash + 1 >= path.size()) {
+    return false;  // need both a bucket and a non-empty object name
+  }
+  bucket = path.substr(0, slash);
+  object = path.substr(slash + 1);
+  return true;
+}
+
+}  // namespace clio::cae::core

--- a/context-assimilation-engine/core/src/factory/s3_file_assimilator.cc
+++ b/context-assimilation-engine/core/src/factory/s3_file_assimilator.cc
@@ -1,0 +1,377 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <clio_runtime/clio_runtime.h>
+#include <clio_cae/core/factory/s3_file_assimilator.h>
+
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <vector>
+
+// Include clio_cte headers after the clio_cae includes to avoid Method
+// namespace collision (same ordering as BinaryFileAssimilator).
+#include <clio_cte/core/core_client.h>
+#include <clio_cte/core/core_tasks.h>
+
+namespace clio::cae::core {
+
+namespace {
+
+// The S3 download is performed by a SEPARATE process (`cae_s3_tool`), never by
+// linking the AWS SDK into this runtime. Loading libaws-cpp-sdk-core.so into the
+// CLIO runtime process corrupts runtime startup (its load-time global ctors /
+// static-baked s2n collide with CLIO's init), so the SDK is fully isolated in the
+// helper and reached via fork+exec — the same approach the Globus assimilator uses
+// to shell out to curl.
+
+/**
+ * Resolve the path/name of the cae_s3_tool helper executable.
+ *
+ * Honors the CAE_S3_TOOL environment override (used by the test harness to point
+ * at the build-tree binary); otherwise returns the bare name, resolved via PATH.
+ *
+ * @return Helper executable path or name.
+ */
+std::string ResolveS3Tool() {
+  const char* override_path = std::getenv("CAE_S3_TOOL");
+  if (override_path && *override_path) {
+    return override_path;
+  }
+  return "cae_s3_tool";
+}
+
+/**
+ * Fork + exec a process and wait for it to finish.
+ *
+ * @param args Full argv (args[0] is the program, resolved via PATH).
+ * @return The child's exit status (0 = success), or -1 if fork/exec failed.
+ */
+int RunProcess(const std::vector<std::string>& args) {
+  pid_t pid = fork();
+  if (pid == -1) {
+    return -1;
+  }
+  if (pid == 0) {
+    std::vector<const char*> argv;
+    argv.reserve(args.size() + 1);
+    for (const auto& a : args) {
+      argv.push_back(a.c_str());
+    }
+    argv.push_back(nullptr);
+    execvp(argv[0], const_cast<char* const*>(argv.data()));
+    _exit(127);  // exec failed
+  }
+  int status = 0;
+  waitpid(pid, &status, 0);
+  if (WIFEXITED(status)) {
+    return WEXITSTATUS(status);
+  }
+  return -1;
+}
+
+/**
+ * Create a unique temporary file and return its path. The file is created empty.
+ *
+ * @param out_path Output: the created temp file path (unchanged on failure).
+ * @return true on success, false if the temp file could not be created.
+ */
+bool MakeTempFile(std::string& out_path) {
+  const char* tmpdir = std::getenv("TMPDIR");
+  std::string tmpl = (tmpdir && *tmpdir) ? tmpdir : "/tmp";
+  tmpl += "/cae_s3_XXXXXX";
+  std::vector<char> buf(tmpl.begin(), tmpl.end());
+  buf.push_back('\0');
+  int fd = mkstemp(buf.data());
+  if (fd == -1) {
+    return false;
+  }
+  close(fd);  // helper reopens by name; keep only the path
+  out_path.assign(buf.data());
+  return true;
+}
+
+}  // namespace
+
+S3FileAssimilator::S3FileAssimilator(
+    std::shared_ptr<clio::cte::core::Client> cte_client)
+    : cte_client_(cte_client) {}
+
+clio::run::TaskResume S3FileAssimilator::Schedule(const AssimilationCtx& ctx,
+                                                  int& error_code) {
+#ifdef __NVCOMPILER
+  thread_local clio::run::RunContext _fb_rctx;
+  clio::run::RunContext* _fp = clio::run::GetCurrentRunContextFromWorker();
+  clio::run::RunContext& rctx = _fp ? *_fp : _fb_rctx;
+#endif
+  CLIO_TASK_BODY_BEGIN
+  HLOG(kDebug,
+       "S3FileAssimilator::Schedule ENTRY: src='{}', dst='{}', range_off={}, "
+       "range_size={}",
+       ctx.src, ctx.dst, ctx.range_off, ctx.range_size);
+
+  // Validate destination protocol
+  std::string dst_protocol = GetUrlProtocol(ctx.dst);
+  if (dst_protocol != "iowarp") {
+    HLOG(kError,
+         "S3FileAssimilator: Destination protocol must be 'iowarp', got '{}'",
+         dst_protocol);
+    error_code = -1;
+    CLIO_CO_RETURN;
+  }
+
+  // Extract tag name from destination URL
+  std::string tag_name = GetUrlPath(ctx.dst);
+  if (tag_name.empty()) {
+    HLOG(kError,
+         "S3FileAssimilator: Invalid destination URL, no tag name found");
+    error_code = -2;
+    CLIO_CO_RETURN;
+  }
+
+  // Get or create the tag in CTE
+  auto tag_task = cte_client_->AsyncGetOrCreateTag(tag_name);
+  CLIO_CO_AWAIT(tag_task);
+  clio::cte::core::TagId tag_id = tag_task->tag_id_;
+  if (tag_id.IsNull()) {
+    HLOG(kError, "S3FileAssimilator: Failed to get or create tag '{}'",
+         tag_name);
+    error_code = -3;
+    CLIO_CO_RETURN;
+  }
+
+  // Dependency-based scheduling is not yet supported (mirrors binary backend).
+  if (!ctx.depends_on.empty()) {
+    HLOG(kDebug,
+         "S3FileAssimilator: Dependency handling not yet implemented "
+         "(depends_on: {})",
+         ctx.depends_on);
+    error_code = 0;
+    CLIO_CO_RETURN;
+  }
+
+  // Parse the S3 source URL into bucket + key
+  std::string bucket;
+  std::string key;
+  if (!ParseS3Url(ctx.src, bucket, key)) {
+    HLOG(kError, "S3FileAssimilator: Invalid S3 source URL '{}'", ctx.src);
+    error_code = -4;
+    CLIO_CO_RETURN;
+  }
+
+  // Download the object to a temp file via the out-of-process cae_s3_tool helper
+  // (the AWS SDK must not be loaded into this runtime process). The helper reads
+  // credentials / region / endpoint from the standard AWS environment.
+  std::string tmp_path;
+  if (!MakeTempFile(tmp_path)) {
+    HLOG(kError, "S3FileAssimilator: Failed to create temp file for download");
+    error_code = -5;
+    CLIO_CO_RETURN;
+  }
+  std::vector<std::string> args = {ResolveS3Tool(), "get", bucket, key,
+                                   tmp_path};
+  if (ctx.range_size > 0) {
+    args.push_back(std::to_string(ctx.range_off));
+    args.push_back(std::to_string(ctx.range_size));
+  }
+  int tool_rc = RunProcess(args);
+  if (tool_rc != 0) {
+    HLOG(kError,
+         "S3FileAssimilator: cae_s3_tool get failed (rc={}) for s3://{}/{}",
+         tool_rc, bucket, key);
+    ::unlink(tmp_path.c_str());
+    error_code = -7;
+    CLIO_CO_RETURN;
+  }
+
+  // Open the downloaded file and stream it into CTE. Unlinking the open file
+  // makes cleanup automatic on every return path below (POSIX: the bytes stay
+  // readable until the stream closes).
+  std::ifstream body(tmp_path, std::ios::binary);
+  ::unlink(tmp_path.c_str());
+  if (!body) {
+    HLOG(kError, "S3FileAssimilator: Failed to open downloaded object '{}'",
+         tmp_path);
+    error_code = -8;
+    CLIO_CO_RETURN;
+  }
+  body.seekg(0, std::ios::end);
+  size_t total_size = static_cast<size_t>(body.tellg());
+  body.seekg(0, std::ios::beg);
+  size_t chunk_offset = (ctx.range_size > 0) ? ctx.range_off : 0;
+  HLOG(kDebug, "S3FileAssimilator: s3://{}/{} -> {} bytes (offset {})", bucket,
+       key, total_size, chunk_offset);
+
+  // Store object metadata as the "description" blob (mirrors binary backend).
+  std::string description = "binary<size=" + std::to_string(total_size) +
+                            ", offset=" + std::to_string(chunk_offset) + ">";
+  size_t desc_size = description.size();
+  auto desc_buffer = CLIO_IPC->AllocateBuffer(desc_size);
+  std::memcpy(desc_buffer.ptr_, description.c_str(), desc_size);
+  auto desc_task =
+      cte_client_->AsyncPutBlob(tag_id, "description", 0, desc_size,
+                                desc_buffer.shm_.template Cast<void>(), 1.0f,
+                                clio::cte::core::Context(), 0);
+  CLIO_CO_AWAIT(desc_task);
+  if (desc_task->return_code_ != 0) {
+    HLOG(kError,
+         "S3FileAssimilator: Failed to store description for tag '{}' (code {})",
+         tag_name, desc_task->return_code_);
+    error_code = -9;
+    CLIO_CO_RETURN;
+  }
+
+  // Stream the object body into CTE in chunks, keeping up to kMaxParallelTasks
+  // PutBlob tasks in flight (identical wait-and-drain shape to binary backend).
+  static constexpr size_t kMaxChunkSize = 1024 * 1024;  // 1 MB
+  static constexpr size_t kMaxParallelTasks = 32;
+  size_t chunk_idx = 0;
+  size_t bytes_processed = 0;
+  std::vector<clio::run::Future<clio::cte::core::PutBlobTask>> active_tasks;
+
+  while (bytes_processed < total_size) {
+    while (active_tasks.size() < kMaxParallelTasks &&
+           bytes_processed < total_size) {
+      size_t current_chunk_size =
+          std::min(kMaxChunkSize, total_size - bytes_processed);
+      auto buffer_ptr = CLIO_IPC->AllocateBuffer(current_chunk_size);
+      char* buffer = buffer_ptr.ptr_;
+
+      body.read(buffer, current_chunk_size);
+      std::streamsize bytes_read = body.gcount();
+      if (bytes_read != static_cast<std::streamsize>(current_chunk_size)) {
+        if (body.eof() && bytes_read > 0) {
+          current_chunk_size = static_cast<size_t>(bytes_read);
+        } else {
+          HLOG(kError,
+               "S3FileAssimilator: Short read on chunk {} from s3://{}/{} "
+               "(bytes_read={}, eof={}, fail={})",
+               chunk_idx, bucket, key, bytes_read, body.eof(), body.fail());
+          CLIO_IPC->FreeBuffer(buffer_ptr);
+          error_code = -9;
+          CLIO_CO_RETURN;
+        }
+      }
+
+      std::string blob_name = "chunk_" + std::to_string(chunk_idx);
+      auto task =
+          cte_client_->AsyncPutBlob(tag_id, blob_name, 0, current_chunk_size,
+                                    buffer_ptr.shm_.template Cast<void>(), 1.0f,
+                                    clio::cte::core::Context(), 0);
+      active_tasks.push_back(task);
+      bytes_processed += current_chunk_size;
+      chunk_idx++;
+    }
+
+    if (!active_tasks.empty()) {
+      auto& first_task = active_tasks.front();
+      CLIO_CO_AWAIT(first_task);
+      if (first_task->return_code_ != 0) {
+        HLOG(kError, "S3FileAssimilator: PutBlob task failed with code {}",
+             first_task->return_code_);
+        CLIO_IPC->FreeBuffer(first_task->blob_data_.template Cast<char>());
+        error_code = -10;
+        CLIO_CO_RETURN;
+      }
+      CLIO_IPC->FreeBuffer(first_task->blob_data_.template Cast<char>());
+      active_tasks.erase(active_tasks.begin());
+    }
+  }
+
+  // Drain any remaining in-flight tasks.
+  for (auto& task : active_tasks) {
+    CLIO_CO_AWAIT(task);
+    if (task->return_code_ != 0) {
+      HLOG(kError, "S3FileAssimilator: PutBlob task failed with code {}",
+           task->return_code_);
+      CLIO_IPC->FreeBuffer(task->blob_data_.template Cast<char>());
+      error_code = -10;
+      CLIO_CO_RETURN;
+    }
+    CLIO_IPC->FreeBuffer(task->blob_data_.template Cast<char>());
+  }
+
+  HLOG(kDebug,
+       "S3FileAssimilator: Imported s3://{}/{} ({} chunks) into tag '{}'",
+       bucket, key, chunk_idx, tag_name);
+  error_code = 0;
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
+std::string S3FileAssimilator::GetUrlProtocol(const std::string& url) {
+  size_t pos_standard = url.find("://");
+  if (pos_standard != std::string::npos) {
+    return url.substr(0, pos_standard);
+  }
+  size_t pos_custom = url.find("::");
+  if (pos_custom != std::string::npos) {
+    return url.substr(0, pos_custom);
+  }
+  return "";
+}
+
+std::string S3FileAssimilator::GetUrlPath(const std::string& url) {
+  size_t pos_standard = url.find("://");
+  if (pos_standard != std::string::npos) {
+    return url.substr(pos_standard + 3);
+  }
+  size_t pos_custom = url.find("::");
+  if (pos_custom != std::string::npos) {
+    return url.substr(pos_custom + 2);
+  }
+  return "";
+}
+
+bool S3FileAssimilator::ParseS3Url(const std::string& url, std::string& bucket,
+                                   std::string& key) {
+  // Strip the scheme (`s3://` or `s3::`) -> "bucket/key".
+  std::string path = GetUrlPath(url);
+  if (path.empty()) {
+    return false;
+  }
+  size_t slash = path.find('/');
+  if (slash == std::string::npos || slash == 0 || slash + 1 >= path.size()) {
+    return false;  // need both a bucket and a non-empty key
+  }
+  bucket = path.substr(0, slash);
+  key = path.substr(slash + 1);
+  return true;
+}
+
+}  // namespace clio::cae::core

--- a/context-assimilation-engine/core/src/factory/tools/s3_tool_main.cc
+++ b/context-assimilation-engine/core/src/factory/tools/s3_tool_main.cc
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * s3_tool_main.cc - Standalone S3 helper executable (`cae_s3_tool`).
+ *
+ * This program is the AWS-SDK side of the CAE S3 importer. It is deliberately a
+ * SEPARATE process from the CLIO runtime: loading libaws-cpp-sdk-core.so into the
+ * CLIO runtime process corrupts runtime startup (the SDK's load-time global
+ * constructors / static-baked s2n collide with CLIO's init), so all AWS SDK calls
+ * are isolated here and invoked via fork+exec from S3FileAssimilator (mirroring the
+ * way the Globus assimilator shells out to curl).
+ *
+ * Subcommands:
+ *   cae_s3_tool get <bucket> <key> <out_path> [range_off] [range_size]
+ *       Download an object (optionally a byte range) to <out_path>.
+ *   cae_s3_tool put <bucket> <key> <in_path>
+ *       Ensure <bucket> exists (best-effort) and upload <in_path> as <key>.
+ *   cae_s3_tool del <bucket> <key>
+ *       Delete an object (best-effort; missing object is not an error).
+ *
+ * Configuration is read from the standard AWS environment:
+ *   AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_SESSION_TOKEN (cred chain),
+ *   AWS_DEFAULT_REGION (default us-east-1),
+ *   S3_ENDPOINT or AWS_ENDPOINT_URL (S3-compatible endpoint -> path-style addressing).
+ *
+ * Exit status: 0 on success, non-zero on failure (with a message on stderr).
+ */
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include <aws/core/Aws.h>
+#include <aws/core/auth/AWSAuthSigner.h>
+#include <aws/core/client/ClientConfiguration.h>
+#include <aws/core/utils/memory/stl/AWSStringStream.h>
+#include <aws/s3/S3Client.h>
+#include <aws/s3/model/CreateBucketRequest.h>
+#include <aws/s3/model/DeleteObjectRequest.h>
+#include <aws/s3/model/GetObjectRequest.h>
+#include <aws/s3/model/PutObjectRequest.h>
+
+namespace {
+
+/**
+ * Build an S3 client from the standard AWS environment.
+ *
+ * Region comes from AWS_DEFAULT_REGION (default "us-east-1"). When S3_ENDPOINT or
+ * AWS_ENDPOINT_URL is set (MinIO and other S3-compatible stores), the endpoint is
+ * overridden and path-style addressing is used. Credentials resolve through the
+ * SDK's default provider chain.
+ *
+ * @return A configured Aws::S3::S3Client.
+ */
+Aws::S3::S3Client MakeS3Client() {
+  Aws::Client::ClientConfiguration cfg;
+  const char* region_env = std::getenv("AWS_DEFAULT_REGION");
+  cfg.region = (region_env && *region_env) ? region_env : "us-east-1";
+
+  const char* endpoint_env = std::getenv("S3_ENDPOINT");
+  if (!endpoint_env || !*endpoint_env) {
+    endpoint_env = std::getenv("AWS_ENDPOINT_URL");
+  }
+  bool use_path_style = false;
+  if (endpoint_env && *endpoint_env) {
+    cfg.endpointOverride = endpoint_env;
+    use_path_style = true;
+  }
+  return Aws::S3::S3Client(
+      cfg, Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never,
+      /*useVirtualAddressing=*/!use_path_style);
+}
+
+/**
+ * Download an object (optionally a byte range) to a local file.
+ *
+ * @param s3 S3 client.
+ * @param bucket Bucket name.
+ * @param key Object key.
+ * @param out_path Destination file path.
+ * @param has_range Whether a byte range was requested.
+ * @param range_off Range start offset (used when has_range is true).
+ * @param range_size Range length in bytes (used when has_range is true).
+ * @return 0 on success, non-zero on failure.
+ */
+int DoGet(Aws::S3::S3Client& s3, const std::string& bucket,
+          const std::string& key, const std::string& out_path, bool has_range,
+          uint64_t range_off, uint64_t range_size) {
+  Aws::S3::Model::GetObjectRequest request;
+  request.SetBucket(Aws::String(bucket.c_str()));
+  request.SetKey(Aws::String(key.c_str()));
+  if (has_range) {
+    std::string range = "bytes=" + std::to_string(range_off) + "-" +
+                        std::to_string(range_off + range_size - 1);
+    request.SetRange(Aws::String(range.c_str()));
+  }
+
+  auto outcome = s3.GetObject(request);
+  if (!outcome.IsSuccess()) {
+    std::cerr << "cae_s3_tool get: GetObject failed for s3://" << bucket << "/"
+              << key << ": " << outcome.GetError().GetMessage() << "\n";
+    return 1;
+  }
+
+  std::ofstream out(out_path, std::ios::binary | std::ios::trunc);
+  if (!out) {
+    std::cerr << "cae_s3_tool get: cannot open output file '" << out_path
+              << "'\n";
+    return 1;
+  }
+  // Stream the body straight to disk (the SDK owns the body stream).
+  out << outcome.GetResult().GetBody().rdbuf();
+  out.flush();
+  if (!out) {
+    std::cerr << "cae_s3_tool get: write failed for '" << out_path << "'\n";
+    return 1;
+  }
+  return 0;
+}
+
+/**
+ * Ensure a bucket exists (best-effort) and upload a local file as an object.
+ *
+ * @param s3 S3 client.
+ * @param bucket Bucket name.
+ * @param key Object key.
+ * @param in_path Source file path.
+ * @return 0 on success, non-zero on failure.
+ */
+int DoPut(Aws::S3::S3Client& s3, const std::string& bucket,
+          const std::string& key, const std::string& in_path) {
+  Aws::S3::Model::CreateBucketRequest create_bucket;
+  create_bucket.SetBucket(Aws::String(bucket.c_str()));
+  s3.CreateBucket(create_bucket);  // best-effort: already-exists is fine
+
+  auto body = Aws::MakeShared<Aws::FStream>(
+      "cae_s3_tool", in_path.c_str(), std::ios::in | std::ios::binary);
+  if (!body || !body->good()) {
+    std::cerr << "cae_s3_tool put: cannot open input file '" << in_path
+              << "'\n";
+    return 1;
+  }
+
+  Aws::S3::Model::PutObjectRequest put;
+  put.SetBucket(Aws::String(bucket.c_str()));
+  put.SetKey(Aws::String(key.c_str()));
+  put.SetBody(body);
+  auto outcome = s3.PutObject(put);
+  if (!outcome.IsSuccess()) {
+    std::cerr << "cae_s3_tool put: PutObject failed for s3://" << bucket << "/"
+              << key << ": " << outcome.GetError().GetMessage() << "\n";
+    return 1;
+  }
+  return 0;
+}
+
+/**
+ * Delete an object (best-effort).
+ *
+ * @param s3 S3 client.
+ * @param bucket Bucket name.
+ * @param key Object key.
+ * @return 0 always (a missing object is not treated as an error).
+ */
+int DoDel(Aws::S3::S3Client& s3, const std::string& bucket,
+          const std::string& key) {
+  Aws::S3::Model::DeleteObjectRequest del;
+  del.SetBucket(Aws::String(bucket.c_str()));
+  del.SetKey(Aws::String(key.c_str()));
+  s3.DeleteObject(del);
+  return 0;
+}
+
+void PrintUsage() {
+  std::cerr
+      << "usage:\n"
+      << "  cae_s3_tool get <bucket> <key> <out_path> [range_off range_size]\n"
+      << "  cae_s3_tool put <bucket> <key> <in_path>\n"
+      << "  cae_s3_tool del <bucket> <key>\n";
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+  if (argc < 2) {
+    PrintUsage();
+    return 2;
+  }
+  const std::string cmd = argv[1];
+
+  Aws::SDKOptions options;
+  Aws::InitAPI(options);
+  int rc = 2;
+  {
+    Aws::S3::S3Client s3 = MakeS3Client();
+    if (cmd == "get" && (argc == 5 || argc == 7)) {
+      bool has_range = (argc == 7);
+      uint64_t off = has_range ? std::strtoull(argv[5], nullptr, 10) : 0;
+      uint64_t size = has_range ? std::strtoull(argv[6], nullptr, 10) : 0;
+      rc = DoGet(s3, argv[2], argv[3], argv[4], has_range, off, size);
+    } else if (cmd == "put" && argc == 5) {
+      rc = DoPut(s3, argv[2], argv[3], argv[4]);
+    } else if (cmd == "del" && argc == 4) {
+      rc = DoDel(s3, argv[2], argv[3]);
+    } else {
+      PrintUsage();
+      rc = 2;
+    }
+  }
+  Aws::ShutdownAPI(options);
+  return rc;
+}

--- a/context-assimilation-engine/test/unit/CMakeLists.txt
+++ b/context-assimilation-engine/test/unit/CMakeLists.txt
@@ -223,6 +223,72 @@ if(HDF5_ENABLED)
 endif()
 
 #------------------------------------------------------------------------------
+# Test: Cloud Assimilator Factory Guard (always on)
+#------------------------------------------------------------------------------
+# Exercises AssimilatorFactory protocol dispatch for s3://, gs://, gcs:// — the
+# loud-fail guard returns nullptr when a backend is compiled out, and a backend
+# when it is compiled in. Touches no cloud service. Links the runtime library
+# (where the factory + backends live) and is told which backends are enabled.
+#------------------------------------------------------------------------------
+add_cae_unit_test(cae_cloud_factory_guard
+  ${CMAKE_CURRENT_SOURCE_DIR}/cloud_factory_guard/test_cloud_factory_guard.cc
+  EXTRA_LIBS clio_cae_core_runtime
+)
+if(CAE_ENABLE_S3)
+  target_compile_definitions(cae_cloud_factory_guard PRIVATE CAE_ENABLE_S3)
+endif()
+if(CAE_ENABLE_GCS)
+  target_compile_definitions(cae_cloud_factory_guard PRIVATE CAE_ENABLE_GCS)
+endif()
+set_tests_properties(cae_cloud_factory_guard PROPERTIES LABELS "cloud;factory;msan_skip")
+
+#------------------------------------------------------------------------------
+# Test: S3 (s3://) Assimilation (Conditional, self-skips without S3_ENDPOINT)
+#------------------------------------------------------------------------------
+# Seeds an object into an S3-compatible store (MinIO) and imports it through
+# ParseOmni, verifying the bytes landed in CTE. Both seeding and the import run
+# the AWS SDK out-of-process via the cae_s3_tool helper, so the test binary links
+# NO AWS SDK (linking it would corrupt CLIO runtime startup). Requires
+# -DCAE_ENABLE_S3=ON; the test self-skips at runtime unless S3_ENDPOINT is set.
+#------------------------------------------------------------------------------
+if(CAE_ENABLE_S3)
+  add_cae_unit_test(cae_s3_assim
+    ${CMAKE_CURRENT_SOURCE_DIR}/s3_assim/test_s3_assim.cc
+  )
+  set_tests_properties(cae_s3_assim PROPERTIES LABELS "cloud;s3;msan_skip")
+  # Build the helper before the test, and point both the test (seeding) and the
+  # in-process assimilator (import) at the build-tree helper binary.
+  add_dependencies(cae_s3_assim cae_s3_tool)
+  set_property(TEST cae_s3_assim APPEND PROPERTY
+    ENVIRONMENT "CAE_S3_TOOL=$<TARGET_FILE:cae_s3_tool>")
+
+  install(FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/s3_assim/s3_assim_omni.yaml
+    DESTINATION share/clio_cae/test/s3_assim
+  )
+endif()
+
+#------------------------------------------------------------------------------
+# Test: GCS (gs://) Assimilation (Conditional, self-skips without GCS_ENDPOINT)
+#------------------------------------------------------------------------------
+# Seeds an object into GCS (fake-gcs-server / real GCS) via google-cloud-cpp,
+# imports it through ParseOmni, and verifies the bytes landed in CTE. Requires
+# -DCAE_ENABLE_GCS=ON; self-skips at runtime unless GCS_ENDPOINT is set.
+#------------------------------------------------------------------------------
+if(CAE_ENABLE_GCS)
+  add_cae_unit_test(cae_gcs_assim
+    ${CMAKE_CURRENT_SOURCE_DIR}/gcs_assim/test_gcs_assim.cc
+    EXTRA_LIBS google-cloud-cpp::storage
+  )
+  set_tests_properties(cae_gcs_assim PROPERTIES LABELS "cloud;gcs;msan_skip")
+
+  install(FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/gcs_assim/gcs_assim_omni.yaml
+    DESTINATION share/clio_cae/test/gcs_assim
+  )
+endif()
+
+#------------------------------------------------------------------------------
 # Test 5: Globus Transfer Integration (Conditional) - REMOVED
 #------------------------------------------------------------------------------
 # Globus integration testing has been moved to integration tests only

--- a/context-assimilation-engine/test/unit/cloud_factory_guard/test_cloud_factory_guard.cc
+++ b/context-assimilation-engine/test/unit/cloud_factory_guard/test_cloud_factory_guard.cc
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * test_cloud_factory_guard.cc - Always-on test of AssimilatorFactory protocol
+ * dispatch for the cloud (s3://, gs://, gcs://) backends.
+ *
+ * This test does NOT touch any cloud service. It only checks the factory's
+ * compile-time guard behaviour:
+ *   - An unsupported protocol returns nullptr.
+ *   - The always-available `file::` protocol returns a backend.
+ *   - `s3://`   returns a backend iff CAE_ENABLE_S3 was compiled in, else nullptr.
+ *   - `gs://` / `gcs://` return a backend iff CAE_ENABLE_GCS was compiled in.
+ *
+ * The factory is built with a null CTE client: the guard/unsupported paths
+ * never dereference it, and the enabled paths only store it in the backend.
+ * The test CMake passes CAE_ENABLE_S3 / CAE_ENABLE_GCS to this target so the
+ * expectations track the build configuration.
+ */
+
+#include <memory>
+#include <string>
+
+#include <clio_ctp/util/logging.h>
+#include <clio_runtime/clio_runtime.h>
+#include <clio_cae/core/factory/assimilator_factory.h>
+
+namespace {
+
+/** Report one expectation; returns 0 on pass, 1 on failure. */
+int Expect(const std::string& label, bool ok) {
+  if (ok) {
+    HLOG(kSuccess, "PASS: {}", label);
+    return 0;
+  }
+  HLOG(kError, "FAIL: {}", label);
+  return 1;
+}
+
+}  // namespace
+
+int main(int /*argc*/, char* /*argv*/[]) {
+  HLOG(kInfo, "========================================");
+  HLOG(kInfo, "Cloud Assimilator Factory Guard Test");
+  HLOG(kInfo, "========================================");
+
+  // The runtime is initialized so logging and worker context are available;
+  // the factory itself is exercised with a null CTE client.
+  if (!clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, true)) {
+    HLOG(kError, "Failed to initialize Clio");
+    return 1;
+  }
+
+  clio::cae::core::AssimilatorFactory factory(
+      std::shared_ptr<clio::cte::core::Client>(nullptr));
+
+  int failures = 0;
+
+  // Unsupported protocol -> nullptr.
+  failures += Expect("unsupported protocol -> nullptr",
+                     factory.Get("frobnicate://bucket/key") == nullptr);
+
+  // Always-available local file backend -> non-null.
+  failures += Expect("file:: -> backend",
+                     factory.Get("file::/tmp/example.bin") != nullptr);
+
+  // S3 dispatch tracks CAE_ENABLE_S3.
+#ifdef CAE_ENABLE_S3
+  failures += Expect("s3:// -> backend (CAE_ENABLE_S3 on)",
+                     factory.Get("s3://bucket/key") != nullptr);
+#else
+  failures += Expect("s3:// -> nullptr (CAE_ENABLE_S3 off)",
+                     factory.Get("s3://bucket/key") == nullptr);
+#endif
+
+  // GCS dispatch tracks CAE_ENABLE_GCS (both gs:// and gcs:// forms).
+#ifdef CAE_ENABLE_GCS
+  failures += Expect("gs:// -> backend (CAE_ENABLE_GCS on)",
+                     factory.Get("gs://bucket/object") != nullptr);
+  failures += Expect("gcs:// -> backend (CAE_ENABLE_GCS on)",
+                     factory.Get("gcs://bucket/object") != nullptr);
+#else
+  failures += Expect("gs:// -> nullptr (CAE_ENABLE_GCS off)",
+                     factory.Get("gs://bucket/object") == nullptr);
+  failures += Expect("gcs:// -> nullptr (CAE_ENABLE_GCS off)",
+                     factory.Get("gcs://bucket/object") == nullptr);
+#endif
+
+  HLOG(kInfo, "========================================");
+  HLOG(kInfo, failures == 0 ? "TEST PASSED" : "TEST FAILED");
+  HLOG(kInfo, "========================================");
+  return failures == 0 ? 0 : 1;
+}

--- a/context-assimilation-engine/test/unit/gcs_assim/gcs_assim_omni.yaml
+++ b/context-assimilation-engine/test/unit/gcs_assim/gcs_assim_omni.yaml
@@ -1,0 +1,14 @@
+name: test_gcs_assim
+
+# Example OMNI transfer importing an object directly from Google Cloud Storage
+# into CTE. Credentials resolve through Google Application Default Credentials
+# (GOOGLE_APPLICATION_CREDENTIALS, gcloud ADC, or the GCE/GKE metadata server);
+# an optional GCS-compatible endpoint (e.g. fake-gcs-server) is set via
+# GCS_ENDPOINT. Both gs:// and gcs:// source schemes are accepted.
+transfers:
+  - src: gs://clio-cae-test/example_object
+    dst: iowarp::test_gcs_assim_tag
+    format: binary
+    depends_on: ""
+    range_off: 0
+    range_size: 0

--- a/context-assimilation-engine/test/unit/gcs_assim/test_gcs_assim.cc
+++ b/context-assimilation-engine/test/unit/gcs_assim/test_gcs_assim.cc
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * test_gcs_assim.cc - End-to-end test for GCS (gs://) assimilation into CTE.
+ *
+ * The test:
+ *   1. Self-skips (exit 0) unless GCS_ENDPOINT is set (so default CI passes
+ *      without a GCS endpoint / fake-gcs-server).
+ *   2. Seeds a known, patterned object into GCS using google-cloud-cpp.
+ *   3. Runs ParseOmni with src="gs://<bucket>/<object>", format="binary".
+ *   4. Verifies the object's bytes landed in CTE (tag size == object size).
+ *   5. Tears down the seeded object.
+ *
+ * Environment:
+ *   GCS_ENDPOINT     GCS-compatible endpoint (e.g. http://127.0.0.1:4443 for
+ *                    fake-gcs-server). REQUIRED — the test self-skips unset.
+ *   GCS_TEST_BUCKET  Bucket to use (default clio-cae-test).
+ *   GCS_PROJECT_ID   Project used only when creating the bucket (default
+ *                    clio-prototype).
+ */
+
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include <unistd.h>
+
+#include <google/cloud/credentials.h>
+#include <google/cloud/options.h>
+#include <google/cloud/storage/client.h>
+#include <google/cloud/storage/options.h>
+
+#include <clio_ctp/introspect/system_info.h>
+#include <clio_ctp/util/logging.h>
+#include <clio_runtime/clio_runtime.h>
+#include <clio_cae/core/core_client.h>
+#include <clio_cae/core/constants.h>
+#include <clio_cae/core/factory/assimilation_ctx.h>
+#include <clio_cte/core/core_client.h>
+
+namespace gcs = google::cloud::storage;
+namespace gc = google::cloud;
+
+namespace {
+
+constexpr size_t kObjectSize = 3 * 1024 * 1024;  // 3 MB -> exercises chunking
+const std::string kTagName = "test_gcs_assim_tag";
+
+/** Build a deterministic, verifiable byte pattern (4-byte block index LE). */
+std::string MakePatternedData(size_t size_bytes) {
+  std::string data(size_bytes, '\0');
+  for (size_t i = 0; i + 4 <= size_bytes; i += 4) {
+    uint32_t value = static_cast<uint32_t>(i / 4);
+    std::memcpy(&data[i], &value, 4);
+  }
+  return data;
+}
+
+}  // namespace
+
+int main(int /*argc*/, char* /*argv*/[]) {
+  HLOG(kInfo, "========================================");
+  HLOG(kInfo, "GCS (gs://) Assimilation Test");
+  HLOG(kInfo, "========================================");
+
+  // Self-skip unless a GCS target is configured. GCS_ENDPOINT selects an
+  // emulator (e.g. fake-gcs-server) with anonymous creds; GCS_TEST_BUCKET (with
+  // GCS_ENDPOINT unset) selects real GCS via Application Default Credentials.
+  const char* endpoint = std::getenv("GCS_ENDPOINT");
+  const char* bucket_env = std::getenv("GCS_TEST_BUCKET");
+  if ((!endpoint || !*endpoint) && (!bucket_env || !*bucket_env)) {
+    HLOG(kInfo,
+         "Neither GCS_ENDPOINT nor GCS_TEST_BUCKET set -> skipping GCS "
+         "assimilation test");
+    return 0;
+  }
+
+  std::string bucket = "clio-cae-test";
+  if (bucket_env && *bucket_env) {
+    bucket = bucket_env;
+  }
+  std::string project = "clio-prototype";
+  if (const char* p = std::getenv("GCS_PROJECT_ID"); p && *p) {
+    project = p;
+  }
+  const std::string object =
+      "cae_gcs_test/obj_" + std::to_string(static_cast<long>(::getpid()));
+  const std::string data = MakePatternedData(kObjectSize);
+
+  // Build a GCS client. Mirror the assimilator's credential logic: an emulator
+  // endpoint (GCS_ENDPOINT) uses that endpoint with anonymous creds, otherwise
+  // fall through to Application Default Credentials for real GCS.
+  gc::Options options;
+  if (endpoint && *endpoint) {
+    options.set<gcs::RestEndpointOption>(endpoint);
+    options.set<gc::UnifiedCredentialsOption>(gc::MakeInsecureCredentials());
+  }
+  auto client = gcs::Client(std::move(options));
+
+  // Ensure the bucket exists (best effort; already-exists is fine).
+  auto made = client.CreateBucketForProject(bucket, project, gcs::BucketMetadata());
+  HLOG(kInfo, "GCS ensure bucket '{}' ({})", bucket,
+       made ? "created" : made.status().message());
+
+  // Seed the object.
+  auto inserted = client.InsertObject(bucket, object, data);
+  if (!inserted) {
+    HLOG(kError, "Failed to seed gs://{}/{}: {}", bucket, object,
+         inserted.status().message());
+    return 1;
+  }
+  HLOG(kSuccess, "Seeded gs://{}/{} ({} bytes)", bucket, object, data.size());
+
+  int exit_code = 0;
+  try {
+    // Bring up CLIO + CTE + CAE.
+    if (!clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, true)) {
+      HLOG(kError, "Failed to initialize Clio");
+      return 1;
+    }
+    clio::cte::core::CLIO_CTE_CLIENT_INIT();
+    CLIO_CAE_CLIENT_INIT();
+
+    clio::cae::core::Client cae_client;
+    clio::cae::core::CreateParams params;
+    auto create_task = cae_client.AsyncCreate(clio::run::PoolQuery::Local(),
+                                              "test_cae_pool",
+                                              clio::cae::core::kCaePoolId,
+                                              params);
+    create_task.Wait();
+
+    // Assimilate the GCS object.
+    clio::cae::core::AssimilationCtx ctx;
+    ctx.src = "gs://" + bucket + "/" + object;
+    ctx.dst = "iowarp::" + kTagName;
+    ctx.format = "binary";
+    std::vector<clio::cae::core::AssimilationCtx> contexts{ctx};
+
+    HLOG(kInfo, "Calling ParseOmni for {}", ctx.src);
+    auto parse_task = cae_client.AsyncParseOmni(contexts);
+    parse_task.Wait();
+    clio::run::u32 result_code = parse_task->GetReturnCode();
+    clio::run::u32 num_scheduled = parse_task->num_tasks_scheduled_;
+    HLOG(kInfo, "ParseOmni result_code={} num_tasks_scheduled={}", result_code,
+         num_scheduled);
+    if (result_code != 0 || num_scheduled == 0) {
+      HLOG(kError, "ParseOmni failed for GCS source");
+      exit_code = 1;
+    }
+
+    // Verify the bytes landed in CTE.
+    auto cte_client = CLIO_CTE_CLIENT;
+    auto tag_task = cte_client->AsyncGetOrCreateTag(kTagName);
+    tag_task.Wait();
+    clio::cte::core::TagId tag_id = tag_task->tag_id_;
+    if (tag_id.IsNull()) {
+      HLOG(kError, "Tag not found in CTE: {}", kTagName);
+      exit_code = 1;
+    } else {
+      auto size_task = cte_client->AsyncGetTagSize(tag_id);
+      size_task.Wait();
+      size_t tag_size = size_task->tag_size_;
+      // The assimilator stores the object bytes plus a "binary<size=N,
+      // offset=0>" description blob (mirrors the binary backend), and CTE's
+      // tag size sums all blobs. Account for that 30-byte (for 3 MB) metadata
+      // blob, matching the S3 test fix (commit 4474b83d). Whole-object import
+      // -> offset=0.
+      std::string description =
+          "binary<size=" + std::to_string(kObjectSize) + ", offset=0>";
+      size_t expected_size = kObjectSize + description.size();
+      HLOG(kInfo, "CTE tag size={} (expected {})", tag_size, expected_size);
+      if (tag_size != expected_size) {
+        HLOG(kError, "Tag size mismatch: got {}, expected {}", tag_size,
+             expected_size);
+        exit_code = 1;
+      } else {
+        HLOG(kSuccess, "GCS object bytes verified in CTE");
+      }
+    }
+  } catch (const std::exception& e) {
+    HLOG(kError, "Exception: {}", e.what());
+    exit_code = 1;
+  }
+
+  // Teardown the seeded object (best effort).
+  client.DeleteObject(bucket, object);
+
+  HLOG(kInfo, "========================================");
+  HLOG(kInfo, exit_code == 0 ? "TEST PASSED" : "TEST FAILED");
+  HLOG(kInfo, "========================================");
+  ctp::SystemInfo::TerminateProcessNow(exit_code);
+  return exit_code;
+}

--- a/context-assimilation-engine/test/unit/s3_assim/s3_assim_omni.yaml
+++ b/context-assimilation-engine/test/unit/s3_assim/s3_assim_omni.yaml
@@ -1,0 +1,14 @@
+name: test_s3_assim
+
+# Example OMNI transfer importing an object directly from Amazon S3 (or any
+# S3-compatible store such as MinIO) into CTE. Credentials, region, and an
+# optional S3-compatible endpoint are resolved from the standard AWS
+# environment (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_SESSION_TOKEN,
+# AWS_DEFAULT_REGION, S3_ENDPOINT or AWS_ENDPOINT_URL).
+transfers:
+  - src: s3://clio-cae-test/example_key
+    dst: iowarp::test_s3_assim_tag
+    format: binary
+    depends_on: ""
+    range_off: 0
+    range_size: 0

--- a/context-assimilation-engine/test/unit/s3_assim/test_s3_assim.cc
+++ b/context-assimilation-engine/test/unit/s3_assim/test_s3_assim.cc
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * test_s3_assim.cc - End-to-end test for S3 (s3://) assimilation into CTE.
+ *
+ * The test:
+ *   1. Self-skips (exit 0) unless S3_ENDPOINT is set (so default CI, which has
+ *      no object store, passes without an endpoint).
+ *   2. Seeds a known, patterned object into the S3-compatible store (MinIO)
+ *      using the out-of-process cae_s3_tool helper (the AWS SDK must NOT be
+ *      linked into this process, which initializes the CLIO runtime).
+ *   3. Runs ParseOmni with src="s3://<bucket>/<key>", format="binary".
+ *   4. Verifies the object's bytes landed in CTE (tag size == object size).
+ *   5. Tears down the seeded object (via cae_s3_tool del).
+ *
+ * Environment:
+ *   S3_ENDPOINT        S3-compatible endpoint (e.g. http://127.0.0.1:9000).
+ *                      REQUIRED — the test self-skips when unset.
+ *   AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY   Credentials (read by the helper).
+ *   AWS_DEFAULT_REGION Region (default us-east-1 for MinIO).
+ *   S3_TEST_BUCKET     Bucket to use (default clio-cae-test).
+ *   CAE_S3_TOOL        Path to the cae_s3_tool helper (set by CTest to the
+ *                      build-tree binary; defaults to "cae_s3_tool" on PATH).
+ */
+
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include <clio_ctp/introspect/system_info.h>
+#include <clio_ctp/util/logging.h>
+#include <clio_runtime/clio_runtime.h>
+#include <clio_cae/core/core_client.h>
+#include <clio_cae/core/constants.h>
+#include <clio_cae/core/factory/assimilation_ctx.h>
+#include <clio_cte/core/core_client.h>
+
+namespace {
+
+constexpr size_t kObjectSize = 3 * 1024 * 1024;  // 3 MB -> exercises chunking
+const std::string kTagName = "test_s3_assim_tag";
+
+/** Build a deterministic, verifiable byte pattern (4-byte block index LE). */
+std::string MakePatternedData(size_t size_bytes) {
+  std::string data(size_bytes, '\0');
+  for (size_t i = 0; i + 4 <= size_bytes; i += 4) {
+    uint32_t value = static_cast<uint32_t>(i / 4);
+    std::memcpy(&data[i], &value, 4);
+  }
+  return data;
+}
+
+/** Resolve the cae_s3_tool helper (CAE_S3_TOOL override, else PATH lookup). */
+std::string ResolveS3Tool() {
+  const char* override_path = std::getenv("CAE_S3_TOOL");
+  if (override_path && *override_path) {
+    return override_path;
+  }
+  return "cae_s3_tool";
+}
+
+/** Fork+exec a process and return its exit status (0 = success, -1 = failure). */
+int RunProcess(const std::vector<std::string>& args) {
+  pid_t pid = fork();
+  if (pid == -1) {
+    return -1;
+  }
+  if (pid == 0) {
+    std::vector<const char*> argv;
+    argv.reserve(args.size() + 1);
+    for (const auto& a : args) {
+      argv.push_back(a.c_str());
+    }
+    argv.push_back(nullptr);
+    execvp(argv[0], const_cast<char* const*>(argv.data()));
+    _exit(127);
+  }
+  int status = 0;
+  waitpid(pid, &status, 0);
+  return WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+}
+
+}  // namespace
+
+int main(int /*argc*/, char* /*argv*/[]) {
+  HLOG(kInfo, "========================================");
+  HLOG(kInfo, "S3 (s3://) Assimilation Test");
+  HLOG(kInfo, "========================================");
+
+  // Self-skip when no S3 endpoint is configured.
+  const char* endpoint = std::getenv("S3_ENDPOINT");
+  if (!endpoint || !*endpoint) {
+    HLOG(kInfo, "S3_ENDPOINT not set -> skipping S3 assimilation test");
+    return 0;
+  }
+
+  std::string bucket = "clio-cae-test";
+  if (const char* b = std::getenv("S3_TEST_BUCKET"); b && *b) {
+    bucket = b;
+  }
+  const std::string key =
+      "cae_s3_test/obj_" + std::to_string(static_cast<long>(::getpid()));
+  const std::string data = MakePatternedData(kObjectSize);
+  const std::string s3_tool = ResolveS3Tool();
+
+  int exit_code = 0;
+
+  // Bring up CLIO + CTE + CAE. The AWS SDK is never linked into this process;
+  // all S3 I/O happens out-of-process via the cae_s3_tool helper, so the runtime
+  // starts cleanly (linking the AWS SDK here corrupts runtime startup).
+  if (!clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, true)) {
+    HLOG(kError, "Failed to initialize Clio");
+    return 1;
+  }
+  clio::cte::core::CLIO_CTE_CLIENT_INIT();
+  CLIO_CAE_CLIENT_INIT();
+  clio::cae::core::Client cae_client;
+  {
+    clio::cae::core::CreateParams params;
+    auto create_task = cae_client.AsyncCreate(clio::run::PoolQuery::Local(),
+                                              "test_cae_pool",
+                                              clio::cae::core::kCaePoolId, params);
+    create_task.Wait();
+  }
+
+  // Seed the object via the helper: write the pattern to a temp file, then
+  // `cae_s3_tool put` it (the helper ensures the bucket exists).
+  std::string seed_path = "/tmp/cae_s3_seed_" +
+                          std::to_string(static_cast<long>(::getpid())) + ".bin";
+  {
+    std::ofstream seed(seed_path, std::ios::binary | std::ios::trunc);
+    seed.write(data.data(), static_cast<std::streamsize>(data.size()));
+    seed.close();
+    if (!seed) {
+      HLOG(kError, "Failed to write seed file '{}'", seed_path);
+      return 1;
+    }
+    int put_rc = RunProcess({s3_tool, "put", bucket, key, seed_path});
+    ::unlink(seed_path.c_str());
+    if (put_rc != 0) {
+      HLOG(kError, "Failed to seed s3://{}/{} via cae_s3_tool (rc={})", bucket,
+           key, put_rc);
+      return 1;
+    }
+    HLOG(kSuccess, "Seeded s3://{}/{} ({} bytes)", bucket, key, data.size());
+  }
+
+  try {
+    // Assimilate the S3 object.
+    clio::cae::core::AssimilationCtx ctx;
+    ctx.src = "s3://" + bucket + "/" + key;
+    ctx.dst = "iowarp::" + kTagName;
+    ctx.format = "binary";
+    std::vector<clio::cae::core::AssimilationCtx> contexts{ctx};
+
+    HLOG(kInfo, "Calling ParseOmni for {}", ctx.src);
+    auto parse_task = cae_client.AsyncParseOmni(contexts);
+    parse_task.Wait();
+    clio::run::u32 result_code = parse_task->GetReturnCode();
+    clio::run::u32 num_scheduled = parse_task->num_tasks_scheduled_;
+    HLOG(kInfo, "ParseOmni result_code={} num_tasks_scheduled={}", result_code,
+         num_scheduled);
+    if (result_code != 0 || num_scheduled == 0) {
+      HLOG(kError, "ParseOmni failed for S3 source");
+      exit_code = 1;
+    }
+
+    // Verify the bytes landed in CTE.
+    auto cte_client = CLIO_CTE_CLIENT;
+    auto tag_task = cte_client->AsyncGetOrCreateTag(kTagName);
+    tag_task.Wait();
+    clio::cte::core::TagId tag_id = tag_task->tag_id_;
+    if (tag_id.IsNull()) {
+      HLOG(kError, "Tag not found in CTE: {}", kTagName);
+      exit_code = 1;
+    } else {
+      auto size_task = cte_client->AsyncGetTagSize(tag_id);
+      size_task.Wait();
+      size_t tag_size = size_task->tag_size_;
+      // The assimilator stores a "description" metadata blob alongside the data
+      // chunks (mirrors BinaryFileAssimilator), so the tag holds the object
+      // bytes PLUS that blob. Reconstruct the exact description string the
+      // assimilator writes (offset 0 for a whole-object, non-range import) to
+      // get its byte count, and expect the tag to equal data + metadata.
+      std::string description =
+          "binary<size=" + std::to_string(kObjectSize) + ", offset=0>";
+      size_t expected_size = kObjectSize + description.size();
+      HLOG(kInfo, "CTE tag size={} (expected {} = {} object + {} description)",
+           tag_size, expected_size, kObjectSize, description.size());
+      if (tag_size != expected_size) {
+        HLOG(kError, "Tag size mismatch: got {}, expected {}", tag_size,
+             expected_size);
+        exit_code = 1;
+      } else {
+        HLOG(kSuccess, "S3 object bytes verified in CTE");
+      }
+    }
+  } catch (const std::exception& e) {
+    HLOG(kError, "Exception: {}", e.what());
+    exit_code = 1;
+  }
+
+  // Teardown the seeded object (best effort).
+  RunProcess({s3_tool, "del", bucket, key});
+
+  HLOG(kInfo, "========================================");
+  HLOG(kInfo, exit_code == 0 ? "TEST PASSED" : "TEST FAILED");
+  HLOG(kInfo, "========================================");
+  ctp::SystemInfo::TerminateProcessNow(exit_code);
+  return exit_code;
+}

--- a/installers/conda/meta.yaml
+++ b/installers/conda/meta.yaml
@@ -42,6 +42,11 @@ requirements:
     - nlohmann_json
     - libcurl
     - libboost-devel  # Boost.Context: optional stackful coroutine backend (#620)
+    # Optional cloud-import SDKs for the CAE assimilator. Uncomment alongside
+    # the matching CMake flag: aws-sdk-cpp for -DCAE_ENABLE_S3=ON (s3://),
+    # google-cloud-cpp for -DCAE_ENABLE_GCS=ON (gs://).
+    # - aws-sdk-cpp
+    # - google-cloud-cpp
   run:
     - python
     - zeromq
@@ -54,6 +59,9 @@ requirements:
     - liburing    # [linux]
     - nlohmann_json
     - libcurl
+    # Optional cloud-import SDKs for the CAE assimilator (see build/host notes).
+    # - aws-sdk-cpp
+    # - google-cloud-cpp
     - pyyaml
     - msgpack-python
     - flask

--- a/installers/spack/packages/google-cloud-cpp/package.py
+++ b/installers/spack/packages/google-cloud-cpp/package.py
@@ -1,0 +1,74 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class GoogleCloudCpp(CMakePackage):
+    """Google Cloud C++ client libraries — IOWarp storage-only overlay.
+
+    This is a deliberately narrow, storage-only build of google-cloud-cpp for
+    the CAE GCS assimilator (``gs://`` / ``gcs://`` import, Issue #626). It
+    shadows the Spack builtin recipe on purpose:
+
+    The builtin declares ``depends_on("grpc")`` unconditionally, which drags in
+    ``grpc`` + a hard-pinned ``re2@2023-09-01``. Both fail to compile against
+    the 2026-era abseil/libstdc++ toolchain on our target systems (missing
+    transitive ``<cstring>``/``<string>``/``<limits>``/``<algorithm>`` includes).
+    The **storage** component is a pure libcurl+REST client — it never links
+    grpc or re2 — so this recipe omits them entirely and builds only storage.
+
+    If you ever need the grpc-based libraries (bigtable, pubsub, spanner, …),
+    use the Spack builtin recipe with per-node force-include flags instead;
+    this overlay intentionally does not support them.
+    """
+
+    homepage = "https://github.com/googleapis/google-cloud-cpp"
+    git = "https://github.com/googleapis/google-cloud-cpp.git"
+
+    maintainers("iowarp")
+
+    license("Apache-2.0")
+
+    # Git-tag versions (no sha256 needed; pin `commit=` when promoting to a
+    # release build). 2.30.0 is the version validated on Ares (spack hash
+    # zjblapm) for the CAE GCS assimilator.
+    version("main", branch="main")
+    version("2.30.0", tag="v2.30.0")
+    version("2.29.0", tag="v2.29.0")
+
+    variant("shared", default=True,
+            description="Build shared libraries (required to link into the "
+                        "CLIO CAE runtime .so: the static archive has a "
+                        "non-PIC thread_local that fails R_X86_64_TPOFF32 "
+                        "relocation into a shared object)")
+    variant("cxxstd", default="17", values=("14", "17", "20"), multi=False,
+            description="C++ standard")
+
+    # Storage-only dependency set: libcurl (HTTPS/REST + OAuth token refresh),
+    # abseil (base/strings/time), google-crc32c (upload/download checksums),
+    # nlohmann-json (REST payloads). protobuf is pulled by the common layer's
+    # build but storage does not link grpc/re2 — those are intentionally absent.
+    depends_on("cmake@3.16:", type="build")
+    depends_on("curl")
+    depends_on("abseil-cpp")
+    depends_on("google-crc32c")
+    depends_on("nlohmann-json")
+    depends_on("protobuf")
+
+    # C++17 is the floor for modern google-cloud-cpp.
+    conflicts("cxxstd=14", when="@2.20.0:")
+
+    def cmake_args(self):
+        return [
+            # Build ONLY the storage component -> its CMake never calls
+            # find_package(gRPC), so grpc/re2 are unnecessary at configure too.
+            self.define("GOOGLE_CLOUD_CPP_ENABLE", "storage"),
+            self.define("BUILD_TESTING", False),
+            self.define("GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES", False),
+            self.define("GOOGLE_CLOUD_CPP_WITH_MOCKS", False),
+            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+            self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
+        ]

--- a/installers/spack/packages/iowarp/package.py
+++ b/installers/spack/packages/iowarp/package.py
@@ -46,6 +46,11 @@ class Iowarp(CMakePackage):
     variant('rocm', default=False, description='Enable ROCm support')
     variant('adios2', default=False, description='Build with ADIOS2 support')
     variant('fuse', default=False, description='Enable FUSE3 adapter (CTE)')
+    variant('s3', default=False,
+            description='Enable Amazon S3 (s3://) import in CAE (aws-sdk-cpp)')
+    variant('gcs', default=False,
+            description='Enable Google Cloud Storage (gs://) import in CAE '
+                        '(google-cloud-cpp storage)')
     variant('boost_coro', default=False,
             description='Use Boost.Context stackful coroutine backend (issue #620)')
 
@@ -76,6 +81,15 @@ class Iowarp(CMakePackage):
     depends_on('adios2', when='+adios2')
     depends_on('libfuse@3:', when='+fuse')
     depends_on('boost+context', when='+boost_coro')
+
+    # CAE cloud import backends (opt-in). aws-sdk-cpp for the S3 assimilator
+    # (find_package(AWSSDK COMPONENTS s3)); the iowarp-overlay storage-only
+    # google-cloud-cpp for the GCS assimilator (find_package(google_cloud_cpp_storage)).
+    depends_on('aws-sdk-cpp', when='+s3')
+    depends_on('google-cloud-cpp', when='+gcs')
+
+    conflicts('+s3', when='~cae', msg='S3 import lives under CAE; enable +cae')
+    conflicts('+gcs', when='~cae', msg='GCS import lives under CAE; enable +cae')
 
     conflicts('+fuse', when='~cte', msg='fuse adapter lives under CTE; enable +cte')
 
@@ -230,6 +244,10 @@ class Iowarp(CMakePackage):
                 args.append(self.define('CAE_ENABLE_CUDA', 'ON'))
             if '+rocm' in self.spec:
                 args.append(self.define('CAE_ENABLE_ROCM', 'ON'))
+            if '+s3' in self.spec:
+                args.append(self.define('CAE_ENABLE_S3', 'ON'))
+            if '+gcs' in self.spec:
+                args.append(self.define('CAE_ENABLE_GCS', 'ON'))
 
         return args
 


### PR DESCRIPTION
Adds Amazon S3 (s3://) and Google Cloud Storage (gs://, gcs://) import backends to the Context Assimilation Engine, so objects from cloud stores assimilate into CTE end-to-end.

Factory & backends
- AssimilatorFactory dispatches s3:// -> S3FileAssimilator and gs://|gcs:// -> GcsFileAssimilator; a clear "not compiled in, rebuild with -DCAE_ENABLE_S3/GCS=ON" error otherwise.
- S3 backend runs the AWS SDK out-of-process via a cae_s3_tool helper (get/put/del) because linking aws-sdk-cpp into the runtime stack-smashes init; GCS's google-cloud-cpp (abseil/curl) is benign and runs in-process.
- Credentials resolve from the standard environment: S3 via AWS_* (+ region and an overridable S3_ENDPOINT/AWS_ENDPOINT_URL for MinIO); GCS via Application Default Credentials, with an optional GCS_ENDPOINT for fake-gcs-server.

Build
- CAE_ENABLE_S3 / CAE_ENABLE_GCS options (OFF by default); when ON but the SDK is absent, configure warns and self-disables rather than failing.
- A storage-only google-cloud-cpp spack overlay package (no grpc/re2, which fail against the 2026 abseil/libstdc++ toolchain) and +s3/+gcs variants on the iowarp package so `spack install iowarp +gcs +s3` builds it all.

Tests
- cae_s3_assim / cae_gcs_assim import a patterned object from each store and assert the bytes land in CTE with the correct tag size (object + the binary<size=N,offset=0> description blob). A cae_cloud_factory_guard checks the SDK-linked runtime inits cleanly. Validated on Ares against real AWS S3 and real GCS (ADC).

Docs + installers
- INSTALL.md, CAE README, conda meta.yaml, spack overlay, and an Ares provisioning runbook updated for the new dependencies.