### PR TITLE
test(cte): multi-node MPI producer/consumer reproducer for #714

### DIFF
--- a/context-transfer-engine/test/integration/CMakeLists.txt
+++ b/context-transfer-engine/test/integration/CMakeLists.txt
@@ -9,6 +9,7 @@ if(CLIO_CORE_ENABLE_DOCKER_CI)
     message(STATUS "CTE integration tests enabled (Docker CI)")
     add_subdirectory(distributed)
     add_subdirectory(cfs_distributed)  # #685: cross-node CFS namespace test
+    add_subdirectory(mpi_producer_consumer)  # #714: cross-node blob data (MPI)
     add_subdirectory(jarvis_deploy)
 
     # FUSE integration test requires Docker with FUSE support

--- a/context-transfer-engine/test/integration/mpi_producer_consumer/CMakeLists.txt
+++ b/context-transfer-engine/test/integration/mpi_producer_consumer/CMakeLists.txt
@@ -1,0 +1,63 @@
+# Multi-node MPI producer/consumer test (issue #714).
+#
+# Builds two small MPI binaries — one driving the CTE core client, one the CFS
+# filesystem client — each run as `mpirun -np 2` across a 2-node Docker cluster
+# (rank 0 producer, rank 1 consumer). They reproduce the cross-node blob-data
+# gap: a blob/file written on node A must be readable on node B. Requires MPI
+# (CLIO_CORE_ENABLE_MPI=ON) and the CFS adapter for the CFS variant.
+
+cmake_minimum_required(VERSION 3.10)
+
+if(NOT CLIO_CORE_ENABLE_MPI)
+    message(STATUS "CTE mpi_producer_consumer test skipped (CLIO_CORE_ENABLE_MPI=OFF)")
+    return()
+endif()
+if(NOT CLIO_CTE_ENABLE_FILESYSTEM)
+    message(STATUS "CTE mpi_producer_consumer test skipped (CLIO_CTE_ENABLE_FILESYSTEM=OFF)")
+    return()
+endif()
+
+set(PC_TEST_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+# Both binaries land in build/bin/ so the docker-compose (which mounts the
+# workspace) can invoke /workspace/build/bin/<binary>.
+add_executable(test_cte_producer_consumer test_cte_producer_consumer.cc)
+set_target_properties(test_cte_producer_consumer PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+target_link_libraries(test_cte_producer_consumer
+    clio_cte_core_client
+    clio_admin_client
+    clio_run_cxx
+    ctp::cxx
+    ctp::mpi
+    ${CMAKE_THREAD_LIBS_INIT}
+)
+add_dependencies(test_cte_producer_consumer clio_run)
+
+add_executable(test_cfs_producer_consumer test_cfs_producer_consumer.cc)
+set_target_properties(test_cfs_producer_consumer PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+target_link_libraries(test_cfs_producer_consumer
+    clio_cte_filesystem_client
+    clio_cte_core_client
+    clio_admin_client
+    clio_run_cxx
+    ctp::cxx
+    ctp::mpi
+    ${CMAKE_THREAD_LIBS_INIT}
+)
+add_dependencies(test_cfs_producer_consumer clio_run clio_cte_filesystem_runtime)
+
+# Docker-based ctest: spins up the 2-node cluster and runs mpirun across it.
+add_test(
+    NAME cte_mpi_producer_consumer_integration_docker
+    COMMAND ${PC_TEST_DIR}/run_tests.sh
+    WORKING_DIRECTORY ${PC_TEST_DIR}
+)
+set_tests_properties(cte_mpi_producer_consumer_integration_docker PROPERTIES
+    LABELS "integration;docker;distributed;mpi;cfs"
+    TIMEOUT 600  # 10-minute cap for the Docker-based cross-node MPI test
+)
+
+message(STATUS "CTE mpi_producer_consumer integration test configured (issue #714)")
+message(STATUS "  Run with: ctest -R cte_mpi_producer_consumer_integration_docker")

--- a/context-transfer-engine/test/integration/mpi_producer_consumer/README.md
+++ b/context-transfer-engine/test/integration/mpi_producer_consumer/README.md
@@ -1,0 +1,45 @@
+# Multi-node MPI producer/consumer test (issue #714)
+
+Dockerized 2-node **producer/consumer** reproducer for the cross-node blob-data
+gap tracked in [#714](https://github.com/iowarp/clio-core/issues/714): after
+#685 the CTE **tag namespace** is cluster-wide, but a blob's **payload** written
+on node A is not retrievable from node B (a cross-node `GetBlob`/`read` returns
+0 bytes). Two binaries cover both layers:
+
+| binary | client | producer (rank 0) | consumer (rank 1) |
+|---|---|---|---|
+| `test_cte_producer_consumer` | CTE core | `PutBlob("0")` | `GetTagSize` / `GetBlobSize("0")` / **`GetBlob("0")`** |
+| `test_cfs_producer_consumer` | CFS (filesystem) | `Open`+`Write`+`Close` | `Getattr(size)` / `Open`+**`Read`** |
+
+**MPI** is used only for cross-rank coordination — `MPI_Barrier` orders
+write-before-read and (CTE only) `MPI_Bcast` hands the tag id to the consumer.
+The data path under test is CLIO's own cross-node routing, never MPI. Each rank
+attaches to its **own local daemon** (`CLIO_INIT(kClient)`, `CLIO_WITH_RUNTIME=0`);
+distributed memory = one rank per node in its own address space.
+
+The consumer's cross-node `GetBlob`/`Read` is the authoritative assertion:
+- **#714 unfixed:** returns 0 bytes → the MPI job exits non-zero → test FAILS
+  (this is a reproducer).
+- **#714 fixed:** returns the producer's bytes intact → test PASSES.
+
+## Layout
+
+- `test_cte_producer_consumer.cc` / `test_cfs_producer_consumer.cc` — the MPI binaries.
+- `docker-compose.yaml` — two containers (`iowarp-node1`/`iowarp-node2`), one clio daemon each.
+- `node1_entrypoint.sh` — sets up passwordless SSH, starts the daemon, runs `mpirun -np 2` across both nodes.
+- `node2_entrypoint.sh` — starts the daemon and serves `sshd` so `mpirun` can start rank 1 here.
+- `clio_config.yaml` — composes the CTE core (512.0) + CFS (560.0) pools on every node.
+- `hostfile` — clio runtime hostfile; `mpi_hostfile` — OpenMPI hostfile (1 slot/node).
+- `run_tests.sh` — brings the cluster up and keys the result on node 1 (the mpirun launcher).
+
+## Running
+
+Requires Docker + a build with `-DCLIO_CORE_ENABLE_MPI=ON`,
+`-DCLIO_CTE_ENABLE_FILESYSTEM=ON`, and `-DCLIO_CORE_ENABLE_DOCKER_CI=ON` (so the
+ctest is registered) whose binaries are in `build/bin/`:
+
+```
+ctest -R cte_mpi_producer_consumer_integration_docker
+# or directly:
+./run_tests.sh
+```

--- a/context-transfer-engine/test/integration/mpi_producer_consumer/clio_config.yaml
+++ b/context-transfer-engine/test/integration/mpi_producer_consumer/clio_config.yaml
@@ -1,0 +1,65 @@
+---
+# Multi-node CTE/CFS producer-consumer test config (issue #714).
+# Two-node cluster: composes the CTE core pool (512.0) AND the CTE filesystem
+# adapter pool (560.0) on every node, so both the CTE-core and CFS producer/
+# consumer binaries can attach to a local daemon on each node and exercise the
+# cross-node blob-data path (#714).
+
+memory:
+  main_segment_size: auto
+  client_data_segment_size: 2GB
+  runtime_data_segment_size: 2GB
+
+networking:
+  port: 8080
+  neighborhood_size: 2
+  hostfile: /workspace/context-transfer-engine/test/integration/mpi_producer_consumer/hostfile
+
+logging:
+  level: info
+  file: /tmp/clio.log
+
+runtime:
+  num_threads: 8
+  queue_depth: 1024
+  local_sched: "default"
+  heartbeat_interval: 1000
+
+compose:
+  # CTE Core storage pool — one container per node (pool_query: local + the
+  # neighborhood below), so tags/blobs are distributed across the cluster.
+  - mod_name: clio_cte_core
+    pool_name: cte_main
+    pool_query: local
+    pool_id: "512.0"
+    storage:
+      - path: /mnt/hdd1
+        bdev_type: file
+        capacity_limit: 4GB
+        score: 0.5
+      - path: /mnt/hdd2
+        bdev_type: file
+        capacity_limit: 4GB
+        score: 0.5
+    dpe:
+      dpe_type: max_bw
+    targets:
+      neighborhood: 2
+      default_target_timeout_ms: 30000
+      poll_period_ms: 5000
+    performance:
+      target_stat_interval_ms: 5000
+      blob_cache_size_mb: 4096
+      max_concurrent_operations: 64
+      score_threshold: 0.7
+      score_difference_threshold: 0.05
+
+  # CTE filesystem (CFS) adapter pool over the core pool above. Canonical
+  # kCfsPoolId is 560.0; next_pool_id points the adapter at the CTE core (512.0).
+  - mod_name: clio_cte_filesystem
+    pool_name: clio_cte_filesystem
+    pool_query: local
+    pool_id: "560.0"
+    next_pool_id: "512.0"
+    targets:
+      neighborhood: 2

--- a/context-transfer-engine/test/integration/mpi_producer_consumer/docker-compose.yaml
+++ b/context-transfer-engine/test/integration/mpi_producer_consumer/docker-compose.yaml
@@ -1,0 +1,75 @@
+# Multi-node MPI producer/consumer test (issue #714).
+#
+# Two nodes, one clio daemon each, on a private docker network. Both run their
+# own local daemon; node 1 additionally sets up passwordless SSH and launches
+# `mpirun -np 2` across both containers (rank 0 producer on node 1, rank 1
+# consumer on node 2). node 2 serves sshd so mpirun can start rank 1 there.
+#
+# Hostnames MUST be iowarp-node1/iowarp-node2 to match hostfile + mpi_hostfile.
+# Usage: ./run_tests.sh  (keys the result on node 1, the mpirun launcher).
+
+services:
+  # Node 1 — mpirun launcher; hosts rank 0 (producer)
+  pc-node1:
+    image: ${IOWARP_DOCKER_IMAGE:-iowarp/deps-cpu:latest}
+    security_opt:
+      - seccomp:unconfined
+    container_name: pc-node1
+    hostname: iowarp-node1
+    networks:
+      pc-cluster:
+        ipv4_address: 172.30.0.10
+    volumes:
+      - ${HOST_WORKSPACE:-${IOWARP_CORE_ROOT:-/workspace}}:/workspace:rw
+    tmpfs:
+      - /mnt:mode=1777
+    environment:
+      - NODE_ID=1
+      - CLIO_SERVER_CONF=/workspace/context-transfer-engine/test/integration/mpi_producer_consumer/clio_config.yaml
+      - CONTAINER_HOSTFILE=/workspace/context-transfer-engine/test/integration/mpi_producer_consumer/hostfile
+      - CLIO_WITH_RUNTIME=0
+      - PATH=/workspace/build/bin:/usr/local/bin:/usr/bin:/bin
+      - LD_LIBRARY_PATH=/workspace/build/bin:/usr/local/cuda/lib64:/usr/local/lib
+      - OMPI_ALLOW_RUN_AS_ROOT=1
+      - OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+    mem_limit: 8g
+    working_dir: /workspace
+    entrypoint:
+      - /bin/bash
+      - /workspace/context-transfer-engine/test/integration/mpi_producer_consumer/node1_entrypoint.sh
+
+  # Node 2 — sshd server; hosts rank 1 (consumer)
+  pc-node2:
+    image: ${IOWARP_DOCKER_IMAGE:-iowarp/deps-cpu:latest}
+    security_opt:
+      - seccomp:unconfined
+    container_name: pc-node2
+    hostname: iowarp-node2
+    networks:
+      pc-cluster:
+        ipv4_address: 172.30.0.11
+    volumes:
+      - ${HOST_WORKSPACE:-${IOWARP_CORE_ROOT:-/workspace}}:/workspace:rw
+    tmpfs:
+      - /mnt:mode=1777
+    environment:
+      - NODE_ID=2
+      - CLIO_SERVER_CONF=/workspace/context-transfer-engine/test/integration/mpi_producer_consumer/clio_config.yaml
+      - CONTAINER_HOSTFILE=/workspace/context-transfer-engine/test/integration/mpi_producer_consumer/hostfile
+      - CLIO_WITH_RUNTIME=0
+      - PATH=/workspace/build/bin:/usr/local/bin:/usr/bin:/bin
+      - LD_LIBRARY_PATH=/workspace/build/bin:/usr/local/cuda/lib64:/usr/local/lib
+      - OMPI_ALLOW_RUN_AS_ROOT=1
+      - OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+    mem_limit: 8g
+    working_dir: /workspace
+    entrypoint:
+      - /bin/bash
+      - /workspace/context-transfer-engine/test/integration/mpi_producer_consumer/node2_entrypoint.sh
+
+networks:
+  pc-cluster:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.30.0.0/24

--- a/context-transfer-engine/test/integration/mpi_producer_consumer/hostfile
+++ b/context-transfer-engine/test/integration/mpi_producer_consumer/hostfile
@@ -1,0 +1,2 @@
+iowarp-node1
+iowarp-node2

--- a/context-transfer-engine/test/integration/mpi_producer_consumer/mpi_hostfile
+++ b/context-transfer-engine/test/integration/mpi_producer_consumer/mpi_hostfile
@@ -1,0 +1,4 @@
+# OpenMPI hostfile: one slot per node so `mpirun -np 2` lands rank 0 on node1
+# and rank 1 on node2 (one producer/consumer rank per physical node).
+iowarp-node1 slots=1
+iowarp-node2 slots=1

--- a/context-transfer-engine/test/integration/mpi_producer_consumer/node1_entrypoint.sh
+++ b/context-transfer-engine/test/integration/mpi_producer_consumer/node1_entrypoint.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Node 1 entrypoint — MPI producer/consumer test launcher (issue #714).
+#
+# Node 1 is the primary: it sets up passwordless SSH (OpenMPI's default
+# launcher), starts its local clio daemon, waits for node 2's daemon+sshd, then
+# runs `mpirun -np 2` across both containers. Rank 0 (producer) runs here, rank 1
+# (consumer) is launched on node 2 over SSH; each rank attaches to its own local
+# daemon. The producer/consumer binaries carry the actual #714 assertions; this
+# script's exit code is the combined MPI job result.
+set -u
+
+PC_DIR=/workspace/context-transfer-engine/test/integration/mpi_producer_consumer
+SSH_SHARE="${PC_DIR}/.mpi_ssh"
+export CLIO_SERVER_CONF="${PC_DIR}/clio_config.yaml"
+# Keep the producer's post-write keep-alive short: the MPI barrier already
+# orders write-before-read, and the blob lives in the (independently running)
+# daemon, not the rank process.
+export PC_KEEPALIVE_SEC="${PC_KEEPALIVE_SEC:-5}"
+
+echo '=== Node 1: SSH setup ==='
+mkdir -p /home/iowarp/.ssh && chmod 700 /home/iowarp/.ssh
+ssh-keygen -t rsa -b 2048 -N '' -f /home/iowarp/.ssh/id_rsa -q 2>/dev/null || true
+cat /home/iowarp/.ssh/id_rsa.pub >> /home/iowarp/.ssh/authorized_keys
+chmod 600 /home/iowarp/.ssh/authorized_keys
+printf 'Host *\n  StrictHostKeyChecking no\n  UserKnownHostsFile /dev/null\n' \
+    >> /home/iowarp/.ssh/config
+# Publish node1's key so node2 can authorize us (via the shared workspace).
+sudo mkdir -p "${SSH_SHARE}" && sudo chmod 777 "${SSH_SHARE}"
+cp /home/iowarp/.ssh/id_rsa.pub "${SSH_SHARE}/node1.pub"
+sudo /usr/sbin/sshd
+
+echo '=== Node 1: starting local clio daemon ==='
+/workspace/build/bin/clio_run runtime start &
+echo "Node 1: daemon PID $!"
+
+echo '=== Node 1: waiting for node2 SSH ==='
+NODE2_READY=0
+for i in $(seq 1 90); do
+    if ssh -o ConnectTimeout=3 -o BatchMode=yes iowarp-node2 'echo ready' 2>/dev/null; then
+        NODE2_READY=1; break
+    fi
+    sleep 1
+done
+if [ "$NODE2_READY" = "0" ]; then
+    echo 'ERROR: node2 SSH not ready after 90s'; exit 1
+fi
+# Give both daemons a moment to form the 2-node cluster.
+sleep 6
+
+# The two producer/consumer binaries share the same cluster; run both and
+# combine their results. Rank 0 -> node1, rank 1 -> node2 (mpi_hostfile).
+MPIRUN_ARGS=(
+    -np 2 --hostfile "${PC_DIR}/mpi_hostfile"
+    -x LD_LIBRARY_PATH -x PATH -x CLIO_SERVER_CONF -x PC_KEEPALIVE_SEC
+    -x OMPI_ALLOW_RUN_AS_ROOT -x OMPI_ALLOW_RUN_AS_ROOT_CONFIRM
+)
+
+OVERALL=0
+for bin in test_cte_producer_consumer test_cfs_producer_consumer; do
+    echo "=== Node 1: mpirun ${bin} ==="
+    mpirun "${MPIRUN_ARGS[@]}" "/workspace/build/bin/${bin}"
+    rc=$?
+    echo "=== Node 1: ${bin} exit ${rc} ==="
+    [ "$rc" != "0" ] && OVERALL=$rc
+done
+
+# Signal node2 to stop serving sshd (so its container exits and compose returns).
+touch "${SSH_SHARE}/done"
+echo "=== Node 1: overall exit ${OVERALL} ==="
+exit $OVERALL

--- a/context-transfer-engine/test/integration/mpi_producer_consumer/node2_entrypoint.sh
+++ b/context-transfer-engine/test/integration/mpi_producer_consumer/node2_entrypoint.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Node 2 entrypoint — MPI producer/consumer test (issue #714).
+#
+# Node 2 is secondary: it starts its local clio daemon, authorizes node 1's SSH
+# key, and serves sshd so mpirun (launched on node 1) can start rank 1 (the
+# consumer) here. It does no launching itself — it stays up until node 1 signals
+# completion, then exits so docker-compose returns.
+set -u
+
+PC_DIR=/workspace/context-transfer-engine/test/integration/mpi_producer_consumer
+SSH_SHARE="${PC_DIR}/.mpi_ssh"
+export CLIO_SERVER_CONF="${PC_DIR}/clio_config.yaml"
+
+echo '=== Node 2: SSH setup ==='
+mkdir -p /home/iowarp/.ssh && chmod 700 /home/iowarp/.ssh
+ssh-keygen -t rsa -b 2048 -N '' -f /home/iowarp/.ssh/id_rsa -q 2>/dev/null || true
+printf 'Host *\n  StrictHostKeyChecking no\n  UserKnownHostsFile /dev/null\n' \
+    >> /home/iowarp/.ssh/config
+
+echo '=== Node 2: starting local clio daemon ==='
+/workspace/build/bin/clio_run runtime start &
+echo "Node 2: daemon PID $!"
+
+echo '=== Node 2: waiting for node1 SSH public key ==='
+for i in $(seq 1 120); do
+    [ -f "${SSH_SHARE}/node1.pub" ] && break
+    sleep 0.5
+done
+if [ ! -f "${SSH_SHARE}/node1.pub" ]; then
+    echo 'ERROR: node1 public key never appeared'; exit 1
+fi
+cat "${SSH_SHARE}/node1.pub" >> /home/iowarp/.ssh/authorized_keys
+chmod 600 /home/iowarp/.ssh/authorized_keys
+
+echo '=== Node 2: starting sshd; serving until node1 signals done ==='
+sudo /usr/sbin/sshd
+
+# Stay alive so mpirun can launch rank 1 here; exit once node1 is finished.
+for i in $(seq 1 600); do
+    [ -f "${SSH_SHARE}/done" ] && { echo 'Node 2: node1 signalled done'; break; }
+    sleep 1
+done
+echo '=== Node 2: exiting ==='
+exit 0

--- a/context-transfer-engine/test/integration/mpi_producer_consumer/run_tests.sh
+++ b/context-transfer-engine/test/integration/mpi_producer_consumer/run_tests.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# Multi-node MPI producer/consumer test runner (issue #714).
+#
+# Brings up a 2-node clio cluster in Docker and launches `mpirun -np 2` across
+# both containers (rank 0 producer on node 1, rank 1 consumer on node 2) for
+# both the CTE-core and CFS producer/consumer binaries. The authoritative result
+# is node 1's exit code (the mpirun launcher): the MPI job reduces every rank's
+# result, so a cross-node data failure (#714) surfaces there as non-zero.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../../" && pwd)"
+
+if [ -n "${HOST_WORKSPACE:-}" ]; then
+    export IOWARP_CORE_ROOT="${HOST_WORKSPACE}"
+elif [ -z "${IOWARP_CORE_ROOT:-}" ]; then
+    export IOWARP_CORE_ROOT="${REPO_ROOT}"
+fi
+
+cd "$SCRIPT_DIR"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; BLUE='\033[0;34m'; NC='\033[0m'
+say()  { echo -e "${BLUE}$*${NC}"; }
+ok()   { echo -e "${GREEN}✓ $*${NC}"; }
+err()  { echo -e "${RED}✗ $*${NC}"; }
+
+command -v docker >/dev/null 2>&1 || { err "Docker not installed"; exit 1; }
+docker compose version >/dev/null 2>&1 || { err "docker compose not available"; exit 1; }
+docker ps >/dev/null 2>&1 || { err "Docker daemon not running"; exit 1; }
+
+# Match the docker image to the built binary (CPU vs CUDA), mirroring the sibling
+# distributed tests.
+if [ -z "${IOWARP_DOCKER_IMAGE:-}" ]; then
+    CLIO_BIN="${IOWARP_CORE_ROOT:-/workspace}/build/bin/clio_run"
+    if [ -f "$CLIO_BIN" ] && ldd "$CLIO_BIN" 2>/dev/null | grep -q "libcudart"; then
+        export IOWARP_DOCKER_IMAGE="iowarp/deps-nvidia:latest"
+        _bindir="$(dirname "$CLIO_BIN")"
+        ldd "$CLIO_BIN" 2>/dev/null | awk '/libcudart/{print $3}' | while read -r _lib; do
+            { [ -n "$_lib" ] && [ -f "$_lib" ] && cp -Lu "$_lib" "$_bindir/" 2>/dev/null; } || true
+        done
+    else
+        export IOWARP_DOCKER_IMAGE="iowarp/deps-cpu:latest"
+    fi
+fi
+say "Using image: ${IOWARP_DOCKER_IMAGE}"
+
+# Clear any stale SSH-exchange state from a previous run.
+rm -rf "${SCRIPT_DIR}/.mpi_ssh" 2>/dev/null || sudo rm -rf "${SCRIPT_DIR}/.mpi_ssh" 2>/dev/null || true
+
+cleanup() {
+    docker compose down -v >/dev/null 2>&1 || true
+    rm -rf "${SCRIPT_DIR}/.mpi_ssh" 2>/dev/null || sudo rm -rf "${SCRIPT_DIR}/.mpi_ssh" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+say "=== Cleaning any previous run ==="
+docker compose down -v >/dev/null 2>&1 || true
+
+say "=== Starting 2-node MPI producer/consumer cluster ==="
+if ! docker compose up -d; then
+    err "docker compose up failed"
+    docker compose logs || true
+    exit 1
+fi
+
+say "=== Waiting for node 1 (mpirun launcher) to finish ==="
+node1_rc=$(docker wait pc-node1 2>/dev/null || echo 1)
+
+say "=== Node 1 (launcher) log ==="
+docker logs pc-node1 2>&1 | tail -60
+say "=== Node 2 (consumer host) log (tail) ==="
+docker logs pc-node2 2>&1 | tail -30
+
+echo ""
+say "=== Result ==="
+echo "node1(launcher) exit=${node1_rc}"
+
+if [ "$node1_rc" = "0" ]; then
+    ok "Multi-node producer/consumer PASSED (cross-node blob data works, #714)"
+    exit 0
+else
+    err "Multi-node producer/consumer FAILED (node1=${node1_rc})."
+    err "  A cross-node GetBlob/Read returning 0 bytes means blob payload is node-local (#714)."
+    exit 1
+fi

--- a/context-transfer-engine/test/integration/mpi_producer_consumer/test_cfs_producer_consumer.cc
+++ b/context-transfer-engine/test/integration/mpi_producer_consumer/test_cfs_producer_consumer.cc
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved. BSD 3-Clause license.
+ */
+
+/**
+ * Multi-node CFS (CTE filesystem) producer/consumer test (issue #714).
+ *
+ * The CFS sits on top of the CTE core, so it inherits the same cross-node gap:
+ * a file created+written on node A is visible by PATH from node B (shared tag
+ * namespace, #685), but its CONTENT reads back as 0 bytes cross-node (#714).
+ * This drives the CFS client directly, one rank per node, using MPI barriers
+ * for coordination (never for the data path under test).
+ *
+ * Launched as `mpirun -np 2` across two containers (see docker-compose here);
+ * rank 0 -> node 1, rank 1 -> node 2, each attaching to its OWN local daemon.
+ *
+ *   Rank 0 (producer, node A):
+ *     Open(O_CREAT|O_RDWR); Write(payload); Close
+ *     MPI_Barrier            -- publish: the file is written
+ *     Getattr(size)          -- own-node sanity
+ *
+ *   Rank 1 (consumer, node B):
+ *     MPI_Barrier            -- wait until the producer has written
+ *     Getattr(size)          -- file size must be visible cross-node
+ *     Open(O_RDONLY); Read   -- THE #714 CHECK: content must come back intact
+ *
+ * The consumer's Read is the authoritative cross-node assertion: until #714 is
+ * fixed it returns 0 bytes and this test FAILS by design; once cross-node blob
+ * transfer works it reads the producer's bytes and passes.
+ */
+#include <fcntl.h>
+#include <mpi.h>
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <thread>
+
+#include <clio_runtime/clio_runtime.h>
+#include <clio_cte/filesystem/filesystem_client.h>
+
+namespace {
+
+// The CFS filesystem pool composed on every node in clio_config.yaml.
+constexpr clio::run::u32 kCfsPoolMajor = 560;
+constexpr clio::run::u64 kFileSize = 1024u * 1024u;  // 1 MiB
+constexpr const char *kSharedPath = "/mpi_pc/cfs_shared.bin";
+
+int EnvSecs(const char *name, int def) {
+  const char *e = std::getenv(name);
+  if (!e || !*e) return def;
+  int v = std::atoi(e);
+  return v > 0 ? v : def;
+}
+
+unsigned char PayloadByte(clio::run::u64 i) {
+  return static_cast<unsigned char>((i * 197u + 23u) & 0xFFu);
+}
+
+void Log(int rank, const char *role, const std::string &msg) {
+  std::fprintf(stderr, "[cfs-pc rank%d %s] %s\n", rank, role, msg.c_str());
+  std::fflush(stderr);
+}
+
+bool AttachClient(int rank, const char *role) {
+  setenv("CLIO_WITH_RUNTIME", "0", 1);
+  if (!clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, false)) {
+    Log(rank, role, "FAIL: CLIO_INIT(kClient) failed");
+    return false;
+  }
+  return true;
+}
+
+// ---- rank 0: producer -----------------------------------------------------
+int RunProducer() {
+  const char *role = "producer";
+  if (!AttachClient(0, role)) {
+    MPI_Barrier(MPI_COMM_WORLD);
+    return 2;
+  }
+  clio::cte::filesystem::Client cfs;
+  cfs.Init(clio::run::PoolId(kCfsPoolMajor, 0));
+  auto *ipc = CLIO_IPC;
+  int failed = 0;
+
+  auto open = cfs.AsyncOpen(kSharedPath, O_CREAT | O_RDWR, 0644);
+  open.Wait();
+  clio::run::u64 h = open->handle_;
+  if (open->GetReturnCode() != 0 || h == 0) {
+    Log(0, role, "FAIL: Open(create) rc=" + std::to_string(open->GetReturnCode()));
+    failed = 1;
+  }
+
+  if (!failed) {
+    ctp::ipc::FullPtr<char> wbuf = ipc->AllocateBuffer(kFileSize);
+    for (clio::run::u64 j = 0; j < kFileSize; ++j) wbuf.ptr_[j] = PayloadByte(j);
+    auto w = cfs.AsyncWrite(h, 0, kFileSize, wbuf.shm_.template Cast<void>());
+    w.Wait();
+    if (w->GetReturnCode() != 0 || w->bytes_written_ != kFileSize) {
+      Log(0, role, "FAIL: Write rc=" + std::to_string(w->GetReturnCode()) +
+                       " bytes=" + std::to_string(w->bytes_written_));
+      failed = 1;
+    }
+    ipc->FreeBuffer(wbuf);
+    auto cl = cfs.AsyncClose(h);
+    cl.Wait();
+  }
+
+  // Publish "file written".
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // Own-node sanity: the producer must see the exact logical size.
+  if (!failed) {
+    auto ga = cfs.AsyncGetattr(kSharedPath);
+    ga.Wait();
+    Log(0, role, "local view exists=" + std::to_string(ga->exists_) +
+                     " size=" + std::to_string(ga->size_));
+    if (ga->GetReturnCode() != 0 || ga->size_ != kFileSize) {
+      Log(0, role, "FAIL: producer-local Getattr size mismatch");
+      failed = 1;
+    }
+  }
+
+  // Keep this node's daemon alive through the consumer's read window.
+  std::this_thread::sleep_for(std::chrono::seconds(EnvSecs("PC_KEEPALIVE_SEC", 30)));
+  return failed ? 4 : 0;
+}
+
+// ---- rank 1: consumer -----------------------------------------------------
+int RunConsumer() {
+  const char *role = "consumer";
+  bool attached = AttachClient(1, role);
+  MPI_Barrier(MPI_COMM_WORLD);
+  if (!attached) return 3;
+
+  clio::cte::filesystem::Client cfs;
+  cfs.Init(clio::run::PoolId(kCfsPoolMajor, 0));
+  auto *ipc = CLIO_IPC;
+
+  // File metadata (size) must be visible cross-node by path (post-#685).
+  auto ga = cfs.AsyncGetattr(kSharedPath);
+  ga.Wait();
+  Log(1, role, "cross-node view exists=" + std::to_string(ga->exists_) +
+                   " size=" + std::to_string(ga->size_));
+  if (ga->GetReturnCode() != 0 || ga->exists_ != 1 || ga->size_ != kFileSize) {
+    Log(1, role, "FAIL: cross-node Getattr rc=" +
+                     std::to_string(ga->GetReturnCode()) + " exists=" +
+                     std::to_string(ga->exists_) + " size=" +
+                     std::to_string(ga->size_) + " (expected " +
+                     std::to_string(kFileSize) + ")");
+    return 6;
+  }
+
+  // THE #714 CHECK: the content written on the producer node must read back
+  // byte-for-byte here. On the current (buggy) runtime this returns 0 bytes.
+  auto open = cfs.AsyncOpen(kSharedPath, O_RDONLY, 0644);
+  open.Wait();
+  clio::run::u64 h = open->handle_;
+  if (open->GetReturnCode() != 0 || h == 0) {
+    Log(1, role, "FAIL: cross-node Open(RDONLY) rc=" +
+                     std::to_string(open->GetReturnCode()));
+    return 7;
+  }
+  ctp::ipc::FullPtr<char> rbuf = ipc->AllocateBuffer(kFileSize);
+  std::memset(rbuf.ptr_, 0, kFileSize);
+  auto r = cfs.AsyncRead(h, 0, kFileSize, rbuf.shm_.template Cast<void>());
+  r.Wait();
+  auto cl = cfs.AsyncClose(h);
+  cl.Wait();
+  if (r->GetReturnCode() != 0 || r->bytes_read_ != kFileSize) {
+    Log(1, role, "FAIL: cross-node Read rc=" +
+                     std::to_string(r->GetReturnCode()) + " bytes_read=" +
+                     std::to_string(r->bytes_read_) + " (expected " +
+                     std::to_string(kFileSize) +
+                     ") — file content is node-local (#714)");
+    ipc->FreeBuffer(rbuf);
+    return 8;
+  }
+  for (clio::run::u64 i = 0; i < kFileSize; ++i) {
+    if (static_cast<unsigned char>(rbuf.ptr_[i]) != PayloadByte(i)) {
+      Log(1, role, "FAIL: cross-node content mismatch at " + std::to_string(i));
+      ipc->FreeBuffer(rbuf);
+      return 9;
+    }
+  }
+  ipc->FreeBuffer(rbuf);
+  Log(1, role, "PASS: cross-node Read of " + std::to_string(kFileSize) +
+                   " bytes matched the producer");
+  return 0;
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+  MPI_Init(&argc, &argv);
+  int rank = 0, size = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  if (size != 2) {
+    if (rank == 0) {
+      std::fprintf(stderr,
+                   "test_cfs_producer_consumer requires exactly 2 ranks "
+                   "(got %d)\n",
+                   size);
+    }
+    MPI_Finalize();
+    return 64;
+  }
+
+  int local_rc = (rank == 0) ? RunProducer() : RunConsumer();
+  int global_rc = 0;
+  MPI_Reduce(&local_rc, &global_rc, 1, MPI_INT, MPI_MAX, 0, MPI_COMM_WORLD);
+  MPI_Finalize();
+  return (rank == 0) ? global_rc : local_rc;
+}

--- a/context-transfer-engine/test/integration/mpi_producer_consumer/test_cte_producer_consumer.cc
+++ b/context-transfer-engine/test/integration/mpi_producer_consumer/test_cte_producer_consumer.cc
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved. BSD 3-Clause license.
+ */
+
+/**
+ * Multi-node CTE-core producer/consumer test (issue #714).
+ *
+ * Reproduces the cross-node blob-data gap: after #685 the CTE tag namespace is
+ * cluster-wide (a tag created on node A is visible from node B), but a blob's
+ * PAYLOAD written on node A is not retrievable from node B (a cross-node
+ * GetBlob returns 0 bytes). This test drives that path directly with the CTE
+ * core client, one rank per node, synchronizing with MPI barriers (MPI is used
+ * ONLY for cross-rank coordination and to hand the tag id to the consumer via
+ * distributed memory — never for the data movement under test).
+ *
+ * Launched as `mpirun -np 2` across two containers (see docker-compose in this
+ * directory); rank 0 lands on node 1, rank 1 on node 2, and each attaches to
+ * its OWN local daemon (CLIO_INIT(kClient), CLIO_WITH_RUNTIME=0).
+ *
+ *   Rank 0 (producer, node A):
+ *     PutBlob("0")            -- write the payload (Dynamic-routed)
+ *     MPI_Bcast(tag_id)       -- share the tag handle with the consumer
+ *     MPI_Barrier             -- publish: the blob is written
+ *     GetTagSize() / GetBlobSize("0")  -- own-node sanity
+ *
+ *   Rank 1 (consumer, node B):
+ *     MPI_Bcast(tag_id)       -- receive the tag handle
+ *     MPI_Barrier             -- wait until the producer has written
+ *     GetTagSize()            -- tag metadata must be visible cross-node (#685)
+ *     GetBlobSize("0")        -- blob size must be visible cross-node
+ *     GetBlob("0")            -- THE #714 CHECK: payload must come back intact
+ *
+ * The consumer's GetBlob is the authoritative cross-node assertion. Until #714
+ * is fixed it returns 0 bytes and this test FAILS by design (a reproducer); once
+ * cross-node blob transfer works it reads the producer's bytes and passes.
+ *
+ * Exit code 0 == all ranks' checks passed (reduced to rank 0).
+ */
+#include <mpi.h>
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <thread>
+
+#include <clio_runtime/clio_runtime.h>
+#include <clio_cte/core/core_client.h>
+
+namespace {
+
+// The CTE core pool composed on every node in clio_config.yaml.
+constexpr clio::run::u32 kCorePoolMajor = 512;
+// Shared, deterministic payload so the consumer proves it read the PRODUCER's
+// bytes cross-node (not zeros/garbage). One blob named "0" under a shared tag.
+constexpr clio::run::u64 kBlobSize = 1024u * 1024u;  // 1 MiB
+constexpr const char *kTagName = "/mpi_pc/cte_shared_tag";
+constexpr const char *kBlobName = "0";
+
+int EnvSecs(const char *name, int def) {
+  const char *e = std::getenv(name);
+  if (!e || !*e) return def;
+  int v = std::atoi(e);
+  return v > 0 ? v : def;
+}
+
+unsigned char PayloadByte(clio::run::u64 i) {
+  return static_cast<unsigned char>((i * 131u + 7u) & 0xFFu);
+}
+
+void Log(int rank, const char *role, const std::string &msg) {
+  std::fprintf(stderr, "[cte-pc rank%d %s] %s\n", rank, role, msg.c_str());
+  std::fflush(stderr);
+}
+
+// Attach to this node's local daemon as a client (never spawn a runtime).
+bool AttachClient(int rank, const char *role) {
+  setenv("CLIO_WITH_RUNTIME", "0", 1);
+  if (!clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, false)) {
+    Log(rank, role, "FAIL: CLIO_INIT(kClient) failed");
+    return false;
+  }
+  return true;
+}
+
+// ---- rank 0: producer -----------------------------------------------------
+// Writes the blob, hands the tag id to the consumer, then checks its own view.
+int RunProducer() {
+  const char *role = "producer";
+  if (!AttachClient(0, role)) {
+    // Still participate in the collectives so the consumer does not hang.
+    std::uint64_t z = 0;
+    MPI_Bcast(&z, 1, MPI_UINT64_T, 0, MPI_COMM_WORLD);
+    MPI_Barrier(MPI_COMM_WORLD);
+    return 2;
+  }
+  clio::cte::core::Client core;
+  core.Init(clio::run::PoolId(kCorePoolMajor, 0));
+  auto *ipc = CLIO_IPC;
+
+  // Create the shared tag (cluster-wide namespace) and PutBlob the payload.
+  auto mk = core.AsyncGetOrCreateTag(kTagName, clio::cte::core::TagId::GetNull(),
+                                     clio::run::PoolQuery::Dynamic());
+  mk.Wait();
+  clio::cte::core::TagId tag_id = mk->tag_id_;
+  int failed = 0;
+  if (mk->GetReturnCode() != 0 || tag_id.IsNull()) {
+    Log(0, role, "FAIL: GetOrCreateTag rc=" + std::to_string(mk->GetReturnCode()));
+    failed = 1;
+  }
+
+  if (!failed) {
+    ctp::ipc::FullPtr<char> wbuf = ipc->AllocateBuffer(kBlobSize);
+    for (clio::run::u64 j = 0; j < kBlobSize; ++j) wbuf.ptr_[j] = PayloadByte(j);
+    auto pb = core.AsyncPutBlob(tag_id, kBlobName, 0, kBlobSize,
+                                wbuf.shm_.template Cast<void>(), -1.0f,
+                                clio::cte::core::Context(), 0u,
+                                clio::run::PoolQuery::Dynamic());
+    pb.Wait();
+    if (pb->GetReturnCode() != 0) {
+      Log(0, role, "FAIL: PutBlob rc=" + std::to_string(pb->GetReturnCode()));
+      failed = 1;
+    }
+    ipc->FreeBuffer(wbuf);
+  }
+
+  // Hand the tag id to the consumer (distributed-memory share), then publish
+  // "blob written" via the barrier.
+  std::uint64_t tag_u64 = failed ? 0 : tag_id.ToU64();
+  MPI_Bcast(&tag_u64, 1, MPI_UINT64_T, 0, MPI_COMM_WORLD);
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // Own-node sanity: the producer must see its own tag/blob sizes.
+  if (!failed) {
+    auto ts = core.AsyncGetTagSize(tag_id, clio::run::PoolQuery::Dynamic());
+    ts.Wait();
+    auto bs = core.AsyncGetBlobSize(tag_id, kBlobName,
+                                    clio::run::PoolQuery::Dynamic());
+    bs.Wait();
+    Log(0, role, "local view tag_size=" + std::to_string(ts->tag_size_) +
+                     " blob_size=" + std::to_string(bs->size_));
+    if (bs->GetReturnCode() != 0 || bs->size_ != kBlobSize) {
+      Log(0, role, "FAIL: producer-local GetBlobSize mismatch");
+      failed = 1;
+    }
+  }
+
+  // Stay alive so this node's daemon (owner of the blob's container) survives
+  // the consumer's read window.
+  int keepalive = EnvSecs("PC_KEEPALIVE_SEC", 30);
+  std::this_thread::sleep_for(std::chrono::seconds(keepalive));
+  return failed ? 4 : 0;
+}
+
+// ---- rank 1: consumer -----------------------------------------------------
+// Receives the tag id and must read the producer's payload cross-node.
+int RunConsumer() {
+  const char *role = "consumer";
+  bool attached = AttachClient(1, role);
+
+  std::uint64_t tag_u64 = 0;
+  MPI_Bcast(&tag_u64, 1, MPI_UINT64_T, 0, MPI_COMM_WORLD);
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  if (!attached) return 3;
+  if (tag_u64 == 0) {
+    Log(1, role, "FAIL: producer reported no tag (see producer log)");
+    return 5;
+  }
+  clio::cte::core::Client core;
+  core.Init(clio::run::PoolId(kCorePoolMajor, 0));
+  auto *ipc = CLIO_IPC;
+  clio::cte::core::TagId tag_id = clio::cte::core::TagId::FromU64(tag_u64);
+
+  // Tag metadata must be visible cross-node (this already works post-#685).
+  auto ts = core.AsyncGetTagSize(tag_id, clio::run::PoolQuery::Dynamic());
+  ts.Wait();
+  auto bs = core.AsyncGetBlobSize(tag_id, kBlobName,
+                                  clio::run::PoolQuery::Dynamic());
+  bs.Wait();
+  Log(1, role, "cross-node view tag_size=" + std::to_string(ts->tag_size_) +
+                   " blob_size=" + std::to_string(bs->size_));
+  if (bs->GetReturnCode() != 0 || bs->size_ != kBlobSize) {
+    Log(1, role, "FAIL: cross-node GetBlobSize rc=" +
+                     std::to_string(bs->GetReturnCode()) + " size=" +
+                     std::to_string(bs->size_) + " (expected " +
+                     std::to_string(kBlobSize) + ")");
+    return 6;
+  }
+
+  // THE #714 CHECK: the payload written on the producer node must come back
+  // byte-for-byte here. On the current (buggy) runtime this returns 0 bytes.
+  ctp::ipc::FullPtr<char> rbuf = ipc->AllocateBuffer(kBlobSize);
+  std::memset(rbuf.ptr_, 0, kBlobSize);
+  auto gb = core.AsyncGetBlob(tag_id, kBlobName, 0, kBlobSize, 0u,
+                              rbuf.shm_.template Cast<void>(),
+                              clio::run::PoolQuery::Dynamic());
+  gb.Wait();
+  if (gb->GetReturnCode() != 0 || gb->bytes_read_ != kBlobSize) {
+    Log(1, role, "FAIL: cross-node GetBlob rc=" +
+                     std::to_string(gb->GetReturnCode()) + " bytes_read=" +
+                     std::to_string(gb->bytes_read_) + " (expected " +
+                     std::to_string(kBlobSize) +
+                     ") — blob payload is node-local (#714)");
+    ipc->FreeBuffer(rbuf);
+    return 7;
+  }
+  for (clio::run::u64 i = 0; i < kBlobSize; ++i) {
+    if (static_cast<unsigned char>(rbuf.ptr_[i]) != PayloadByte(i)) {
+      Log(1, role, "FAIL: cross-node payload mismatch at " + std::to_string(i));
+      ipc->FreeBuffer(rbuf);
+      return 8;
+    }
+  }
+  ipc->FreeBuffer(rbuf);
+  Log(1, role, "PASS: cross-node GetBlob of " + std::to_string(kBlobSize) +
+                   " bytes matched the producer");
+  return 0;
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+  MPI_Init(&argc, &argv);
+  int rank = 0, size = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  if (size != 2) {
+    if (rank == 0) {
+      std::fprintf(stderr,
+                   "test_cte_producer_consumer requires exactly 2 ranks "
+                   "(got %d)\n",
+                   size);
+    }
+    MPI_Finalize();
+    return 64;
+  }
+
+  int local_rc = (rank == 0) ? RunProducer() : RunConsumer();
+
+  // Reduce every rank's result: the job passes only if all ranks passed. The
+  // consumer (rank 1) carries the authoritative cross-node signal.
+  int global_rc = 0;
+  MPI_Reduce(&local_rc, &global_rc, 1, MPI_INT, MPI_MAX, 0, MPI_COMM_WORLD);
+  MPI_Finalize();
+  return (rank == 0) ? global_rc : local_rc;
+}

--- a/context-transfer-engine/test/integration/mpi_producer_consumer/test_cte_producer_consumer.cc
+++ b/context-transfer-engine/test/integration/mpi_producer_consumer/test_cte_producer_consumer.cc
@@ -199,12 +199,15 @@ int RunConsumer() {
                               rbuf.shm_.template Cast<void>(),
                               clio::run::PoolQuery::Dynamic());
   gb.Wait();
-  if (gb->GetReturnCode() != 0 || gb->bytes_read_ != kBlobSize) {
+  // GetBlob is all-or-nothing: rc==0 means all kBlobSize bytes landed in rbuf;
+  // a short/failed cross-node read reports rc!=0 (GetBlobTask has no separate
+  // bytes-read field). The byte-for-byte check below is the payload assertion —
+  // it also catches the #714 "reads zeros" symptom even if rc were 0.
+  if (gb->GetReturnCode() != 0) {
     Log(1, role, "FAIL: cross-node GetBlob rc=" +
-                     std::to_string(gb->GetReturnCode()) + " bytes_read=" +
-                     std::to_string(gb->bytes_read_) + " (expected " +
+                     std::to_string(gb->GetReturnCode()) + " (expected " +
                      std::to_string(kBlobSize) +
-                     ") — blob payload is node-local (#714)");
+                     " bytes) — blob payload is node-local (#714)");
     ipc->FreeBuffer(rbuf);
     return 7;
   }


### PR DESCRIPTION
## What

Adds a dockerized **2-node producer/consumer** integration test that reproduces the cross-node blob-data gap in [#714](https://github.com/iowarp/clio-core/issues/714): after #685 the CTE **tag namespace** is cluster-wide, but a blob/file **payload** written on node A is not retrievable from node B (a cross-node `GetBlob`/`read` returns 0 bytes).

Two MPI binaries, **one rank per node**, cover both layers (as requested):

**`test_cte_producer_consumer`** (CTE core)
| rank 0 (producer, node A) | rank 1 (consumer, node B) |
|---|---|
| `PutBlob("0")` → `MPI_Bcast(tag_id)` → `MPI_Barrier` → `GetTagSize`/`GetBlobSize` | `MPI_Bcast(tag_id)` → `MPI_Barrier` → `GetTagSize` → `GetBlobSize` → **`GetBlob("0")`** |

**`test_cfs_producer_consumer`** (CFS filesystem)
| rank 0 (producer) | rank 1 (consumer) |
|---|---|
| `Open`+`Write`+`Close` → `MPI_Barrier` → `Getattr(size)` | `MPI_Barrier` → `Getattr(size)` → `Open(RDONLY)`+**`Read`** |

**MPI is used only for coordination** — `MPI_Barrier` orders write-before-read, and (CTE) `MPI_Bcast` hands the tag id to the consumer (distributed memory). The data path under test is CLIO's own cross-node routing, never MPI. Each rank attaches to its **own local daemon** (`CLIO_INIT(kClient)`, `CLIO_WITH_RUNTIME=0`).

The consumer's cross-node `GetBlob`/`Read` is the authoritative assertion. **This is a reproducer: it currently FAILS** (0 bytes) and will pass once #714's cross-node blob transfer is fixed.

## Harness

Mirrors the existing `cfs_distributed` (#685) test plus the `jarvis_deploy` passwordless-SSH setup:
- `docker-compose.yaml` — two daemons (`iowarp-node1`/`iowarp-node2`) on a private network.
- `node1_entrypoint.sh` — sets up SSH, starts its daemon, runs `mpirun -np 2` across both containers (OpenMPI + sshd ship in `iowarp/deps-cpu`).
- `node2_entrypoint.sh` — starts its daemon and serves `sshd` so `mpirun` starts rank 1 there.
- `clio_config.yaml` composes CTE core (512.0) + CFS (560.0) on every node; `hostfile`/`mpi_hostfile`; `run_tests.sh` keys the result on node 1.

## CI impact

Registered under `if(CLIO_CORE_ENABLE_MPI)` (+ `CLIO_CTE_ENABLE_FILESYSTEM`) with a docker ctest labeled `integration;docker;distributed;mpi;cfs` — **excluded from the normal unit/coverage CI**; it only runs in the docker/cluster path (and needs `-DCLIO_CORE_ENABLE_MPI=ON -DCLIO_CORE_ENABLE_DOCKER_CI=ON`).

## Validation note

Authored by mirroring the working `cfs_distributed` test + `test_mpi_bdev_transport` (client-init/MPI patterns) and verified against the current CTE/CFS client APIs. I could not run it locally (Windows host, no docker MPI cluster) — it needs a 2-node docker/cluster run to exercise end-to-end. Expected outcome today: **reader fails with 0 bytes**, confirming #714.

🤖 Generated with [Claude Code](https://claude.com/claude-code)