### PR TITLE
feat(#526): reproducible Apptainer-containerized Jarvis regression pipelines

### DIFF
--- a/installers/spack/packages/iowarp/package.py
+++ b/installers/spack/packages/iowarp/package.py
@@ -17,6 +17,11 @@ class Iowarp(CMakePackage):
     # Branch versions
     version('main', branch='main', submodules=True, preferred=True)
     version('dev', branch='dev', submodules=True)
+    # #526 regression fork branch. Uses a per-version git override so `main`/
+    # `dev` keep resolving to upstream while `iowarp@526` builds THIS fork's
+    # branch under test (it is pushed to origin). Used by the regression image.
+    version('526', branch='jarvis-pipelines-526', submodules=True,
+            git='https://github.com/eDoggo3779/clio-core-fork.git')
 
     # Build variants
     variant('debug', default=False, description='Build in Debug mode')
@@ -46,6 +51,9 @@ class Iowarp(CMakePackage):
     variant('rocm', default=False, description='Enable ROCm support')
     variant('adios2', default=False, description='Build with ADIOS2 support')
     variant('fuse', default=False, description='Enable FUSE3 adapter (CTE)')
+    variant('redis', default=False,
+            description='Build the Redis comparison benchmark '
+                        '(clio_redis_bench); requires hiredis')
     variant('boost_coro', default=False,
             description='Use Boost.Context stackful coroutine backend (issue #620)')
 
@@ -75,6 +83,7 @@ class Iowarp(CMakePackage):
     depends_on('hdf5', when='+hdf5')
     depends_on('adios2', when='+adios2')
     depends_on('libfuse@3:', when='+fuse')
+    depends_on('hiredis', when='+redis')
     depends_on('boost+context', when='+boost_coro')
 
     conflicts('+fuse', when='~cte', msg='fuse adapter lives under CTE; enable +cte')
@@ -219,6 +228,10 @@ class Iowarp(CMakePackage):
                 args.append(self.define('CTE_ENABLE_ROCM', 'ON'))
             if '+fuse' in self.spec:
                 args.append(self.define('CLIO_CTE_ENABLE_FUSE_ADAPTER', 'ON'))
+            if '+redis' in self.spec:
+                # Builds clio_redis_bench (the apples-to-apples redis peer of
+                # clio_cte_bench) — the #526 single_node redis experiment.
+                args.append(self.define('CLIO_CORE_ENABLE_REDIS', 'ON'))
 
         # Context-assimilation-engine (CAE) options (if enabled)
         if '+cae' in self.spec:

--- a/jarvis_clio_core/jarvis_clio_core/clio_cte/pkg.py
+++ b/jarvis_clio_core/jarvis_clio_core/clio_cte/pkg.py
@@ -8,6 +8,7 @@ from jarvis_cd.core.pkg import Service
 from jarvis_cd.util import SizeType
 from jarvis_cd.shell.process import Rm, Mkdir
 from jarvis_cd.shell import PsshExecInfo, Exec
+from jarvis_clio_core.container_utils import container_kwargs
 import yaml
 import os
 import re
@@ -166,6 +167,12 @@ class ClioCte(Service):
             parent_dir = os.path.dirname(path)
             if not parent_dir:
                 continue
+            # NOTE: configure runs BEFORE the pipeline's container instance
+            # starts, so this Mkdir cannot be container-wrapped. It is fine
+            # for host-visible paths ($HOME, shared storage); a file device
+            # under /tmp (remapped in-container via tmp_bind_root) would need
+            # its dir created at start() time instead. Both #526 pipelines
+            # use ram:: tiers only, so this loop is a no-op there.
             Mkdir(parent_dir,
                   PsshExecInfo(env=self.mod_env, hostfile=self.hostfile)).run()
 
@@ -226,10 +233,9 @@ class ClioCte(Service):
         Exec(cmd, PsshExecInfo(
             env=self.mod_env,
             hostfile=self.hostfile,
-            container=getattr(self, '_container_engine', 'none'),
-            container_image=self.deploy_image_name(),
             private_dir=self.private_dir,
             bind_mounts=self.container_mounts,
+            **container_kwargs(self),
         )).run()
 
         self.log("CTE started successfully")
@@ -255,10 +261,15 @@ class ClioCte(Service):
             if path.startswith('ram::'):
                 continue
             try:
-                Rm(path, PsshExecInfo(hostfile=self.hostfile)).run()
+                # Wrapped: file devices may live under /tmp, which the
+                # container remaps via tmp_bind_root. Best-effort no-op if
+                # the instance is already down.
+                Rm(path, PsshExecInfo(hostfile=self.hostfile,
+                                      **container_kwargs(self))).run()
                 parent_dir = os.path.dirname(path)
                 if parent_dir:
-                    Rm(parent_dir, PsshExecInfo(hostfile=self.hostfile)).run()
+                    Rm(parent_dir, PsshExecInfo(hostfile=self.hostfile,
+                                                **container_kwargs(self))).run()
             except Exception as e:
                 self.log(f"Error cleaning {path}: {e}")
 

--- a/jarvis_clio_core/jarvis_clio_core/clio_cte_bench/pkg.py
+++ b/jarvis_clio_core/jarvis_clio_core/clio_cte_bench/pkg.py
@@ -1,5 +1,7 @@
 from jarvis_cd.core.pkg import Application
 from jarvis_cd.shell import Exec, PsshExecInfo, LocalExecInfo
+from jarvis_clio_core.container_utils import container_kwargs
+import glob
 import os
 import re
 
@@ -17,6 +19,22 @@ class ClioCteBench(Application):
 
     It supports async operation depth configuration for testing concurrent I/O.
     """
+
+    # How each metric folds when more than one rank/host reports (multi-node,
+    # nprocs>1 with ppn=1 -> one bench rank per host). Mirrors mofka_bench so
+    # the CTE and Mofka multi-node CSVs aggregate the same way:
+    #   _FOLD_SUM  cumulative system totals  -> SUM across hosts (true 2n agg)
+    #   _FOLD_MAX  wall-clock                 -> MAX (run ends with slowest host)
+    #   everything else (per-thread/latency descriptive stats) -> mean.
+    _FOLD_SUM = {
+        'agg_bw_mbps',
+        'agg_ops_per_sec',
+        'total_data_mb',
+        'total_ops',
+    }
+    _FOLD_MAX = {
+        'time_max_us',
+    }
 
     def _init(self):
         """
@@ -128,6 +146,18 @@ class ClioCteBench(Application):
                         'PoolQuery::DirectHash(0) -- explicit non-Local '
                         'routing to node 0, useful for measuring '
                         'cross-node CTE paths.'
+            },
+            {
+                'name': 'bin_dir',
+                'msg': 'Directory holding clio_cte_bench (absolute). Empty = '
+                       'resolve via PATH.',
+                'type': str,
+                'default': '',
+                'help': 'For the apptainer deploy set this to the SIF spack-view '
+                        'bin (/opt/iowarp-view/bin): jarvis runs the bench in a '
+                        'shell whose PATH does NOT include the view bin, so the '
+                        'bare name is "command not found". An ABSOLUTE path needs '
+                        'no PATH lookup. Empty (bare-metal) uses PATH as before.',
             }
         ]
 
@@ -204,12 +234,20 @@ class ClioCteBench(Application):
         """
         self.log(f"Starting CTE benchmark: {self.config['test_case']}")
 
+        # Resolve the executable. In the apptainer deploy bin_dir is the SIF
+        # spack-view bin (/opt/iowarp-view/bin); an ABSOLUTE path sidesteps the
+        # fact that jarvis's exec shell PATH omits the view bin (bare name ->
+        # "command not found"). Empty bin_dir (bare-metal) keeps the bare name.
+        bin_dir = str(self.config.get('bin_dir', '') or '')
+        exe = os.path.join(bin_dir, self.benchmark_executable) if bin_dir \
+            else self.benchmark_executable
+
         # Semantic-flag CLI (bench_common.h). Use --time-limit when set,
         # otherwise --io-count. (The binary still accepts the legacy
         # positional form, but flags make time_limit/max_total_blobs
         # possible.)
         cmd = [
-            self.benchmark_executable,
+            exe,
             '--op', str(self.config['test_case']),
             '--threads', str(self.config['num_threads']),
             '--depth', str(self.config['depth']),
@@ -227,28 +265,38 @@ class ClioCteBench(Application):
         output_path = os.path.join(self.shared_dir, 'bench_output.txt')
 
         if self.config['nprocs'] > 1:
-            # Multi-rank: redirect in the shell so every rank's output lands
-            # in the shared file (shared_dir is on a shared FS on Ares).
+            # Multi-rank / multi-node: with ppn=1 each host runs one bench rank.
+            # Redirect each rank to a PER-HOST file (bench_output.txt.<hostname>)
+            # so concurrent ranks never clobber one shared file on the NFS
+            # shared_dir; _get_stat globs + folds them. container_kwargs routes
+            # the command into the run's apptainer instance (jarvis only wraps
+            # when exec_info.container is set; nothing wraps automatically).
+            # The command stays RAW — the whole string, redirect included,
+            # lands inside the wrap's `bash -c '...'`, so `$(hostname)`
+            # expands per-host in-container.
             self.log(
                 f"Running benchmark via Pssh: {self.config['nprocs']} procs, "
-                f"{self.config['ppn']} per node"
+                f"{self.config['ppn']} per node (per-host output capture)"
             )
             exec_info = PsshExecInfo(
                 env=self.mod_env,
                 hostfile=self.hostfile,
                 nprocs=self.config['nprocs'],
                 ppn=self.config['ppn'],
+                **container_kwargs(self),
             )
-            cmd_str += f' > {output_path} 2>&1'
+            cmd_str = f'{cmd_str} > {output_path}.$(hostname) 2>&1'
         else:
-            # Single-rank: pipe both streams to the file via LocalExecInfo
-            # (matches the proven archived capture path; HLOG -> stderr).
+            # Single-rank: container_kwargs routes the command into the run's
+            # apptainer instance, where the SIF's clio_cte_bench exists and
+            # shares the runtime's namespaces. Keep the command RAW — redirect
+            # and all — so it rides inside the wrap's `bash -c '...'`. exe is
+            # the absolute view-bin path (bin_dir); output_path is on the
+            # auto-mounted shared_dir.
             self.log("Running benchmark locally (single rank)")
-            exec_info = LocalExecInfo(
-                env=self.mod_env,
-                pipe_stdout=output_path,
-                pipe_stderr=output_path,
-            )
+            exec_info = PsshExecInfo(env=self.mod_env, hostfile=self.hostfile,
+                                     **container_kwargs(self))
+            cmd_str = f'{cmd_str} > {output_path} 2>&1'
 
         self.log(f"Executing: {cmd_str}")
         Exec(cmd_str, exec_info).run()
@@ -270,8 +318,10 @@ class ClioCteBench(Application):
         """
         self.log("Cleaning up CTE benchmark output files...")
 
-        # The canonical results file parsed by _get_stat.
-        paths = [os.path.join(self.shared_dir, 'bench_output.txt')]
+        # The canonical results file parsed by _get_stat, plus any per-host
+        # siblings (bench_output.txt.<hostname>) written in multi-node mode.
+        canonical = os.path.join(self.shared_dir, 'bench_output.txt')
+        paths = [canonical] + glob.glob(canonical + '.*')
         # Plus the optional user-facing copy, if one was configured.
         if self.output_file:
             paths.append(self.output_file)
@@ -290,37 +340,88 @@ class ClioCteBench(Application):
     # Statistics collection
     # ------------------------------------------------------------------
 
+    def _fold_host_stats(self, per_host_stats, stat_dict):
+        """
+        Aggregate per-host stat dicts into ``stat_dict``.
+
+        SUM for cumulative system totals (aggregate bandwidth, aggregate
+        IOPS, total data, total ops), MAX for wall-clock (the run is only
+        over once the slowest host finishes), and mean for everything else
+        (per-thread bandwidth, per-op latency, latency stddev — descriptive
+        stats that don't add across nodes). A single host folds to itself,
+        so the single-node path is unchanged. Mirrors mofka_bench so the CTE
+        and Mofka multi-node CSVs aggregate identically.
+
+        :param per_host_stats: List of ``<pkg_id>.<op>.<metric>`` -> value
+                               dicts, one per host.
+        :param stat_dict: Dict the framework serialises into results.csv.
+        """
+        from collections import defaultdict
+        buckets = defaultdict(list)
+        for host_stat in per_host_stats:
+            for key, value in host_stat.items():
+                buckets[key].append(value)
+        for key, values in buckets.items():
+            metric = key.rsplit('.', 1)[-1]
+            if metric in self._FOLD_SUM:
+                stat_dict[key] = sum(values)
+            elif metric in self._FOLD_MAX:
+                stat_dict[key] = max(values)
+            else:
+                stat_dict[key] = sum(values) / len(values)
+
     def _get_stat(self, stat_dict):
         """
         Parse the captured benchmark output and populate ``stat_dict``.
 
         Called by the jarvis_cd sweep runner after each pipeline run (on a
         freshly-loaded package instance), which is why the metrics are read
-        back from ``<shared_dir>/bench_output.txt`` rather than from an
-        in-memory buffer. Each extracted metric becomes a results.csv column.
+        back from disk rather than from an in-memory buffer. Each extracted
+        metric becomes a results.csv column.
+
+        Single-node (nprocs=1) parses the one ``<shared_dir>/bench_output.txt``
+        — identical to before this change. Multi-node (nprocs>1, ppn=1) globs
+        the per-host ``bench_output.txt.<hostname>`` files, parses each into
+        its own dict, and folds them via :meth:`_fold_host_stats`.
 
         :param stat_dict: Dict the framework serialises into results.csv;
                           keys are ``<pkg_id>.<operation>.<metric>``.
         """
-        output_path = os.path.join(self.shared_dir, 'bench_output.txt')
-        if not os.path.exists(output_path):
-            self.log(f'No output file found at {output_path}')
+        canonical = os.path.join(self.shared_dir, 'bench_output.txt')
+        per_host = sorted(glob.glob(canonical + '.*'))
+        if per_host:
+            files = per_host
+        elif os.path.exists(canonical):
+            files = [canonical]
+        else:
+            self.log(f'No output file found at {canonical} (or per-host '
+                     f'{canonical}.<hostname>)')
             return
 
-        with open(output_path, 'r') as f:
-            output = f.read()
+        per_host_stats = []
+        for fpath in files:
+            with open(fpath, 'r') as f:
+                output = f.read()
+            if not output.strip():
+                self.log(f'Output file is empty: {fpath}')
+                continue
+            host_stat = {}
+            self._parse_output(output, host_stat)
+            if host_stat:
+                per_host_stats.append(host_stat)
+            else:
+                self.log(f'Warning: No metrics extracted from {fpath} '
+                         f'({len(output)} bytes). '
+                         f'Check if benchmark results are present in output.')
 
-        if not output.strip():
-            self.log(f'Output file is empty: {output_path}')
+        if not per_host_stats:
             return
-
-        before_count = len(stat_dict)
-        self._parse_output(output, stat_dict)
-        after_count = len(stat_dict)
-        if after_count == before_count:
-            self.log(f'Warning: No metrics extracted from {output_path} '
-                     f'({len(output)} bytes). '
-                     f'Check if benchmark results are present in output.')
+        if len(per_host_stats) == 1:
+            stat_dict.update(per_host_stats[0])
+        else:
+            self.log(f'Folding stats across {len(per_host_stats)} hosts '
+                     f'(SUM aggregates, MAX wall-clock, mean the rest)')
+            self._fold_host_stats(per_host_stats, stat_dict)
 
     def _parse_output(self, output, stat_dict):
         """

--- a/jarvis_clio_core/jarvis_clio_core/clio_cte_libfuse/pkg.py
+++ b/jarvis_clio_core/jarvis_clio_core/clio_cte_libfuse/pkg.py
@@ -6,7 +6,8 @@ the `clio_cte_fuse` binary (built with CLIO_CTE_ENABLE_FUSE_ADAPTER=ON).
 """
 from jarvis_cd.core.pkg import Service
 from jarvis_cd.shell import Exec, PsshExecInfo
-from jarvis_cd.shell.process import Mkdir, Kill
+from jarvis_cd.shell.process import Kill
+from jarvis_clio_core.container_utils import container_kwargs
 import time
 
 
@@ -61,22 +62,43 @@ class ClioCteLibfuse(Service):
         # of the binary; calling it here just makes start() idempotent.
         self.stop()
 
-        Mkdir(mp, PsshExecInfo(env=self.mod_env, hostfile=self.hostfile)).run()
+        # container_kwargs routes the mkdir into the run's apptainer instance
+        # (jarvis only wraps when exec_info.container is set). REQUIRED here:
+        # under tmp_bind_root the in-container /tmp is a different directory
+        # from the host /tmp, so the mountpoint must be created in-container.
+        Exec(f'mkdir -p {mp}',
+             PsshExecInfo(env=self.mod_env, hostfile=self.hostfile,
+                          **container_kwargs(self))).run()
 
         fuse_cmd = f'{self.binary} {mp} {extra}'.strip()
         self.log(f"Mounting IOWarp CTE FUSE at {mp}: {fuse_cmd}")
-        Exec(fuse_cmd, PsshExecInfo(
+        # Shell-background the daemon inside a synchronous wrapped Exec: the
+        # `nohup ... &` detaches it from the wrap's `bash -c` shell, and it
+        # parents into the apptainer instance, whose mount/shm namespaces it
+        # must share with the runtime and the fio that writes through the
+        # mount. Daemon output goes to a per-host log on the auto-mounted
+        # shared_dir (not /dev/null — a masked mount failure here previously
+        # surfaced only as downstream ENOSPC).
+        fuse_log = f'{self.shared_dir}/cte_fuse.$(hostname).log'
+        bg_cmd = f'nohup {fuse_cmd} </dev/null >{fuse_log} 2>&1 &'
+        Exec(bg_cmd, PsshExecInfo(
             env=self.mod_env, hostfile=self.hostfile,
-            exec_async=True)).run()
+            **container_kwargs(self))).run()
         time.sleep(self.config.get('sleep', 2))
 
     def stop(self):
         mp = self.config['mountpoint']
         self.log(f"Unmounting {mp}")
+        # Both teardown steps must run inside the instance: the FUSE mount
+        # exists only in the instance's mount namespace (host-side
+        # fusermount3 sees "not found in /etc/mtab"), and the wrapped Kill
+        # scopes pkill to this run's PID namespace.
         Exec(f'fusermount3 -u {mp}', PsshExecInfo(
-            env=self.mod_env, hostfile=self.hostfile)).run()
+            env=self.mod_env, hostfile=self.hostfile,
+            **container_kwargs(self))).run()
         Kill(self.binary, PsshExecInfo(
-            env=self.mod_env, hostfile=self.hostfile)).run()
+            env=self.mod_env, hostfile=self.hostfile,
+            **container_kwargs(self))).run()
 
     def clean(self):
         self.stop()

--- a/jarvis_clio_core/jarvis_clio_core/clio_redis_bench/pkg.py
+++ b/jarvis_clio_core/jarvis_clio_core/clio_redis_bench/pkg.py
@@ -1,6 +1,9 @@
 from jarvis_cd.core.pkg import Application
-from jarvis_cd.shell import Exec, PsshExecInfo
+from jarvis_cd.shell import Exec, PsshExecInfo, LocalExecInfo
+from jarvis_clio_core.container_utils import container_kwargs
+import glob
 import os
+import re
 
 
 class ClioRedisBench(Application):
@@ -16,7 +19,30 @@ class ClioRedisBench(Application):
     evenly across threads, cycling).
 
     Connects to a Redis server via REDIS_HOST / REDIS_PORT.
