### PR TITLE
fix(kvhdf5): compile GPU tests under nvcc C++17

### DIFF
--- a/context-transfer-engine/adapter/kvhdf5/include/clio_cte/kvhdf5/blob_backend.h
+++ b/context-transfer-engine/adapter/kvhdf5/include/clio_cte/kvhdf5/blob_backend.h
@@ -3,12 +3,27 @@
 #include "defines.h"
 #include <cuda/std/span>
 #include <cuda/std/expected>
+
+// The BlobBackend concept is a C++20 language feature. The host build compiles
+// as C++20 (see CMAKE_CXX_STANDARD), but the GPU tests are compiled by nvcc as
+// C++17, where `concept`/`requires` and <cuda/std/concepts> are unavailable.
+// Under C++17 we degrade the concept to an unconstrained `typename` template
+// parameter (KVHDF5_BLOB_BACKEND) so the same headers still compile in device
+// tests; the constraint is still enforced on the C++20 host build. The
+// <cuda/std/concepts> include MUST stay at file scope (not inside a namespace,
+// or libcu++'s own declarations get nested and its internals stop compiling).
+#if defined(__cpp_concepts) && __cpp_concepts >= 201907L
 #include <cuda/std/concepts>
+#define KVHDF5_BLOB_BACKEND BlobBackend
+#else
+#define KVHDF5_BLOB_BACKEND typename
+#endif
 
 namespace kvhdf5 {
 
 enum class BlobError : uint8_t { NotFound, NotEnoughSpace, BackendFailure };
 
+#if defined(__cpp_concepts) && __cpp_concepts >= 201907L
 // A chunk store keyed by a host-formatted blob name (chunk-coord text). The
 // value is raw chunk bytes. InMemBlobBackend satisfies this for runtime-free
 // CPU tests; GpuCteBlobStore (Slice 2) is the real iowarp producer path.
@@ -21,5 +36,6 @@ concept BlobBackend = requires(T s,
     { s.ReadChunk(name, out) } -> cstd::same_as<cstd::expected<cstd::span<byte_t>, BlobError>>;
     { s.ChunkExists(name) } -> cstd::same_as<bool>;
 };
+#endif
 
 }  // namespace kvhdf5

--- a/context-transfer-engine/adapter/kvhdf5/include/clio_cte/kvhdf5/cpu_dataset.h
+++ b/context-transfer-engine/adapter/kvhdf5/include/clio_cte/kvhdf5/cpu_dataset.h
@@ -49,7 +49,7 @@ enum class IoError : uint8_t { BadLayout, SizeMismatch, Unsupported, NotFound, B
 //
 // MVP: one chunk per dataset. `data`/`out` are the full row-major array. The
 // multi-chunk gather/scatter is Phase 1+ (returns Unsupported until then).
-template<BlobBackend B>
+template<KVHDF5_BLOB_BACKEND B>
 class Dataset {
     DatasetMeta* meta_;
     B* backend_;

--- a/context-transfer-engine/adapter/kvhdf5/include/clio_cte/kvhdf5/cpu_file.h
+++ b/context-transfer-engine/adapter/kvhdf5/include/clio_cte/kvhdf5/cpu_file.h
@@ -14,7 +14,7 @@ namespace kvhdf5 {
 // Group hierarchy is carried in the path string for now; a real Group tree and
 // path->TagId resolution land in Slice 2. DatasetMeta is heap-owned so its
 // address stays stable across rehash (Dataset holds a DatasetMeta*).
-template<BlobBackend B>
+template<KVHDF5_BLOB_BACKEND B>
 class File {
     B backend_;
     std::unordered_map<std::string, std::unique_ptr<DatasetMeta>> datasets_;

--- a/context-transfer-engine/adapter/kvhdf5/include/clio_cte/kvhdf5/inmem_blob_backend.h
+++ b/context-transfer-engine/adapter/kvhdf5/include/clio_cte/kvhdf5/inmem_blob_backend.h
@@ -41,6 +41,8 @@ public:
     [[nodiscard]] size_t ChunkCount() const { return blobs_.size(); }
 };
 
+#if defined(__cpp_concepts) && __cpp_concepts >= 201907L
 static_assert(BlobBackend<InMemBlobBackend>);
+#endif
 
 }  // namespace kvhdf5

--- a/context-transfer-engine/adapter/kvhdf5/include/clio_cte/kvhdf5/tag_path.h
+++ b/context-transfer-engine/adapter/kvhdf5/include/clio_cte/kvhdf5/tag_path.h
@@ -12,7 +12,8 @@
 // Convention (mirrors chunking::ChunkCoordToName): an empty result == failure. A
 // valid tag is always non-empty, so the empty string is an unambiguous sentinel.
 
-#include <span>
+#include "defines.h"
+#include <cuda/std/span>
 #include <string>
 #include <string_view>
 
@@ -43,7 +44,7 @@ inline constexpr char kTagSep = '/';
 // Build a canonical tag from already-separated hierarchy components (file name,
 // group names, dataset name). Strict: returns "" if any component is empty or
 // itself contains the separator (an embedded '/' would corrupt the path depth).
-[[nodiscard]] inline std::string JoinTag(std::span<const std::string_view> components) {
+[[nodiscard]] inline std::string JoinTag(cstd::span<const std::string_view> components) {
     std::string out;
     for (std::string_view c : components) {
         if (c.empty() || c.find(kTagSep) != std::string_view::npos) return {};


### PR DESCRIPTION
## Summary

Fixes the 11 compilation errors in the kvhdf5 GPU e2e tests. Those tests (`.../kvhdf5/test/e2e/*.cu`) are compiled by **nvcc at `-std=c++17`**, but three headers used **C++20-only features**. The host build compiles as C++20, so the CPU unit tests were unaffected — only the nvcc device path broke.

## Changes (5 files, +23/−4)

- **`blob_backend.h`** — guard the `BlobBackend` concept and `<cuda/std/concepts>` behind `#if defined(__cpp_concepts)`, with a `KVHDF5_BLOB_BACKEND` macro that is `BlobBackend` on the C++20 host build and plain `typename` under nvcc's C++17. The `#include` stays at **file scope** — nesting a libcu++ header inside `namespace kvhdf5` breaks its internals.
- **`cpu_dataset.h` / `cpu_file.h`** — `template<BlobBackend B>` → `template<KVHDF5_BLOB_BACKEND B>`.
- **`inmem_blob_backend.h`** — guard the `static_assert(BlobBackend<...>)`.
- **`tag_path.h`** — replace the outlier `std::span`/`<span>` with the module's `cstd::span` (`cuda::std::span`, backported to C++17 by libcu++), matching every other file in the module.

The C++20 constraint is still enforced on the host build; nothing is weakened.

## Testing

- Host `g++-14 -std=gnu++20` compile of `dataset_io_test.cpp` / `tag_path_test.cpp` → **0 errors**
- nvcc `-std=c++17` compile of the e2e `.cu` tests → **0 errors**
- Full GPU build (`clio_core_gpu_dev`, CUDA + GPU runtime) → **Build: OK**

Remaining ctest failures in the build environment are runtime-only (no CUDA-capable device present: `nvidia-smi` fails to initialize NVML) and unrelated to this change.

Fixes #723

🤖 Generated with [Claude Code](https://claude.com/claude-code)