### PR TITLE
fix(cte): GetTagSize broadcast must be found-if-any, not fail-if-any (#714)

### DIFF
--- a/context-runtime/test/unit/test_autogen_coverage.cc
+++ b/context-runtime/test/unit/test_autogen_coverage.cc
@@ -1632,6 +1632,65 @@ TEST_CASE("Autogen - CTE Task AggregateOut operations", "[autogen][cte][aggregat
     }
   }
 
+  // GetTagSize is a Broadcast SUM whose replicas are per-container: a container
+  // holding none of the tag's blobs returns rc=1 (no local TagInfo), which is a
+  // zero contribution, NOT an error. The aggregate must be "found if ANY" — rc=0
+  // (and the summed size preserved) if any replica found the tag, and rc=1 only
+  // if every container missed. Regression guard for the cross-node 0-byte read
+  // in #714, where a not-found replica's rc=1 poisoned the aggregate and the
+  // filesystem adapter then discarded the correctly-summed size.
+  SECTION("AggregateOut for GetTagSizeTask is found-if-any") {
+    // Both constructors seed the accumulator "not found" (rc=1) so the aggregate
+    // reports rc=1 only when every replica missed. Cover the emplace ctor too
+    // (NewTask below exercises the default ctor).
+    clio::cte::core::GetTagSizeTask emplaced(
+        clio::run::TaskId(1, 2, 3), clio::run::PoolId(560, 0),
+        clio::run::PoolQuery::Local(), clio::cte::core::TagId::GetNull());
+    REQUIRE(emplaced.GetReturnCode() != 0);
+
+    // A freshly constructed GetTagSizeTask is seeded "not found" (rc=1) so the
+    // aggregate reports rc=1 only when every replica missed.
+    auto origin = ipc_manager->NewTask<clio::cte::core::GetTagSizeTask>();
+    auto missing = ipc_manager->NewTask<clio::cte::core::GetTagSizeTask>();
+    auto found = ipc_manager->NewTask<clio::cte::core::GetTagSizeTask>();
+    if (!origin.IsNull() && !missing.IsNull() && !found.IsNull()) {
+      REQUIRE(origin->GetReturnCode() != 0);  // seeded not-found
+
+      // A replica that holds none of the tag's blobs: rc=1, size 0.
+      missing->SetReturnCode(1);
+      missing->tag_size_ = 0;
+      // A replica that holds the tag's bytes: rc=0, real share.
+      found->SetReturnCode(0);
+      found->tag_size_ = 28;
+
+      // Aggregating the not-found replica first must NOT flip the aggregate to
+      // "found", and must not poison a later found result.
+      origin->AggregateOut(missing.template Cast<clio::run::Task>());
+      REQUIRE(origin->GetReturnCode() != 0);  // still not found
+      REQUIRE(origin->tag_size_ == 0);
+
+      // Aggregating the found replica makes the whole query succeed with the
+      // real size, regardless of the earlier not-found replica.
+      origin->AggregateOut(found.template Cast<clio::run::Task>());
+      REQUIRE(origin->GetReturnCode() == 0);  // found-if-any
+      REQUIRE(origin->tag_size_ == 28);
+
+      // A subsequent not-found replica must not re-poison the found aggregate.
+      auto missing2 = ipc_manager->NewTask<clio::cte::core::GetTagSizeTask>();
+      if (!missing2.IsNull()) {
+        missing2->SetReturnCode(1);
+        missing2->tag_size_ = 0;
+        origin->AggregateOut(missing2.template Cast<clio::run::Task>());
+        REQUIRE(origin->GetReturnCode() == 0);
+        REQUIRE(origin->tag_size_ == 28);
+        missing2.reset();
+      }
+      origin.reset();
+      missing.reset();
+      found.reset();
+    }
+  }
+
   SECTION("AggregateOut for GetContainedBlobsTask") {
     auto origin_task = ipc_manager->NewTask<clio::cte::core::GetContainedBlobsTask>();
     auto replica_task = ipc_manager->NewTask<clio::cte::core::GetContainedBlobsTask>();

--- a/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
@@ -2343,7 +2343,13 @@ struct GetTagSizeTask : public clio::run::Task {
         tag_size_(0),
         ctime_(0),
         mtime_(0),
-        atime_(0) {}
+        atime_(0) {
+    // Seed the aggregate accumulator as "not found" so a Broadcast GetTagSize
+    // reports rc=1 only when EVERY container missed the tag; AggregateOut flips
+    // it to 0 as soon as any container reports a share (see AggregateOut). A
+    // locally-executed task overwrites this in Runtime::GetTagSize.
+    return_code_.store(1);
+  }
 
   // Emplace constructor
   CTP_CROSS_FUN explicit GetTagSizeTask(const clio::run::TaskId &task_id,
@@ -2361,6 +2367,8 @@ struct GetTagSizeTask : public clio::run::Task {
     method_ = Method::kGetTagSize;
     task_flags_.Clear();
     pool_query_ = pool_query;
+    // See the SHM constructor: seed "not found" for the Broadcast aggregate.
+    return_code_.store(1);
   }
 
   /**
@@ -2395,13 +2403,48 @@ struct GetTagSizeTask : public clio::run::Task {
   }
 
   /**
-   * AggregateOut results from a replica task
-   * Sums the tag_size_ values from multiple nodes; keeps the newest timestamps.
+   * AggregateOut results from a replica task.
+   *
+   * GetTagSize is a Broadcast SUM: the tag's bytes are spread across every
+   * container that `HashBlobToContainer` routed one of its blobs to, and each
+   * such container carries a TagInfo holding its share. A container that holds
+   * NONE of the tag's blobs has no local TagInfo and legitimately returns
+   * return_code_=1 ("not found here") with tag_size_=0 — that is a zero
+   * contribution to the sum, NOT an error for the whole query.
+   *
+   * The base Task::AggregateOut propagates any non-zero replica return code onto
+   * the aggregate, which poisoned the result: on a multi-node cluster the
+   * reader's own container often holds none of a just-written file's blobs, so
+   * its rc=1 replica made the aggregate rc=1 even though another container
+   * returned the real size. CfsIo::Open only trusts the size when rc==0, so it
+   * discarded the correct size and every cross-node read of that file returned
+   * 0 bytes (issue #714, Bug 2).
+   *
+   * Correct semantics — "found if ANY": the aggregate succeeds (rc=0) if at
+   * least one replica found the tag, summing the found replicas' shares; it
+   * stays "not found" (rc=1) only if EVERY replica missed (e.g. the tag was
+   * deleted cluster-wide — readdir's liveness check relies on this). The origin
+   * accumulator is seeded rc=1 in the constructors so that this holds
+   * regardless of the order replicas are aggregated in.
    */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
-    Task::AggregateOut(other_base);
+    if (other_base.IsNull()) return;
     auto replica = other_base.template Cast<GetTagSizeTask>();
+    // Keep the base completer bookkeeping, but NOT its return-code poisoning.
+    SetCompleter(other_base->GetCompleter());
+    // Sum each container's share. A container that holds none of the tag's
+    // blobs reports tag_size_=0, so summing it is a no-op — the total is the
+    // sum of the found containers' shares.
     tag_size_ += replica->tag_size_;
+    // "found if ANY": the tag exists cluster-wide if at least one container has
+    // a local TagInfo (rc==0). Clear the "not found" seed as soon as a replica
+    // reports the tag; a not-found replica (rc=1) must NEVER poison the
+    // aggregate (that discarded correctly-summed sizes on cross-node reads --
+    // #714). rc stays 1 only if every container missed (tag deleted
+    // cluster-wide), which readdir's liveness check relies on.
+    if (replica->GetReturnCode() == 0) {
+      SetReturnCode(0);
+    }
     if (replica->ctime_ > ctime_) ctime_ = replica->ctime_;
     if (replica->mtime_ > mtime_) mtime_ = replica->mtime_;
     if (replica->atime_ > atime_) atime_ = replica->atime_;


### PR DESCRIPTION
## Fix cross-node CFS reads returning 0 bytes (issue #714, Bug 2)

### Symptom
On a multi-node cluster, a file written on node A reads back **0 bytes** from node B a large fraction of the time (flaky by hash placement), even though `open` succeeds and same-node write→read always works.

### Root cause
`GetTagSize` is a **Broadcast SUM**: a file's bytes are spread across whichever containers `HashBlobToContainer` routed its blobs to, and each such container keeps a `TagInfo` holding its share. A container that holds **none** of the tag's blobs has no local `TagInfo` and legitimately returns `return_code_=1` with `tag_size_=0` — a zero contribution, not an error.

But `GetTagSizeTask::AggregateOut` called the base `Task::AggregateOut`, which **propagates any non-zero replica return code onto the aggregate** (`task.h`):
```cpp
if (!replica_task.IsNull() && replica_task->GetReturnCode() != 0) {
  SetReturnCode(replica_task->GetReturnCode());
}
```
So when the reader's own container held none of a just-written file's blobs (the common cross-node case), its `rc=1` replica poisoned the aggregate to `rc=1` even though another container returned the real size. `CfsIo::Open` only trusts the size when `rc==0`, so it discarded the correct size → the reader's file size stayed 0 → `Runtime::Read` early-returns 0 bytes.

This is deterministic given hash placement, which made it look flaky across files: it passed only when the reader's local container happened to hold a `TagInfo` for the tag.

### Fix
Give `GetTagSize` **"found if ANY"** aggregate semantics (in `GetTagSizeTask` only):
- seed the accumulator `return_code_=1` in both constructors;
- in `AggregateOut`, sum only found (`rc==0`) replicas' shares and clear `rc→0` as soon as any replica reports the tag — independent of aggregation order;
- `rc` stays `1` only if **every** container missed (tag deleted cluster-wide), preserving the readdir liveness check that treats `rc!=0` as "tag gone".

### Validation
2-node aarch64 cluster (TACC Vista), cross-node `write@A → read@B`:
- **before:** ~⅔ pass (flaky);
- **after:** **10/10 pass** on the debug build and **10/10 pass** on the release build; same-node still 10/10; no daemon crashes.

Instrumented traces confirm the reader now aggregates `rc=0/size=N` even when its local container returns `rc=1` (no local `TagInfo`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)