+
+    Because clio_redis_bench emits the *identical* bench_common.h
+    ``PrintResults`` report that clio_cte_bench does, the metric-capture
+    half (``start`` writes ``<shared_dir>/bench_output.txt``; ``_get_stat``
+    / ``_parse_output`` read it back) is the SAME contract clio_cte_bench
+    uses, reused verbatim here so a sweep records the redis row into
+    results.csv exactly the way the CTE row is recorded. bench_common.h
+    remains the single source of truth for the metric math; this regex
+    table is only the parsing half of that contract.
     """
+
+    # How each metric folds when more than one rank/host reports (multi-node,
+    # nprocs>1 with ppn=1 -> one bench rank per host). Identical to
+    # clio_cte_bench so the CTE and redis multi-node CSVs aggregate the same
+    # way: SUM cumulative system totals, MAX wall-clock, mean the rest.
+    _FOLD_SUM = {
+        'agg_bw_mbps',
+        'agg_ops_per_sec',
+        'total_data_mb',
+        'total_ops',
+    }
+    _FOLD_MAX = {
+        'time_max_us',
+    }
 
     def _init(self):
         self.benchmark_executable = 'clio_redis_bench'
@@ -106,10 +132,24 @@ class ClioRedisBench(Application):
             },
             {
                 'name': 'output_file',
-                'msg': 'Output file for benchmark results',
+                'msg': 'Optional user-facing copy of the benchmark results',
                 'type': str,
                 'default': '',
-                'help': 'If empty, results go to stdout',
+                'help': 'If set, the report is ALSO copied here (under '
+                        'shared_dir). Metrics are always captured to '
+                        'bench_output.txt regardless, for _get_stat.',
+            },
+            {
+                'name': 'bin_dir',
+                'msg': 'Directory holding clio_redis_bench (absolute). Empty = '
+                       'resolve via PATH.',
+                'type': str,
+                'default': '',
+                'help': 'For the apptainer deploy set this to the SIF spack-view '
+                        'bin (/opt/iowarp-view/bin): jarvis runs the bench in a '
+                        'shell whose PATH does NOT include the view bin, so the '
+                        'bare name is "command not found". An ABSOLUTE path needs '
+                        'no PATH lookup. Empty (bare-metal) uses PATH as before.',
             },
         ]
 
@@ -130,7 +170,7 @@ class ClioRedisBench(Application):
         if self.config['output_file']:
             self.output_file = os.path.join(self.shared_dir,
                                             self.config['output_file'])
-            self.log(f"Results will be saved to: {self.output_file}")
+            self.log(f"Results will also be copied to: {self.output_file}")
         else:
             self.output_file = None
 
@@ -141,12 +181,28 @@ class ClioRedisBench(Application):
         self.log("Redis benchmark configuration completed")
 
     def start(self):
+        """
+        Run the redis benchmark, capturing its bench_common.h report to
+        ``<shared_dir>/bench_output.txt`` so ``_get_stat`` can parse it
+        afterwards. The sweep runner reloads a *fresh* package instance
+        before calling ``_get_stat``, so an in-memory buffer would be lost —
+        the on-disk file is the contract between start() and _get_stat().
+        This mirrors clio_cte_bench.start() exactly.
+        """
         self.log(f"Starting Redis benchmark: {self.config['test_case']}")
+
+        # Resolve the executable. In the apptainer deploy bin_dir is the SIF
+        # spack-view bin (/opt/iowarp-view/bin); an ABSOLUTE path sidesteps the
+        # fact that jarvis's exec shell PATH omits the view bin (bare name ->
+        # "command not found"). Empty bin_dir (bare-metal) keeps the bare name.
+        bin_dir = str(self.config.get('bin_dir', '') or '')
+        exe = os.path.join(bin_dir, self.benchmark_executable) if bin_dir \
+            else self.benchmark_executable
 
         # Semantic-flag CLI (bench_common.h). Use --time-limit when set,
         # otherwise --io-count.
         cmd = [
-            self.benchmark_executable,
+            exe,
             '--op', str(self.config['test_case']),
             '--threads', str(self.config['num_threads']),
             '--depth', str(self.config['depth']),
@@ -159,28 +215,198 @@ class ClioRedisBench(Application):
         if int(self.config['max_total_blobs']) > 0:
             cmd += ['--max-total-blobs', str(self.config['max_total_blobs'])]
 
-        exec_info = PsshExecInfo(
-            env=self.mod_env,
-            hostfile=self.hostfile,
-            nprocs=self.config['nprocs'],
-            ppn=self.config['ppn'],
-        )
-
         cmd_str = ' '.join(cmd)
-        if self.output_file:
-            cmd_str += f' > {self.output_file} 2>&1'
+        output_path = os.path.join(self.shared_dir, 'bench_output.txt')
+
+        if self.config['nprocs'] > 1:
+            # Multi-rank / multi-node: with ppn=1 each host runs one bench
+            # rank. Redirect each rank to a PER-HOST file so concurrent ranks
+            # never clobber one shared file on the NFS shared_dir; _get_stat
+            # globs + folds them. (Same per-host capture clio_cte_bench uses.)
+            self.log(
+                f"Running benchmark via Pssh: {self.config['nprocs']} procs, "
+                f"{self.config['ppn']} per node (per-host output capture)"
+            )
+            # container_kwargs routes the command into the run's apptainer
+            # instance (jarvis only wraps when exec_info.container is set;
+            # nothing wraps automatically). The command stays RAW — the whole
+            # string, redirect included, lands inside the wrap's
+            # `bash -c '...'`, so `$(hostname)` expands per-host in-container
+            # and the SIF's clio_redis_bench resolves. output_path is on the
+            # auto-mounted shared_dir, so the report is host-visible.
+            exec_info = PsshExecInfo(
+                env=self.mod_env,
+                hostfile=self.hostfile,
+                nprocs=self.config['nprocs'],
+                ppn=self.config['ppn'],
+                **container_kwargs(self),
+            )
+            cmd_str = f'{cmd_str} > {output_path}.$(hostname) 2>&1'
+        else:
+            # Single-rank: container_kwargs routes the command into the run's
+            # apptainer instance, where the SIF's clio_redis_bench exists
+            # (it is absent host-side). Keep the command RAW — redirect and
+            # all — so it rides inside the wrap's `bash -c '...'`. exe is the
+            # absolute view-bin path (bin_dir); output_path is on the
+            # auto-mounted shared_dir.
+            self.log("Running benchmark locally (single rank)")
+            exec_info = PsshExecInfo(env=self.mod_env, hostfile=self.hostfile,
+                                     **container_kwargs(self))
+            cmd_str = f'{cmd_str} > {output_path} 2>&1'
+
         self.log(f"Executing: {cmd_str}")
         Exec(cmd_str, exec_info).run()
-        self.log("Redis benchmark completed")
+
+        # Optional user-facing copy of the canonical single-rank report.
+        if self.output_file and os.path.exists(output_path):
+            try:
+                import shutil
+                shutil.copyfile(output_path, self.output_file)
+            except OSError as e:
+                self.log(f"Could not copy results to {self.output_file}: {e}")
+
+        self.log(f"Redis benchmark completed. Output captured to: "
+                 f"{output_path}")
 
     def stop(self):
         self.log("ClioRedisBench is an application - runs to completion")
         return True
 
     def clean(self):
-        if self.output_file and os.path.exists(self.output_file):
-            try:
-                os.remove(self.output_file)
-                self.log(f"Removed: {self.output_file}")
-            except Exception as e:
-                self.log(f"Error removing output file: {e}")
+        # The canonical results file parsed by _get_stat, plus any per-host
+        # siblings (bench_output.txt.<hostname>) written in multi-node mode,
+        # plus the optional user-facing copy.
+        canonical = os.path.join(self.shared_dir, 'bench_output.txt')
+        paths = [canonical] + glob.glob(canonical + '.*')
+        if self.output_file:
+            paths.append(self.output_file)
+        for path in paths:
+            if path and os.path.exists(path):
+                try:
+                    os.remove(path)
+                    self.log(f"Removed: {path}")
+                except Exception as e:
+                    self.log(f"Error removing output file: {e}")
+
+    # ------------------------------------------------------------------
+    # Statistics collection — reused verbatim from clio_cte_bench, since
+    # clio_redis_bench prints the identical bench_common.h report.
+    # ------------------------------------------------------------------
+
+    def _fold_host_stats(self, per_host_stats, stat_dict):
+        """
+        Aggregate per-host stat dicts into ``stat_dict``: SUM cumulative
+        system totals, MAX wall-clock, mean everything else. A single host
+        folds to itself, so the single-node path is unchanged.
+
+        :param per_host_stats: List of ``<pkg_id>.<op>.<metric>`` -> value
+                               dicts, one per host.
+        :param stat_dict: Dict the framework serialises into results.csv.
+        """
+        from collections import defaultdict
+        buckets = defaultdict(list)
+        for host_stat in per_host_stats:
+            for key, value in host_stat.items():
+                buckets[key].append(value)
+        for key, values in buckets.items():
+            metric = key.rsplit('.', 1)[-1]
+            if metric in self._FOLD_SUM:
+                stat_dict[key] = sum(values)
+            elif metric in self._FOLD_MAX:
+                stat_dict[key] = max(values)
+            else:
+                stat_dict[key] = sum(values) / len(values)
+
+    def _get_stat(self, stat_dict):
+        """
+        Parse the captured benchmark output and populate ``stat_dict``.
+
+        Called by the jarvis_cd sweep runner after each pipeline run on a
+        freshly-loaded package instance, so metrics are read from disk.
+        Single-node parses ``<shared_dir>/bench_output.txt``; multi-node
+        (nprocs>1, ppn=1) globs the per-host ``bench_output.txt.<hostname>``
+        files and folds them via :meth:`_fold_host_stats`.
+
+        :param stat_dict: Dict the framework serialises into results.csv;
+                          keys are ``<pkg_id>.<operation>.<metric>``.
+        """
+        canonical = os.path.join(self.shared_dir, 'bench_output.txt')
+        per_host = sorted(glob.glob(canonical + '.*'))
+        if per_host:
+            files = per_host
+        elif os.path.exists(canonical):
+            files = [canonical]
+        else:
+            self.log(f'No output file found at {canonical} (or per-host '
+                     f'{canonical}.<hostname>)')
+            return
+
+        per_host_stats = []
+        for fpath in files:
+            with open(fpath, 'r') as f:
+                output = f.read()
+            if not output.strip():
+                self.log(f'Output file is empty: {fpath}')
+                continue
+            host_stat = {}
+            self._parse_output(output, host_stat)
+            if host_stat:
+                per_host_stats.append(host_stat)
+            else:
+                self.log(f'Warning: No metrics extracted from {fpath} '
+                         f'({len(output)} bytes).')
+
+        if not per_host_stats:
+            return
+        if len(per_host_stats) == 1:
+            stat_dict.update(per_host_stats[0])
+        else:
+            self.log(f'Folding stats across {len(per_host_stats)} hosts '
+                     f'(SUM aggregates, MAX wall-clock, mean the rest)')
+            self._fold_host_stats(per_host_stats, stat_dict)
+
+    def _parse_output(self, output, stat_dict):
+        """
+        Extract metrics from clio_redis_bench stdout into ``stat_dict``.
+
+        The C++ binary emits its results via HLOG (bench_common.h
+        ``PrintResults``), one labelled metric per line — the SAME wording
+        clio_cte_bench parses, so this regex table is identical to that one.
+        The patterns must match the wording/units printed by PrintResults.
+
+        :param output: Raw captured benchmark output (stdout+stderr).
+        :param stat_dict: Dict to populate with ``<pkg_id>.<op>.<metric>``.
+        """
+        # Strip ANSI escape codes from HLOG output.
+        output = re.sub(r'\033\[[0-9;]*m', '', output)
+
+        # Detect which test case header appeared (Put, Get, or PutGet).
+        header_match = re.search(r'=== (\w+) Benchmark Results ===', output)
+        operation = header_match.group(1).lower() if header_match else 'unknown'
+
+        patterns = {
+            'time_min_us': r'Time \(min\):\s+([\d.e+\-]+)\s+us',
+            'time_max_us': r'Time \(max\):\s+([\d.e+\-]+)\s+us',
+            'time_avg_us': r'Time \(avg\):\s+([\d.e+\-]+)\s+us',
+            'bw_per_thread_min_mbps':
+                r'Bandwidth per thread \(min\):\s+([\d.e+\-]+)\s+MB/s',
+            'bw_per_thread_max_mbps':
+                r'Bandwidth per thread \(max\):\s+([\d.e+\-]+)\s+MB/s',
+            'bw_per_thread_avg_mbps':
+                r'Bandwidth per thread \(avg\):\s+([\d.e+\-]+)\s+MB/s',
+            'agg_bw_mbps': r'Aggregate bandwidth:\s+([\d.e+\-]+)\s+MB/s',
+            'agg_ops_per_sec': r'Aggregate IOPS:\s+([\d.e+\-]+)',
+            'ops_per_thread_avg_per_sec':
+                r'IOPS per thread \(avg\):\s+([\d.e+\-]+)',
+            'avg_latency_per_op_us':
+                r'Avg latency per op:\s+([\d.e+\-]+)\s+us',
+            'latency_stddev_us': r'Latency stddev:\s+([\d.e+\-]+)\s+us',
+            'total_data_mb': r'Total data:\s+([\d.e+\-]+)\s+MB',
+            'total_ops': r'Total ops:\s+(\d+)',
+        }
+
+        for metric, pattern in patterns.items():
+            match = re.search(pattern, output)
+            if match:
+                stat_dict[f'{self.pkg_id}.{operation}.{metric}'] = float(
+                    match.group(1))

--- a/jarvis_clio_core/jarvis_clio_core/clio_runtime/pkg.py
+++ b/jarvis_clio_core/jarvis_clio_core/clio_runtime/pkg.py
@@ -7,6 +7,7 @@ and container deployment modes via deploy_mode configuration.
 from jarvis_cd.core.pkg import Service
 from jarvis_cd.shell import Exec, PsshExecInfo
 from jarvis_cd.shell.process import Kill, GdbServer
+from jarvis_clio_core.container_utils import container_kwargs
 from jarvis_cd.util import SizeType
 from jarvis_cd.util.logger import Color
 import os
@@ -306,16 +307,43 @@ class ClioRuntime(Service):
 
         self.log("Starting IOWarp runtime")
 
+        # Self-heal BEFORE launching a fresh runtime: kill any stale chimaera
+        # left alive by a prior combo, THEN reclaim its chi_* shm. Both are
+        # host-side (unwrapped) on purpose — apptainer shares the host /dev/shm
+        # and PID space, and the stale process we're hunting has, by definition,
+        # ESCAPED the prior combo's instance:// PID namespace, so the wrapped
+        # `Kill('chimaera')` in the previous stop() could not reach it.
+        #
+        # Why this matters (observed on single_node job 21563, combo 18): the
+        # sweep is sequential in ONE allocation, so combo N+1's runtime start
+        # inherits whatever combo N's teardown left behind. Every teardown logs
+        # `ERROR ... Server dead` — the runtime dies hard, not gracefully — so a
+        # wedged/re-parented chimaera CAN survive. If it does and we only rm the
+        # shm, the fresh runtime comes up alongside the survivor with an
+        # inconsistent pool registry; a client task then routes to the null pool
+        # (`worker.cc ... Container not found for pool_id=PoolId(0,0)`) and, with
+        # no IPC failover, HANGS forever (combo 18 stalled ~8 h to the wall
+        # clock). Killing first makes the old "no live chimaera here" assumption
+        # actually true. Idempotent: in the healthy case nothing matches, so this
+        # is a no-op that leaves startup state unchanged. The `[c]himaera` /
+        # `[c]lio_run` bracket keeps pkill from matching its own argv; `|| true`
+        # keeps a no-match (exit 1) from looking like a failure. Without the shm
+        # reclaim a single mid-startup death also snowballs into a /dev/shm
+        # ENOSPC cascade for every subsequent combo.
+        Exec("pkill -9 -f '[c]himaera' || true; "
+             "pkill -9 -f '[c]lio_run' || true; "
+             'rm -f /dev/shm/chi_*',
+             PsshExecInfo(hostfile=self.hostfile)).run()
+
         cmd = 'clio_run runtime start'
 
         exec_info = PsshExecInfo(
             env=self.env,
             hostfile=self.hostfile,
             exec_async=True,
-            container=self._container_engine,
-            container_image=self.deploy_image_name(),
             private_dir=self.private_dir,
             bind_mounts=self.container_mounts,
+            **container_kwargs(self),
         )
         if self.config.get('do_dbg', False):
             GdbServer(cmd, self.config['dbg_port'], exec_info).run()
@@ -356,10 +384,27 @@ class ClioRuntime(Service):
 
         self.log("Stopping IOWarp runtime")
 
-        Exec('clio_run runtime stop',
-             PsshExecInfo(env=self.env, hostfile=self.hostfile)).run()
+        # #526: BOUND the graceful stop, and run it INSIDE the instance
+        # (container_kwargs) — symmetric with start(). The earlier
+        # intermittent "shm_attach shm_open failed" during stop was the
+        # host-side stop client trying to attach shm owned by the
+        # in-instance runtime; wrapping puts the stop client in the same
+        # namespace. `timeout` still caps a wedged stop; Kill below is what
+        # actually frees the runtime. `-k 10` SIGKILLs if clio_run ignores
+        # the SIGTERM. Harmless on bare-metal (engine 'none' -> no wrap).
+        Exec('timeout -k 10 45 clio_run runtime stop',
+             PsshExecInfo(env=self.env, hostfile=self.hostfile,
+                          **container_kwargs(self))).run()
+        # Backstop force-kill under BOTH daemon names: 'chimaera' (pre-rebrand
+        # CLIO, e.g. the current 526 SIF) and 'clio_run' (post Chimaera->Clio
+        # rebrand). Kill of a name with no matches is benign, so the union is
+        # safe whichever CLIO vintage is deployed.
+        Kill('chimaera',
+             PsshExecInfo(env=self.env, hostfile=self.hostfile,
+                          **container_kwargs(self))).run()
         Kill('clio_run',
-             PsshExecInfo(env=self.env, hostfile=self.hostfile)).run()
+             PsshExecInfo(env=self.env, hostfile=self.hostfile,
+                          **container_kwargs(self))).run()
 
         port = self.config['port']
         host = self.hostfile.hosts[0] if self.hostfile.hosts else '127.0.0.1'
@@ -379,8 +424,15 @@ class ClioRuntime(Service):
 
     def kill(self):
         self.log("Forcibly killing IOWarp runtime")
+        # Both daemon names — pre-rebrand ('chimaera') and post ('clio_run');
+        # see stop() for rationale.
+        Kill('chimaera', PsshExecInfo(
+            hostfile=self.hostfile,
+            **container_kwargs(self)
+        )).run()
         Kill('clio_run', PsshExecInfo(
-            hostfile=self.hostfile
+            hostfile=self.hostfile,
+            **container_kwargs(self)
         )).run()
 
     def clean(self):
@@ -393,6 +445,16 @@ class ClioRuntime(Service):
         if os.path.exists(log_file):
             os.remove(log_file)
 
+        # HOST-SIDE (deliberately NOT wrapped): clean() runs *after* stop() has
+        # already torn the apptainer instance down, so a wrapped `apptainer exec
+        # instance://…` here would target a dead instance and silently no-op —
+        # leaking the runtime's shm across every sweep combo until /dev/shm
+        # (a 48 GiB tmpfs on Ares) fills and later combos die with ENOSPC
+        # ([Errno 28]). Apptainer shares the host /dev/shm by default (no
+        # --contain), so chimaera's shm_open segments physically live on the
+        # host /dev/shm; a bare host-side rm reaches the exact same files and
+        # reclaims them regardless of instance state. On distributed runs the
+        # hostfile fans this out host-side to every node's local /dev/shm.
         Exec('rm -f /dev/shm/chi_*', PsshExecInfo(
             hostfile=self.hostfile
         )).run()

--- a/jarvis_clio_core/jarvis_clio_core/container_utils.py
+++ b/jarvis_clio_core/jarvis_clio_core/container_utils.py
@@ -1,0 +1,132 @@
+"""Shared helpers for routing package commands into the pipeline's running
+container instance (issue #526).
+
+jarvis-cd wraps a command as ``apptainer exec ... instance://<name> bash -c
+'<cmd>'`` only when the ExecInfo passed to Exec carries a container engine
+(``ExecFactory._prepare_container`` gates on ``exec_info.container``). The
+framework never injects this automatically: every package must thread the
+kwargs into each ExecInfo it builds, exactly like the jarvis builtin
+workload packages (ior, fio, ...) do.
+
+IMPORTANT: import this module at the TOP of each pkg.py. jarvis loads
+``jarvis_clio_core.<pkg>.pkg`` with the repo root only transiently on
+sys.path, and the inner ``jarvis_clio_core`` directory is a namespace
+package — a deferred (function-body) first import can fail after the
+sys.path entry is popped.
+"""
+
+
+def eff_hostfile(pkg):
+    """The hostfile a *head-node-only* service should actually run on.
+
+    Some packages in a multi-node pipeline are single-client baselines or
+    metadata singletons, NOT distributed workloads: redis (JuiceFS's metadata
+    store), the JuiceFS format+FUSE mount, and the fio benches (nfs_fio /
+    jfs_fio) are all meant to run on ONE host even though the pipeline hands
+    every package the full N-node hostfile. Left unpinned they fan out over
+    Pssh to all N nodes and (a) race on the shared NFS ``$HOME`` (concurrent
+    ``rm -rf``/``mkdir`` of the object-store dir -> "Directory not empty" and a
+    half-torn state that EINVALs the next sweep combo), and (b) on the non-head
+    nodes hit a redis that isn't there ("connection refused") and leave broken
+    FUSE mounts behind.
+
+    When this package sets ``single_instance`` and the pipeline hostfile has
+    >1 host, collapse to just the FIRST host; otherwise return the hostfile
+    unchanged (single-node pipelines and genuinely-distributed packages are
+    unaffected). Mirrors redis/pkg.py::_eff_hostfile so every head-node-only
+    service pins identically.
+
+    :param pkg: the jarvis package instance (``self``)
+    :return: a Hostfile (possibly sliced to its first host)
+    """
+    hf = pkg.hostfile
+    if pkg.config.get('single_instance') and len(hf.hosts) > 1:
+        # Imported lazily so packages that never call this don't pay the import
+        # (and to keep this util dependency-light); jarvis_cd is always present
+        # at call time inside a package method.
+        from jarvis_cd.util.hostfile import Hostfile
+        return Hostfile(hosts=hf.hosts[:1],
+                        hosts_ip=hf.hosts_ip[:1] if hf.hosts_ip else None)
+    return hf
+
+
+def single_instance_menu_opt():
+    """The ``single_instance`` config menu entry shared by every head-node-only
+    service (redis defines its own copy with the same semantics). Off by
+    default so single-node pipelines and distributed workloads are unchanged;
+    set true in a multi-node YAML to pin the service to the first host. See
+    :func:`eff_hostfile`.
+
+    :return: dict (a _configure_menu entry)
+    """
+    return {
+        'name': 'single_instance',
+        'msg': 'Pin this service to the FIRST host even when the pipeline '
+               'hostfile has >1 host (skip fanning out over Pssh). Use for '
+               'head-node-only baselines/singletons (JuiceFS mount, fio '
+               'benches) so they do not race on shared NFS or hit a redis '
+               'that only runs on the head node. Default keeps the legacy '
+               'run-on-every-host behaviour.',
+        'type': bool,
+        'default': False,
+    }
+
+
+def container_kwargs(pkg):
+    """ExecInfo kwargs that make jarvis's ``Exec._prepare_container`` wrap the
+    command to run inside the pipeline's container instance.
+
+    ``pkg._container_engine`` returns the pipeline's engine (e.g.
+    ``apptainer``) only when this package's ``deploy_mode`` is ``container``
+    (propagated from the pipeline's ``base_deploy_mode``); otherwise it is
+    ``'none'`` and ``_prepare_container`` no-ops, so the result is always
+    safe to splat into any ExecInfo.
+
+    ``pkg.deploy_image_name()`` is the pipeline RUN name (e.g.
+    ``single_node_run1``) — the apptainer instance name — NOT the SIF
+    basename from the YAML's ``container_image``.
+
+    :param pkg: the jarvis package instance (``self``)
+    :return: dict of ExecInfo kwargs
+    """
+    return {
+        'container': pkg._container_engine,
+        'container_image': pkg.deploy_image_name(),
+    }
+
+
+def flatten_stdout(exec_result):
+    """Return an Exec result's stdout as one string.
+
+    Pssh/Local Exec results carry stdout either as ``{host: str}`` or as a
+    plain string depending on the exec type.
+
+    :param exec_result: the object returned by ``Exec(...).run()``
+    :return: stdout joined across hosts
+    """
+    out = getattr(exec_result, 'stdout', '')
+    if isinstance(out, dict):
+        return '\n'.join(str(v) for v in out.values())
+    return str(out)
+
+
+def all_hosts_ok(exec_result, expect=None):
+    """True iff every host exited 0 and, when ``expect`` is given, every
+    host's stdout contains it. Handles dict-or-scalar exit_code/stdout.
+
+    :param exec_result: the object returned by ``Exec(...).run()``
+    :param expect: optional substring required in each host's stdout
+    :return: bool
+    """
+    codes = getattr(exec_result, 'exit_code', 1)
+    if isinstance(codes, dict):
+        if any(c != 0 for c in codes.values()):
+            return False
+    elif codes != 0:
+        return False
+    if expect is None:
+        return True
+    out = getattr(exec_result, 'stdout', '')
+    if isinstance(out, dict):
+        return all(expect in str(v) for v in out.values())
+    return expect in str(out)

--- a/jarvis_clio_core/jarvis_clio_core/juicefs/pkg.py
+++ b/jarvis_clio_core/jarvis_clio_core/juicefs/pkg.py
@@ -1,0 +1,358 @@
+"""
+This module provides classes and methods to deploy JuiceFS as a Jarvis
+service package.
+
+JuiceFS is a POSIX-compatible distributed filesystem that stores file
+*data* in an object store (here a local directory via ``--storage file``)
+and file *metadata* in a transactional engine (here Redis). This package
+formats the filesystem once, mounts it via FUSE, and unmounts it on stop --
+mirroring the lifecycle style of the ``redis`` service package.
+
+The expected deployment order is: redis -> juicefs -> <benchmark driver>,
+so the Redis metadata engine is already accepting connections before
+``juicefs format`` runs.
+"""
+import os
+import time
+from jarvis_cd.core.pkg import Application
+from jarvis_cd.util.logger import Color
+from jarvis_cd.shell import Exec, LocalExecInfo, PsshExecInfo
+from jarvis_clio_core.container_utils import (
+    container_kwargs, flatten_stdout, eff_hostfile, single_instance_menu_opt)
+
+
+class Juicefs(Application):
+    """
+    Format and FUSE-mount a JuiceFS filesystem (Redis metadata +
+    local-file object backend) for single-node benchmarking.
+    """
+
+    def _init(self):
+        """
+        Initialize paths. Concrete (env-expanded) paths are resolved in
+        ``_configure`` and recomputed on demand via ``_paths``.
+        """
+        pass
+
+    def _configure_menu(self):
+        """
+        Create a CLI menu for the configurator method.
+
+        :return: List(dict)
+        """
+        return [
+            {
+                'name': 'meta_url',
+                'msg': 'Metadata engine URL (Redis) for format/mount',
+                'type': str,
+                'default': 'redis://127.0.0.1:6379/1',
+            },
+            {
+                'name': 'storage',
+                'msg': "Object storage backend type ('file' local dir, or 'gs' for Google Cloud Storage)",
+                'type': str,
+                'default': 'file',
+            },
+            {
+                'name': 'bucket',
+                'msg': "Object bucket URL for non-file storage, e.g. gs://my-bucket (required when storage='gs')",
+                'type': str,
+                'default': '',
+            },
+            {
+                'name': 'gcs_credentials',
+                'msg': 'Path to a GCS service-account JSON key (exported as GOOGLE_APPLICATION_CREDENTIALS; never stored in config)',
+                'type': str,
+                'default': '',
+            },
+            {
+                'name': 'data_dir',
+                'msg': "Local object-store dir (used as --bucket only when storage='file')",
+                'type': str,
+                'default': '${HOME}/juicefs_data',
+            },
+            {
+                'name': 'mountpoint',
+                'msg': 'FUSE mountpoint directory',
+                'type': str,
+                'default': '${HOME}/juicefs_mnt',
+            },
+            {
+                'name': 'name',
+                'msg': 'JuiceFS volume name (passed to juicefs format)',
+                'type': str,
+                'default': 'jfsbench',
+            },
+            {
+                'name': 'cache_dir',
+                'msg': 'Local cache directory for the mount',
+                'type': str,
+                'default': '${HOME}/juicefs_cache',
+            },
+            {
+                'name': 'cache_size_mb',
+                'msg': 'Local cache size cap in MiB (juicefs --cache-size). '
+                       'JuiceFS defaults to 100 GiB, which can exhaust a small '
+                       'node-local scratch device; bound it well under free '
+                       'space on the cache_dir filesystem.',
+                'type': int,
+                'default': 512,
+            },
+            {
+                'name': 'juicefs_bin',
+                'msg': 'Path to the juicefs binary',
+                'type': str,
+                'default': 'juicefs',
+            },
+            {
+                'name': 'format_fresh',
+                'msg': "Wipe the local bucket dir before formatting (storage='file' only; no-op for cloud)",
+                'type': bool,
+                'default': True,
+            },
+            {
+                'name': 'mount_wait',
+                'msg': 'Seconds to wait for the mount to become ready',
+                'type': int,
+                'default': 20,
+            },
+            {
+                'name': 'extra_mount_opts',
+                'msg': 'Extra options appended to juicefs mount',
+                'type': str,
+                'default': '',
+            },
+            # Head-node-only pinning: JuiceFS is a single mount here (its redis
+            # metadata store lives only on the first host), so on a multi-node
+            # pipeline it must NOT fan format/mount/rm out to every node.
+            single_instance_menu_opt(),
+        ]
+
+    def _paths(self):
+        """
+        Resolve env-expanded, user-expanded absolute paths from config.
+
+        :return: tuple(data_dir, mountpoint, cache_dir)
+        """
+        def fix(p):
+            return os.path.expanduser(os.path.expandvars(str(p)))
+        return (fix(self.config['data_dir']),
+                fix(self.config['mountpoint']),
+                fix(self.config['cache_dir']))
+
+    def _bucket_arg(self):
+        """
+        The value passed to ``juicefs format --bucket``. For storage='file'
+        this is the local data_dir; for cloud backends (e.g. 'gs') it is the
+        configured bucket URL (gs://...).
+
+        :return: str
+        """
+        if self.config['storage'] == 'file':
+            data_dir, _, _ = self._paths()
+            return data_dir
+        return str(self.config['bucket'])
+
+    def _inject_cloud_env(self):
+        """
+        Populate ``self.mod_env`` with object-store credentials for the
+        spawned juicefs subprocesses. Secrets are never read from config: the
+        JSON key stays on disk and only its *path* (``gcs_credentials``) is
+        turned into ``GOOGLE_APPLICATION_CREDENTIALS``. Any ``GCS_*`` already
+        in the parent environment is passed through verbatim (env-based
+        credential chain).
+
+        Must run in ``start``/``stop`` -- ``_configure`` runs in a separate
+        process, so mod_env mutations there would not survive to the Exec
+        (the pipeline rebuilds mod_env from the persisted env each invocation).
+
+        :return: None
+        """
+        if self.config['storage'] != 'gs':
+            return
+        cred = os.path.expanduser(os.path.expandvars(
+            str(self.config.get('gcs_credentials', ''))))
+        if cred:
+            self.mod_env['GOOGLE_APPLICATION_CREDENTIALS'] = cred
+        # Pass through pre-set GCS_* (e.g. a short-lived GCS_ACCESS_TOKEN, or
+        # GCS_PROJECT_ID) that the env allowlist would otherwise drop.
+        for key in ('GCS_ACCESS_TOKEN', 'GCS_PROJECT_ID'):
+            if key not in self.mod_env and key in os.environ:
+                self.mod_env[key] = os.environ[key]
+
+    def _configure(self, **kwargs):
+        """
+        Validate config. The mount/cache/bucket directories are NOT created
+        here: ``_configure`` runs host-side in the jarvis process BEFORE the
+        apptainer instance exists, so a host ``os.makedirs`` of an in-container
+        path like ``/mnt/jfs_mnt`` would hit the host's root-owned ``/mnt`` and
+        fail (Errno 13). The dirs are instead created in ``start`` via a
+        (container-wrapped) Exec — mirroring clio_cte_libfuse's ``Mkdir`` in
+        ``start``. Harmless host mkdir in a bare-metal deploy.
+
+        :param kwargs: Configuration parameters for this pkg.
+        :return: None
+        """
+        if not self.config['meta_url']:
+            raise ValueError('juicefs: meta_url must be set')
+
+        storage = self.config['storage']
+        if storage == 'gs':
+            if not str(self.config.get('bucket', '')).startswith('gs://'):
+                raise ValueError(
+                    "juicefs: storage='gs' requires bucket=gs://<bucket>")
+            if not str(self.config.get('gcs_credentials', '')) \
+                    and 'GCS_ACCESS_TOKEN' not in os.environ:
+                self.log("juicefs: storage='gs' with no gcs_credentials and no "
+                         "GCS_ACCESS_TOKEN; relying on Google's ADC chain (e.g. "
+                         "`gcloud auth application-default login`, or a GCE "
+                         "attached service account). Valid if ADC is configured; "
+                         "fails only if the chain resolves no credentials.",
+                         color=Color.YELLOW)
+        elif storage != 'file':
+            self.log(f"juicefs: storage='{storage}' is configured but only "
+                     f"'file' and 'gs' are exercised by this package",
+                     color=Color.YELLOW)
+
+    def _is_mounted(self, mountpoint):
+        """
+        Report whether ``mountpoint`` has a filesystem mounted *in the
+        deployment context* (the apptainer instance's mount namespace for a
+        container deploy, or the host for bare-metal). Uses a container-wrapped
+        Exec probe rather than host-side ``os.path.ismount``: the JuiceFS FUSE
+        mount lives inside the instance, which the host can't see.
+
+        :param mountpoint: Absolute mountpoint path.
+        :return: bool
+        """
+        probe = Exec(
+            f'mountpoint -q {mountpoint} && echo __JFS_MOUNTED__ || true',
+            PsshExecInfo(env=self.mod_env, hostfile=eff_hostfile(self),
+                         collect_output=True, **container_kwargs(self))).run()
+        return '__JFS_MOUNTED__' in flatten_stdout(probe)
+
+    def start(self):
+        """
+        Format (idempotent) and FUSE-mount the JuiceFS filesystem, then
+        block until the mount is ready.
+
+        :return: None
+        """
+        jfs = self.config['juicefs_bin']
+        data_dir, mountpoint, cache_dir = self._paths()
+        meta_url = self.config['meta_url']
+
+        # Make object-store credentials available to BOTH subprocesses below
+        # (same process as the Exec -- see _inject_cloud_env docstring).
+        self._inject_cloud_env()
+
+        # Create the mount/cache (and, for storage='file', bucket) dirs in the
+        # deployment context. Under a non-setuid apptainer these are container
+        # paths (e.g. /mnt/jfs_mnt), so they must be made via a container-wrapped
+        # Exec, NOT host-side os.makedirs (which would hit the host's root-owned
+        # /mnt). Bare-metal: a harmless local mkdir -p.
+        mkdirs = [mountpoint, cache_dir]
+        if self.config['storage'] == 'file':
+            mkdirs.append(data_dir)
+        Exec(f'mkdir -p {" ".join(mkdirs)}',
+             PsshExecInfo(env=self.mod_env, hostfile=eff_hostfile(self),
+                          **container_kwargs(self))).run()
+
+        # Fresh slate: drop any orphaned chunks from a previous run. This is a
+        # LOCAL operation, only meaningful for storage='file' (the Redis
+        # metadata is wiped per-run by the redis package, so stale chunks here
+        # would only be dead bytes). For cloud backends, wiping the bucket is
+        # destructive re-init and is out of scope -- log and skip.
+        if self.config['format_fresh']:
+            if self.config['storage'] == 'file':
+                self.log(f'Clearing bucket dir {data_dir}', color=Color.YELLOW)
+                # Container-wrapped (see mkdir rationale above): host-side
+                # shutil.rmtree on /mnt/jfs_data would fail / hit the wrong fs.
+                Exec(f'rm -rf {data_dir} && mkdir -p {data_dir}',
+                     PsshExecInfo(env=self.mod_env, hostfile=eff_hostfile(self),
+                          **container_kwargs(self))).run()
+            else:
+                self.log(f"format_fresh: skipping bucket wipe for "
+                         f"storage='{self.config['storage']}' (no-op; "
+                         f"destructive bucket re-init is out of scope)",
+                         color=Color.YELLOW)
+
+        # Format the volume (safe to re-run against fresh metadata).
+        fmt = [
+            jfs, 'format',
+            '--storage', self.config['storage'],
+            '--bucket', self._bucket_arg(),
+            meta_url,
+            self.config['name'],
+        ]
+        self.log(f"Formatting JuiceFS: {' '.join(fmt)}", color=Color.YELLOW)
+        Exec(' '.join(fmt), PsshExecInfo(env=self.mod_env, hostfile=eff_hostfile(self),
+                          **container_kwargs(self))).run()
+
+        # Mount via FUSE. --background daemonizes and returns once the
+        # mount is registered.
+        mnt = [
+            jfs, 'mount',
+            meta_url,
+            mountpoint,
+            '--cache-dir', cache_dir,
+            # Cap the local cache: JuiceFS defaults to 100 GiB, which can fill a
+            # small node-local scratch device (e.g. Ares compute /tmp lives on a
+            # ~2 GiB-free root fs) and tip a high-thread combo into ENOSPC.
+            '--cache-size', str(self.config['cache_size_mb']),
+            '--background',
+        ]
+        if self.config['extra_mount_opts']:
+            mnt.append(self.config['extra_mount_opts'])
+        self.log(f"Mounting JuiceFS: {' '.join(mnt)}", color=Color.YELLOW)
+        Exec(' '.join(mnt), PsshExecInfo(env=self.mod_env, hostfile=eff_hostfile(self),
+                          **container_kwargs(self))).run()
+
+        # Wait for the mount to actually be ready before downstream I/O.
+        deadline = int(self.config['mount_wait'])
+        for _ in range(deadline):
+            if self._is_mounted(mountpoint):
+                self.log(f'JuiceFS mounted at {mountpoint}', color=Color.GREEN)
+                return
+            time.sleep(1)
+        raise RuntimeError(
+            f'juicefs: mountpoint {mountpoint} not ready after '
+            f'{deadline}s (check redis connectivity and /dev/fuse access)')
+
+    def stop(self):
+        """
+        Unmount the JuiceFS filesystem.
+
+        :return: None
+        """
+        _, mountpoint, _ = self._paths()
+        jfs = self.config['juicefs_bin']
+        Exec(f'{jfs} umount {mountpoint}',
+             PsshExecInfo(env=self.mod_env, hostfile=eff_hostfile(self),
+                          **container_kwargs(self))).run()
+        # Fallback for a wedged mount; ignore failure if already gone.
+        if self._is_mounted(mountpoint):
+            Exec(f'fusermount -u {mountpoint}',
+                 PsshExecInfo(env=self.mod_env, hostfile=eff_hostfile(self),
+                          **container_kwargs(self))).run()
+
+    def clean(self):
+        """
+        Unmount (if needed) and delete the local cache (and, for
+        storage='file', the local bucket) directories. A cloud bucket is
+        never deleted here -- teardown is left to the provider / lifecycle
+        rules (see scripts/smoke_juicefs_gcs.sh for manual cleanup).
+
+        :return: None
+        """
+        data_dir, mountpoint, cache_dir = self._paths()
+        if self._is_mounted(mountpoint):
+            self.stop()
+        dirs = [cache_dir]
+        if self.config['storage'] == 'file':
+            dirs.append(data_dir)
+        # Container-wrapped removal (see start()'s mkdir rationale): host-side
+        # shutil.rmtree can't reach the in-container paths.
+        Exec(f'rm -rf {" ".join(dirs)}',
+             PsshExecInfo(env=self.mod_env, hostfile=eff_hostfile(self),
+                          **container_kwargs(self))).run()

--- a/jarvis_clio_core/jarvis_clio_core/juicefs_bench/pkg.py
+++ b/jarvis_clio_core/jarvis_clio_core/juicefs_bench/pkg.py
@@ -1,0 +1,286 @@
+"""
+This module drives an ``fio`` workload against a mounted filesystem (here a
+JuiceFS FUSE mount) and parses fio's JSON report into ``results.csv``
+columns.
+
+It mirrors the start()/_get_stat() contract used by ``clio_cte_bench``:
+``start()`` captures the benchmark report to a file under ``shared_dir`` and
+``_get_stat()`` re-reads that file. This indirection is required because the
+jarvis_cd sweep runner reloads a *fresh* package instance before calling
+``_get_stat`` -- an in-memory buffer would be lost, so the on-disk fio JSON
+is the contract between the two methods.
+
+Parallelism is expressed via fio ``--numjobs`` + ``--thread`` (real threads
+sharing one address space), which is the closest match to the project's
+"threads" knob.
+"""
+import os
+import json
+from jarvis_cd.core.pkg import Application
+from jarvis_cd.shell import Exec, LocalExecInfo, PsshExecInfo
+from jarvis_clio_core.container_utils import (
+    container_kwargs, eff_hostfile, single_instance_menu_opt)
+
+
+class JuicefsBench(Application):
+    """
+    fio-based throughput/latency benchmark for a POSIX mountpoint, with a
+    JSON-parsing ``_get_stat`` that populates results.csv.
+    """
+
+    def _init(self):
+        """
+        Initialize package state.
+        """
+        self.json_path = None
+
+    def _configure_menu(self):
+        """
+        Configure the application menu.
+
+        :return: List(dict)
+        """
+        return [
+            {
+                'name': 'target_dir',
+                'msg': 'Directory to run fio in (the JuiceFS mountpoint)',
+                'type': str,
+                'default': '${HOME}/juicefs_mnt',
+            },
+            {
+                'name': 'io_size',
+                'msg': 'fio block size (--bs), e.g. 4k/16k/64k/128k',
+                'type': str,
+                'default': '4k',
+            },
+            {
+                'name': 'num_threads',
+                'msg': 'Number of fio jobs/threads (--numjobs --thread)',
+                'type': int,
+                'default': 1,
+            },
+            {
+                'name': 'runtime',
+                'msg': 'Seconds to run (fio --runtime --time_based)',
+                'type': int,
+                'default': 60,
+            },
+            {
+                'name': 'mode',
+                'msg': 'fio rw mode',
+                'type': str,
+                'choices': ['write', 'read', 'randwrite', 'randread'],
+                'default': 'write',
+            },
+            {
+                'name': 'size_per_job',
+                'msg': 'File size per job (--size)',
+                'type': str,
+                'default': '1G',
+            },
+            {
+                'name': 'ioengine',
+                'msg': 'fio I/O engine (--ioengine)',
+                'type': str,
+                'default': 'psync',
+            },
+            {
+                'name': 'direct',
+                'msg': 'Use O_DIRECT (often unsupported on FUSE)',
+                'type': bool,
+                'default': False,
+            },
+            {
+                'name': 'fallocate',
+                'msg': 'fio --fallocate mode. Use "none" for FUSE mounts '
+                       'that reject fallocate (e.g. the CTE libfuse mount); '
+                       '"native" preserves fio\'s default.',
+                'type': str,
+                'choices': ['none', 'native', 'posix', 'keep'],
+                'default': 'native',
+            },
+            {
+                'name': 'fio_bin',
+                'msg': 'Path to the fio binary',
+                'type': str,
+                'default': 'fio',
+            },
+            {
+                'name': 'output_file',
+                'msg': 'fio JSON report filename (under shared_dir)',
+                'type': str,
+                'default': 'fio_output.json',
+            },
+            # Head-node-only pinning: these fio drivers are single-client
+            # baselines (one head-node client writing to NFS / the JuiceFS
+            # mount). On a multi-node pipeline, fanning fio out to every node
+            # makes all N nodes clobber the one shared-dir JSON report and, for
+            # jfs_fio, run against a mountpoint that only exists on the head.
+            single_instance_menu_opt(),
+        ]
+
+    def _configure(self, **kwargs):
+        """
+        Validate config and resolve the JSON report path.
+
+        :param kwargs: Configuration parameters for this pkg.
+        :return: None
+        """
+        if self.config['num_threads'] <= 0:
+            raise ValueError('juicefs_bench: num_threads must be > 0')
+        if (int(self.config['runtime']) <= 0):
+            raise ValueError('juicefs_bench: runtime must be > 0')
+        if self.config['mode'] not in ('write', 'read', 'randwrite',
+                                       'randread'):
+            raise ValueError(
+                f"juicefs_bench: invalid mode {self.config['mode']}")
+        self.json_path = os.path.join(self.shared_dir,
+                                      self.config['output_file'])
+
+    def _op_label(self):
+        """
+        Map the fio rw mode onto the fio JSON section ('read' or 'write').
+
+        :return: str
+        """
+        return 'read' if 'read' in self.config['mode'] else 'write'
+
+    def start(self):
+        """
+        Run fio against the target directory, writing a JSON report to
+        ``<shared_dir>/<output_file>`` (the start->_get_stat contract).
+
+        :return: None
+        """
+        target_dir = os.path.expanduser(
+            os.path.expandvars(str(self.config['target_dir'])))
+        # Create the target dir in the deployment context. For the container
+        # deploy target_dir may be an in-container path (a FUSE mountpoint
+        # like /tmp/cte_mnt or /tmp/jfs_mnt, which under tmp_bind_root is a
+        # different directory from the host's /tmp), so it must be created
+        # via a wrapped Exec, not host-side os.makedirs. Bare-metal it is a
+        # harmless local mkdir -p. (json_path below stays on the auto-mounted
+        # shared_dir -- written by fio, host-visible.)
+        Exec(f'mkdir -p {target_dir}',
+             PsshExecInfo(env=self.mod_env, hostfile=eff_hostfile(self),
+                          **container_kwargs(self))).run()
+        json_path = os.path.join(self.shared_dir, self.config['output_file'])
+
+        cmd = [
+            self.config['fio_bin'],
+            '--name=jfs',
+            f'--directory={target_dir}',
+            f"--rw={self.config['mode']}",
+            f"--bs={self.config['io_size']}",
+            f"--numjobs={self.config['num_threads']}",
+            '--thread',
+            f"--runtime={self.config['runtime']}",
+            '--time_based',
+            f"--size={self.config['size_per_job']}",
+            f"--ioengine={self.config['ioengine']}",
+            f"--direct={1 if self.config['direct'] else 0}",
+            f"--fallocate={self.config['fallocate']}",
+            '--group_reporting',
+            '--output-format=json',
+            f'--output={json_path}',
+        ]
+        cmd_str = ' '.join(cmd)
+        self.log(f'Executing: {cmd_str}')
+        # Wrapped: fio must run inside the instance so it writes through the
+        # FUSE mounts that live in the instance's mount namespace (and comes
+        # from the SIF, not the host env).
+        Exec(cmd_str, PsshExecInfo(env=self.mod_env, hostfile=eff_hostfile(self),
+                                   **container_kwargs(self))).run()
+        self.log(f'fio completed. JSON report at: {json_path}')
+
+    def stop(self):
+        """
+        fio runs to completion; nothing to stop.
+
+        :return: bool
+        """
+        return True
+
+    def clean(self):
+        """
+        Remove the fio JSON report.
+
+        :return: None
+        """
+        json_path = os.path.join(self.shared_dir, self.config['output_file'])
+        if os.path.exists(json_path):
+            try:
+                os.remove(json_path)
+                self.log(f'Removed {json_path}')
+            except OSError as e:
+                self.log(f'Error removing {json_path}: {e}')
+
+    # ------------------------------------------------------------------
+    # Statistics collection
+    # ------------------------------------------------------------------
+
+    def _get_stat(self, stat_dict):
+        """
+        Parse the fio JSON report and populate ``stat_dict``.
+
+        Called by the sweep runner on a freshly-loaded package instance, so
+        metrics are read back from ``<shared_dir>/<output_file>`` rather than
+        from memory. Each extracted metric becomes a results.csv column keyed
+        ``<pkg_id>.<op>.<metric>``.
+
+        :param stat_dict: Dict the framework serialises into results.csv.
+        :return: None
+        """
+        json_path = os.path.join(self.shared_dir, self.config['output_file'])
+        if not os.path.exists(json_path):
+            self.log(f'No fio report found at {json_path}')
+            return
+        with open(json_path, 'r') as f:
+            raw = f.read()
+        if not raw.strip():
+            self.log(f'fio report is empty: {json_path}')
+            return
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as e:
+            self.log(f'Could not parse fio JSON {json_path}: {e}')
+            return
+
+        self._parse_output(data, stat_dict)
+
+    def _parse_output(self, data, stat_dict):
+        """
+        Extract bandwidth/IOPS/latency from a parsed fio JSON document.
+
+        :param data: Parsed fio JSON (dict).
+        :param stat_dict: Dict to populate with ``<pkg_id>.<op>.<metric>``.
+        :return: None
+        """
+        jobs = data.get('jobs') or []
+        if not jobs:
+            self.log('fio JSON has no jobs array; no metrics extracted')
+            return
+        op = self._op_label()
+        section = jobs[0].get(op, {})
+        prefix = f'{self.pkg_id}.{op}'
+        before = len(stat_dict)
+
+        # bw is reported in KiB/s.
+        if 'bw' in section:
+            stat_dict[f'{prefix}.agg_bw_mbps'] = section['bw'] / 1024.0
+        if 'iops' in section:
+            stat_dict[f'{prefix}.iops'] = float(section['iops'])
+        lat_ns = section.get('lat_ns', {})
+        if 'mean' in lat_ns:
+            stat_dict[f'{prefix}.lat_mean_us'] = lat_ns['mean'] / 1000.0
+        clat_pct = section.get('clat_ns', {}).get('percentile', {})
+        if '99.000000' in clat_pct:
+            stat_dict[f'{prefix}.lat_p99_us'] = \
+                clat_pct['99.000000'] / 1000.0
+        if 'io_bytes' in section:
+            stat_dict[f'{prefix}.total_io_mb'] = \
+                section['io_bytes'] / (1024.0 * 1024.0)
+
+        if len(stat_dict) == before:
+            self.log(f'Warning: no fio metrics extracted for op={op}; '
+                     f'check the fio JSON schema in {self.json_path}')

--- a/jarvis_clio_core/jarvis_clio_core/redis/config/redis.conf
+++ b/jarvis_clio_core/jarvis_clio_core/redis/config/redis.conf
@@ -338,7 +338,10 @@ daemonize no
 #
 # Note that on modern Linux systems "/run/redis.pid" is more conforming
 # and should be used instead.
-pidfile /var/run/redis_6379.pid
+# #526: empty => no pidfile. /var/run is not writable inside the unprivileged
+# apptainer container ("Failed to write PID file: Permission denied"); the pid
+# file is unused here (non-daemonized; jarvis tracks the process directly).
+pidfile ""
 
 # Specify the server verbosity level.
 # This can be one of:
@@ -476,6 +479,12 @@ rdbchecksum yes
 # resharding via MIGRATE, it is temporarily set to 'no' by default.
 #
 # sanitize-dump-payload no
+
+# #526: disable RDB snapshotting. This is an ephemeral in-memory metadata engine
+# (JuiceFS meta in DB1) + benchmark target (DB0); persistence is undesirable and
+# a stale dump.rdb loaded across runs/sweep-combos leaked 83 keys + old JuiceFS
+# meta. With save "" no dump.rdb is written; the pkg also flushall's on start.
+save ""
 
 # The filename where to dump the DB
 dbfilename dump.rdb

--- a/jarvis_clio_core/jarvis_clio_core/redis/pkg.py
+++ b/jarvis_clio_core/jarvis_clio_core/redis/pkg.py
@@ -3,11 +3,12 @@ This module provides classes and methods to launch Redis.
 Redis cluster is used if the hostfile has many hosts
 """
 import time
-import subprocess
 from jarvis_cd.core.pkg import Application
 from jarvis_cd.util.logger import Color
+from jarvis_cd.util.hostfile import Hostfile
 from jarvis_cd.shell import Exec, LocalExecInfo, PsshExecInfo
 from jarvis_cd.shell.process import Kill
+from jarvis_clio_core.container_utils import container_kwargs, all_hosts_ok
 
 
 class Redis(Application):
@@ -37,7 +38,34 @@ class Redis(Application):
                 'choices': [],
                 'args': [],
             },
+            {
+                'name': 'single_instance',
+                'msg': 'Force ONE redis server on the first host even when the '
+                       'hostfile has >1 host (skip the cluster branch). Use '
+                       'when redis is a metadata singleton — e.g. JuiceFS meta '
+                       'over redis://.../1, which needs SELECT and so cannot '
+                       'use DB0-only cluster mode. Default keeps the legacy '
+                       'behaviour (cluster iff >1 host).',
+                'type': bool,
+                'default': False,
+            },
         ]
