### PR TITLE
fix(ci): windows-adapters applocal race + upload filesystem (CFS) coverage

### DIFF
--- a/.github/workflows/ci-adapters.yml
+++ b/.github/workflows/ci-adapters.yml
@@ -218,12 +218,22 @@ jobs:
           git pull
           .\bootstrap-vcpkg.bat
       - name: Configure CMake (hdf5_vol + WinFsp fuse)
+        # X_VCPKG_APPLOCAL_DEPS_SERIALIZED=ON serializes vcpkg's per-target
+        # post-build "z-applocal" DLL deployment. With HDF5_VOL=ON this job
+        # links hdf5/szip/zd/zmq + the clio runtime DLLs into many parallel
+        # test-exe targets, and under `-j` two targets would occasionally copy
+        # the SAME shared DLL into build/bin/ at once -> intermittent
+        # `error MSB3073: vcpkg z-applocal ... exited with code 32`
+        # (ERROR_SHARING_VIOLATION). Serializing the applocal step removes the
+        # race. ci-windows.yml doesn't hit this because it builds HDF5_VOL=OFF
+        # (far fewer shared DLLs). See issue: flaky windows-adapters build.
         run: |
           cmake -B build -A x64 `
             -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
             -DVCPKG_TARGET_TRIPLET="x64-windows" `
             -DVCPKG_MANIFEST_DIR="${{ github.workspace }}/installers/vcpkg" `
             -DVCPKG_OVERLAY_PORTS="${{ github.workspace }}/installers/vcpkg/overlay-ports" `
+            -DX_VCPKG_APPLOCAL_DEPS_SERIALIZED=ON `
             -DCMAKE_BUILD_TYPE=Debug `
             -DSITE="windows-2025" `
             -DBUILDNAME="adapters/msvc/x64/d" `


### PR DESCRIPTION
## Problem

The **CI Adapters / `adapters (windows, hdf5_vol + winfsp)`** job fails intermittently at build time with:

```
error MSB3073: C:\vcpkg\vcpkg.exe z-applocal --target-binary=.../<test>.exe ... exited with code 32
```

Exit code **32 = `ERROR_SHARING_VIOLATION`** ("file in use by another process").

## Root cause

vcpkg attaches a per-target post-build `z-applocal` step that copies each executable's dependent DLLs next to it in `build/bin/`. This job configures `CLIO_CTE_ENABLE_HDF5_VOL=ON`, pulling in `hdf5.dll` / `szip.dll` / `zd.dll` (plus zmq + the clio runtime DLLs) that are shared across **many** parallel test-exe targets. Under `-j`, two targets occasionally copy the **same** shared DLL into `build/bin/` at the same instant — one wins, the other hits a sharing violation and fails the whole build.

Evidence this is a nondeterministic race, not a code defect:
- Failing runs [28950420456](https://github.com/iowarp/core/actions/runs/28950420456) and [28911511141](https://github.com/iowarp/core/actions/runs/28911511141) fail on **different** targets (`clio_run_recovery_tests`, `test_bdev_leak_stress`).
- The vast majority of runs (incl. dev pushes) pass with identical source.
- The mainline `ci-windows.yml` job never hits this — it builds `HDF5_VOL=OFF`, so far fewer shared DLLs collide.

## Fix

Pass `-DX_VCPKG_APPLOCAL_DEPS_SERIALIZED=ON` to the windows-adapters CMake configure. This makes vcpkg serialize the applocal post-build deployment across targets, so no two targets copy the same DLL concurrently. Small, CI-only change; no product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)