### PR TITLE
[CI baseline probe — DO NOT MERGE] trivial no-op on dev

### DIFF
--- a/_ci_baseline_probe.md
+++ b/_ci_baseline_probe.md
@@ -1,0 +1,5 @@
+CI baseline probe for iowarp/clio-core dev.
+
+Throwaway branch to run the full CI on a near-pristine dev, to check whether
+the adapters job is green on dev independent of the feat/hdf5-vol PR (#699).
+Do not merge.


### PR DESCRIPTION
Throwaway PR to run the full CI pipeline (esp. the **adapters** job) against a near-pristine `dev`.

Purpose: isolate whether the `adapters` failure seen on #699 (`cte_hdf5_vol_compat_suite` → `clio_run did not become ready`) is tied to that PR's VOL changes or is a pre-existing/environmental issue on `dev`. `dev` does not contain the compat suite, so this run exercises the VOL build + in-process VOL I/O tests only.

**Do not merge** — will be closed once CI results are captured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)