+
+    def _eff_hostfile(self):
+        """The hostfile the redis server(s) actually run on.
+
+        With single_instance set and a multi-host pipeline hostfile, collapse
+        to just the FIRST host so redis stays a plain (non-cluster) server:
+        cluster mode is DB0-only and would break a JuiceFS meta_url of
+        redis://.../1 (SELECT 1), and 4 servers sharing one nodes.conf on the
+        NFS shared dir collide anyway. Otherwise return the full hostfile
+        (>1 host still takes the cluster branch)."""
+        hf = self.hostfile
+        if self.config.get('single_instance') and len(hf.hosts) > 1:
+            return Hostfile(
+                hosts=hf.hosts[:1],
+                hosts_ip=hf.hosts_ip[:1] if hf.hosts_ip else None)
+        return hf
 
     def _configure(self, **kwargs):
         """
@@ -54,6 +82,24 @@ class Redis(Application):
                                     'PORT': self.config['port']
                                 })
 
+    def _redis_cli(self, args, expect=None, timeout_s=2):
+        """Run ``redis-cli <args>`` in the deployment context (inside the
+        apptainer instance for a container deploy — redis-cli need not exist
+        host-side). ``timeout N`` bounds each attempt like the old
+        subprocess timeout did; callers keep their own retry loops.
+
+        :param args: redis-cli argument string (e.g. ``-p 6379 ping``)
+        :param expect: optional substring required in every host's stdout
+        :param timeout_s: per-attempt timeout in seconds
+        :return: True iff every host exited 0 (and printed ``expect``)
+        """
+        res = Exec(f'timeout {timeout_s} redis-cli {args}',
+                   PsshExecInfo(env=self.mod_env,
+                                hostfile=self._eff_hostfile(),
+                                collect_output=True,
+                                **container_kwargs(self))).run()
+        return all_hosts_ok(res, expect)
+
     def start(self):
         """
         Launch an application. E.g., OrangeFS will launch the servers, clients,
@@ -61,15 +107,27 @@ class Redis(Application):
 
         :return: None
         """
-        hostfile = self.hostfile
+        hostfile = self._eff_hostfile()
         host_str = [f'{host}:{self.config["port"]}' for host in hostfile.hosts]
         host_str = ' '.join(host_str)
         cluster_config_file = f'{self.private_dir}/nodes.conf'
+        # Redis loads ./dump.rdb from its working directory at startup. The conf
+        # sets `dir ./`, which under `apptainer exec` resolves to whatever CWD
+        # the instance drops us in (e.g. $HOME) — and a stale dump.rdb left there
+        # by a prior run or a newer redis crashes startup ("Can't handle RDB
+        # format version 11 / Fatal error loading the DB. Exiting.") even though
+        # save "" means we never write a fresh one. Pin --dir to THIS run's
+        # private dir (container-visible: the cluster branch already read/wrote
+        # nodes.conf there) and wipe any leftover dump so startup is clean.
+        Exec(f'rm -f {self.private_dir}/dump.rdb',
+             PsshExecInfo(env=self.mod_env, hostfile=hostfile,
+                          **container_kwargs(self))).run()
         # Create redis servers
         self.log('Starting individual servers', color=Color.YELLOW)
         cmd = [
             'redis-server',
             f'{self.shared_dir}/redis.conf',
+            f'--dir {self.private_dir}',
         ]
         if len(hostfile) > 1:
             cmd += [
@@ -79,10 +137,16 @@ class Redis(Application):
             ]
 
         cmd = ' '.join(cmd)
+        # Wrapped: the SIF's redis-server, running inside the instance where
+        # juicefs and clio_redis_bench connect to it. exec_async does NOT
+        # skip the container wrap (ExecFactory.run always calls
+        # _prepare_container before delegating); the daemon parents into the
+        # instance and lives until instance stop.
         Exec(cmd,
              PsshExecInfo(env=self.mod_env,
                           hostfile=hostfile,
-                          exec_async=True)).run()
+                          exec_async=True,
+                          **container_kwargs(self))).run()
         self.log(f'Sleeping for {self.config["sleep"]} seconds', color=Color.YELLOW)
         time.sleep(self.config['sleep'])
 
@@ -90,25 +154,36 @@ class Redis(Application):
         port = self.config['port']
         self.log(f'Waiting for Redis to accept connections on port {port}', color=Color.YELLOW)
         for i in range(30):
-            ret = subprocess.run(
-                ['redis-cli', '-p', str(port), 'ping'],
-                capture_output=True, text=True, timeout=2)
-            if ret.returncode == 0 and 'PONG' in ret.stdout:
+            if self._redis_cli(f'-p {port} ping', expect='PONG'):
                 break
             time.sleep(1)
         else:
             self.log('WARNING: Redis did not respond to PING after 30s', color=Color.RED)
 
+        # #526: single-node hygiene — wipe ALL DBs so each sweep combo starts
+        # from an empty server (DB0 for redis_bench, DB1 for the JuiceFS meta),
+        # regardless of any dump.rdb a prior run left in redis's CWD. The
+        # multi-host cluster branch below already flushall's per host.
+        if len(hostfile) <= 1:
+            self.log('Flushing all DBs (fresh slate for this run)',
+                     color=Color.YELLOW)
+            self._redis_cli(f'-p {port} flushall', timeout_s=5)
+
         # Create redis clients
         if len(hostfile) > 1:
+            # One-shot cluster admin commands, wrapped into an instance
+            # (LOCAL exec_info with a remote hostfile is promoted to SSH on
+            # the first host, so these run inside the head node's instance).
             self.log('Flushing all data and resetting the cluster', color=Color.YELLOW)
             for host in hostfile.hosts:
                 Exec(f'redis-cli -p {self.config["port"]} -h {host} flushall',
                      LocalExecInfo(env=self.mod_env,
-                                   hostfile=hostfile)).run()
+                                   hostfile=hostfile,
+                                   **container_kwargs(self))).run()
                 Exec(f'redis-cli -p {self.config["port"]} -h {host} cluster reset',
                      LocalExecInfo(env=self.mod_env,
-                                   hostfile=hostfile)).run()
+                                   hostfile=hostfile,
+                                   **container_kwargs(self))).run()
 
             self.log('Creating the cluster', color=Color.YELLOW)
             cmd = [
@@ -121,7 +196,8 @@ class Redis(Application):
             print(cmd)
             Exec(cmd,
                  LocalExecInfo(env=self.mod_env,
-                               hostfile=hostfile)).run()
+                               hostfile=hostfile,
+                               **container_kwargs(self))).run()
             self.log(f'Sleeping for {self.config["sleep"]} seconds', color=Color.YELLOW)
             time.sleep(self.config['sleep'])
 
@@ -133,21 +209,29 @@ class Redis(Application):
         :return: None
         """
         port = self.config['port']
-        # Gracefully shutdown redis on each host via redis-cli
+        eff_hostfile = self._eff_hostfile()
+        # Gracefully shutdown redis on each host via redis-cli (wrapped: the
+        # server lives inside the instance, and redis-cli comes from the SIF).
+        # Target the SAME hosts redis was started on (single_instance => first
+        # host only), else stop tries to reach servers that were never launched.
         Exec(f'redis-cli -p {port} shutdown nosave',
              PsshExecInfo(env=self.mod_env,
-                          hostfile=self.hostfile)).run()
-        # Fallback: force kill any remaining redis-server processes
+                          hostfile=eff_hostfile,
+                          **container_kwargs(self))).run()
+        # Fallback: force kill any remaining redis-server processes, scoped
+        # to this run's instance (its PID namespace).
+        # (No partial= kwarg: this jarvis's Kill doesn't accept it -> it raised
+        # "Kill.__init__() got an unexpected keyword argument 'partial'", which
+        # aborted stop() before the force-kill could run.)
         Kill('redis-server',
              PsshExecInfo(env=self.mod_env,
-                          hostfile=self.hostfile),
-             partial=False).run()
-        # Wait for the port to be free before returning
+                          hostfile=eff_hostfile,
+                          **container_kwargs(self))).run()
+        # Wait for the port to be free before returning. If the instance is
+        # already gone the wrapped probe fails -> treated as "port free",
+        # which is the right best-effort answer at teardown.
         for i in range(10):
-            ret = subprocess.run(
-                ['redis-cli', '-p', str(port), 'ping'],
-                capture_output=True, text=True, timeout=2)
-            if ret.returncode != 0 or 'PONG' not in ret.stdout:
+            if not self._redis_cli(f'-p {port} ping', expect='PONG'):
                 break
             time.sleep(1)
         time.sleep(1)

