### PR TITLE
Label autogen dispatch tests `cae`: CAE autogen coverage 2.1% -> 93%

### DIFF
--- a/context-runtime/test/unit/CMakeLists.txt
+++ b/context-runtime/test/unit/CMakeLists.txt
@@ -705,10 +705,16 @@ if(CLIO_CORE_ENABLE_TESTS)
     COMMAND ${AUTOGEN_COVERAGE_TEST_TARGET}
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
   )
+  # "cae": this per-method battery exercises the CAE autogen lib_exec dispatch
+  # arms for the custom task types (ParseOmni/ProcessHdf5Dataset) that the
+  # sweep can't construct generically. Together with cr_autogen_sweep_tests it
+  # lifts context-assimilation-engine/.../autogen/core_lib_exec.cc to ~93% in
+  # the single-node CAE coverage phase (was ~2% — those serialize/copy arms
+  # otherwise only run when a task crosses the network).
   set_tests_properties(cr_autogen_coverage_tests PROPERTIES
     ENVIRONMENT "CLIO_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CLIO_BIND_ADDR=127.0.0.1;CLIO_PORT=10500"
     TIMEOUT 300
-    LABELS "msan_skip"
+    LABELS "cae;msan_skip"
   )
   endif()  # CLIO_CORE_ENABLE_CAE
 

--- a/context-runtime/test/unit/autogen_more/CMakeLists.txt
+++ b/context-runtime/test/unit/autogen_more/CMakeLists.txt
@@ -49,10 +49,16 @@ if(CLIO_CORE_ENABLE_TESTS)
     COMMAND ${AUTOGEN_SWEEP_TEST_TARGET}
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
   )
+  # "cae": this sweep is the ONLY test that exercises the CAE (and CTE) autogen
+  # lib_exec Save/Load/LocalSave/LocalLoad/NewCopy/Aggregate dispatch in-process
+  # — those arms only otherwise run when a task crosses the network, so the
+  # single-node CAE coverage phase (`ctest -L cae`, clean build) left
+  # context-assimilation-engine/.../autogen/core_lib_exec.cc at ~2%. Labeling
+  # it "cae" makes the CAE phase run it, lifting that file to ~90%+.
   set_tests_properties(cr_autogen_sweep_tests PROPERTIES
     ENVIRONMENT "CLIO_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CLIO_BIND_ADDR=127.0.0.1;CLIO_PORT=10597"
     TIMEOUT 120
-    LABELS "msan_skip"
+    LABELS "cae;msan_skip"
   )
 endif()
 


### PR DESCRIPTION
Closes #691.

## Problem

CDash build [3714480](https://my.cdash.org/builds/3714480/coverage) (CAE coverage phase) reports **2.1%** for `context-assimilation-engine/core/src/autogen/core_lib_exec.cc` (8/386 lines).

## Root cause

The CAE phase runs only `ctest -L cae`. The autogen `lib_exec` serialize/copy dispatch arms (`SaveTask`/`LoadTask`/`LocalSaveTask`/`LocalLoadTask`/`NewCopyStart`/`AggregateOut`) only execute when a task crosses the network; a single-node run only fires `Run()`. The two tests that drive that dispatch in-process — `cr_autogen_sweep_tests` and `cr_autogen_coverage_tests` — carried only the `msan_skip` label, so the CAE phase skipped them.

## Change

Add `cae` to the `LABELS` of both tests (kept alongside `msan_skip`). Both are already gated on `CLIO_CORE_ENABLE_CAE`. No source or test-logic changes — labels only.

- `context-runtime/test/unit/autogen_more/CMakeLists.txt` — `cr_autogen_sweep_tests`
- `context-runtime/test/unit/CMakeLists.txt` — `cr_autogen_coverage_tests`

## Result (fresh, zero-counter `ctest -L cae`, matches the CI CAE phase)

| Metric | Before | After |
| --- | --- | --- |
| `core_lib_exec.cc` | 8/386 = 2.1% | 359/386 = **93.0%** |
| CAE component total | — | 771/810 = **95.19%** |

All 36 cae-labeled tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)