### PR TITLE
fix(ctp): use explicit ANSI Win32 APIs for Windows 11 UNICODE builds

### DIFF
--- a/context-transport-primitives/src/system_info.cc
+++ b/context-transport-primitives/src/system_info.cc
@@ -554,12 +554,12 @@ bool SystemInfo::CreateNewSharedMemory(File &fd, const std::string &name,
   // not be reopened by name, breaking every OpenSharedMemory.
   std::string win_name = WinShmName(name);
   fd.windows_fd_ =
-      CreateFileMapping(INVALID_HANDLE_VALUE,    // use paging file
-                        nullptr,                 // default security
-                        PAGE_READWRITE,          // read/write access
-                        0,           // maximum object size (high-order DWORD)
-                        static_cast<DWORD>(size),  // low-order DWORD
-                        win_name.c_str());         // mapping object name
+      CreateFileMappingA(INVALID_HANDLE_VALUE,   // use paging file
+                         nullptr,                // default security
+                         PAGE_READWRITE,         // read/write access
+                         0,          // maximum object size (high-order DWORD)
+                         static_cast<DWORD>(size),  // low-order DWORD
+                         win_name.c_str());         // mapping object name
   return fd.windows_fd_ != nullptr;
 #endif
 }
@@ -580,7 +580,7 @@ bool SystemInfo::OpenSharedMemory(File &fd, const std::string &name) {
 #elif CTP_ENABLE_WINDOWS_SYSINFO
   std::string win_name = WinShmName(name);
   fd.windows_fd_ =
-      OpenFileMapping(FILE_MAP_ALL_ACCESS, FALSE, win_name.c_str());
+      OpenFileMappingA(FILE_MAP_ALL_ACCESS, FALSE, win_name.c_str());
   return fd.windows_fd_ != nullptr;
 #endif
 }
@@ -656,10 +656,10 @@ void *SystemInfo::MapSharedMemory(const File &fd, size_t size, i64 off) {
   if (ret == nullptr) {
     DWORD error = GetLastError();
     LPVOID msg_buf;
-    FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
-                      FORMAT_MESSAGE_IGNORE_INSERTS,
-                  NULL, error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-                  (LPTSTR)&msg_buf, 0, NULL);
+    FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+                       FORMAT_MESSAGE_IGNORE_INSERTS,
+                   NULL, error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                   (LPSTR)&msg_buf, 0, NULL);
     printf("MapViewOfFile failed with error: %s\n", (char *)msg_buf);
     LocalFree(msg_buf);
   }
@@ -1060,8 +1060,8 @@ std::string SystemInfo::Getenv(const char *name, size_t max_size) {
 #elif CTP_ENABLE_WINDOWS_SYSINFO
   std::string var;
   var.resize(max_size);
-  DWORD len = GetEnvironmentVariable(name, var.data(),
-                                     static_cast<DWORD>(var.size()));
+  DWORD len = GetEnvironmentVariableA(name, var.data(),
+                                      static_cast<DWORD>(var.size()));
   if (len == 0) {
     return "";
   }


### PR DESCRIPTION
## Summary

Fixes the Windows 11 build failure in `context-transport-primitives/src/system_info.cc` when the toolchain defines `UNICODE`/`_UNICODE`.

The macro-dispatched Win32 APIs (`CreateFileMapping`, `OpenFileMapping`, `FormatMessage`, `GetEnvironmentVariable`) resolve to their wide-character `W` variants under `UNICODE`, which fails to compile against the narrow `const char *` strings used in this file. This PR calls the explicit ANSI variants instead:

- `CreateFileMapping` → `CreateFileMappingA` (in `CreateNewSharedMemory`)
- `OpenFileMapping` → `OpenFileMappingA` (in `OpenSharedMemory`)
- `FormatMessage` → `FormatMessageA`, `LPTSTR` → `LPSTR` (in `MapSharedMemory` error path)
- `GetEnvironmentVariable` → `GetEnvironmentVariableA` (in `Getenv`)

No behavior change on non-Windows platforms or on Windows builds without `UNICODE` — the macros already resolved to the `A` variants there.

Fixes #701

## Test plan

- Build on Windows 11 (10.0.22621) with `UNICODE` defined — compiles cleanly
- Existing shared-memory tests cover the touched code paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)