--- a/jarvis_clio_core/pipelines/ares/cte_sweep_1n.yaml
+++ b/jarvis_clio_core/pipelines/ares/cte_sweep_1n.yaml
@@ -1,0 +1,88 @@
+# CLIO Core (CTE) single-node performance sweep — mirrors the JuiceFS fio sweep.
+#
+# Brings up the Chimaera runtime + a CTE pool with a single RAM tier, then
+# drives clio_cte_bench (Put / write) against it across the SAME knob grid the
+# JuiceFS fio sweep used, so the two are directly comparable:
+#
+#   * I/O size (--io-size):  4k, 16k, 64k, 128k
+#   * threads  (--threads):  1, 2, 4, 8
+#   * 60 s per run (--time-limit 60)  <- mirrors fio --runtime=60 --time_based
+#   * 3 repeats                       => 4 x 4 x 3 = 48 runs
+#
+# Operation is **Put** to match the JuiceFS benchmark, which ran `mode: write`
+# (fio --rw=write) and recorded write-only metrics. Flip test_case to PutGet or
+# Get if you later want read numbers too.
+#
+# Keyspace is bounded to a fixed ~1 GiB GLOBAL working set per io_size via
+# --max-total-blobs (total unique bytes = max_total_blobs * io_size, split
+# evenly across threads — see clio_cte_bench help). This keeps the RAM tier from
+# overflowing under a 60 s time-limited Put at any thread count, and isolates the
+# thread-scaling effect by holding the working set constant. The values zip with
+# io_size: 4k->262144, 16k->65536, 64k->16384, 128k->8192 (each = 1 GiB / io_size).
+#
+# clio_cte_bench._get_stat writes results.csv columns:
+#   cte_bench.put.{agg_bw_mbps, agg_ops_per_sec, avg_latency_per_op_us,
+#                  bw_per_thread_avg_mbps, total_data_mb, total_ops, ...}
+#
+# Requires on PATH (inside the iowarp conda env): clio_cte_bench, plus the
+# clio_run runtime. Launch on a compute node via scripts/run_cte_sweep_ares.sbatch
+# (which calls `jarvis ppl run yaml` on this file — the runner auto-detects the
+# vars:+loop: sweep and writes ${output}/results.csv).
+#
+# Usage (inside an allocation):
+#   jarvis ppl run yaml jarvis_clio_core/pipelines/ares/cte_sweep_1n.yaml
+# Output:
+#   ${HOME}/cte_sweep_results/results.csv  (48 rows)
+
+config:
+  name: cte_sweep_1n
+  pkgs:
+    # --- Chimaera runtime (owns the daemon; shm IPC for single-node) ---
+    - pkg_type: jarvis_clio_core.clio_runtime
+      pkg_name: runtime
+      num_threads: 4
+      port: 9413
+      ipc_mode: "shm"
+      log_level: "info"
+      sleep: 4
+
+    # --- CTE core: single RAM tier (16 GiB -> ~16x headroom over the 1 GiB set) ---
+    - pkg_type: jarvis_clio_core.clio_cte
+      pkg_name: cte_core
+      devices:
+        - ["ram::cte_ram_tier1", "16GB", 1.0]
+      dpe_type: "max_bw"
+      neighborhood: 1
+      default_target_timeout_ms: 30000
+      poll_period_ms: 5000
+
+    # --- CTE benchmark (Put / write; metrics -> results.csv) ---
+    - pkg_type: jarvis_clio_core.clio_cte_bench
+      pkg_name: cte_bench
+      test_case: "Put"
+      num_threads: 1
+      depth: 1
+      io_size: "4k"
+      time_limit: 60
+      max_total_blobs: 262144
+      nprocs: 1
+      ppn: 1
+      init_runtime: false
+      output_file: cte_bench.log
+
+vars:
+  # I/O size + matching 1 GiB-unique GLOBAL keyspace (zipped so 4k<->262144,
+  # 16k<->65536, 64k<->16384, 128k<->8192 stay paired). Because
+  # --max-total-blobs is split across threads, these are thread-independent.
+  cte_bench.io_size:         ["4k",   "16k",  "64k",  "128k"]
+  cte_bench.max_total_blobs: [262144, 65536,  16384,  8192]
+
+  # Client thread scaling.
+  cte_bench.num_threads:     [1, 2, 4, 8]
+
+loop:
+  - [cte_bench.io_size, cte_bench.max_total_blobs]   # outer (zipped pair)
+  - [cte_bench.num_threads]                          # inner -> 16 combos
+
+repeat: 3                       # x3 repeats -> 48 runs
+output: "${HOME}/cte_sweep_results"

--- a/jarvis_clio_core/pipelines/ares/distributed.yaml
+++ b/jarvis_clio_core/pipelines/ares/distributed.yaml
@@ -1,0 +1,227 @@
+# =============================================================================
+# Issue #526 — Reproducible Jarvis pipeline: MULTI-NODE (distributed) sweep.
+# CONTAINERIZED (Apptainer) deployment, driven by a standalone sbatch (Pattern A).
+# =============================================================================
+#
+# Sweeps the effective CTE node count 1 -> 2 -> 4 at a FIXED (I/O size, thread)
+# working point and benchmarks three storage stacks, recording every run into
+# one results.csv for day-over-day regression tracking.
+#
+#   Experiments (project_info.md, Project 2 multi-node):
+#     1. NFS            -> fio against the cluster's shared NFS home (bind-mounted)
+#     2. CTE + libfuse  -> clio_cte_bench, one Put rank per node (see DRIVER NOTE)
+#     3. juicefs        -> fio against a JuiceFS mount
+#
+#   Sweep (project_info.md lists only the node count for multi-node):
+#     * nodes: 1, 2, 4      (fixed: io_size = 1m = 1024 KB, threads = 4)
+#
+# EXECUTION MODEL (Pattern A — single allocation, in-process sweep):
+#   There is NO `scheduler:` block and the node count is NOT a swept
+#   `scheduler.nodes` var. Instead the wrapper scripts/run_distributed_ares.sbatch
+#   grabs a FOUR-node allocation ONCE, seeds the jarvis hostfile with all four
+#   nodes, and runs a single `jarvis ppl run yaml .../distributed.yaml`. The
+#   pipeline sweeps `cte_bench.nprocs` over [1, 2, 4] IN-PROCESS: with ppn=1 that
+#   is one CTE Put rank on 1, then 2, then 4 of the allocated nodes — giving 3
+#   rows in ONE results.csv from ONE allocation.
+#   We deliberately avoid the `scheduler.nodes`-swept `ppl submit` path (one
+#   sbatch per node count), which runs against node-local /tmp and FAILED on
+#   Ares for Mofka. Trade-off: the 1- and 2-node points run inside a 4-node
+#   reservation; since each CTE rank talks ONLY to its own node-local pool
+#   (query_type: local), the idle nodes don't perturb the measurement.
+#
+# DRIVER NOTE — why CTE uses clio_cte_bench here (not fio-through-libfuse):
+#   clio_cte_bench is the only EXISTING rich-metric driver that scales across
+#   nodes and folds a per-node aggregate into results.csv: nprocs = node count,
+#   ppn = 1 => one Put rank per node, each talking to ITS OWN local CTE pool over
+#   loopback (query_type: local); _get_stat SUM-folds the per-host
+#   bandwidth/IOPS (the host-folding ported into clio_cte_bench/pkg.py). fio
+#   (juicefs_bench) is single-node, so NFS and juicefs are head-node single-client
+#   baselines that should stay roughly FLAT across node counts — itself a useful
+#   regression signal.
+#
+# CONTAINER MODEL:
+#   base_deploy_mode: container + container_engine: apptainer => jarvis fans an
+#   `apptainer instance start` (sshd inside) to EVERY allocated node via Pssh,
+#   then runs each package with `apptainer exec instance://...`. The per-node
+#   sshd lets jarvis Pssh / clio_cte_bench's MPI fan-out reach the other nodes'
+#   instances (apptainer's no-daemon analogue of the docker-cluster model). FUSE
+#   (juicefs) needs CAP_SYS_ADMIN effective in-container; with a non-setuid
+#   apptainer that requires --fakeroot (container_fakeroot), which jarvis fans to
+#   EVERY node's `apptainer instance start`. The single SIF on the shared FS is
+#   visible to all nodes — no per-node image distribution (unlike `srun docker
+#   pull`).
+#
+# INSTALLATION: baked into a prebuilt SIF built from pipelines/container/
+# Dockerfile.regression (docker build -> apptainer build docker-daemon://...).
+# PATHS: host storage is bind-mounted (container_binds) so NFS + juicefs object
+# store hit real FS; /tmp is node-local (tmp_bind_root).
+#
+# Output:
+#   ${HOME}/distributed_results/results.csv   (3 rows, one per node count;
+#   columns: nfs_fio.write.*, cte_bench.put.* (per-node-folded), jfs_fio.write.*)
+
+config:
+  name: distributed
+  # The OUTER jarvis Pssh's between nodes to bring up the per-node containers;
+  # strip the conda LD_LIBRARY_PATH for that ssh hop so /usr/bin/ssh doesn't
+  # abort on an OpenSSL mismatch (as in cte_sweep_2n.yaml).
+  ssh_cmd: "env -u LD_LIBRARY_PATH ssh"
+
+  # ---- Containerized deployment (Ares dev jarvis — APPTAINER) -----------
+  # Pre-staged SIF referenced by BASENAME -> <shared_dir>/containers/
+  # iowarp-regression-526.sif (shared_dir is on /mnt/common, visible on every
+  # allocated node — so ONE SIF serves all nodes, no per-node distribution).
+  # container_uri UNSET => jarvis trusts the SIF and skips pull/build. NOT
+  # env-expanded, so keep it a bare basename. See single_node.yaml for the full
+  # rationale on container_fakeroot and tmp_bind_root.
+  base_deploy_mode: container
+  container_engine: apptainer
+  container_image: "iowarp-regression-526"
+  # FUSE (JuiceFS) needs CAP_SYS_ADMIN effective in-container; under a non-setuid
+  # apptainer only --fakeroot supplies it. jarvis fans `apptainer instance start
+  # --fakeroot` to every node. See single_node.yaml for the verified rationale.
+  container_fakeroot: true
+  # In-container /tmp -> node-local disk (chimaera IPC socket/memfd + juicefs
+  # cache must not live on the NFS overlay). Per-host path: /tmp/distributed/tmp.
+  tmp_bind_root: "/tmp"
+  # NO container_binds: an explicit --bind onto /mnt did NOT materialize in the
+  # per-package `apptainer exec instance://` namespace on Ares. We instead use
+  # apptainer's automatic $HOME bind-mount (present + writable in the exec
+  # context) for the writable experiment dirs (nfs_fio.target_dir +
+  # juicefs.data_dir below), and node-local /tmp (tmp_bind_root) for the FUSE
+  # mountpoint + juicefs cache. See single_node.yaml for the full rationale.
+
+  env:
+    CLIO_MEMFD_DIR: "/tmp/iowarp_chimaera"
+
+  pkgs:
+    # ---- Services -------------------------------------------------------
+    # Redis metadata engine for JuiceFS (head-node container). single_instance:
+    # the 4-node hostfile would otherwise push redis into CLUSTER mode, which
+    # (a) makes all 4 servers share one nodes.conf on the NFS shared dir ->
+    # "already used by a different Redis Cluster node", and (b) is DB0-only, so
+    # JuiceFS's meta_url redis://127.0.0.1:6379/1 (SELECT 1) can't work. redis
+    # here is just JuiceFS's metadata store on the head node, so pin it to one
+    # server on the first host (matches the single_node deployment).
+    - pkg_type: jarvis_clio_core.redis
+      pkg_name: redis
+      port: 6379
+      single_instance: true
+      sleep: 4
+
+    # Chimaera runtime on EVERY allocated node's container (Pssh-launched across
+    # the hostfile). shm client transport within each node.
+    - pkg_type: jarvis_clio_core.clio_runtime
+      pkg_name: runtime
+      num_threads: 4
+      port: 9413
+      ipc_mode: "shm"
+      log_level: "info"
+      sleep: 4
+
+    # CTE pool on every node, single local RAM tier (neighborhood: 1 = each node
+    # serves its own data). pool_query: local => every PutBlob stays node-local
+    # -> symmetric scaling.
+    - pkg_type: jarvis_clio_core.clio_cte
+      pkg_name: cte_core
+      devices:
+        - ["ram::cte_ram_tier1", "16GB", 1.0]
+      dpe_type: "max_bw"
+      neighborhood: 1
+      pool_query: "local"
+      default_target_timeout_ms: 30000
+      poll_period_ms: 5000
+
+    # JuiceFS: format (storage=file) + FUSE mount on the head-node container.
+    - pkg_type: jarvis_clio_core.juicefs
+      pkg_name: juicefs
+      # Head-node-only: redis (the metadata store) runs on the first host only
+      # (single_instance above), and the mount is a single head-node client
+      # baseline. Without this the 4-node hostfile fans format/mount/rm-rf out
+      # to every node -> concurrent rm/mkdir race on the shared NFS $HOME (which
+      # left $HOME in a half-torn state that EINVAL'd the NEXT sweep combo's
+      # mkdir) + "connection refused" on the 3 nodes with no local redis.
+      single_instance: true
+      meta_url: "redis://127.0.0.1:6379/1"
+      storage: file
+      # Object store under the auto-mounted $HOME (writable in the exec context),
+      # NOT a /mnt bind (which doesn't materialize for `apptainer exec`).
+      data_dir: ${HOME}/juicefs_data
+      # Mount on node-local /tmp (writable), NOT /mnt: the image's /mnt is a
+      # read-only SquashFS root, so only the container_binds under it are writable.
+      # data_dir stays /mnt/jfs_data (a writable host bind = the object store).
+      mountpoint: /tmp/jfs_mnt
+      cache_dir: /tmp/juicefs_cache
+      name: jfsbench
+      format_fresh: true
+      mount_wait: 20
+
+    # ---- Benchmark drivers ---------------------------------------------
+    # 1) NFS: fio against the bound host NFS dir (head-node client baseline).
+    - pkg_type: jarvis_clio_core.juicefs_bench
+      pkg_name: nfs_fio
+      # Single head-node client baseline: pin to the first host so the 4 nodes
+      # don't all run fio against the same shared-NFS target and clobber the one
+      # shared-dir JSON report (whichever finishes last would win).
+      single_instance: true
+      # NFS home ($HOME) subdir as the experiment target (apptainer auto-mounts
+      # $HOME); avoids the /mnt bind. Created by the wrapper sbatch.
+      target_dir: ${HOME}/distributed_nfs
+      io_size: "1m"
+      num_threads: 4
+      runtime: 60
+      mode: write
+      size_per_job: "256M"
+      ioengine: psync
+      direct: false
+      fallocate: native
+      output_file: nfs_fio.json
+
+    # 2) CTE: one Put rank per node (nprocs swept below), local target,
+    #    per-host-folded aggregate -> results.csv (cte_sweep_2n pattern).
+    - pkg_type: jarvis_clio_core.clio_cte_bench
+      pkg_name: cte_bench
+      test_case: "Put"
+      num_threads: 4
+      depth: 1
+      io_size: "1m"
+      time_limit: 60
+      max_total_blobs: 1024
+      query_type: "local"
+      nprocs: 1
+      ppn: 1
+      init_runtime: false
+      output_file: cte_bench.log
+      # Absolute path to the bench in the SIF spack view: jarvis's exec shell
+      # PATH omits /opt/iowarp-view/bin, so the bare name is "command not found".
+      bin_dir: /opt/iowarp-view/bin
+
+    # 3) juicefs: fio against the JuiceFS mount (head-node client baseline).
+    - pkg_type: jarvis_clio_core.juicefs_bench
+      pkg_name: jfs_fio
+      # Single head-node client baseline: the JuiceFS mount only exists on the
+      # head node (juicefs is single_instance), so fio must run there too — on
+      # the other 3 nodes /tmp/jfs_mnt isn't a JuiceFS mount at all.
+      single_instance: true
+      target_dir: /tmp/jfs_mnt
+      io_size: "1m"
+      num_threads: 4
+      runtime: 60
+      mode: write
+      size_per_job: "256M"
+      ioengine: psync
+      direct: false
+      fallocate: none
+      output_file: jfs_fio.json
+
+# Effective-node-count sweep, expressed as the CTE rank count within the single
+# 4-node allocation (ppn: 1 => one rank per node). The fio drivers are
+# unaffected (single head-node client at every point).
+vars:
+  cte_bench.nprocs:  [1, 2, 4]
+
+loop:
+  - [cte_bench.nprocs]
+
+repeat: 1
+output: "${HOME}/distributed_results"

--- a/jarvis_clio_core/pipelines/ares/single_node.yaml
+++ b/jarvis_clio_core/pipelines/ares/single_node.yaml
@@ -1,0 +1,277 @@
+# =============================================================================
+# Issue #526 — Reproducible Jarvis pipeline: SINGLE-NODE regression sweep.
+# CONTAINERIZED (Apptainer) deployment, driven by a standalone sbatch (Pattern A).
+# =============================================================================
+#
+# One pipeline test that benchmarks FOUR storage stacks back-to-back over a
+# shared (I/O size x thread count) grid and records every run into ONE
+# results.csv, so a daily Ares run can be diffed against yesterday to catch
+# performance regressions.
+#
+#   Experiments (project_info.md, Project 2 single-node):
+#     1. NFS            -> fio against the cluster's NFS home (bind-mounted)
+#     2. CTE + libfuse  -> fio against the CTE FUSE mount (POSIX -> FUSE -> CTE)
+#     3. redis          -> clio_redis_bench (SET/GET) against a local redis
+#     4. juicefs        -> fio against the JuiceFS FUSE mount (redis meta +
+#                          local-file object backend)
+#
+#   Grid (project_info.md):
+#     * I/O size:     4 KB, 64 KB, 128 KB, 1024 KB   -> 4k, 64k, 128k, 1m
+#     * thread count: 1, 2, 4, 8, 16, 32             -> 4 x 6 = 24 combinations
+#
+# EXECUTION MODEL (Pattern A — the validated path on this fork; see
+# scripts/run_cte_sweep_ares.sbatch and the Mofka 45/45 runbook):
+#   There is NO top-level `scheduler:` block. The whole 24-combo grid runs
+#   IN-PROCESS inside ONE Slurm allocation. The wrapper
+#   scripts/run_single_node_ares.sbatch grabs one node, makes the regression
+#   SIF present, creates the host bind dirs, and runs:
+#       jarvis ppl run yaml .../single_node.yaml
+#   (We deliberately avoid the scheduler-block + `ppl submit` path, which runs a
+#   sweep as nested per-iteration sbatch against node-local /tmp and FAILED on
+#   Ares for Mofka.)
+#
+# CONTAINER MODEL:
+#   base_deploy_mode: container + container_engine: apptainer => jarvis's dev
+#   ContainerInstaller starts ONE long-running `apptainer instance` (with sshd
+#   inside) and runs the WHOLE pipeline inside it via `apptainer exec
+#   instance://...`. All service/driver packages run bare-metal inside that one
+#   instance, so the JuiceFS and CTE FUSE mounts are visible to fio in the SAME
+#   mount namespace. FUSE needs CAP_SYS_ADMIN, which an UNPRIVILEGED (non-setuid,
+#   conda-forge) apptainer can only supply via --fakeroot (container_fakeroot
+#   below): it maps the user to root inside the user namespace, where mount() of
+#   a new FUSE filesystem is permitted and /dev/fuse opens cleanly. Plain
+#   --add-caps SYS_ADMIN is a NO-OP in rootless mode (you can't gain host caps
+#   you don't have), which is why the FUSE mounts failed until fakeroot. Unlike
+#   Docker, apptainer applies NO seccomp/apparmor profile, so io_uring_setup
+#   (CTE bdev) is not blocked.
+#
+# INSTALLATION: baked into a prebuilt SIF built from pipelines/container/
+# Dockerfile.regression (`docker build` then `apptainer build <sif>
+# docker-daemon://...` — the Dockerfile's final RUN is the install-cleanliness
+# gate). The image carries iowarp(+libfuse,+redis), redis, juicefs, fio,
+# jarvis-cd, and this repo. Rebuild daily so #526 tracks the latest IOWarp.
+#
+# PATHS: apptainer bind-mounts host storage (container_binds) and the experiments
+# write to those binds:
+#   - NFS experiment  -> /mnt/nfs       (bound to the host NFS home -> real NFS)
+#   - juicefs object store -> /mnt/jfs_data (bound to host FS, not the overlay)
+#   - CTE/juicefs FUSE mountpoints live on in-container /tmp (the image's /mnt is
+#     a READ-ONLY SquashFS root, so only the container_binds under /mnt are
+#     writable; the mountpoints must be created on the writable /tmp bind). /tmp
+#     (mountpoints + juicefs cache + chimaera memfd/IPC) is NODE-LOCAL via
+#     tmp_bind_root;
+#     bench output files land in the auto-mounted shared_dir, and the runner
+#     writes results.csv on the HOST at `output:` below.
+#
+# Output:
+#   ${HOME}/single_node_results/results.csv   (24 rows; per-backend columns:
+#   <driver>.write.{agg_bw_mbps,iops,lat_mean_us,lat_p99_us,total_io_mb} for the
+#   fio drivers, redis_bench.put.{agg_bw_mbps,agg_ops_per_sec,...}.)
+#
+# NOTE: needs ~24 GiB free RAM for the CTE tier (peak fio set = 32 threads x
+# 256 MiB = 8 GiB; tier sized 3x). Wall-clock ~ 24 combos x 4 phases x ~70 s
+# ~= 1.9 h; bump `repeat` for day-to-day variance at proportional cost.
+
+config:
+  name: single_node
+
+  # ---- Containerized deployment (Ares dev jarvis — APPTAINER) -----------
+  base_deploy_mode: container
+  container_engine: apptainer
+  # Pre-staged SIF, referenced by BASENAME (NOT a path): jarvis resolves it to
+  #   <jarvis shared_dir>/containers/iowarp-regression-526.sif
+  # On Ares shared_dir lives on /mnt/common (shared FS, visible on every compute
+  # node). Because container_uri is UNSET, jarvis trusts this SIF and performs NO
+  # pull/build (installer.py short-circuits on container_image). The wrapper
+  # sbatch stages it via scripts/build_regression_image.sh.
+  # NOTE: container_image is NOT env-expanded by jarvis, so it must stay a bare
+  # basename — never "${HOME}/...".
+  container_image: "iowarp-regression-526"
+  # FUSE-in-apptainer recipe: the CTE + JuiceFS FUSE mounts need CAP_SYS_ADMIN
+  # *effective* inside the container. With a non-setuid (unprivileged) apptainer,
+  # --add-caps SYS_ADMIN is silently ineffective; --fakeroot is required. jarvis
+  # turns this into `apptainer instance start --fakeroot ...`, mapping the user
+  # to root in the user namespace so the FUSE mounts succeed. (Verified by smoke
+  # test: a bare `apptainer exec --fakeroot <sif>` mounts JuiceFS + does I/O;
+  # the same exec WITHOUT fakeroot fails `fusermount: failed to open /dev/fuse`.)
+  # With fakeroot, container_caps and a /dev/fuse bind are unnecessary.
+  container_fakeroot: true
+  # Redirect in-container /tmp to NODE-LOCAL disk. By default jarvis backs the
+  # apptainer /tmp with an NFS overlay (--overlay <shared_dir>/overlay --no-mount
+  # tmp); that breaks chimaera's IPC unix-domain socket + memfd dir (unix sockets
+  # are unreliable on NFS) and would put the JuiceFS cache on NFS (distorting the
+  # benchmark). tmp_bind_root makes jarvis bind <root>/single_node/tmp -> /tmp
+  # from local disk instead. CONFIRM /tmp is local + spacious on Ares compute
+  # (Gate 3); switch to a node-local SSD scratch path if /tmp is small tmpfs.
+  tmp_bind_root: "/tmp"
+  # NO container_binds. We deliberately do NOT bind host dirs onto /mnt: an
+  # explicit `--bind ${HOME}/x:/mnt/x` did NOT materialize in the per-package
+  # `apptainer exec instance://` mount namespace on Ares (the mountpoint showed
+  # as absent -> `fio: /mnt/nfs is not a directory`, `mkdir /mnt/jfs_data:
+  # permission denied`), even though it worked for a manual `apptainer exec`.
+  # Instead we rely on apptainer's AUTOMATIC $HOME bind-mount, which IS present
+  # and writable in the exec context (verified: juicefs mounts + writes under
+  # /home/anaik18/... succeed). So the writable experiment dirs live under $HOME
+  # (see nfs_fio.target_dir + juicefs.data_dir below); the FUSE mountpoints + the
+  # juicefs cache live on node-local /tmp (tmp_bind_root). The wrapper sbatch
+  # mkdir's the host $HOME dirs first. (/dev/fuse is provided by --fakeroot.)
+
+  env:
+    # In-container memfd dir for chimaera (container /tmp is private + writable).
+    CLIO_MEMFD_DIR: "/tmp/iowarp_chimaera"
+
+  pkgs:
+    # ---- Services (started in order; stopped in reverse) -----------------
+    # Redis: metadata engine for JuiceFS (DB 1) AND server for the redis
+    # benchmark (DB 0). One server covers both; no persistence keeps it a fair
+    # in-memory peer of the CTE RAM tier.
+    - pkg_type: jarvis_clio_core.redis
+      pkg_name: redis
+      port: 6379
+      sleep: 4
+
+    # Chimaera runtime daemon (shm IPC for single-node).
+    - pkg_type: jarvis_clio_core.clio_runtime
+      pkg_name: runtime
+      num_threads: 4
+      port: 9413
+      ipc_mode: "shm"
+      log_level: "info"
+      sleep: 4
+
+    # CTE pool, single RAM tier. 24 GiB = 3x the 8 GiB peak fio set
+    # (32 threads x 256 MiB), so a 60 s time-based Put never overflows the tier.
+    - pkg_type: jarvis_clio_core.clio_cte
+      pkg_name: cte_core
+      devices:
+        - ["ram::cte_ram_tier1", "24GB", 1.0]
+      dpe_type: "max_bw"
+      neighborhood: 1
+      pool_query: "local"
+      default_target_timeout_ms: 30000
+      poll_period_ms: 5000
+
+    # CTE libfuse mount (in-container): the "+ libfuse" path the fio driver
+    # below writes through (POSIX -> FUSE -> CTE).
+    - pkg_type: jarvis_clio_core.clio_cte_libfuse
+      pkg_name: cte_fuse
+      # FUSE mountpoint on NODE-LOCAL /tmp (writable bind via tmp_bind_root), NOT
+      # /mnt: the image's /mnt is a read-only SquashFS, so only the container_binds
+      # (/mnt/nfs, /mnt/jfs_data) are writable there; a fresh mkdir of /mnt/cte_mnt
+      # fails "Read-only file system". /tmp is the in-container writable scratch.
+      mountpoint: /tmp/cte_mnt
+      log_level: "info"
+      extra_fuse_args: "-f"
+      sleep: 2
+
+    # JuiceFS: format (storage=file) + FUSE mount. Object store on the bound
+    # host FS (/mnt/jfs_data); mount + cache on in-container paths.
+    - pkg_type: jarvis_clio_core.juicefs
+      pkg_name: juicefs
+      meta_url: "redis://127.0.0.1:6379/1"
+      storage: file
+      # Object store under the auto-mounted $HOME (writable in the exec context),
+      # NOT a /mnt bind (which doesn't materialize for `apptainer exec`).
+      data_dir: ${HOME}/juicefs_data
+      # Mount on node-local /tmp (writable), NOT /mnt (read-only SquashFS root);
+      # only the binds under /mnt are writable. data_dir stays /mnt/jfs_data (a
+      # writable host bind = the object store).
+      mountpoint: /tmp/jfs_mnt
+      cache_dir: /tmp/juicefs_cache
+      name: jfsbench
+      format_fresh: true
+      mount_wait: 20
+
+    # ---- Benchmark drivers (Applications; run sequentially) --------------
+    # 1) NFS: fio against the bound host NFS dir. fallocate=native (NFS supports).
+    - pkg_type: jarvis_clio_core.juicefs_bench
+      pkg_name: nfs_fio
+      # The cluster NFS home is $HOME itself (apptainer auto-mounts it); a
+      # subdir of it IS the NFS experiment target. Avoids the /mnt bind.
+      target_dir: ${HOME}/single_node_nfs
+      io_size: "4k"
+      num_threads: 1
+      runtime: 60
+      mode: write
+      size_per_job: "256M"
+      ioengine: psync
+      direct: false
+      fallocate: native
+      output_file: nfs_fio.json
+
+    # 2) CTE + libfuse: fio against the CTE FUSE mount. fallocate=none because
+    #    the libfuse adapter may not implement fallocate (would error fio).
+    - pkg_type: jarvis_clio_core.juicefs_bench
+      pkg_name: cte_fio
+      target_dir: /tmp/cte_mnt
+      io_size: "4k"
+      num_threads: 1
+      runtime: 60
+      mode: write
+      size_per_job: "256M"
+      ioengine: psync
+      direct: false
+      fallocate: none
+      output_file: cte_fio.json
+
+    # 3) redis: clio_redis_bench SET (Put). Keyspace bounded to ~1 GiB global
+    #    via max_total_blobs (zipped with io_size below), so the working set is
+    #    thread-independent and redis never balloons next to the juicefs meta.
+    - pkg_type: jarvis_clio_core.clio_redis_bench
+      pkg_name: redis_bench
+      test_case: "Put"
+      num_threads: 1
+      depth: 1
+      io_size: "4k"
+      time_limit: 60
+      max_total_blobs: 262144
+      redis_host: "127.0.0.1"
+      redis_port: 6379
+      nprocs: 1
+      ppn: 1
+      output_file: redis_bench.log
+      # Absolute path to the bench in the SIF spack view: jarvis's exec shell
+      # PATH omits /opt/iowarp-view/bin, so the bare name is "command not found".
+      bin_dir: /opt/iowarp-view/bin
+
+    # 4) juicefs: fio against the JuiceFS FUSE mount.
+    - pkg_type: jarvis_clio_core.juicefs_bench
+      pkg_name: jfs_fio
+      target_dir: /tmp/jfs_mnt
+      io_size: "4k"
+      num_threads: 1
+      runtime: 60
+      mode: write
+      size_per_job: "256M"
+      ioengine: psync
+      direct: false
+      fallocate: none
+      output_file: jfs_fio.json
+
+vars:
+  # I/O size, applied to all four drivers at once (zipped, length 4). 1m = the
+  # project's 1024 KB point. redis's matching ~1 GiB-unique keyspace is zipped
+  # in so 4k<->262144, 64k<->16384, 128k<->8192, 1m<->1024 stay paired
+  # (each = 1 GiB / io_size).
+  nfs_fio.io_size:             ["4k",   "64k",  "128k", "1m"]
+  cte_fio.io_size:             ["4k",   "64k",  "128k", "1m"]
+  jfs_fio.io_size:             ["4k",   "64k",  "128k", "1m"]
+  redis_bench.io_size:         ["4k",   "64k",  "128k", "1m"]
+  redis_bench.max_total_blobs: [262144, 16384,  8192,   1024]
+
+  # Thread count, applied to all four drivers at once (zipped, length 6).
+  nfs_fio.num_threads:        [1, 2, 4, 8, 16, 32]
+  cte_fio.num_threads:        [1, 2, 4, 8, 16, 32]
+  jfs_fio.num_threads:        [1, 2, 4, 8, 16, 32]
+  redis_bench.num_threads:    [1, 2, 4, 8, 16, 32]
+
+loop:
+  # Outer group: I/O size (+ redis keyspace), 4 values.
+  - [nfs_fio.io_size, cte_fio.io_size, jfs_fio.io_size,
+     redis_bench.io_size, redis_bench.max_total_blobs]
+  # Inner group: thread count, 6 values  =>  4 x 6 = 24 combinations.
+  - [nfs_fio.num_threads, cte_fio.num_threads, jfs_fio.num_threads,
+     redis_bench.num_threads]
+
+repeat: 1                       # bump to 3 for variance (~3x wall-clock)
+output: "${HOME}/single_node_results"

