### PR TITLE
fix(ci): upload filesystem (CFS) coverage from the fuse phase

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -70,7 +70,14 @@ jobs:
             # Skip the live-mount suites (real FUSE mount needs /dev/fuse +
             # privileges); those run in ci-adapters' mount-smoke step for now.
             exclude_labels: "docker|copy_workspace|integration"
-            extract: "*/context-transfer-engine/adapter/*"
+            # Scope to BOTH the adapter tree and the filesystem (CFS) tree: the
+            # FUSE adapter (fuse_cte.cc / cfs_io.h) sits on top of the CFS
+            # filesystem client+runtime and the fuse|adapter unit tests exercise
+            # it, so its coverage must be uploaded too. Extracting adapter/*
+            # alone silently dropped context-transfer-engine/filesystem/**,
+            # making filesystem_client/runtime/tasks read 0% on Codecov even
+            # though the fuse phase runs them.
+            extract: "*/context-transfer-engine/adapter/* */context-transfer-engine/filesystem/*"
           # Context Assimilation Engine
           - phase: cae
             arch: amd64

--- a/codecov.yml
+++ b/codecov.yml
@@ -34,6 +34,9 @@ component_management:
     - component_id: fuse
       name: FUSE adapter
       paths: ["context-transfer-engine/adapter/**"]
+    - component_id: filesystem
+      name: Context Filesystem (CFS)
+      paths: ["context-transfer-engine/filesystem/**"]
     - component_id: cae
       name: Context Assimilation Engine
       paths: ["context-assimilation-engine/**"]


### PR DESCRIPTION
## Problem

The dev→main sync report ([#707](https://github.com/iowarp/clio-core/pull/707)) shows `context-transfer-engine/filesystem/**` at **0%** coverage — `filesystem_client.{h,cc}`, `filesystem_runtime.cc`, `filesystem_tasks.h` — even though the **fuse** build-and-test phase exercises them.

## Root cause — a coverage *upload* bug, not missing tests

The `fuse` phase (`ci-linux.yml`) builds `-DCLIO_CTE_ENABLE_FILESYSTEM=ON` and runs the `fuse|adapter` unit tests (`test_fuse_adapter.cc`). The FUSE adapter is layered directly on the CFS filesystem client+runtime — both `context-transfer-engine/adapter/libfuse/fuse_cte.cc` and `adapter/cfs/cfs_io.h` `#include "clio_cte/filesystem/filesystem_client.h"` — so those tests genuinely execute the filesystem code.

But `calculate_coverage.sh` scopes each phase's upload with `lcov --extract $PHASE_EXTRACT_PATHS`, and the fuse phase set that to `*/context-transfer-engine/adapter/*` **only**. The CFS lives at `context-transfer-engine/filesystem/` — a *sibling* of `adapter/`, not under it — so every executed filesystem line was extracted away before the Codecov upload. Result: 0%.

## Fix (CI-only, no product code)

- **`ci-linux.yml`**: add `*/context-transfer-engine/filesystem/*` to the fuse phase's `extract` paths, so the executed CFS coverage uploads under the existing `fuse` flag.
- **`codecov.yml`**: add a `filesystem` component (Context Filesystem (CFS), `context-transfer-engine/filesystem/**`) so the tree is tracked as its own area.

## Note

The previously-merged #708 (windows-adapters applocal race fix) came from this same branch; that commit is already in `dev`, so this PR's diff is just the two files above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)