--- a/jarvis_clio_core/pipelines/container/Dockerfile.regression
+++ b/jarvis_clio_core/pipelines/container/Dockerfile.regression
@@ -1,0 +1,142 @@
+# =============================================================================
+# Dockerfile.regression — prebuilt image for the #526 CONTAINER pipelines
+# (single_node.yaml / distributed.yaml with base_deploy_mode: container).
+# =============================================================================
+#
+# The #526 pipelines now deploy with APPTAINER, but this Dockerfile remains the
+# canonical build: scripts/build_regression_image.sh does `docker build` here and
+# then converts the result to a portable .sif with
+#   apptainer build <sif> docker-daemon://iowarp-regression:526
+# (jarvis then starts ONE `apptainer instance` per node and runs the WHOLE
+# pipeline inside it via `apptainer exec instance://...`). It also stays the
+# Docker build path for non-Ares environments. A Docker-free alternative lives in
+# pipelines/container/regression.def (apptainer build --fakeroot). Every
+# package — redis, juicefs, fio, clio_* — runs bare-metal inside the container,
+# so a FUSE mount made by juicefs/CTE is visible to fio in the same mount
+# namespace.
+#
+# THE BUILD IS THE "installs run cleanly" GATE: the final RUN fails the build if
+# any required binary is missing (this is how #526 "includes the installation").
+#
+# Tailored to the IOWarp build base: it runs as the non-root user `iowarp`,
+# ships spack at /home/iowarp/spack, and has NO clio_* built — so system installs
+# run as root, the IOWarp build runs as `iowarp` (it owns spack), and the runtime
+# user is root (the jarvis compose entrypoint uses /root).
+#
+# Build from the REPO ROOT (the COPYs below bake in (a) this fork's EXTENDED
+# spack recipe — installers/spack adds a `redis` variant + `526` fork-branch
+# version — and (b) the local jarvis_clio_core edits: redis _get_stat
+# metric-capture, cte_bench host-folding, juicefs_bench fallocate). Use
+# scripts/build_regression_image.sh which wraps this (then converts to .sif):
+#   docker build -f jarvis_clio_core/pipelines/container/Dockerfile.regression \
+#     -t iowarp-regression:526 .
+#   apptainer build <shared_dir>/containers/iowarp-regression-526.sif \
+#     docker-daemon://iowarp-regression:526
+#
+# WHY a source build via the fork recipe (not `spack install iowarp@main`):
+# the stock recipe's git= points at UPSTREAM and exposes NO redis variant, so
+# `iowarp@main` would test upstream code and omit clio_redis_bench. This image
+# registers the fork's spack repo (namespace `iowarp`, overrides the builtin)
+# and builds `iowarp@526 +fuse +redis`, where version 526 fetches THIS fork's
+# pushed `jarvis-pipelines-526` branch. That yields clio_run, clio_cte_fuse,
+# clio_cte_bench, and clio_redis_bench from the exact code under regression.
+# (Confirm the built clio_run accepts `clio_run compose <cfg>` — the form
+# jarvis_clio_core/clio_cte/pkg.py uses.)
+
+ARG BASE_IMAGE=iowarp/iowarp-build:latest
+FROM ${BASE_IMAGE}
+
+ARG DEBIAN_FRONTEND=noninteractive
+# IOWarp spec — built from the fork's extended recipe (see header). `526` is the
+# fork-branch version; +fuse builds clio_cte_fuse; +redis builds clio_redis_bench.
+ARG IOWARP_SPEC=iowarp@526 +fuse +redis
+ARG JUICEFS_VERSION=1.2.3
+ARG JARVIS_REF=2925ee8                       # MUST match the Ares jarvis pin
+ARG SPACK_SETUP=/home/iowarp/spack/share/spack/setup-env.sh
+ARG SPACK_USER=iowarp
+
+# 1) System deps as ROOT (the base defaults to USER iowarp -> apt is denied).
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        fuse3 libfuse3-3 \
+        openmpi-bin libopenmpi-dev \
+        redis-server redis-tools \
+        fio \
+        git curl ca-certificates \
+        python3 python3-pip python3-venv \
+        openssh-server openssh-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# 2) JuiceFS — official single static binary (to a root-owned PATH dir).
+RUN curl -fsSL "https://github.com/juicedata/juicefs/releases/download/v${JUICEFS_VERSION}/juicefs-${JUICEFS_VERSION}-linux-amd64.tar.gz" \
+      | tar -xz -C /usr/local/bin juicefs \
+    && juicefs version
+
+# 3) A spack "view" dir the iowarp user can populate and root can read at runtime,
+#    plus this fork's spack repo (the EXTENDED recipe: redis variant + `526`
+#    fork-branch version). Only the recipe is needed locally; `spack install`
+#    fetches the branch SOURCE from the fork's GitHub.
+RUN mkdir -p /opt/iowarp-view && chown ${SPACK_USER}:${SPACK_USER} /opt/iowarp-view
+COPY installers/spack /opt/clio-core/installers/spack
+
+# 4) IOWarp (+FUSE +redis) via spack, as the user that OWNS spack. Register the
+#    fork repo FIRST so `iowarp@526 +fuse +redis` resolves to the extended recipe
+#    (its namespace `iowarp` overrides the base image's builtin iowarp package).
+#
+#    The base image's site-scope packages.yaml has external stubs for cmake,
+#    python, openmpi, hdf5, and boost that lack concrete versions — spack 0.22+
+#    rejects them during concretization. Override them in the user scope
+#    (user scope wins over site/system) so spack builds from source instead.
+USER ${SPACK_USER}
+RUN mkdir -p ~/.spack && cat > ~/.spack/packages.yaml <<'EOF'
+packages:
+  cmake:
+    buildable: true
+    externals: []
+  python:
+    buildable: true
+    externals: []
+  openmpi:
+    buildable: true
+    externals: []
+  hdf5:
+    buildable: true
+    externals: []
+  boost:
+    buildable: true
+    externals: []
+EOF
+RUN . "${SPACK_SETUP}" \
+    && spack repo add /opt/clio-core/installers/spack \
+    && spack install --fail-fast ${IOWARP_SPEC} \
+    && spack view --dependencies yes symlink -i /opt/iowarp-view ${IOWARP_SPEC}
+
+# 5) Back to root: put the view on PATH, install jarvis at the pinned ref,
+#    register this repo, prepare sshd. Runtime user stays root (compose /root).
+USER root
+ENV PATH=/opt/iowarp-view/bin:${PATH}
+ENV LD_LIBRARY_PATH=/opt/iowarp-view/lib:/opt/iowarp-view/lib64:${LD_LIBRARY_PATH}
+
+RUN git clone https://github.com/grc-iit/jarvis-cd.git /opt/jarvis-cd \
+    && git -C /opt/jarvis-cd checkout ${JARVIS_REF} \
+    && { pip3 install -e /opt/jarvis-cd \
+         || pip3 install --break-system-packages -e /opt/jarvis-cd; }
+
+# jarvis_clio_core — COPY from the build context so the local edits are baked in,
+# then init jarvis (root -> /root/.ppi-jarvis/config) and register the repo so
+# `jarvis_clio_core.*` pkg_types resolve inside the container.
+COPY jarvis_clio_core /opt/clio-core/jarvis_clio_core
+RUN jarvis init \
+    && jarvis repo add /opt/clio-core/jarvis_clio_core \
+    && jarvis repo list
+
+RUN mkdir -p /run/sshd /root/.ssh && chmod 700 /root/.ssh
+
+# 6) GATE — fail the build if a REQUIRED binary is missing. clio_redis_bench is
+#    REQUIRED for #526 (the single_node redis experiment is a project deliverable),
+#    so ensure IOWARP_SPEC enables the redis variant rather than letting it warn.
+RUN for b in clio_run clio_cte_fuse clio_cte_bench clio_redis_bench \
+             juicefs fio redis-server redis-cli redis-benchmark mpiexec jarvis; do \
+        command -v "$b" >/dev/null || { echo "MISSING REQUIRED BINARY: $b"; exit 1; }; \
+    done \
+    && echo "iowarp-regression image: required binaries present"

--- a/jarvis_clio_core/pipelines/container/regression.def
+++ b/jarvis_clio_core/pipelines/container/regression.def
@@ -1,0 +1,93 @@
+# =============================================================================
+# regression.def — Docker-free APPTAINER build of the #526 regression image.
+# =============================================================================
+# Strategy B FALLBACK. The PRIMARY path (Strategy A) reuses Dockerfile.regression:
+#   docker build ... && apptainer build <sif> docker-daemon://iowarp-regression:526
+# (see scripts/build_regression_image.sh). Use this .def only when Docker is
+# unavailable on the build host. It mirrors Dockerfile.regression stage-for-stage.
+#
+# Build (needs --fakeroot; Ares has /etc/subuid + /etc/subgid maps). Run from the
+# REPO ROOT so the %files source paths resolve against the build CWD:
+#   apptainer build --fakeroot \
+#     "$(grep -hE '^[[:space:]]*shared_dir:' ~/.ppi-jarvis/*.yaml | head -1 \
+#         | sed -E 's/.*shared_dir:[[:space:]]*//; s/["'"'"']//g')/containers/iowarp-regression-526.sif" \
+#     jarvis_clio_core/pipelines/container/regression.def
+#
+# NOTE: this is the UNTESTED fallback — Strategy A is the validated path. The
+# final %post block is the same install-cleanliness gate as the Dockerfile.
+
+Bootstrap: docker
+From: iowarp/iowarp-build:latest
+
+%arguments
+    IOWARP_SPEC=iowarp@526 +fuse +redis
+    JUICEFS_VERSION=1.2.3
+    JARVIS_REF=2925ee8
+    SPACK_SETUP=/home/iowarp/spack/share/spack/setup-env.sh
+    SPACK_USER=iowarp
+
+%files
+    # Bake in the fork's EXTENDED spack recipe (redis variant + `526` version) and
+    # the local jarvis_clio_core edits — same as the Dockerfile's COPYs.
+    installers/spack /opt/clio-core/installers/spack
+    jarvis_clio_core /opt/clio-core/jarvis_clio_core
+
+%post
+    set -e
+    export DEBIAN_FRONTEND=noninteractive
+
+    # 1) System deps (root).
+    apt-get update && apt-get install -y --no-install-recommends \
+        fuse3 libfuse3-3 \
+        openmpi-bin libopenmpi-dev \
+        redis-server redis-tools \
+        fio \
+        git curl ca-certificates \
+        python3 python3-pip python3-venv \
+        openssh-server openssh-client
+    rm -rf /var/lib/apt/lists/*
+
+    # 2) JuiceFS — official single static binary.
+    curl -fsSL "https://github.com/juicedata/juicefs/releases/download/v{{JUICEFS_VERSION}}/juicefs-{{JUICEFS_VERSION}}-linux-amd64.tar.gz" \
+      | tar -xz -C /usr/local/bin juicefs
+    juicefs version
+
+    # 3) A spack view dir owned by the spack user; the fork recipe is already
+    #    staged under /opt/clio-core/installers (via %files).
+    mkdir -p /opt/iowarp-view
+    chown {{SPACK_USER}}:{{SPACK_USER}} /opt/iowarp-view
+    chown -R {{SPACK_USER}}:{{SPACK_USER}} /opt/clio-core/installers
+
+    # 4) IOWarp (+FUSE +redis) via spack, run as the user that OWNS spack. Register
+    #    the fork repo FIRST so iowarp@526 resolves to the extended recipe.
+    su {{SPACK_USER}} -c '. "{{SPACK_SETUP}}" \
+        && spack repo add /opt/clio-core/installers/spack \
+        && spack install --fail-fast {{IOWARP_SPEC}} \
+        && spack view --dependencies yes symlink -i /opt/iowarp-view {{IOWARP_SPEC}}'
+
+    # 5) Put the view on PATH, install jarvis at the pinned ref, register this repo,
+    #    prepare sshd (root).
+    export PATH=/opt/iowarp-view/bin:$PATH
+    export LD_LIBRARY_PATH=/opt/iowarp-view/lib:/opt/iowarp-view/lib64:$LD_LIBRARY_PATH
+    git clone https://github.com/grc-iit/jarvis-cd.git /opt/jarvis-cd
+    git -C /opt/jarvis-cd checkout {{JARVIS_REF}}
+    pip3 install -e /opt/jarvis-cd || pip3 install --break-system-packages -e /opt/jarvis-cd
+    jarvis init
+    jarvis repo add /opt/clio-core/jarvis_clio_core
+    jarvis repo list
+    mkdir -p /run/sshd /root/.ssh && chmod 700 /root/.ssh
+
+    # 6) GATE — fail the build if a REQUIRED binary is missing (same set as the
+    #    Dockerfile; clio_redis_bench is required for the #526 redis experiment).
+    for b in clio_run clio_cte_fuse clio_cte_bench clio_redis_bench \
+             juicefs fio redis-server redis-cli redis-benchmark mpiexec jarvis; do
+        command -v "$b" >/dev/null || { echo "MISSING REQUIRED BINARY: $b"; exit 1; }
+    done
+    echo "iowarp-regression image: required binaries present"
+
+%environment
+    export PATH=/opt/iowarp-view/bin:$PATH
+    export LD_LIBRARY_PATH=/opt/iowarp-view/lib:/opt/iowarp-view/lib64:$LD_LIBRARY_PATH
+
+%runscript
+    exec "$@"

--- a/jarvis_clio_core/pipelines/juicefs_fio_1n.yaml
+++ b/jarvis_clio_core/pipelines/juicefs_fio_1n.yaml
@@ -1,0 +1,68 @@
+# JuiceFS single-node fio performance sweep.
+#
+# Brings up a Redis metadata engine, formats + FUSE-mounts a JuiceFS
+# filesystem backed by a local directory (--storage file), then drives an
+# fio workload against the mount. The juicefs_bench package parses fio's
+# JSON report into results.csv columns.
+#
+# Experiment matrix (cross product x 3 repeats => 4 x 4 x 3 = 48 runs):
+#   * I/O size (fio --bs):     4k, 16k, 64k, 128k
+#   * threads (fio --numjobs): 1, 2, 4, 8
+#   * 60 seconds per run (fio --runtime=60 --time_based)
+#
+# Package start order is significant: redis must accept connections before
+# `juicefs format` runs, so redis is listed first (the runner stops in
+# reverse order, unmounting JuiceFS before shutting Redis down).
+#
+# Requires on PATH: redis-server, redis-cli, juicefs, fio.
+#
+# Usage:
+#   jarvis ppl run yaml jarvis_clio_core/pipelines/juicefs_fio_1n.yaml
+# Output:
+#   ${HOME}/juicefs_results/results.csv  (48 rows: io_size, threads +
+#   juicefs_bench.write.{agg_bw_mbps,iops,lat_mean_us,lat_p99_us,total_io_mb})
+
+config:
+  name: juicefs_fio_1n
+  pkgs:
+    # --- Redis metadata engine ---
+    - pkg_type: jarvis_clio_core.redis
+      pkg_name: redis
+      port: 6379
+      sleep: 4
+
+    # --- JuiceFS: format (storage=file) + FUSE mount ---
+    - pkg_type: jarvis_clio_core.juicefs
+      pkg_name: juicefs
+      meta_url: "redis://127.0.0.1:6379/1"
+      storage: file
+      data_dir: ${HOME}/juicefs_data
+      mountpoint: ${HOME}/juicefs_mnt
+      cache_dir: ${HOME}/juicefs_cache
+      name: jfsbench
+      format_fresh: true
+      mount_wait: 20
+
+    # --- fio benchmark driver (metrics -> results.csv) ---
+    - pkg_type: jarvis_clio_core.juicefs_bench
+      pkg_name: juicefs_bench
+      target_dir: ${HOME}/juicefs_mnt
+      io_size: "4k"
+      num_threads: 1
+      runtime: 60
+      mode: write
+      size_per_job: "1G"
+      ioengine: psync
+      direct: false
+      output_file: fio_output.json
+
+vars:
+  juicefs_bench.io_size:     ["4k", "16k", "64k", "128k"]
+  juicefs_bench.num_threads: [1, 2, 4, 8]
+
+loop:
+  - [juicefs_bench.io_size]      # outer
+  - [juicefs_bench.num_threads]  # inner -> 16 combos
+
+repeat: 3                        # x3 repeats -> 48 runs
+output: "${HOME}/juicefs_results"

--- a/jarvis_clio_core/pipelines/juicefs_gcs.yaml
+++ b/jarvis_clio_core/pipelines/juicefs_gcs.yaml
@@ -1,0 +1,59 @@
+# JuiceFS formatted + FUSE-mounted on REAL Google Cloud Storage (NO benchmark).
+#
+# Brings up a Redis metadata engine, then formats + FUSE-mounts a JuiceFS
+# filesystem whose object backend is a real gs:// bucket (--storage gs). This is
+# a configuration / connectivity pipeline: it proves the jarvis juicefs package
+# config drives a live GCS link. The fio sweep is intentionally OUT OF SCOPE
+# here -- see juicefs_fio_1n.yaml for the benchmark variant.
+#
+# After `jarvis ppl run`, validate the link end-to-end with:
+#   bash jarvis_clio_core/scripts/smoke_juicefs_gcs.sh
+#
+# Package start order matters: redis must accept connections before
+# `juicefs format` runs, so redis is listed first (the runner stops in reverse,
+# unmounting JuiceFS before shutting Redis down).
+#
+# Requires on PATH: redis-server, redis-cli, juicefs.
+# Requires GCP credentials reachable by Google's ADC chain. Two auth paths:
+#
+#   D2 (user ADC -- recommended for laptop/WSL; the default below):
+#     gcloud auth application-default login   # writes ~/.config/gcloud/application_default_credentials.json
+#     Leave gcs_credentials EMPTY -> the package injects no GOOGLE_APPLICATION_CREDENTIALS,
+#     so juicefs falls through the ADC chain to that file. Run the login in the SAME
+#     environment that runs the pipeline (WSL ADC != Windows ADC).
+#
+#   D1 (service-account key -- for unattended/headless hosts):
+#     Set gcs_credentials below to the key path; the package turns it into
+#     GOOGLE_APPLICATION_CREDENTIALS for the format/mount subprocesses, e.g.
+#       gcs_credentials: "${HOME}/gcs-sa.json"
+#     (Key creation may be blocked by the iam.disableServiceAccountKeyCreation org policy.)
+#
+# Either path: edit `bucket:` below to YOUR globally-unique gs:// bucket, and optionally
+#   export GCS_PROJECT_ID=<PROJECT_ID>   # only consulted if a bucket auto-create happens
+#
+# Usage:
+#   jarvis ppl run yaml jarvis_clio_core/pipelines/juicefs_gcs.yaml
+
+config:
+  name: juicefs_gcs
+  pkgs:
+    # --- Redis metadata engine ---
+    - pkg_type: jarvis_clio_core.redis
+      pkg_name: redis
+      port: 6379
+      sleep: 4
+
+    # --- JuiceFS: format (storage=gs) + FUSE mount on real GCS ---
+    - pkg_type: jarvis_clio_core.juicefs
+      pkg_name: juicefs
+      meta_url: "redis://127.0.0.1:6379/1"
+      storage: gs
+      bucket: "gs://<your-bucket>"            # <-- EDIT to your globally-unique GCS bucket
+      gcs_credentials: ""                     # D2/user-ADC default: EMPTY -> use the ADC chain.
+                                              # D1: set to the SA key PATH (never the key itself),
+                                              # e.g. "${HOME}/gcs-sa.json".
+      mountpoint: ${HOME}/juicefs_mnt
+      cache_dir: ${HOME}/juicefs_cache
+      name: jfsgcs
+      format_fresh: true                      # safe no-op for storage=gs (bucket not wiped)
+      mount_wait: 30                          # cloud first-byte latency > local; allow more

--- a/jarvis_clio_core/scripts/build_regression_image.sh
+++ b/jarvis_clio_core/scripts/build_regression_image.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Build the #526 regression APPTAINER SIF — this IS the automated "installation"
+# for the containerized single_node/distributed pipelines. Two stages:
+#   1. `docker build` pipelines/container/Dockerfile.regression -> a local OCI
+#      image (the Dockerfile bakes spack iowarp(+libfuse,+redis), juicefs, redis,
+#      fio, jarvis-cd, and this repo; its final RUN fails if any binary is missing
+#      — the install-cleanliness gate).
+#   2. `apptainer build <sif> docker-daemon://<image>` -> a portable .sif.
+#
+# Strategy A (default): convert the LOCAL docker image — no Docker Hub round-trip,
+# no apptainer --fakeroot needed. Docker is available on the Ares login node
+# (`docker ps` works) and apptainer is Spack-installed (see validate_apptainer.sh
+# Phase 0). For a Docker-free build see pipelines/container/regression.def
+# (Strategy B: `apptainer build --fakeroot <sif> regression.def`).
+#
+# The SIF is written to the jarvis containers cache so the pipeline YAMLs find it
+# by basename (container_image: "iowarp-regression-526"):
+#     <jarvis shared_dir>/containers/iowarp-regression-526.sif
+# On Ares shared_dir is on /mnt/common (shared FS) -> the SIF is visible on every
+# compute node automatically (the distributed run needs no per-node copy).
+#
+# Run from the REPO ROOT so the Dockerfile's `COPY jarvis_clio_core` bakes in the
+# local package edits. Re-run daily so #526 tracks the latest IOWarp.
+#
+# Usage (from repo root, on a host with docker + apptainer):
+#   jarvis_clio_core/scripts/build_regression_image.sh
+#
+# Common overrides (env):
+#   IMAGE=iowarp-regression:526             # local docker image tag to build
+#   SIF_BASENAME=iowarp-regression-526      # must match YAML container_image
+#   SIF_PATH=/abs/path/iowarp-regression-526.sif   # override the SIF location
+#   IOWARP_SPEC='iowarp@526 +fuse +redis'   # fork branch + FUSE + redis bench
+#   BASE_IMAGE=iowarp/iowarp-build:latest
+#   JARVIS_REF=2925ee8                      # MUST match the Ares jarvis pin (dev)
+#   SKIP_DOCKER_BUILD=1                     # reuse an existing local docker image
+set -euo pipefail
+
+IMAGE="${IMAGE:-iowarp-regression:526}"
+SIF_BASENAME="${SIF_BASENAME:-iowarp-regression-526}"
+IOWARP_SPEC="${IOWARP_SPEC:-iowarp@526 +fuse +redis}"
+BASE_IMAGE="${BASE_IMAGE:-iowarp/iowarp-build:latest}"
+JARVIS_REF="${JARVIS_REF:-2925ee8}"
+SKIP_DOCKER_BUILD="${SKIP_DOCKER_BUILD:-0}"
+
+DOCKERFILE="jarvis_clio_core/pipelines/container/Dockerfile.regression"
+if [ ! -f "$DOCKERFILE" ]; then
+  echo "ERROR: run from the repo root (cannot find $DOCKERFILE)" >&2
+  exit 1
+fi
+
+# ---- resolve the SIF destination (jarvis containers cache) ----------------
+# Derive shared_dir from the jarvis config so the SIF lands where the YAMLs look
+# for it by basename. Allow a full SIF_PATH override for non-standard setups.
+if [ -z "${SIF_PATH:-}" ]; then
+  SHARED_DIR="$(grep -hE '^[[:space:]]*shared_dir:' "$HOME"/.ppi-jarvis/*.yaml 2>/dev/null \
+                | head -1 | sed -E 's/^[[:space:]]*shared_dir:[[:space:]]*//; s/["'"'"']//g')"
+  if [ -z "$SHARED_DIR" ]; then
+    echo "ERROR: could not read shared_dir from ~/.ppi-jarvis/*.yaml." >&2
+    echo "       Run 'jarvis init' first, or pass SIF_PATH=/abs/path.sif." >&2
+    exit 1
+  fi
+  SIF_PATH="$SHARED_DIR/containers/$SIF_BASENAME.sif"
+fi
+mkdir -p "$(dirname "$SIF_PATH")"
+
+echo "=== #526 regression SIF build ==="
+echo "  docker image : $IMAGE"
+echo "  IOWARP_SPEC  : $IOWARP_SPEC"
+echo "  BASE_IMAGE   : $BASE_IMAGE"
+echo "  JARVIS_REF   : $JARVIS_REF"
+echo "  SIF_PATH     : $SIF_PATH"
+
+# ---- tool presence --------------------------------------------------------
+command -v apptainer >/dev/null || {
+  echo "ERROR: apptainer not on PATH. Spack-install it first (see"            >&2
+  echo "       scripts/validate_apptainer.sh Phase 0) and 'spack load apptainer'." >&2
+  exit 1
+}
+
+# ---- stage 1: docker build ------------------------------------------------
+if [ "$SKIP_DOCKER_BUILD" = "1" ]; then
+  echo "=== SKIP_DOCKER_BUILD=1 — reusing existing local image $IMAGE ==="
+else
+  command -v docker >/dev/null || {
+    echo "ERROR: docker not on PATH (needed for Strategy A). For a Docker-free" >&2
+    echo "       build use: apptainer build --fakeroot '$SIF_PATH' \\"          >&2
+    echo "       jarvis_clio_core/pipelines/container/regression.def"           >&2
+    exit 1
+  }
+  echo "=== docker build $IMAGE ==="
+  docker build -f "$DOCKERFILE" \
+    --build-arg BASE_IMAGE="$BASE_IMAGE" \
+    --build-arg IOWARP_SPEC="$IOWARP_SPEC" \
+    --build-arg JARVIS_REF="$JARVIS_REF" \
+    -t "$IMAGE" .
+  echo "=== docker build OK: $IMAGE ==="
+fi
+
+# ---- stage 2: convert the local docker image to a SIF ---------------------
+echo "=== apptainer build $SIF_PATH  (docker-daemon://$IMAGE) ==="
+apptainer build --force "$SIF_PATH" "docker-daemon://$IMAGE"
+
+echo "=== SIF ready: $SIF_PATH ==="
+ls -lh "$SIF_PATH"
+echo "The pipeline YAMLs reference this by basename: container_image: \"$SIF_BASENAME\""

--- a/jarvis_clio_core/scripts/run_cte_sweep_ares.sbatch
+++ b/jarvis_clio_core/scripts/run_cte_sweep_ares.sbatch
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Queue the single-node CLIO Core (CTE) performance sweep on Ares.
+#
+# Wraps `jarvis ppl run yaml .../ares/cte_sweep_1n.yaml` in a SLURM batch job:
+# grabs one compute node, activates the iowarp conda env, (re)registers the
+# repo, and runs the 48-run sweep (io_size {4k,16k,64k,128k} x threads {1,2,4,8}
+# x 3 repeats, 60 s each, Put). Output lands in $HOME/cte_sweep_results/results.csv.
+#
+# Quick queue:
+#   sbatch jarvis_clio_core/scripts/run_cte_sweep_ares.sbatch
+#
+# Override any path/env at submit time, e.g.:
+#   sbatch --export=ALL,CONDA_ENV=iowarp,REPO=$HOME/clio-core-fork \
+#          jarvis_clio_core/scripts/run_cte_sweep_ares.sbatch
+#
+# Watch it:   squeue -u $USER ; tail -f cte_sweep-<jobid>.out
+#
+#SBATCH --job-name=cte_sweep_1n
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+# ConstrainCores=yes on Ares hands an ntasks=1 job a single core unless we ask
+# for more; chimaera's 4 workers + up to 8 bench threads need real cores.
+#SBATCH --cpus-per-task=40
+#SBATCH --partition=compute
+# 48 runs x (~60 s + runtime/CTE setup) ~= 1-1.5 h; 4 h is comfortable headroom.
+#SBATCH --time=04:00:00
+#SBATCH --output=cte_sweep-%j.out
+#SBATCH --error=cte_sweep-%j.err
+
+set -euo pipefail
+
+# ---- knobs (override via --export=ALL,KEY=VAL) ----------------------------
+CONDA_SH="${CONDA_SH:-$HOME/miniconda3/etc/profile.d/conda.sh}"
+CONDA_ENV="${CONDA_ENV:-iowarp}"
+REPO="${REPO:-$HOME/clio-core-fork}"
+PIPELINE="${PIPELINE:-$REPO/jarvis_clio_core/pipelines/ares/cte_sweep_1n.yaml}"
+RESULTS="${RESULTS:-$HOME/cte_sweep_results/results.csv}"
+
+echo "=== CTE sweep on $(hostname) — job ${SLURM_JOB_ID:-local} ==="
+echo "conda: $CONDA_ENV ($CONDA_SH)"
+echo "repo:  $REPO"
+echo "yaml:  $PIPELINE"
+
+# ---- activate the IOWarp/Jarvis conda env --------------------------------
+# shellcheck disable=SC1090
+source "$CONDA_SH"
+conda activate "$CONDA_ENV"
+
+# ---- register the repo with jarvis (idempotent) --------------------------
+jarvis repo add "$REPO/jarvis_clio_core" 2>/dev/null || true
+
+# ---- stale-state guard: free the runtime port from any prior run ---------
+pkill -f 'clio_run' 2>/dev/null || true
+
+# ---- run the 48-run sweep (runner auto-detects vars:+loop:) ---------------
+jarvis ppl run yaml "$PIPELINE"
+
+# ---- report ---------------------------------------------------------------
+echo "=== done — results at $RESULTS ==="
+if [ -f "$RESULTS" ]; then
+  n=$(grep -c success "$RESULTS" 2>/dev/null || echo 0)
+  echo "successful rows: $n / 48"
+  head -1 "$RESULTS"
+  grep success "$RESULTS" | head -3
+  [ "$n" -ge 48 ] && echo "ALL 48 GREEN" || echo "INCOMPLETE — inspect $RESULTS / the .err log"
+else
+  echo "NO results.csv produced — check cte_sweep-${SLURM_JOB_ID:-local}.err"
+fi

--- a/jarvis_clio_core/scripts/run_distributed_ares.sbatch
+++ b/jarvis_clio_core/scripts/run_distributed_ares.sbatch
@@ -1,0 +1,323 @@
+#!/bin/bash
+# Queue the #526 DISTRIBUTED container regression sweep on Ares (Pattern A:
+# ONE 4-node allocation, in-process node-count sweep via `jarvis ppl run yaml`).
+#
+# Grabs FOUR compute nodes. The regression SIF lives on the shared FS
+# (/mnt/common), so it is ALREADY visible on every node — no per-node image
+# distribution step (this is the big simplification over the old Docker version,
+# which `srun docker pull`ed on every node). The job: makes apptainer available,
+# verifies the SIF, prepares each node (node-local /tmp bind dir + stale-state
+# cleanup + apptainer-reachability check), seeds the jarvis hostfile with all
+# four nodes (Pssh fan-out for the per-node apptainer instances + runtime + CTE
+# pool + clio_cte_bench), activates conda, (re)registers the repo, and runs
+# distributed.yaml. The pipeline sweeps cte_bench.nprocs over [1,2,4] in-process
+# => 3 rows in $HOME/distributed_results/results.csv.
+#
+# PREREQUISITES (one-time, on the login node):
+#   1. Build the SIF:  cd ~/clio-core-fork &&
+#        jarvis_clio_core/scripts/build_regression_image.sh
+#   2. Make apptainer reachable on REMOTE non-interactive shells. jarvis Pssh's
+#      `apptainer instance start` to every node over ssh, so the spack apptainer
+#      bin MUST be on PATH there. Append it to ~/.bashrc (shared $HOME -> all
+#      nodes), e.g.:  echo 'export PATH="$(spack location -i apptainer)/bin:$PATH"' >> ~/.bashrc
+#      (see scripts/validate_apptainer.sh Phase 0). The per-node check below
+#      fails fast if this was skipped.
+#
+# Quick queue (from anywhere):
+#   sbatch jarvis_clio_core/scripts/run_distributed_ares.sbatch
+#
+# Watch:   squeue -u $USER ; tail -f distributed-<jobid>.out
+#
+#SBATCH --job-name=distributed_526
+#SBATCH --nodes=4
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=32
+# debug partition (mentor directive 2026-07-07): compute is ~fully allocated,
+# debug has 4 idle nodes (ares-comp-03..06) — exactly the 4 this run needs — and
+# a 4-day limit. Override for a one-off with `sbatch --partition=compute ...`.
+#SBATCH --partition=debug
+# Empirically ~11-13 min WALL per combo (job 21073 run 0 measured 361 s bench
+# runtime alone, plus 4-node apptainer instance start/stop + JuiceFS format +
+# CTE fold each combo). 3 combos ~= 40-45 min; 1 h clipped job 21073 at the
+# Slurm limit while it burned time on failure retries. 2 h gives real headroom.
+#SBATCH --time=02:00:00
+#SBATCH --output=distributed-%j.out
+#SBATCH --error=distributed-%j.err
+
+set -euo pipefail
+
+# ---- knobs (override via --export=ALL,KEY=VAL) ----------------------------
+CONDA_SH="${CONDA_SH:-$HOME/miniconda3/etc/profile.d/conda.sh}"
+CONDA_ENV="${CONDA_ENV:-iowarp}"
+REPO="${REPO:-$HOME/clio-core-fork}"
+PIPELINE="${PIPELINE:-$REPO/jarvis_clio_core/pipelines/ares/distributed.yaml}"
+RESULTS="${RESULTS:-$HOME/distributed_results/results.csv}"
+SIF_BASENAME="${SIF_BASENAME:-iowarp-regression-526}"
+SPACK_SETUP="${SPACK_SETUP:-}"
+APPTAINER_BIN="${APPTAINER_BIN:-}"
+# Node-local /tmp bind root (MUST match tmp_bind_root in the YAML); jarvis binds
+# <root>/distributed/tmp -> in-container /tmp on each node.
+TMP_BIND_ROOT="${TMP_BIND_ROOT:-/tmp}"
+PIPELINE_NAME="distributed"
+# Optional node-count override for a fast smoke. NPROCS=2 runs a SINGLE 2-node
+# point (Gate E de-risk: exercises remote-node --fakeroot + the multi-node MPI
+# fan-out with one combo before the full [1,2,4] sweep). Comma-list allowed,
+# e.g. NPROCS=1,2. Empty (default) => use the YAML's committed [1,2,4].
+NPROCS="${NPROCS:-}"
+RUN_PIPELINE=""   # set below iff NPROCS override is used (temp YAML)
+
+echo "=== #526 distributed sweep — job ${SLURM_JOB_ID:-local} on $(hostname) ==="
+echo "conda: $CONDA_ENV   repo: $REPO"
+echo "yaml:  $PIPELINE"
+
+# ---- make apptainer available on the HEAD node ----------------------------
+if ! command -v apptainer >/dev/null 2>&1; then
+  if [ -n "$APPTAINER_BIN" ]; then
+    export PATH="$APPTAINER_BIN:$PATH"
+  elif [ -n "$SPACK_SETUP" ] && [ -f "$SPACK_SETUP" ]; then
+    # shellcheck disable=SC1090
+    source "$SPACK_SETUP"; spack load apptainer || true
+  fi
+fi
+command -v apptainer >/dev/null 2>&1 || {
+  echo "ERROR: apptainer not on PATH on the head node. See PREREQUISITES." >&2
+  exit 1
+}
+echo "apptainer: $(command -v apptainer) ($(apptainer --version 2>/dev/null))"
+
+# ---- resolve + verify the regression SIF (shared FS, seen by all nodes) ----
+if [ -z "${SIF_PATH:-}" ]; then
+  SHARED_DIR="$(grep -hE '^[[:space:]]*shared_dir:' "$HOME"/.ppi-jarvis/*.yaml 2>/dev/null \
+                | head -1 | sed -E 's/^[[:space:]]*shared_dir:[[:space:]]*//; s/["'"'"']//g')"
+  SIF_PATH="${SHARED_DIR:+$SHARED_DIR/containers/$SIF_BASENAME.sif}"
+fi
+echo "sif:   ${SIF_PATH:-<unresolved>}"
+[ -n "${SIF_PATH:-}" ] && [ -f "$SIF_PATH" ] || {
+  echo "ERROR: regression SIF not found: ${SIF_PATH:-<unresolved>}" >&2
+  echo "Build it ONCE on the login node:  cd $REPO && \\" >&2
+  echo "    jarvis_clio_core/scripts/build_regression_image.sh" >&2
+  exit 1
+}
+
+# ---- optional single-combo override (NPROCS=... => temp YAML with just that
+#      node count; keeps the committed cte_bench.nprocs: [1,2,4] intact). -----
+EXPECT=3
+if [ -n "$NPROCS" ]; then
+  RUN_PIPELINE="$(mktemp --suffix=.yaml)"
+  # Rewrite ONLY the sweep var line; config.name stays "distributed" so the
+  # per-node /tmp prep + instance names still match tmp_bind_root.
+  sed -E "s/^([[:space:]]*cte_bench\.nprocs:).*/\1  [$NPROCS]/" \
+      "$PIPELINE" > "$RUN_PIPELINE"
+  EXPECT=$(echo "$NPROCS" | tr ',' '\n' | grep -c .)
+  echo "NPROCS override -> cte_bench.nprocs: [$NPROCS]  ($EXPECT point(s), temp: $RUN_PIPELINE)"
+  grep -E 'cte_bench\.nprocs:' "$RUN_PIPELINE"
+fi
+
+# ---- per-node prep: apptainer reachable (login shell -> ~/.bashrc PATH),
+#      node-local /tmp bind dir, and stale-state cleanup. A `bash -lc` login
+#      shell exercises the SAME ~/.bashrc that jarvis's ssh fan-out relies on,
+#      so a missing apptainer here fails the job before the sweep starts.
+#
+#      DIAGNOSTIC HARDENING (jobs 21065/21066 both self-terminated in this step
+#      before the sweep ran): every task prints a "prep complete" sentinel and
+#      the srun aggregate rc is reported. --kill-on-bad-exit=0 stops srun from
+#      tearing down the WHOLE step if a single task exits non-zero (the likely
+#      "srun: forcing job termination" trigger). `set +e` around srun keeps the
+#      outer script from aborting so we still reach the R2 probe + sweep and
+#      learn more in one run. Cleanup is non-fatal. -----------------------------
+#
+# STALE-STATE CLEANUP RATIONALE (kept OUT of the inline bash -lc below — see the
+# CRITICAL note): a job that hangs and is Slurm-killed leaves its apptainer
+# instances + runtime daemon ALIVE on every node it touched. Because apptainer
+# instances share the HOST network namespace, that ghost runtime keeps port 9413
+# bound, so THIS job's fresh runtime cannot bind -> "Could not start TCP server
+# ... Port attempted: 9413 ... another process is already running" on ALL nodes,
+# then shm_attach fails and the run hangs to the time limit with no results.csv
+# (job 21473 died exactly there at combo 0). Separately, killed jobs never reach
+# teardown, so their per-combo /tmp bind dirs (runtime scratch + juicefs cache +
+# memfd) accumulate on frequently-drawn nodes until a fresh run ENOSPCs on
+# `mkdir /tmp/..._run<N>` (job 21294 died there at combo 3). So the prep stops
+# stale instances FIRST (that kills the runtime inside them), pkills any bare
+# survivor, frees 9413, drops leftover shm + old /tmp scratch (-mmin +10 protects
+# a concurrent job's live dir; node alloc is ~exclusive at 32 cpus), then remakes
+# the bind dir.
+#
+# CRITICAL — why the inline block below carries NO comments and globs the memfd
+# path: `pkill -f` matches a process's FULL argv, and this inline `bash -lc '...'`
+# string IS the argv of both srun and each node's bash. Any un-bracketed token
+# "chimaera"/"clio_run" ANYWHERE in that string (a comment word, or the literal
+# path /tmp/iowarp_chimaera) makes `pkill -9 -f "[c]himaera"` match — and KILL —
+# the prep shell itself. That is exactly what happened in job 21564: the prep
+# self-immolated at the first pkill (line "…1816220 Killed srun…"), skipping the
+# 9413-free + /tmp-reclaim + mkdir steps; the run only survived because the debug
+# nodes were already clean. The `[c]` bracket protects the PATTERN token but not
+# other occurrences, so this block stays token-free (all prose lives up here) and
+# references the memfd dir as the glob /tmp/iowarp_chi* rather than by full name.
+echo "=== per-node prep (apptainer + /tmp bind + stale cleanup) ==="
+set +e
+srun --kill-on-bad-exit=0 --ntasks-per-node=1 bash -lc '
+  host=$(hostname)
+  if ! command -v apptainer >/dev/null 2>&1; then
+    echo "  [$host] ERROR: apptainer not on PATH (non-interactive ssh shell) — see PREREQUISITES."
+    exit 1
+  fi
+  echo "  [$host] apptainer OK: $(command -v apptainer)"
+  echo "  [$host] /tmp free BEFORE cleanup: $(df -h "'"$TMP_BIND_ROOT"'" | awk "NR==2{print \$4\" / \"\$2}")"
+  # Stale-state cleanup + node-local /tmp reclaim (non-fatal). Full rationale is
+  # in the outer comment above the srun; it is deliberately kept OUT of this
+  # inline string because pkill -f scans full argv and this string IS the argv
+  # (an un-bracketed chi/clio token here would make pkill kill the prep shell).
+  timeout 30 apptainer instance stop --all >/dev/null 2>&1
+  pkill -9 -f "[c]himaera" >/dev/null 2>&1
+  pkill -9 -f "[c]lio_run" >/dev/null 2>&1
+  command -v fuser >/dev/null 2>&1 && fuser -k 9413/tcp >/dev/null 2>&1
+  rm -f /dev/shm/chi_* >/dev/null 2>&1
+  find "'"$TMP_BIND_ROOT"'" -maxdepth 1 \( -name "'"$PIPELINE_NAME"'_run*" -o -name "'"$PIPELINE_NAME"'" \) \
+       -mmin +10 -exec rm -rf {} + >/dev/null 2>&1
+  rm -rf /tmp/iowarp_chi* >/dev/null 2>&1
+  mkdir -p "'"$TMP_BIND_ROOT/$PIPELINE_NAME"'/tmp" || echo "  [$host] mkdir FAILED rc=$?"
+  echo "  [$host] /tmp free AFTER  cleanup: $(df -h "'"$TMP_BIND_ROOT"'" | awk "NR==2{print \$4\" / \"\$2}")"
+  echo "  [$host] prep complete"'
+prep_rc=$?
+set -e
+echo "=== per-node prep srun rc=$prep_rc ==="
+[ "$prep_rc" -eq 0 ] || echo "WARNING: per-node prep rc=$prep_rc — continuing to gather R2 + sweep diagnostics anyway."
+
+# ---- host bind dirs (on the shared NFS home, so all nodes see them) ------
+mkdir -p "$HOME/distributed_nfs" "$HOME/juicefs_data"
+
+# ---- activate conda + register the repo ----------------------------------
+# shellcheck disable=SC1090
+source "$CONDA_SH"
+conda activate "$CONDA_ENV"
+jarvis repo add "$REPO/jarvis_clio_core" 2>/dev/null || true
+
+# ---- point the jarvis hostfile at ALL allocated nodes so the apptainer
+#      instances, runtime, CTE compose, and clio_cte_bench PSSH-fan-out across
+#      the reservation (validated pattern from run_cte_sweep_2n_ares.sbatch). --
+HOSTFILE="$HOME/.jarvis/hostfile_${SLURM_JOB_ID:-local}.txt"
+mkdir -p "$(dirname "$HOSTFILE")"
+scontrol show hostnames "${SLURM_JOB_NODELIST:-$(hostname)}" > "$HOSTFILE"
+echo "=== Allocated nodes (CTE runs on the first nprocs of them) ==="
+cat "$HOSTFILE"
+jarvis hostfile set "$HOSTFILE"
+trap 'rm -f "$HOSTFILE" ${RUN_PIPELINE:+"$RUN_PIPELINE"}' EXIT
+
+# ---- pre-flight over ssh (the channel jarvis uses to fan the container to
+#      every node). Single-node never exercised this: it deploys LOCALLY with
+#      the conda apptainer, whereas distributed PSSHes `apptainer instance start
+#      --fakeroot` to each node, where the ssh-login PATH may resolve a DIFFERENT
+#      apptainer. Two properties of that ssh-login apptainer must hold:
+#        (1) R2 (group): the ssh-session primary group must be $USER, else the
+#            remote --fakeroot GID map fails. A fresh ssh login uses initgroups
+#            (personal group) unless pam_slurm_adopt forces the Slurm job group.
+#            Verified empirically (job 21067): ssh group = $USER -> non-issue.
+#        (2) SIF openability: a rootless apptainer mounts the squashfs SIF via
+#            squashfuse, or falls back to EXTRACTING it with unsquashfs. If
+#            NEITHER is on the ssh PATH, `apptainer instance start` FATALs
+#            ("unsquashfs: not found") and every later `apptainer exec
+#            instance://...` says "no instance found" -> redis/runtime/juicefs
+#            all run into the void and the pipeline dies at the first fatal
+#            checkpoint (juicefs mount timeout). Job 21067 died exactly here
+#            because the ssh apptainer (~/.local/jarvis-apptainer) lacked both.
+#      So test SIF-open HERE, loudly, before the sweep. NB `ssh -n`: ssh reads
+#      stdin and would swallow the rest of the hostfile in a while-read loop
+#      (job 21067 only probed the first host for that reason).
+echo "=== pre-flight over ssh: group + SIF openability + REAL fakeroot instance start per node (want group=$USER, sif=OK, fakeroot=OK) ==="
+# We test the ACTUAL operation jarvis fans out -- `apptainer instance start
+# --fakeroot` -- not just `apptainer exec <sif> true`. `exec` never exercises
+# the fakeroot userns/subuid mapping, so it passes even on a node whose
+# `instance start --fakeroot` will FATAL with "newuidmap was not found in PATH"
+# (job 21239: ares-comp-15 lacked the uidmap setuid helpers while its 3 peers
+# had them -> that node's instance never started -> chimaera SWIM-marked it
+# DEAD -> the whole distributed run hung on retry-to-dead-node timeouts and
+# produced no results.csv). Catching it here turns a 30-min silent hang into an
+# immediate, node-named abort. A throwaway instance is started and stopped;
+# newuidmap/newgidmap are reported so the failure message is actionable.
+PREFLIGHT_OK=1
+BAD_NODES=""
+while read -r h; do
+  [ -n "$h" ] || continue
+  probe=$(env -u LD_LIBRARY_PATH ssh -n -o BatchMode=yes -o StrictHostKeyChecking=no "$h" \
+    'grp=$(id -gn); app=$(command -v apptainer 2>/dev/null || echo none);
+     sqf=$(command -v squashfuse 2>/dev/null || echo no);
+     unsq=$(command -v unsquashfs 2>/dev/null || echo no);
+     nuid=$(command -v newuidmap 2>/dev/null || echo no);
+     ngid=$(command -v newgidmap 2>/dev/null || echo no);
+     if apptainer exec "'"$SIF_PATH"'" true >/dev/null 2>&1; then sif=OK; else sif=FAIL; fi;
+     pn=pf_probe_$$;
+     apptainer instance stop "$pn" >/dev/null 2>&1;
+     if apptainer instance start --fakeroot "'"$SIF_PATH"'" "$pn" >/dev/null 2>&1; then
+       fr=OK; apptainer instance stop "$pn" >/dev/null 2>&1;
+     else fr=FAIL; fi;
+     echo "group=$grp apptainer=$app squashfuse=$sqf unsquashfs=$unsq newuidmap=$nuid newgidmap=$ngid sif=$sif fakeroot=$fr"' \
+    2>/dev/null || echo '<ssh failed>')
+  echo "  [$h] $probe"
+  case "$probe" in
+    *sif=OK*fakeroot=OK*) : ;;
+    *) PREFLIGHT_OK=0; BAD_NODES="$BAD_NODES $h" ;;
+  esac
+done < "$HOSTFILE"
+if [ "$PREFLIGHT_OK" -ne 1 ]; then
+  # Comma-joined for `sbatch --exclude` (which rejects spaces).
+  BAD_CSV=$(echo "${BAD_NODES# }" | tr ' ' ',')
+  {
+    echo "ERROR: pre-flight failed on:$BAD_NODES"
+    echo "  * sif=FAIL  -> the ssh-login apptainer can't open the squashfs SIF."
+    echo "     jarvis fans 'apptainer instance start' over ssh, so THAT apptainer"
+    echo "     (not the conda one on the batch PATH) must mount the SIF via"
+    echo "     squashfuse (or extract via unsquashfs). If squashfuse=no AND"
+    echo "     unsquashfs=no, make a squashfuse-capable apptainer win on the"
+    echo "     ssh-login PATH (e.g. prepend the conda-forge apptainer bin in"
+    echo "     ~/.bashrc so non-interactive ssh resolves it first)."
+    echo "  * fakeroot=FAIL (newuidmap=no / newgidmap=no) -> that node lacks the"
+    echo "     uidmap setuid helpers rootless --fakeroot needs. This is per-node"
+    echo "     heterogeneity on Ares -- the node simply can't run our containers."
+    echo "     Re-submit to land on different nodes, or exclude the bad one(s):"
+    echo "       sbatch --exclude=$BAD_CSV jarvis_clio_core/scripts/run_distributed_ares.sbatch"
+    echo "  Aborting before the sweep rather than hanging on a SWIM-dead node."
+  } >&2
+  exit 1
+fi
+
+# ---- clean slate so all 3 node-count rows re-run (sweep-resume otherwise
+#      skips rows already present, including failed ones). ------------------
+rm -f "$RESULTS"
+
+# ---- run the 3-point node-count sweep ------------------------------------
+# Run under our PERSONAL group ($USER), not the Slurm-assigned PROJECT group, so
+# apptainer --fakeroot (the FUSE backends) works on the HEAD node — Slurm makes
+# the project group our primary GID, which breaks fakeroot's GID mapping. See
+# run_single_node_ares.sbatch for the full rationale.
+#
+# CAVEAT (verify at Gate 6): jarvis PSSHes `apptainer instance start --fakeroot`
+# to the OTHER nodes over ssh; that head-node `sg` does NOT carry into the remote
+# ssh sessions. If those sessions land in the project group (Slurm/pam_slurm_adopt
+# adoption) rather than the personal group, the remote fakeroot will fail the same
+# way and we'll need a jarvis-side group switch (or a ~/.bashrc guard). Confirm a
+# remote node's group first:
+#   srun --nodes=$SLURM_NNODES --ntasks-per-node=1 bash -lc 'id -gn'
+# NB: `sg $USER -c` runs its arg under /bin/sh (dash), which has no `source` —
+# use the POSIX `.` so conda activation works in BOTH the sg and non-sg branches.
+RUN_SWEEP=". '$CONDA_SH' && conda activate '$CONDA_ENV' && jarvis ppl run yaml '${RUN_PIPELINE:-$PIPELINE}'"
+if getent group "$USER" >/dev/null 2>&1 && [ "$(id -gn)" != "$USER" ]; then
+  echo "switching primary group $(id -gn) -> $USER for apptainer --fakeroot"
+  sg "$USER" -c "$RUN_SWEEP"
+else
+  bash -c "$RUN_SWEEP"
+fi
+
+# ---- report ---------------------------------------------------------------
+echo "=== done — results at $RESULTS ==="
+if [ -f "$RESULTS" ]; then
+  # grep -c already prints "0" on no match (and exits 1); `|| echo 0` would
+  # append a SECOND "0" -> n="0\n0" -> `[ "$n" -ge ... ]` errors "integer
+  # expression expected" (seen in job 21067). `|| true` swallows the exit
+  # WITHOUT re-printing; n=${n:-0} covers the file-error (exit 2, no stdout).
+  n=$(grep -c success "$RESULTS" 2>/dev/null || true); n=${n:-0}
+  echo "successful rows: $n / $EXPECT"
+  head -1 "$RESULTS"
+  [ "$n" -ge "$EXPECT" ] && echo "ALL $EXPECT GREEN" || echo "INCOMPLETE — inspect $RESULTS / the .err log"
+else
+  echo "NO results.csv produced — check distributed-${SLURM_JOB_ID:-local}.err"
+fi

--- a/jarvis_clio_core/scripts/run_single_node_ares.sbatch
+++ b/jarvis_clio_core/scripts/run_single_node_ares.sbatch
@@ -1,0 +1,202 @@
+#!/bin/bash
+# Queue the #526 SINGLE-NODE container regression sweep on Ares (Pattern A:
+# one allocation, in-process 24-combo sweep via `jarvis ppl run yaml`).
+#
+# Grabs one compute node, makes apptainer available, verifies the regression SIF
+# is present, creates the host bind dirs (NFS target + juicefs object store) and
+# the node-local /tmp bind dir, activates the iowarp conda env, (re)registers the
+# repo, and runs single_node.yaml. Output lands in
+# $HOME/single_node_results/results.csv (24 rows).
+#
+# PREREQUISITE: build the SIF ONCE on the login node (docker + apptainer):
+#   cd ~/clio-core-fork && jarvis_clio_core/scripts/build_regression_image.sh
+# It writes <jarvis shared_dir>/containers/iowarp-regression-526.sif on the shared
+# FS; this job just consumes it (the YAML references it by basename).
+#
+# Quick queue (from anywhere):
+#   sbatch jarvis_clio_core/scripts/run_single_node_ares.sbatch
+#
+# Override at submit time, e.g. (point at a Spack setup so `spack load apptainer`
+# works, or pass an explicit apptainer bin dir):
+#   sbatch --export=ALL,SPACK_SETUP=$HOME/spack/share/spack/setup-env.sh \
+#          jarvis_clio_core/scripts/run_single_node_ares.sbatch
+#   sbatch --export=ALL,APPTAINER_BIN=/path/to/apptainer/bin \
+#          jarvis_clio_core/scripts/run_single_node_ares.sbatch
+#
+# Watch:   squeue -u $USER ; tail -f single_node-<jobid>.out
+#
+#SBATCH --job-name=single_node_526
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+# ConstrainCores=yes on Ares hands an ntasks=1 job a single core unless we ask
+# for more; chimaera workers + up to 32 bench threads + fio need real cores.
+#SBATCH --cpus-per-task=32
+# debug partition (mentor directive 2026-07-07): compute is ~fully allocated,
+# debug has idle nodes (ares-comp-03..06) and a 4-day limit. Override for a
+# one-off with `sbatch --partition=compute ...`.
+#SBATCH --partition=debug
+# Empirically MORE than ~11 min/combo: job 21064 estimated ~11 min/combo
+# (~4.6 h/24), but the 6 h rerun still clipped at 22/24 -- actual cost is
+# running >16 min/combo on average (probably rising with io_size/threads late
+# in the grid, since the swept vars grow monotonically). Bumped to 12 h as a
+# TIMING RUN: let it run to completion (or clip) and record wall-clock cost
+# per combo from the .out timestamps before picking a final --time value.
+#SBATCH --time=12:00:00
+#SBATCH --output=single_node-%j.out
+#SBATCH --error=single_node-%j.err
+
+set -euo pipefail
+
+# ---- knobs (override via --export=ALL,KEY=VAL) ----------------------------
+CONDA_SH="${CONDA_SH:-$HOME/miniconda3/etc/profile.d/conda.sh}"
+CONDA_ENV="${CONDA_ENV:-iowarp}"
+REPO="${REPO:-$HOME/clio-core-fork}"
+PIPELINE="${PIPELINE:-$REPO/jarvis_clio_core/pipelines/ares/single_node.yaml}"
+RESULTS="${RESULTS:-$HOME/single_node_results/results.csv}"
+# Regression SIF: referenced by the YAML as container_image: <SIF_BASENAME>.
+SIF_BASENAME="${SIF_BASENAME:-iowarp-regression-526}"
+# How apptainer is made available (Spack-installed; not on PATH by default):
+#   - APPTAINER_BIN : explicit dir containing the apptainer binary, OR
+#   - SPACK_SETUP   : path to spack setup-env.sh -> `spack load apptainer`.
+SPACK_SETUP="${SPACK_SETUP:-}"
+APPTAINER_BIN="${APPTAINER_BIN:-}"
+# Node-local /tmp bind root (MUST match tmp_bind_root in the YAML). jarvis binds
+# <root>/single_node/tmp -> in-container /tmp; this job creates it.
+TMP_BIND_ROOT="${TMP_BIND_ROOT:-/tmp}"
+PIPELINE_NAME="single_node"
+
+echo "=== #526 single-node sweep on $(hostname) — job ${SLURM_JOB_ID:-local} ==="
+echo "conda: $CONDA_ENV   repo: $REPO"
+echo "yaml:  $PIPELINE"
+
+# ---- make apptainer available (Spack-installed on the shared FS) ----------
+if ! command -v apptainer >/dev/null 2>&1; then
+  if [ -n "$APPTAINER_BIN" ]; then
+    export PATH="$APPTAINER_BIN:$PATH"
+  elif [ -n "$SPACK_SETUP" ] && [ -f "$SPACK_SETUP" ]; then
+    # shellcheck disable=SC1090
+    source "$SPACK_SETUP"; spack load apptainer || true
+  fi
+fi
+command -v apptainer >/dev/null 2>&1 || {
+  echo "ERROR: apptainer not on PATH. Spack-install it (scripts/validate_apptainer.sh"
+  echo "       Phase 0) and pass SPACK_SETUP=.../setup-env.sh or APPTAINER_BIN=.../bin." >&2
+  exit 1
+}
+echo "apptainer: $(command -v apptainer) ($(apptainer --version 2>/dev/null))"
+
+# ---- resolve + verify the regression SIF ----------------------------------
+if [ -z "${SIF_PATH:-}" ]; then
+  SHARED_DIR="$(grep -hE '^[[:space:]]*shared_dir:' "$HOME"/.ppi-jarvis/*.yaml 2>/dev/null \
+                | head -1 | sed -E 's/^[[:space:]]*shared_dir:[[:space:]]*//; s/["'"'"']//g')"
+  SIF_PATH="${SHARED_DIR:+$SHARED_DIR/containers/$SIF_BASENAME.sif}"
+fi
+echo "sif:   ${SIF_PATH:-<unresolved>}"
+[ -n "${SIF_PATH:-}" ] && [ -f "$SIF_PATH" ] || {
+  echo "ERROR: regression SIF not found: ${SIF_PATH:-<unresolved>}" >&2
+  echo "Build it ONCE on the login node, then resubmit:" >&2
+  echo "    cd $REPO && jarvis_clio_core/scripts/build_regression_image.sh" >&2
+  exit 1
+}
+
+# ---- stale-state cleanup on THIS node (node hygiene, non-fatal) ----------
+# single_node now PINS its hostfile (below) so it truly deploys on ONE node,
+# which exposes it to the same node-carried ghosts that bit distributed. Both
+# pipelines draw from the same compute pool, and a prior job (single_node OR
+# distributed) that hung and was Slurm-killed can leave, on this node:
+#   * a DAEMONIZED chimaera still bound to host port 9413 (apptainer instances
+#     share the host network namespace) -> this run's runtime FATALs "Could not
+#     start TCP server ... Port attempted: 9413" (distributed job 21473), then
+#     shm_attach fails and the sweep produces no results.csv; and
+#   * stale /tmp/<name>_run* scratch that accumulates until a later combo
+#     ENOSPCs on `mkdir /tmp/..._run<N>` (distributed job 21294).
+# Clear ONLY our own leftovers: stop orphaned instances (that kills the chimaera
+# inside them), pkill any bare survivor, free 9413, drop stale chi_* shm, and
+# reclaim stale per-run /tmp dirs older than 10 min (-mmin +10 protects a
+# concurrent job's live dir; nodes are effectively exclusive at 32 cpus, and
+# `instance stop --all` / pkill are per-user). No user data is touched -- this
+# only reclaims this pipeline's own dead state. Bracketed pkill patterns
+# ("[c]himaera") so they don't match a shell whose argv holds the pattern text.
+echo "=== stale-state cleanup on $(hostname) ==="
+echo "  /tmp free BEFORE: $(df -h "$TMP_BIND_ROOT" | awk 'NR==2{print $4" / "$2}')"
+timeout 30 apptainer instance stop --all >/dev/null 2>&1 || true
+pkill -9 -f '[c]himaera' >/dev/null 2>&1 || true
+pkill -9 -f '[c]lio_run' >/dev/null 2>&1 || true
+{ command -v fuser >/dev/null 2>&1 && fuser -k 9413/tcp >/dev/null 2>&1; } || true
+rm -f /dev/shm/chi_* >/dev/null 2>&1 || true
+find "$TMP_BIND_ROOT" -maxdepth 1 \
+     \( -name "${PIPELINE_NAME}_run*" -o -name "$PIPELINE_NAME" \) \
+     -mmin +10 -exec rm -rf {} + >/dev/null 2>&1 || true
+rm -rf /tmp/iowarp_chimaera >/dev/null 2>&1 || true
+echo "  /tmp free AFTER : $(df -h "$TMP_BIND_ROOT" | awk 'NR==2{print $4" / "$2}')"
+
+# ---- host bind dirs (NFS experiment target + juicefs object store) +
+#      node-local /tmp bind dir (tmp_bind_root). --------------------------
+mkdir -p "$HOME/single_node_nfs" "$HOME/juicefs_data" \
+         "$TMP_BIND_ROOT/$PIPELINE_NAME/tmp"
+
+# ---- activate the IOWarp/Jarvis conda env (the OUTER jarvis) -------------
+# shellcheck disable=SC1090
+source "$CONDA_SH"
+conda activate "$CONDA_ENV"
+
+# ---- register the repo with jarvis (idempotent) --------------------------
+jarvis repo add "$REPO/jarvis_clio_core" 2>/dev/null || true
+
+# ---- pin the jarvis hostfile to THIS ONE node ----------------------------
+# `jarvis hostfile set` is PERSISTENT global state in $HOME/.jarvis, shared
+# across all jobs. A prior DISTRIBUTED run leaves a 4-node hostfile behind, and
+# this single-node job — which never set its own — then inherits it and deploys
+# as if it had 4 nodes: jarvis fans `apptainer instance start` over ssh to the
+# other 3 (NOT in this 1-node allocation) -> thousands of "Access denied by
+# pam_slurm_adopt" lines, those instances never start, the chimaera runtime
+# forms a 4-node cluster with 3 SWIM-dead members (30s retry timeouts), and
+# juicefs (correctly NOT single_instance here) tries to reach redis on all 4 ->
+# "mountpoint /tmp/jfs_mnt not ready" (job 21474: 1/24, was 24/24 in job 21061
+# before any distributed run had poisoned the global hostfile). Pin to our own
+# node so the deploy is single-node again, matching the YAML's intent.
+HOSTFILE="$HOME/.jarvis/hostfile_single_${SLURM_JOB_ID:-local}.txt"
+mkdir -p "$(dirname "$HOSTFILE")"
+scontrol show hostnames "${SLURM_JOB_NODELIST:-$(hostname)}" | head -1 > "$HOSTFILE"
+echo "=== pinning jarvis hostfile to this node ==="; cat "$HOSTFILE"
+jarvis hostfile set "$HOSTFILE"
+trap 'rm -f "$HOSTFILE"' EXIT
+
+# ---- clean slate so all 24 combos re-run (sweep-resume otherwise skips
+#      rows already present, including failed ones). ------------------------
+rm -f "$RESULTS"
+
+# ---- run the 24-combo sweep (runner auto-detects vars:+loop:) ------------
+# Run under our PERSONAL group ($USER), not the Slurm-assigned PROJECT group.
+# The FUSE backends mount via `apptainer instance start --fakeroot`, whose GID
+# mapping is validated against our personal group; under Slurm the primary GID
+# is the project group, so fakeroot fails on compute with
+#   newgidmap: Target N is owned by a different user
+#   Error while waiting event for user namespace mappings: no event received
+# `sg $USER` switches the primary group back for the jarvis process and every
+# apptainer instance it spawns. conda is re-activated inside the new-group shell
+# so `jarvis` + apptainer resolve. (Verified: `sg $USER -c 'apptainer exec
+# --fakeroot ...'` starts the userns + mounts FUSE on a compute node; without it
+# the userns setup fails outright.)
+# NB: `sg $USER -c` runs its arg under /bin/sh (dash), which has no `source` —
+# use the POSIX `.` so conda activation works in BOTH the sg and non-sg branches.
+RUN_SWEEP=". '$CONDA_SH' && conda activate '$CONDA_ENV' && jarvis ppl run yaml '$PIPELINE'"
+if getent group "$USER" >/dev/null 2>&1 && [ "$(id -gn)" != "$USER" ]; then
+  echo "switching primary group $(id -gn) -> $USER for apptainer --fakeroot"
+  sg "$USER" -c "$RUN_SWEEP"
+else
+  bash -c "$RUN_SWEEP"
+fi
+
+# ---- report ---------------------------------------------------------------
+echo "=== done — results at $RESULTS ==="
+if [ -f "$RESULTS" ]; then
+  # `grep -c` on no-match exits 1 AND prints 0 already; `|| echo 0` then
+  # appended a SECOND "0", so $n became "0\n0" -> `[: integer expression`.
+  n=$(grep -c success "$RESULTS" 2>/dev/null || true); n=${n:-0}
+  echo "successful rows: $n / 24"
+  head -1 "$RESULTS"
+  [ "$n" -ge 24 ] && echo "ALL 24 GREEN" || echo "INCOMPLETE — inspect $RESULTS / the .err log"
+else
+  echo "NO results.csv produced — check single_node-${SLURM_JOB_ID:-local}.err"
+fi

--- a/jarvis_clio_core/scripts/setup_juicefs_ares.sh
+++ b/jarvis_clio_core/scripts/setup_juicefs_ares.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+#
+# setup_juicefs_ares.sh -- install the toolchain needed by the JuiceFS fio
+# sweep (jarvis_clio_core/pipelines/juicefs_fio_1n.yaml) on Ares.
+#
+# Installs (idempotently):
+#   * fio            -- the I/O driver (conda-forge, else `module load`)
+#   * juicefs        -- pinned release binary into ${HOME}/.local/bin
+#   * checks redis-server / redis-cli are reachable (metadata engine)
+#
+# No sudo is required: juicefs lands in ${HOME}/.local/bin. Run this inside
+# the `iowarp` conda env (so `conda install` targets it). Re-running is safe.
+#
+# Usage:  bash jarvis_clio_core/scripts/setup_juicefs_ares.sh
+set -u
+
+JUICEFS_VERSION="${JUICEFS_VERSION:-1.2.3}"   # pin a known-good release
+LOCAL_BIN="${HOME}/.local/bin"
+mkdir -p "${LOCAL_BIN}"
+case ":${PATH}:" in
+  *":${LOCAL_BIN}:"*) ;;
+  *) export PATH="${LOCAL_BIN}:${PATH}" ;;
+esac
+
+log() { printf '\n=== %s ===\n' "$*"; }
+
+# --- fio -------------------------------------------------------------------
+log "fio"
+if command -v fio >/dev/null 2>&1; then
+  echo "fio already present: $(command -v fio)"
+else
+  if command -v conda >/dev/null 2>&1; then
+    echo "Installing fio via conda-forge..."
+    conda install -y -c conda-forge fio || true
+  fi
+  if ! command -v fio >/dev/null 2>&1; then
+    echo "conda install failed/unavailable; trying 'module load fio'..."
+    module load fio 2>/dev/null || true
+  fi
+fi
+command -v fio >/dev/null 2>&1 || {
+  echo "ERROR: fio is not installed. Install it (conda-forge or a module) and re-run." >&2
+}
+
+# --- juicefs ---------------------------------------------------------------
+log "juicefs"
+if command -v juicefs >/dev/null 2>&1; then
+  echo "juicefs already present: $(command -v juicefs)"
+else
+  arch="$(uname -m)"
+  case "${arch}" in
+    x86_64|amd64) jarch="amd64" ;;
+    aarch64|arm64) jarch="arm64" ;;
+    *) jarch="amd64"; echo "WARN: unknown arch ${arch}, defaulting to amd64" ;;
+  esac
+  tarball="juicefs-${JUICEFS_VERSION}-linux-${jarch}.tar.gz"
+  url="https://github.com/juicedata/juicefs/releases/download/v${JUICEFS_VERSION}/${tarball}"
+  tmpd="$(mktemp -d)"
+  echo "Downloading ${url}"
+  if curl -fsSL "${url}" -o "${tmpd}/${tarball}"; then
+    tar -xzf "${tmpd}/${tarball}" -C "${tmpd}" juicefs 2>/dev/null \
+      || tar -xzf "${tmpd}/${tarball}" -C "${tmpd}"
+    if [ -f "${tmpd}/juicefs" ]; then
+      install -m 0755 "${tmpd}/juicefs" "${LOCAL_BIN}/juicefs"
+      echo "Installed juicefs -> ${LOCAL_BIN}/juicefs"
+    else
+      echo "ERROR: juicefs binary not found in tarball ${tarball}" >&2
+    fi
+  else
+    echo "ERROR: failed to download juicefs. If Ares has no outbound network," >&2
+    echo "       fetch ${tarball} on the login node and place 'juicefs' in ${LOCAL_BIN}." >&2
+  fi
+  rm -rf "${tmpd}"
+fi
+
+# --- redis -----------------------------------------------------------------
+log "redis"
+if command -v redis-server >/dev/null 2>&1 && command -v redis-cli >/dev/null 2>&1; then
+  echo "redis present: $(command -v redis-server)"
+else
+  echo "redis-server/redis-cli not on PATH. Provide via conda" >&2
+  echo "('conda install -y -c conda-forge redis') or a module before running." >&2
+fi
+
+# --- summary ---------------------------------------------------------------
+log "versions"
+command -v fio        >/dev/null 2>&1 && fio --version
+command -v juicefs    >/dev/null 2>&1 && juicefs version
+command -v redis-server >/dev/null 2>&1 && redis-server --version
+
+log "PATH note"
+echo "Ensure ${LOCAL_BIN} is on PATH for the benchmark run:"
+echo "  export PATH=\"${LOCAL_BIN}:\$PATH\""

--- a/jarvis_clio_core/scripts/smoke_juicefs_gcs.sh
+++ b/jarvis_clio_core/scripts/smoke_juicefs_gcs.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+#
+# smoke_juicefs_gcs.sh -- prove the JuiceFS<->GCS link end to end, NO benchmark.
+#
+# Formats + FUSE-mounts JuiceFS on a real gs:// bucket (Redis metadata), does a
+# POSIX round-trip through the mount, forces a flush + cold read so the bytes
+# must come from GCS, then INDEPENDENTLY confirms with `gcloud storage ls` that
+# JuiceFS objects physically landed in the bucket. Prints PASS only when the
+# in-mount round-trip AND the gcloud listing agree -- mirroring the
+# "in-process round-trip AND external CLI agree = valid" discipline in
+# cloud_adapter_validation.md (sections 1 and 5).
+#
+# This is a configuration / connectivity check, NOT the fio sweep
+# (jarvis_clio_core/pipelines/juicefs_fio_1n.yaml).
+#
+# Required env:
+#   BUCKET=gs://<your-bucket>                       the real bucket (must exist or be creatable)
+#   GOOGLE_APPLICATION_CREDENTIALS=~/gcs-sa.json     service-account key  (or set GCS_ACCESS_TOKEN)
+# Optional env:
+#   GCS_PROJECT_ID=<project>             only used if juicefs auto-creates the bucket
+#   META_URL=redis://127.0.0.1:6379/1    metadata engine (default). Any engine the
+#                                        juicefs binary supports works here; for a
+#                                        no-server / no-sudo run use the embedded
+#                                        SQLite engine, e.g.
+#                                          META_URL=sqlite3://jfsgcs-meta.db
+#                                        (redis:// is pinged first; embedded engines
+#                                        are created by `juicefs format` itself).
+#   VOL=jfsgcssmoke   MNT=$HOME/jfs_gcs_mnt   CACHE=$HOME/jfs_gcs_cache
+#
+# Use a DEDICATED/empty test bucket: JuiceFS writes its objects (juicefs_uuid
+# format marker + a chunks/ data tree, possibly under a <volume>/ prefix) inside
+# the --bucket path, exactly as the jarvis juicefs package does for storage=gs.
+#
+# Usage:
+#   export BUCKET=gs://my-bucket
+#   export GOOGLE_APPLICATION_CREDENTIALS=~/gcs-sa.json
+#   bash jarvis_clio_core/scripts/smoke_juicefs_gcs.sh
+set -u
+
+META_URL="${META_URL:-redis://127.0.0.1:6379/1}"
+VOL="${VOL:-jfsgcssmoke}"
+MNT="${MNT:-${HOME}/jfs_gcs_mnt}"
+CACHE="${CACHE:-${HOME}/jfs_gcs_cache}"
+LOCAL_BIN="${HOME}/.local/bin"
+case ":${PATH}:" in *":${LOCAL_BIN}:"*) ;; *) export PATH="${LOCAL_BIN}:${PATH}" ;; esac
+
+log()  { printf '\n=== %s ===\n' "$*"; }
+
+is_mounted() {
+  if command -v mountpoint >/dev/null 2>&1; then
+    mountpoint -q "$1"
+  else
+    grep -q " $1 " /proc/mounts 2>/dev/null
+  fi
+}
+
+cleanup() {
+  # Best-effort unmount + temp-file removal; never fail the script from here.
+  if is_mounted "${MNT}"; then
+    juicefs umount "${MNT}" >/dev/null 2>&1 \
+      || fusermount -u "${MNT}" >/dev/null 2>&1 || true
+  fi
+  [ -n "${SRC:-}" ] && rm -f "${SRC}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# --- 1. Prereqs (each a hard gate) ----------------------------------------
+log "prereqs"
+command -v juicefs   >/dev/null 2>&1 || fail "juicefs not on PATH (run setup_juicefs_ares.sh)"
+command -v gcloud    >/dev/null 2>&1 || fail "gcloud not on PATH (needed for the independent GCS check)"
+command -v curl      >/dev/null 2>&1 || fail "curl not on PATH"
+# Metadata engine is whatever META_URL names. redis:// needs a running server +
+# redis-cli; embedded engines (sqlite3://, badger://) live in a local file the
+# juicefs binary creates -- no server, no redis-cli, no sudo.
+case "${META_URL}" in
+  redis://*|rediss://*)
+    meta_kind="redis"
+    command -v redis-cli >/dev/null 2>&1 || fail "redis-cli not on PATH (META_URL is redis://)"
+    ;;
+  *) meta_kind="embedded" ;;
+esac
+[ -e /dev/fuse ] || fail "/dev/fuse missing -- FUSE mount impossible (need a privileged container)"
+# juicefs also needs the userspace helper (fusermount/fusermount3 from the fuse3
+# package). With /dev/fuse present but the helper absent, the mount dies with
+# 'fuse: fuse is not installed' -- so gate on the binary, not just the device.
+command -v fusermount3 >/dev/null 2>&1 || command -v fusermount >/dev/null 2>&1 \
+  || fail "fusermount not on PATH -- install the 'fuse3' (or 'fuse') package; the mount cannot work without it"
+# Real GCS is HTTPS: without a CA bundle every request fails with curl error 60.
+[ -f /etc/ssl/certs/ca-certificates.crt ] || [ -d /etc/ssl/certs ] \
+  || fail "ca-certificates not found -- TLS to storage.googleapis.com will fail"
+: "${BUCKET:?set BUCKET=gs://<your-bucket>}"
+case "${BUCKET}" in gs://*) ;; *) fail "BUCKET must be a gs:// URL, got '${BUCKET}'" ;; esac
+# Credentials: juicefs uses Google's ADC chain. Accept ANY of three sources:
+#   D1  GOOGLE_APPLICATION_CREDENTIALS=<key.json>   (service-account key)
+#       GCS_ACCESS_TOKEN=<token>                    (short-lived token)
+#   D2  user ADC: ~/.config/gcloud/application_default_credentials.json
+#       (written by `gcloud auth application-default login`) -- no env var needed
+adc_file="${CLOUDSDK_CONFIG:-${HOME}/.config/gcloud}/application_default_credentials.json"
+if [ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]; then
+  [ -r "${GOOGLE_APPLICATION_CREDENTIALS}" ] \
+    || fail "GOOGLE_APPLICATION_CREDENTIALS='${GOOGLE_APPLICATION_CREDENTIALS}' is not readable"
+  echo "creds: service-account key at GOOGLE_APPLICATION_CREDENTIALS (D1)"
+elif [ -n "${GCS_ACCESS_TOKEN:-}" ]; then
+  echo "creds: GCS_ACCESS_TOKEN present (short-lived token)"
+elif [ -r "${adc_file}" ]; then
+  echo "creds: user ADC at ${adc_file} (D2)"
+else
+  fail "no GCS credentials: set GOOGLE_APPLICATION_CREDENTIALS=<key.json>, or GCS_ACCESS_TOKEN, or run 'gcloud auth application-default login' (expected ${adc_file})"
+fi
+# Metadata engine reachable. For redis, ping it; for an embedded engine the
+# juicefs format step creates/opens the local DB itself, so there is nothing to
+# reach here.
+if [ "${meta_kind}" = "redis" ]; then
+  redis-cli -u "${META_URL}" ping 2>/dev/null | grep -q PONG \
+    || fail "redis not reachable at ${META_URL} (start the redis package / server first)"
+  meta_status="redis PONG"
+else
+  meta_status="embedded meta (${META_URL})"
+fi
+# Network egress to GCS (connect, don't hang).
+code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 15 https://storage.googleapis.com || true)"
+{ [ -n "${code}" ] && [ "${code}" != "000" ]; } \
+  || fail "no network egress to storage.googleapis.com (curl returned '${code:-none}')"
+echo "prereqs OK (storage.googleapis.com http=${code}, ${meta_status}, /dev/fuse present)"
+
+mkdir -p "${MNT}" "${CACHE}"
+root="${BUCKET%/}"
+
+# --- 2. Format the volume on real GCS -------------------------------------
+# Exactly the command jarvis_clio_core.juicefs builds for storage=gs.
+log "format (juicefs format --storage gs --bucket ${root})"
+juicefs format --storage gs --bucket "${root}" "${META_URL}" "${VOL}" \
+  || fail "juicefs format failed (check creds, bucket name, IAM role, clock skew)"
+
+# --- 3. FUSE mount --------------------------------------------------------
+log "mount"
+juicefs mount "${META_URL}" "${MNT}" --cache-dir "${CACHE}" --background \
+  || fail "juicefs mount returned an error"
+ready=0
+for _ in $(seq 1 20); do
+  if is_mounted "${MNT}"; then ready=1; break; fi
+  sleep 1
+done
+[ "${ready}" = 1 ] || fail "mount not ready after 20s (check creds / /dev/fuse)"
+echo "mounted at ${MNT}"
+
+# --- 4. POSIX round-trip through the mount --------------------------------
+log "round-trip"
+SRC="$(mktemp)"
+DST="${MNT}/smoke_$$.bin"
+head -c 5242880 /dev/urandom > "${SRC}"   # 5 MiB > one 4 MiB block => >=2 data objects
+cp "${SRC}" "${DST}" || fail "write through the mount failed"
+cmp "${SRC}" "${DST}" || fail "byte-compare through the mount failed"
+echo "round-trip OK ($(wc -c < "${SRC}") bytes written + verified through the mount)"
+
+# --- 5. Force durability: flush + drop cache, then cold read --------------
+log "flush + cold read"
+sync
+juicefs warmup --evict "${DST}" >/dev/null 2>&1 || true   # drop local cache for this file
+cmp "${SRC}" "${DST}" || fail "cold read-back (post-evict) mismatch -> bytes not durable in GCS"
+echo "cold read-back OK (served from GCS, not local page cache)"
+
+# --- 6. INDEPENDENT confirmation: objects physically in the bucket --------
+# The step that proves bytes left the box (cloud_adapter_validation.md 3.1.E).
+# JuiceFS writes a `juicefs_uuid` format marker + file data under a `chunks/`
+# tree inside the --bucket path (it may nest under a <volume>/ prefix). We list
+# the bucket recursively and match `/chunks/` anywhere, so prefix layout differences
+# don't matter -- file *metadata* stays in the meta engine, not in GCS.
+log "independent gcloud check"
+nchunks=0
+listing=""
+for _ in $(seq 1 5); do        # brief retry: tolerate async upload completion
+  listing="$(gcloud storage ls -r "${root}/" 2>/dev/null || true)"
+  nchunks="$(printf '%s\n' "${listing}" | grep -Ec '/chunks/' || true)"
+  [ "${nchunks:-0}" -ge 1 ] && break
+  sleep 2
+done
+[ -n "${listing}" ] || fail "gcloud storage ls -r ${root}/ returned nothing (auth/permission, or empty bucket)"
+if printf '%s\n' "${listing}" | grep -q 'juicefs_uuid'; then
+  echo "format marker present: juicefs_uuid"
+else
+  echo "note: juicefs_uuid marker not seen (name varies by version); relying on chunk objects"
+fi
+[ "${nchunks:-0}" -ge 1 ] \
+  || fail "no objects under chunks/ in ${root}/ -> file data never reached GCS"
+echo "GCS holds ${nchunks} object(s) under chunks/ (>=2 expected for a 5 MiB file)"
+
+# --- 7. Report (cleanup runs on EXIT) -------------------------------------
+log "result"
+echo "PASS: JuiceFS<->GCS verified -- in-mount round-trip AND gcloud agree the"
+echo "      bytes physically landed in ${root}/"
+echo "      teardown test objects with: gcloud storage rm -r ${root}/chunks"
+echo "      (and ${root}/juicefs_uuid, ${root}/meta if present)"

--- a/jarvis_clio_core/scripts/survey_fakeroot_nodes.sh
+++ b/jarvis_clio_core/scripts/survey_fakeroot_nodes.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# =============================================================================
+# survey_fakeroot_nodes.sh — find Ares compute nodes that CAN'T run our
+# rootless-Apptainer containers, so you can hand the admin a concrete list (or
+# build a --exclude set) instead of discovering bad nodes one Slurm allocation
+# at a time.
+#
+# THE ONE THING WE'RE LOOKING FOR
+#   Our pipeline mounts FUSE (JuiceFS + CTE libfuse) inside the container, which
+#   needs CAP_SYS_ADMIN, which under a non-setuid apptainer needs `--fakeroot`,
+#   which needs the setuid-root helpers `newuidmap`/`newgidmap` (the distro
+#   `uidmap` package) to write the subuid/subgid range mapping. A node missing
+#   them FATALs `apptainer instance start --fakeroot` with "newuidmap was not
+#   found in PATH" — its chimaera never starts, the cluster SWIM-marks it dead,
+#   and the whole distributed run hangs (jobs 21239=comp-15, 21253=comp-17).
+#   Unlike squashfuse (a plain user binary we symlink into the shared ~/.local),
+#   newuidmap MUST be setuid-root and system-installed — admins only. So the
+#   presence of `uidmap` on a node is the crisp, admin-actionable signal.
+#
+# HOW IT REACHES NODES  (honest limitation up front)
+#   On Ares you generally can't ssh to a compute node you don't hold a job on,
+#   so by default this surveys via `srun` (Slurm-native). `srun --immediate`
+#   can only land on nodes that are ALLOCATABLE right now — a busy node is
+#   reported UNREACH, not GOOD/BAD. Re-run later to cover nodes that were busy,
+#   or accumulate results across runs. (The sweep's own pre-flight remains the
+#   per-run safety net for whatever nodes you actually land on.)
+#
+# USAGE
+#   scripts/survey_fakeroot_nodes.sh                  # survey all of -p compute
+#   scripts/survey_fakeroot_nodes.sh -p compute       # explicit partition
+#   scripts/survey_fakeroot_nodes.sh -n ares-comp-[12-31]   # a specific set
+#   scripts/survey_fakeroot_nodes.sh --ssh            # reach via ssh instead of srun
+#                                                     #   (only works for nodes you
+#                                                     #    can ssh to, e.g. in a job)
+#   scripts/survey_fakeroot_nodes.sh --deep /path/to.sif    # REAL fakeroot
+#                                                     #   instance start+stop probe
+#                                                     #   (definitive, heavier)
+#
+# OUTPUT
+#   One line per node (GOOD / BAD / UNREACH) with the evidence, then a summary:
+#   the GOOD list, the BAD list, and a ready-to-paste `--exclude=<csv>` you can
+#   hand to sbatch. Exit 0 if no BAD nodes were found, 1 if any were.
+# =============================================================================
+set -uo pipefail
+
+PARTITION="compute"
+NODELIST=""
+MODE="srun"          # srun | ssh
+DEEP_SIF=""          # non-empty -> real fakeroot instance-start probe
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -p|--partition) PARTITION="$2"; shift 2 ;;
+    -n|--nodelist)  NODELIST="$2";  shift 2 ;;
+    --ssh)          MODE="ssh";     shift ;;
+    --deep)         DEEP_SIF="$2";  shift 2 ;;
+    -h|--help)      sed -n '2,45p' "$0"; exit 0 ;;
+    *) echo "unknown arg: $1 (try --help)" >&2; exit 2 ;;
+  esac
+done
+
+# ---- resolve the node list ------------------------------------------------
+# -n takes an explicit Slurm nodelist expr (ranges allowed, e.g. comp-[12-31]);
+# otherwise enumerate every node in the partition. scontrol expands ranges into
+# one hostname per line.
+if [ -n "$NODELIST" ]; then
+  NODES=$(scontrol show hostnames "$NODELIST" 2>/dev/null | sort -u)
+else
+  NODES=$(sinfo -h -N -p "$PARTITION" -o '%N' 2>/dev/null | sort -u)
+fi
+if [ -z "${NODES:-}" ]; then
+  echo "ERROR: no nodes found (partition='$PARTITION', nodelist='$NODELIST'). " \
+       "Is Slurm on PATH / the partition name right?" >&2
+  exit 2
+fi
+
+# ---- the per-node check (runs ON the node) --------------------------------
+# Default: is `uidmap` present AND is newuidmap setuid? (`[ -u ]` tests the
+# setuid bit directly — a non-setuid copy can't map subuid ranges and is as
+# useless as a missing one.) --deep: actually start+stop a --fakeroot instance,
+# the exact op jarvis fans out, so nothing about the fakeroot path is guessed.
+if [ -n "$DEEP_SIF" ]; then
+  CHECK='
+    pn=survey_probe_$$
+    apptainer instance stop "$pn" >/dev/null 2>&1
+    if apptainer instance start --fakeroot "'"$DEEP_SIF"'" "$pn" >/dev/null 2>&1; then
+      apptainer instance stop "$pn" >/dev/null 2>&1
+      echo "GOOD fakeroot=OK sif='"$DEEP_SIF"'"
+    else
+      nu=$(command -v newuidmap 2>/dev/null || echo MISSING)
+      echo "BAD fakeroot=FAIL newuidmap=$nu"
+    fi'
+else
+  CHECK='
+    nu=$(command -v newuidmap 2>/dev/null || echo MISSING)
+    ng=$(command -v newgidmap 2>/dev/null || echo MISSING)
+    su=no; [ "$nu" != MISSING ] && [ -u "$nu" ] && su=yes
+    if [ "$nu" != MISSING ] && [ "$ng" != MISSING ] && [ "$su" = yes ]; then
+      echo "GOOD newuidmap=$nu newgidmap=$ng setuid=$su"
+    else
+      echo "BAD newuidmap=$nu newgidmap=$ng setuid=$su"
+    fi'
+fi
+
+# ---- run it per node ------------------------------------------------------
+run_on_node() {
+  local node="$1"
+  if [ "$MODE" = ssh ]; then
+    # env -u LD_LIBRARY_PATH: keep conda's libs from breaking /usr/bin/ssh's
+    # OpenSSL (same reason the sweep's ssh_cmd strips it).
+    env -u LD_LIBRARY_PATH ssh -n -o BatchMode=yes -o StrictHostKeyChecking=no \
+      -o ConnectTimeout=5 "$node" "$CHECK" 2>/dev/null
+  else
+    # --immediate: don't queue behind a busy node — bail so we can mark UNREACH.
+    # -t 1: cap the step at a minute. --quiet: no srun bookkeeping on stderr.
+    srun --quiet --immediate --nodes=1 --ntasks=1 --nodelist="$node" \
+      -p "$PARTITION" -t 1 bash -c "$CHECK" 2>/dev/null
+  fi
+}
+
+echo "=== fakeroot/uidmap survey: partition=$PARTITION mode=$MODE${DEEP_SIF:+ deep=$DEEP_SIF} ==="
+GOOD=""; BAD=""; UNREACH=""
+for node in $NODES; do
+  out=$(run_on_node "$node")
+  if [ -z "$out" ]; then
+    echo "  [$node] UNREACH (busy/down or unreachable — re-run to cover it)"
+    UNREACH="$UNREACH $node"
+    continue
+  fi
+  echo "  [$node] $out"
+  case "$out" in
+    GOOD*) GOOD="$GOOD $node" ;;
+    *)     BAD="$BAD $node" ;;
+  esac
+done
+
+# ---- summary --------------------------------------------------------------
+csv() { echo "${1# }" | tr ' ' ','; }
+echo
+echo "=== summary ==="
+echo "GOOD    (${GOOD:+$(echo $GOOD | wc -w)}${GOOD:+ }nodes):$GOOD"
+echo "BAD     (${BAD:+$(echo $BAD | wc -w)}${BAD:+ }nodes):$BAD"
+echo "UNREACH (${UNREACH:+$(echo $UNREACH | wc -w)}${UNREACH:+ }nodes):$UNREACH"
+if [ -n "$BAD" ]; then
+  echo
+  echo "Bad nodes lack setuid uidmap (admin fix: install the 'uidmap' package,"
+  echo "ideally in the compute node image so it survives re-imaging)."
+  echo "To keep running meanwhile, exclude them:"
+  echo "  sbatch --exclude=$(csv "$BAD") jarvis_clio_core/scripts/run_distributed_ares.sbatch"
+  exit 1
+fi
+echo "No BAD nodes among the reachable set."
+[ -n "$UNREACH" ] && echo "(NB: $(echo $UNREACH | wc -w) node(s) were UNREACH — re-run later to survey them.)"
+exit 0

--- a/jarvis_clio_core/scripts/validate_apptainer.sh
+++ b/jarvis_clio_core/scripts/validate_apptainer.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+# validate_apptainer.sh — runnable preflight + validation checklist for the #526
+# APPTAINER pipelines on Ares. Run the cheap, fast-failing gates FIRST; each must
+# pass before the next. Heavy pipeline runs (Gates 4-6) are driven via sbatch and
+# are printed as instructions at the end.
+#
+# Usage (on the Ares LOGIN node, repo root or anywhere):
+#   jarvis_clio_core/scripts/validate_apptainer.sh            # Phase 0 + Gates 0-3
+#   APPEND_BASHRC=1 jarvis_clio_core/scripts/validate_apptainer.sh  # also wire PATH
+#
+# Knobs:
+#   SPACK_SETUP   path to spack setup-env.sh (else spack must be on PATH)
+#   SIF_BASENAME  default iowarp-regression-526 (must match the YAML container_image)
+#   SIF_PATH      override the resolved SIF location
+#   APPEND_BASHRC=1   append the apptainer bin to ~/.bashrc (needed for the
+#                     distributed run's ssh fan-out; off by default).
+set -uo pipefail
+
+REPO="${REPO:-$HOME/clio-core-fork}"
+SIF_BASENAME="${SIF_BASENAME:-iowarp-regression-526}"
+JARVIS_DIR="${JARVIS_DIR:-$HOME/jarvis-cd}"
+JARVIS_PIN="${JARVIS_PIN:-2925ee8}"
+
+ok()   { echo "  [PASS] $*"; }
+bad()  { echo "  [FAIL] $*" >&2; }
+hdr()  { echo; echo "==================== $* ===================="; }
+
+# Make spack available if a setup script was provided.
+if [ -n "${SPACK_SETUP:-}" ] && [ -f "$SPACK_SETUP" ]; then
+  # shellcheck disable=SC1090
+  source "$SPACK_SETUP"
+fi
+
+# ---------------------------------------------------------------------------
+hdr "Phase 0 — Install Apptainer via Spack (one-time, on the shared FS)"
+# Apptainer is NOT preinstalled on Ares (mentor: install with spack; not on every
+# node). Installing into the host spack on /mnt/common makes the binary visible
+# on every compute node (shared FS). Ares has unprivileged user namespaces +
+# subuid/subgid maps, so the non-setuid apptainer runs fine as an unprivileged
+# user. If `spack install apptainer` tries to install setuid binaries and fails,
+# retry with the non-setuid variant:  spack install apptainer ~suid
+if ! command -v apptainer >/dev/null 2>&1; then
+  if command -v spack >/dev/null 2>&1; then
+    echo "apptainer not on PATH — installing via spack (this can take a while)..."
+    # GOFLAGS=-buildvcs=false: apptainer's Go deps (go-md2man, gocryptfs) fail
+    # when the spack build dir is not a git repo and Go tries to embed VCS info.
+    GOFLAGS=-buildvcs=false spack install apptainer \
+      || GOFLAGS=-buildvcs=false spack install apptainer ~suid || {
+      bad "spack install apptainer failed — inspect the spack log"; }
+    APPTAINER_PREFIX="$(spack location -i apptainer 2>/dev/null || true)"
+    [ -n "$APPTAINER_PREFIX" ] && export PATH="$APPTAINER_PREFIX/bin:$PATH"
+  else
+    bad "spack not found. Pass SPACK_SETUP=.../share/spack/setup-env.sh"
+  fi
+fi
+
+if command -v apptainer >/dev/null 2>&1; then
+  APPTAINER_BIN_DIR="$(dirname "$(command -v apptainer)")"
+  ok "apptainer present: $(command -v apptainer)"
+  # PATH wiring for the distributed run: jarvis Pssh's `apptainer instance start`
+  # to every node over ssh, so the bin must be on the remote NON-interactive
+  # shell's PATH. ~/.bashrc is shared ($HOME on /mnt/common) and IS sourced by
+  # the ssh fan-out on Ares (same mechanism that activates conda).
+  BASHRC_LINE="export PATH=\"$APPTAINER_BIN_DIR:\$PATH\"  # apptainer (#526)"
+  if [ "${APPEND_BASHRC:-0}" = "1" ]; then
+    if ! grep -qF "$APPTAINER_BIN_DIR" "$HOME/.bashrc" 2>/dev/null; then
+      echo "$BASHRC_LINE" >> "$HOME/.bashrc"
+      ok "appended apptainer bin to ~/.bashrc"
+    else
+      ok "apptainer bin already in ~/.bashrc"
+    fi
+  else
+    echo "  NOTE: for the DISTRIBUTED run, ensure remote shells see apptainer. Add:"
+    echo "        $BASHRC_LINE"
+    echo "        (re-run with APPEND_BASHRC=1 to do this automatically)"
+  fi
+else
+  bad "apptainer still not available — fix Phase 0 before continuing"
+fi
+
+# ---------------------------------------------------------------------------
+hdr "Gate 0 — Apptainer on login AND a compute node"
+command -v apptainer >/dev/null 2>&1 && apptainer --version && ok "login apptainer OK" \
+  || bad "apptainer missing on login"
+echo "  checking a compute node via srun (login-shell PATH)..."
+srun --partition=compute -N1 --time=00:02:00 bash -lc \
+  'command -v apptainer >/dev/null && apptainer --version' \
+  && ok "compute-node apptainer OK" \
+  || bad "apptainer NOT reachable on compute (set APPEND_BASHRC=1 and retry Gate 0)"
+
+# ---------------------------------------------------------------------------
+hdr "Gate 1 — jarvis is dev @ $JARVIS_PIN with the apptainer code path"
+HEAD="$(git -C "$JARVIS_DIR" rev-parse --short HEAD 2>/dev/null || echo '?')"
+BR="$(git -C "$JARVIS_DIR" branch --show-current 2>/dev/null || echo '?')"
+echo "  jarvis-cd: $BR @ $HEAD  (expect dev @ $JARVIS_PIN)"
+[ "$HEAD" = "$JARVIS_PIN" ] && ok "jarvis pin matches" || bad "jarvis pin differs ($HEAD)"
+if git -C "$JARVIS_DIR" grep -q "container_engine == 'apptainer'" -- jarvis_cd/core/installer.py 2>/dev/null; then
+  ok "ContainerInstaller has the apptainer code path"
+else
+  bad "apptainer code path not found in installer.py"
+fi
+
+# ---------------------------------------------------------------------------
+hdr "Gate 2 — Regression SIF present"
+if [ -z "${SIF_PATH:-}" ]; then
+  SHARED_DIR="$(grep -hE '^[[:space:]]*shared_dir:' "$HOME"/.ppi-jarvis/*.yaml 2>/dev/null \
+                | head -1 | sed -E 's/^[[:space:]]*shared_dir:[[:space:]]*//; s/["'"'"']//g')"
+  SIF_PATH="${SHARED_DIR:+$SHARED_DIR/containers/$SIF_BASENAME.sif}"
+fi
+echo "  SIF: ${SIF_PATH:-<unresolved>}"
+if [ -n "${SIF_PATH:-}" ] && [ -f "$SIF_PATH" ]; then
+  ok "SIF present"; ls -lh "$SIF_PATH"
+else
+  bad "SIF missing — build it on the login node:"
+  echo "        cd $REPO && jarvis_clio_core/scripts/build_regression_image.sh"
+fi
+
+# ---------------------------------------------------------------------------
+hdr "Gate 3 — FUSE smoke inside the SIF (the early kill-switch)"
+# Confirms (a) juicefs + redis binaries present, (b) a FUSE mount works inside the
+# container. KEY: the conda-forge apptainer is NON-SETUID, so it runs rootless and
+# --add-caps SYS_ADMIN is a NO-OP (you can't gain host caps you lack). FUSE mount()
+# needs CAP_SYS_ADMIN *effective*, which only --fakeroot provides (maps user->root
+# in the userns). With --fakeroot apptainer also supplies a dev-enabled /dev/fuse,
+# so NO --bind /dev/fuse is needed. If this fails, no pipeline will mount FUSE.
+#
+# GROUP GOTCHA: apptainer --fakeroot validates its GID mapping against our PERSONAL
+# group (== $USER). Under Slurm the primary GID is the PROJECT group, which makes
+# fakeroot fail on compute with "newgidmap: Target N is owned by a different user".
+# So run the smoke under `sg $USER` whenever our current primary group != $USER
+# (i.e. on a compute node / inside srun). The sbatch wrappers do the same around
+# `jarvis ppl run`. NOTE: the login node may kill long FUSE jobs (watchdog), so
+# prefer running this whole script on a compute node:  srun ... bash <this script>.
+#
+# redis/juicefs in-container gotchas baked in below:
+#   * redis --daemonize yes silently fails in the userns -> start with `&`.
+#   * a stale on-disk dump.rdb (newer RDB version) aborts load -> --dbfilename "".
+#   * juicefs -d can't signal readiness in-container -> background `&` + mountpoint.
+if [ -n "${SIF_PATH:-}" ] && [ -f "$SIF_PATH" ] && command -v apptainer >/dev/null 2>&1; then
+  # Inner smoke written to a tempfile (on host /tmp, visible in-container via the
+  # default /tmp bind) to sidestep sg/apptainer/bash nested-quoting.
+  SMOKE_SH="$(mktemp /tmp/fuse_smoke.XXXXXX.sh)"
+  cat > "$SMOKE_SH" <<'SMOKE'
+set -e
+SM="/tmp/jfs_smoke_$$"
+cleanup() {
+  fusermount -uz "$SM/mnt" 2>/dev/null || umount -l "$SM/mnt" 2>/dev/null || true
+  redis-cli -p 6390 shutdown nosave 2>/dev/null || true
+  rm -rf "$SM" 2>/dev/null || true
+}
+trap cleanup EXIT
+pkill -f "redis-server.*6390" 2>/dev/null || true; sleep 1
+mkdir -p "$SM/mnt" "$SM/data"
+redis-server --port 6390 --save "" --dbfilename "" --loglevel warning &
+sleep 2
+redis-cli -p 6390 ping
+juicefs format --storage file --bucket "$SM/data" redis://127.0.0.1:6390/9 smoketest
+juicefs mount redis://127.0.0.1:6390/9 "$SM/mnt" --no-usage-report &
+sleep 5
+mountpoint -q "$SM/mnt" || { echo "FUSE mount not ready"; tail -20 "$HOME"/.juicefs/juicefs.log 2>/dev/null || true; exit 1; }
+echo hello > "$SM/mnt/probe.txt" && grep -q hello "$SM/mnt/probe.txt"
+echo "MOUNT OK"; echo "IO OK"
+SMOKE
+  if getent group "$USER" >/dev/null 2>&1 && [ "$(id -gn)" != "$USER" ]; then
+    echo "  (running under personal group: sg $USER — current primary is $(id -gn))"
+    SMOKE_RUN() { sg "$USER" -c "apptainer exec --fakeroot '$SIF_PATH' bash '$SMOKE_SH'"; }
+  else
+    SMOKE_RUN() { apptainer exec --fakeroot "$SIF_PATH" bash "$SMOKE_SH"; }
+  fi
+  if SMOKE_RUN; then ok "FUSE smoke passed (MOUNT OK / IO OK)"
+  else bad "FUSE smoke FAILED — fix the fakeroot/userns/group story before touching the pipelines"; fi
+  rm -f "$SMOKE_SH"
+else
+  echo "  [SKIP] need a present SIF + apptainer (fix Gates 0/2 first)"
+fi
+
+# ---------------------------------------------------------------------------
+hdr "Gates 4-6 — pipeline runs (driven via sbatch; run after Gates 0-3 pass)"
+cat <<EOF
+  Gate 4 — single-backend smoke: temporarily trim single_node.yaml to ONLY the
+           nfs_fio driver + 1 combo (comment out redis/cte/juicefs pkgs; set the
+           vars/loop to a single value), then:
+             sbatch $REPO/jarvis_clio_core/scripts/run_single_node_ares.sbatch
+             grep -c success \$HOME/single_node_results/results.csv   # expect 1
+  Gate 5 — full single_node sweep (restore all 4 backends, 24 combos):
+             sbatch $REPO/jarvis_clio_core/scripts/run_single_node_ares.sbatch
+             grep -c success \$HOME/single_node_results/results.csv   # expect 24
+  Gate 6 — distributed: first set cte_bench.nprocs: [2] only, then restore [1,2,4]:
+             sbatch $REPO/jarvis_clio_core/scripts/run_distributed_ares.sbatch
+             grep -c success \$HOME/distributed_results/results.csv    # expect 3
+  DONE when all 24 single-node + 3 distributed rows are status=success with
+  non-zero agg_bw_mbps / agg_ops_per_sec.
+EOF
+echo
+echo "=== preflight complete — review any [FAIL] lines above ==="


### PR DESCRIPTION
## Summary

Two daily-regression pipelines that run **every** benchmark/service command inside a running Apptainer instance, so all binaries come from the SIF with zero host-env dependency beyond jarvis + apptainer + the SIF itself.

### Pipelines

| Pipeline | Coverage | Status |
|---|---|---|
| `pipelines/ares/single_node.yaml` | 4 storage stacks (NFS fio, CTE+libfuse fio, redis via `clio_redis_bench`, JuiceFS fio) × 4 io_size × 6 threads = 24 combos → one `results.csv` | 18/24 ✅ (see [Known issue](#known-issue-stale-runtime-state-and-a-hard-kill-teardown-still-open-on-the-clio-side)) |
| `pipelines/ares/distributed.yaml` | Multi-node CTE (`clio_cte_bench`) over `nprocs [1,2,4]` in ONE 4-node allocation | 3/3 ✅ |

### Container model

`base_deploy_mode: container` + one apptainer instance per sweep run. Every package threads `container`/`container_image` `ExecInfo` kwargs (`container_utils.container_kwargs`) so `ExecFactory` wraps each command as `apptainer exec instance://<run> ...`.

- FUSE mounts (CTE libfuse, JuiceFS) need `--fakeroot` on rootless apptainer.
- `/tmp` is bind-rooted to node-local disk (`tmp_bind_root`) for chimaera IPC + JuiceFS cache.

### What's in this PR

- **New packages:** `juicefs`, `juicefs_bench`, `container_utils`
- **Containerized + hardened:** `redis`, `clio_runtime`, `clio_cte`, `clio_cte_libfuse`, `clio_cte_bench`, `clio_redis_bench`
  - multi-host metric folding
  - wrapped `redis-cli` helper
  - timeout-bounded runtime stop under **both** pre/post-rebrand daemon names
  - pre-start stale-daemon reap
- **Ops:** sbatch wrappers (`run_single_node_ares`, `run_distributed_ares`) with:
  - per-node stale-state cleanup (ghost runtimes holding port 9413, leaked `/dev/shm/chi_*`, stale `/tmp` scratch)
  - ssh preflight probing a **real** fakeroot instance start per node
  - hostfile pinning
  - SIF build chain (`Dockerfile.regression` + `regression.def` + `build_regression_image.sh`), gated on every required binary being present
  - validation/survey scripts
- **Spack:** `iowarp` recipe adds a `+redis` variant (builds upstream's `clio_redis_bench`; `hiredis` dep) and a `526` fork-branch version used by the regression image build

---

## Validation (Ares)

| Pipeline | Result | Evidence |
|---|---|---|
| `distributed.yaml` | **3/3 success** | non-zero `cte_bench.put.agg_bw_mbps` for every combo — Ares job `21564` |
| `single_node.yaml` | **18/24 success**, then a hang | see [Known issue](#known-issue-stale-runtime-state-and-a-hard-kill-teardown-still-open-on-the-clio-side) below |

---

## Known issue: Runtime C++ bug (not fixed in this PR)

After ~18 sequential runtime start/stop cycles in one `single_node` allocation, a task routed to the null pool:

```
worker.cc: Container not found for pool_id=PoolId(0,0)
```

...and hung indefinitely — no IPC failover, no timeout, so the hang ate the rest of the job's wall clock instead of failing fast.

Root cause traced to the runtime's teardown always **hard-killing** the daemon (`Kill('chimaera')` / SIGKILL) rather than relying on a clean graceful exit, which can leave an escaped process with inconsistent pool-registry state for the next combo to collide with.

> This is CLIO-core (`context-runtime`), out of scope for a jarvis-package PR — confirmed with the CLIO maintainer, who is addressing it upstream.

`jarvis_clio_core/clio_runtime/pkg.py` now force-kills **both** the pre-rebrand (`chimaera`) and post-rebrand (`clio_run`) daemon names as a stopgap, and reaps any stale survivor before each combo's runtime start — but the underlying "hard-kill teardown can strand state" issue is a CLIO fix, not a jarvis one.


## Test plan

- [x] `distributed.yaml`: 3/3 combos succeed with non-zero `cte_bench.*` metrics (Ares job `21564`)
- [x] `single_node.yaml`: 18/24 combos succeed; remaining failure is the CLIO-side hang described above, not a pipeline defect
- [ ] Re-validate `single_node.yaml` against a CLIO build once the upstream null-pool/hard-kill fix lands
