### PR TITLE
Add tiered lifespan health policy

### DIFF
--- a/.devcontainer/nvidia-gpu/Dockerfile
+++ b/.devcontainer/nvidia-gpu/Dockerfile
@@ -144,6 +144,7 @@ RUN set -eux; \
       -DCMAKE_CUDA_FLAGS="--cuda-path=${CUDA_HOME} -Wno-unknown-cuda-version" \
       -DNDZIP_WITH_CUDA=ON \
       -DNDZIP_WITH_MT=OFF \
+      -DHIPSYCL_TARGETS="omp" \
       -DNDZIP_BUILD_BENCHMARK=OFF \
       -DNDZIP_BUILD_TEST=OFF \
       -DCMAKE_POLICY_VERSION_MINIMUM=3.5; \

--- a/context-runtime/modules/bdev/clio_mod.yaml
+++ b/context-runtime/modules/bdev/clio_mod.yaml
@@ -21,3 +21,4 @@ kWrite: 12              # Write data with libaio
 kRead: 13               # Read data with libaio
 kGetStats: 14           # Get performance statistics
 kUpdate: 15             # Update GPU container with device pointers
+kSetLifespan: 16        # Inject predicted device lifespan in days

--- a/context-runtime/modules/bdev/include/clio_runtime/bdev/autogen/bdev_methods.h
+++ b/context-runtime/modules/bdev/include/clio_runtime/bdev/autogen/bdev_methods.h
@@ -24,8 +24,9 @@ GLOBAL_CROSS_CONST clio::run::u32 kWrite = 12;
 GLOBAL_CROSS_CONST clio::run::u32 kRead = 13;
 GLOBAL_CROSS_CONST clio::run::u32 kGetStats = 14;
 GLOBAL_CROSS_CONST clio::run::u32 kUpdate = 15;
+GLOBAL_CROSS_CONST clio::run::u32 kSetLifespan = 16;
 
-GLOBAL_CROSS_CONST clio::run::u32 kMaxMethodId = 16;
+GLOBAL_CROSS_CONST clio::run::u32 kMaxMethodId = 17;
 
 inline const std::vector<std::string>& GetMethodNames() {
   static const std::vector<std::string> names = [] {
@@ -39,6 +40,7 @@ inline const std::vector<std::string>& GetMethodNames() {
     v[13] = "Read";
     v[14] = "GetStats";
     v[15] = "Update";
+    v[16] = "SetLifespan";
     return v;
   }();
   return names;

--- a/context-runtime/modules/bdev/include/clio_runtime/bdev/bdev_client.h
+++ b/context-runtime/modules/bdev/include/clio_runtime/bdev/bdev_client.h
@@ -214,6 +214,23 @@ class Client : public clio::run::ContainerClient {
     return ipc_manager->Send(task);
   }
 
+  /**
+   * Set the predicted lifespan reported by bdev.
+   *
+   * @param pool_query Pool query used to route the override to the target.
+   * @param lifespan_days Remaining lifespan in days. Large values mean healthy
+   *     storage; small values let tests simulate a degrading device.
+   */
+  clio::run::Future<clio::run::bdev::SetLifespanTask> AsyncSetLifespan(
+      const clio::run::PoolQuery& pool_query, clio::run::u32 lifespan_days) {
+    auto* ipc_manager = CLIO_CPU_IPC;
+
+    auto task = ipc_manager->NewTask<clio::run::bdev::SetLifespanTask>(
+        clio::run::CreateTaskId(), pool_id_, pool_query, lifespan_days);
+
+    return ipc_manager->Send(task);
+  }
+
 };
 
 }  // namespace clio::run::bdev

--- a/context-runtime/modules/bdev/include/clio_runtime/bdev/bdev_runtime.h
+++ b/context-runtime/modules/bdev/include/clio_runtime/bdev/bdev_runtime.h
@@ -16,6 +16,8 @@
 #include <chrono>
 #include <memory>
 #include <mutex>
+#include <string>
+#include <thread>
 
 namespace clio::run::bdev {
 
@@ -32,7 +34,7 @@ class Runtime : public clio::run::Container {
               total_bytes_read_(0), total_bytes_written_(0) {
     start_time_ = std::chrono::high_resolution_clock::now();
   }
-  ~Runtime() override = default;
+  ~Runtime() override;
 
   /**
    * Get live task statistics for this task instance.
@@ -45,6 +47,7 @@ class Runtime : public clio::run::Container {
   clio::run::TaskResume Write(clio::run::shared_ptr<WriteTask> &task);
   clio::run::TaskResume Read(clio::run::shared_ptr<ReadTask> &task);
   clio::run::TaskResume GetStats(clio::run::shared_ptr<GetStatsTask> &task);
+  clio::run::TaskResume SetLifespan(clio::run::shared_ptr<SetLifespanTask> &task);
   clio::run::TaskResume Update(clio::run::shared_ptr<UpdateTask> &task);
   clio::run::TaskResume Monitor(clio::run::shared_ptr<MonitorTask> &task);
   clio::run::TaskResume Destroy(clio::run::shared_ptr<DestroyTask> &task);
@@ -85,8 +88,41 @@ class Runtime : public clio::run::Container {
   std::atomic<clio::run::u64> total_bytes_read_;
   std::atomic<clio::run::u64> total_bytes_written_;
   std::chrono::high_resolution_clock::time_point start_time_;
-  
+
   PerfMetrics perf_metrics_;
+
+  // Predictive device health: estimated days until drive failure.
+  // Populated by a background thread that periodically queries the
+  // local prediction server (server.py). Default 999999 = healthy.
+  std::atomic<clio::run::u32> predicted_ttl_days_{999999};
+
+  // Path to the device file this bdev owns (set in Init, used for SMART reads)
+  std::string device_path_;
+
+  // Background health-poll thread and its stop flag.
+  std::thread health_poll_thread_;
+  std::atomic<bool> health_poll_stop_{false};
+
+  // How often (seconds) to re-poll the prediction server.
+  static constexpr unsigned kHealthPollIntervalSec = 300;  // every 5 minutes
+
+  // URL of the local prediction server.  Override via CLIO_PRED_SERVER env var.
+  static constexpr const char *kDefaultPredServerUrl =
+      "http://127.0.0.1:8000/predict/auto";
+
+  /**
+   * Reads SMART attributes from the OS for device_path_ and posts them to the
+   * local prediction server.  Runs on health_poll_thread_.
+   */
+  void PollPredictionServer();
+
+  /**
+   * Stop the background health poll thread and destroy the bdev transport.
+   *
+   * This is shared by Destroy() and the destructor so shutdown is safe even if
+   * the container is torn down without the explicit destroy task.
+   */
+  void StopHealthPolling();
 
   size_t GetWorkerID(clio::run::RunContext& rctx);
 

--- a/context-runtime/modules/bdev/include/clio_runtime/bdev/bdev_tasks.h
+++ b/context-runtime/modules/bdev/include/clio_runtime/bdev/bdev_tasks.h
@@ -623,17 +623,18 @@ struct ReadTask : public clio::run::Task {
  */
 struct GetStatsTask : public clio::run::Task {
   // Task-specific data (no inputs)
-  OUT PerfMetrics metrics_;      // Performance metrics
+  OUT PerfMetrics metrics_;            // Performance metrics
   OUT clio::run::u64 remaining_size_;  // Remaining allocatable space
+  OUT clio::run::u32 predicted_ttl_days_; // Predicted device TTL in days (999999 = healthy)
 
   /** SHM default constructor */
-  GetStatsTask() : clio::run::Task(), remaining_size_(0) {}
+  GetStatsTask() : clio::run::Task(), remaining_size_(0), predicted_ttl_days_(999999) {}
 
   /** Emplace constructor */
   explicit GetStatsTask(const clio::run::TaskId &task_node,
                         const clio::run::PoolId &pool_id,
                         const clio::run::PoolQuery &pool_query)
-      : clio::run::Task(task_node, pool_id, pool_query, 10), remaining_size_(0) {
+      : clio::run::Task(task_node, pool_id, pool_query, 10), remaining_size_(0), predicted_ttl_days_(999999) {
     // Initialize task
     task_id_ = task_node;
     pool_id_ = pool_id;
@@ -653,7 +654,7 @@ struct GetStatsTask : public clio::run::Task {
   template <typename Archive>
   CTP_CROSS_FUN void SerializeOut(Archive &ar) {
     Task::SerializeOut(ar);
-    ar(metrics_, remaining_size_);
+    ar(metrics_, remaining_size_, predicted_ttl_days_);
   }
 
   /**
@@ -666,12 +667,60 @@ struct GetStatsTask : public clio::run::Task {
     // Copy GetStatsTask-specific fields
     metrics_ = other->metrics_;
     remaining_size_ = other->remaining_size_;
+    predicted_ttl_days_ = other->predicted_ttl_days_;
   }
 
   /** AggregateOut replica results into this task */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
     Copy(other_base.template Cast<GetStatsTask>());
+  }
+};
+
+/**
+ * SetLifespanTask - Inject a predicted remaining device lifetime in days.
+ *
+ * This task lets tests and administrative flows override the current health
+ * signal that bdev reports through GetStats/Monitor. A value of 999999 is
+ * treated as healthy, while smaller values are consumed by CTE's TTL filter.
+ */
+struct SetLifespanTask : public clio::run::Task {
+  IN clio::run::u32 lifespan_days_;
+
+  CTP_CROSS_FUN SetLifespanTask()
+      : clio::run::Task(), lifespan_days_(999999) {}
+
+  CTP_CROSS_FUN explicit SetLifespanTask(
+      const clio::run::TaskId &task_node, const clio::run::PoolId &pool_id,
+      const clio::run::PoolQuery &pool_query, clio::run::u32 lifespan_days)
+      : clio::run::Task(task_node, pool_id, pool_query, Method::kSetLifespan),
+        lifespan_days_(lifespan_days) {
+    task_id_ = task_node;
+    pool_id_ = pool_id;
+    method_ = Method::kSetLifespan;
+    task_flags_.Clear();
+    pool_query_ = pool_query;
+  }
+
+  template <typename Archive>
+  CTP_CROSS_FUN void SerializeIn(Archive &ar) {
+    Task::SerializeIn(ar);
+    ar(lifespan_days_);
+  }
+
+  template <typename Archive>
+  CTP_CROSS_FUN void SerializeOut(Archive &ar) {
+    Task::SerializeOut(ar);
+  }
+
+  void Copy(const ctp::ipc::FullPtr<SetLifespanTask> &other) {
+    Task::Copy(other.template Cast<Task>());
+    lifespan_days_ = other->lifespan_days_;
+  }
+
+  void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
+    Task::AggregateOut(other_base);
+    Copy(other_base.template Cast<SetLifespanTask>());
   }
 };
 

--- a/context-runtime/modules/bdev/src/autogen/bdev_lib_exec.cc
+++ b/context-runtime/modules/bdev/src/autogen/bdev_lib_exec.cc
@@ -88,6 +88,11 @@ clio::run::TaskResume Runtime::Run(clio::run::u32 method, clio::run::shared_ptr<
       CLIO_CO_AWAIT(Update(typed_task));
       break;
     }
+    case Method::kSetLifespan: {
+      auto& typed_task = task_ptr.template Cast<SetLifespanTask>();
+      CLIO_CO_AWAIT(SetLifespan(typed_task));
+      break;
+    }
     default: {
       // Unknown method - do nothing
       break;
@@ -145,6 +150,11 @@ void Runtime::SaveTask(clio::run::u32 method, clio::run::SaveTaskArchive& archiv
       archive << *typed_task;
       break;
     }
+    case Method::kSetLifespan: {
+      auto& typed_task = task_ptr.template Cast<SetLifespanTask>();
+      archive << *typed_task;
+      break;
+    }
     default: {
       // Unknown method - do nothing
       break;
@@ -197,6 +207,11 @@ void Runtime::LoadTask(clio::run::u32 method, clio::run::LoadTaskArchive& archiv
     }
     case Method::kUpdate: {
       auto& typed_task = task_ptr.template Cast<UpdateTask>();
+      archive >> *typed_task;
+      break;
+    }
+    case Method::kSetLifespan: {
+      auto& typed_task = task_ptr.template Cast<SetLifespanTask>();
       archive >> *typed_task;
       break;
     }
@@ -272,6 +287,12 @@ void Runtime::LocalLoadTask(clio::run::u32 method, clio::run::DefaultLoadArchive
       archive >> *typed_task;
       break;
     }
+    case Method::kSetLifespan: {
+      auto& typed_task = task_ptr.template Cast<SetLifespanTask>();
+      // Use archive operator which respects msg_type
+      archive >> *typed_task;
+      break;
+    }
     default: {
       // Unknown method - do nothing
       break;
@@ -340,6 +361,12 @@ void Runtime::LocalSaveTask(clio::run::u32 method, clio::run::DefaultSaveArchive
     }
     case Method::kUpdate: {
       auto& typed_task = task_ptr.template Cast<UpdateTask>();
+      // Use archive operator which respects msg_type
+      archive << *typed_task;
+      break;
+    }
+    case Method::kSetLifespan: {
+      auto& typed_task = task_ptr.template Cast<SetLifespanTask>();
       // Use archive operator which respects msg_type
       archive << *typed_task;
       break;
@@ -457,6 +484,16 @@ clio::run::shared_ptr<clio::run::Task> Runtime::NewCopyTask(clio::run::u32 metho
       }
       break;
     }
+    case Method::kSetLifespan: {
+      // Allocate new task
+      auto new_task_ptr = ipc_manager->NewTask<SetLifespanTask>();
+      if (!new_task_ptr.IsNull()) {
+        auto& task_typed = orig_task_ptr.template Cast<SetLifespanTask>();
+        new_task_ptr->Copy(ctp::ipc::FullPtr<SetLifespanTask>(task_typed.get()));
+        return new_task_ptr.template Cast<clio::run::Task>();
+      }
+      break;
+    }
     default: {
       // For unknown methods, create base Task copy
       auto new_task_ptr = ipc_manager->NewTask<clio::run::Task>();
@@ -515,6 +552,10 @@ clio::run::shared_ptr<clio::run::Task> Runtime::NewTask(clio::run::u32 method) {
       auto new_task_ptr = ipc_manager->NewTask<UpdateTask>();
       return new_task_ptr.template Cast<clio::run::Task>();
     }
+    case Method::kSetLifespan: {
+      auto new_task_ptr = ipc_manager->NewTask<SetLifespanTask>();
+      return new_task_ptr.template Cast<clio::run::Task>();
+    }
     default: {
       // For unknown methods, return null pointer
       return clio::run::shared_ptr<clio::run::Task>();
@@ -567,6 +608,11 @@ void Runtime::AggregateOut(clio::run::u32 method, clio::run::shared_ptr<clio::ru
     }
     case Method::kUpdate: {
       auto& typed_task = orig_task.template Cast<UpdateTask>();
+      typed_task->AggregateOut(ctp::ipc::FullPtr<clio::run::Task>(replica_task.get()));
+      break;
+    }
+    case Method::kSetLifespan: {
+      auto& typed_task = orig_task.template Cast<SetLifespanTask>();
       typed_task->AggregateOut(ctp::ipc::FullPtr<clio::run::Task>(replica_task.get()));
       break;
     }

--- a/context-runtime/modules/bdev/src/bdev_runtime.cc
+++ b/context-runtime/modules/bdev/src/bdev_runtime.cc
@@ -12,15 +12,19 @@
 #include <clio_ctp/serialize/msgpack_wrapper.h>
 
 #include <algorithm>
+#include <cctype>
 #include <cmath>
 #include <cstdio>
 #include <cstring>
 #include <limits>
+#include <string>
 #include <thread>
 
 #include "clio_ctp/util/timer.h"
 
 namespace clio::run::bdev {
+
+Runtime::~Runtime() { StopHealthPolling(); }
 
 clio::run::TaskStat Runtime::GetTaskStats(const clio::run::Task *task) const {
   if (!task) return clio::run::TaskStat();
@@ -84,6 +88,14 @@ clio::run::TaskResume Runtime::Create(clio::run::shared_ptr<CreateTask> &task) {
   total_writes_ = 0;
   total_bytes_read_ = 0;
   total_bytes_written_ = 0;
+
+  // Capture the device path so the poll thread can look up SMART attributes.
+  device_path_ = task->pool_name_.str();
+
+  // Start background health-poll thread.  It will periodically query the
+  // local prediction server and update predicted_ttl_days_.
+  health_poll_stop_.store(false, std::memory_order_relaxed);
+  health_poll_thread_ = std::thread(&Runtime::PollPredictionServer, this);
 
   task->return_code_ = 0;
   CLIO_CO_RETURN;
@@ -218,6 +230,25 @@ clio::run::TaskResume Runtime::GetStats(clio::run::shared_ptr<GetStatsTask> &tas
     task->remaining_size_ = 0;
   }
 
+  // Expose the latest ML-predicted TTL so the CTE can make
+  // TTL-aware allocation decisions without any external daemon.
+  task->predicted_ttl_days_ = predicted_ttl_days_.load(std::memory_order_relaxed);
+
+  task->return_code_ = 0;
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
+/**
+ * Update the in-memory predicted lifespan that bdev reports to callers.
+ *
+ * @param task SetLifespan task carrying the new remaining-life estimate.
+ * @return Task resume state for the CLIO scheduler.
+ */
+clio::run::TaskResume Runtime::SetLifespan(
+    clio::run::shared_ptr<SetLifespanTask> &task) {
+  CLIO_TASK_BODY_BEGIN
+  predicted_ttl_days_.store(task->lifespan_days_, std::memory_order_relaxed);
   task->return_code_ = 0;
   CLIO_CO_RETURN;
   CLIO_TASK_BODY_END
@@ -225,10 +256,7 @@ clio::run::TaskResume Runtime::GetStats(clio::run::shared_ptr<GetStatsTask> &tas
 
 clio::run::TaskResume Runtime::Destroy(clio::run::shared_ptr<DestroyTask> &task) {
   CLIO_TASK_BODY_BEGIN
-  if (transport_) {
-    transport_->Destroy();
-    transport_.reset();
-  }
+  StopHealthPolling();
   task->return_code_ = 0;
   CLIO_CO_RETURN;
   CLIO_TASK_BODY_END
@@ -259,7 +287,7 @@ clio::run::TaskResume Runtime::Monitor(clio::run::shared_ptr<MonitorTask> &task)
     msgpack::sbuffer sbuf;
     msgpack::packer<msgpack::sbuffer> pk(sbuf);
 
-    pk.pack_map(15);
+    pk.pack_map(16);
     pk.pack("pool_name");              pk.pack(pool_name_);
     pk.pack("bdev_type");              pk.pack(static_cast<clio::run::u32>(bdev_type_));
     pk.pack("total_capacity");         pk.pack(transport_ ? transport_->GetCapacity() : 0);
@@ -280,6 +308,7 @@ clio::run::TaskResume Runtime::Monitor(clio::run::shared_ptr<MonitorTask> &task)
 
     pk.pack("device_health");          pk.pack(health_json);
     pk.pack("failure_prediction");     pk.pack(prediction_json);
+    pk.pack("predicted_ttl_days");     pk.pack(predicted_ttl_days_.load(std::memory_order_relaxed));
 
     task->results_[container_id_] = std::string(sbuf.data(), sbuf.size());
   }
@@ -289,6 +318,86 @@ clio::run::TaskResume Runtime::Monitor(clio::run::shared_ptr<MonitorTask> &task)
 }
 
 void Runtime::PostGpuContainerCreate() {}
+
+void Runtime::StopHealthPolling() {
+  health_poll_stop_.store(true, std::memory_order_relaxed);
+  if (health_poll_thread_.joinable()) {
+    health_poll_thread_.join();
+  }
+  if (transport_) {
+    transport_->Destroy();
+    transport_.reset();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// PollPredictionServer
+//
+// Background thread body.  Every kHealthPollIntervalSec seconds it:
+//   1. Reads SMART attributes for this device via SystemInfo.
+//   2. Posts them to the local prediction server (server.py).
+//   3. Parses "days_remaining" from the JSON response.
+//   4. Stores the result in predicted_ttl_days_ so GetStats() can expose it
+//      to the CTE on the next poll without any external daemon involved.
+// ---------------------------------------------------------------------------
+void Runtime::PollPredictionServer() {
+  // Derive the drive type string ("hdd" or "ssd") from the pool / device name.
+  const std::string drive_type = ctp::SystemInfo::DeriveDriveType(pool_name_);
+
+  while (!health_poll_stop_.load(std::memory_order_relaxed)) {
+    try {
+      // Step 1: collect SMART attributes.
+      const std::string health_json =
+          ctp::SystemInfo::GetDeviceHealthStats(pool_name_);
+
+      // Step 2 & 3: post to prediction server and get back a JSON response
+      // that contains "days_remaining": <int> | null.
+      const std::string pred_json =
+          ctp::SystemInfo::PredictDriveFailure(drive_type, health_json, pool_name_);
+
+      // Parse days_remaining out of the JSON string.  We use a lightweight
+      // hand-rolled search to avoid pulling in a full JSON library here.
+      //  • "days_remaining": 42   → 42
+      //  • "days_remaining": null → keep current value (healthy)
+      auto extract_days = [](const std::string &json) -> clio::run::u32 {
+        const std::string key = "\"days_remaining\"";
+        auto pos = json.find(key);
+        if (pos == std::string::npos) return 999999;
+        pos += key.size();
+        // Skip whitespace and colon
+        while (pos < json.size() && (json[pos] == ' ' || json[pos] == ':')) ++pos;
+        // "null" means the server says the drive is healthy
+        if (json.size() >= pos + 4 && json.substr(pos, 4) == "null") return 999999;
+        // Parse integer
+        if (pos < json.size() && std::isdigit(static_cast<unsigned char>(json[pos]))) {
+          clio::run::u32 days = 0;
+          while (pos < json.size() &&
+                 std::isdigit(static_cast<unsigned char>(json[pos]))) {
+            days = days * 10 + static_cast<clio::run::u32>(json[pos] - '0');
+            ++pos;
+          }
+          return days;
+        }
+        return 999999;  // Unparseable → treat as healthy
+      };
+
+      clio::run::u32 new_ttl = extract_days(pred_json);
+      predicted_ttl_days_.store(new_ttl, std::memory_order_relaxed);
+
+    } catch (...) {
+      // If the prediction server is unreachable, silently retain the last
+      // known TTL rather than falsely marking the drive as dead.
+    }
+
+    // Sleep in 1-second increments so we can wake promptly on stop.
+    for (unsigned s = 0;
+         s < kHealthPollIntervalSec &&
+         !health_poll_stop_.load(std::memory_order_relaxed);
+         ++s) {
+      std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+  }
+}
 
 }  // namespace clio::run::bdev
 

--- a/context-runtime/modules/bdev/test/test_bdev_chimod.cc
+++ b/context-runtime/modules/bdev/test/test_bdev_chimod.cc
@@ -820,6 +820,33 @@ TEST_CASE("bdev_failure_prediction_integration", "[bdev][prediction][integration
   std::filesystem::remove(health_path, ec);
 }
 
+TEST_CASE("bdev_set_lifespan_overrides_stats", "[bdev][health][ttl]") {
+  BdevChimodFixture fixture;
+  REQUIRE(g_initialized);
+  REQUIRE(fixture.createTestFile(kDefaultFileSize));
+
+  clio::run::PoolId custom_pool_id(9141, 0);
+  clio::run::bdev::Client client(custom_pool_id);
+  bool created = BdevChimodFixture::CreateBdevAsync(
+      client, clio::run::PoolQuery::Broadcast(), fixture.getTestFile(),
+      custom_pool_id, clio::run::bdev::BdevType::kFile);
+  REQUIRE(created);
+
+  auto set_lifespan = client.AsyncSetLifespan(clio::run::PoolQuery::Local(), 3);
+  set_lifespan.Wait();
+  REQUIRE(set_lifespan->GetReturnCode() == 0);
+
+  clio::run::u64 remaining_size = 0;
+  auto stats_task = client.AsyncGetStats();
+  stats_task.Wait();
+  remaining_size = stats_task->remaining_size_;
+
+  REQUIRE(stats_task->predicted_ttl_days_ == 3);
+  REQUIRE(remaining_size > 0);
+
+  HLOG(kInfo, "Injected bdev lifespan: {} days", stats_task->predicted_ttl_days_);
+}
+
 TEST_CASE("bdev_error_conditions", "[bdev][error][edge_cases]") {
   BdevChimodFixture fixture;
 

--- a/context-transfer-engine/core/include/clio_cte/core/core_runtime.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_runtime.h
@@ -59,6 +59,16 @@ namespace clio::cte::core {
 
 
 /**
+ * Determine whether a target is eligible for blob placement under TTL rules.
+ *
+ * @param target Target metadata, including persistence and predicted TTL.
+ * @param min_persistence_level Minimum persistence level required by the blob.
+ * @return True when the target may receive the blob.
+ */
+bool IsTargetEligibleForBlob(const TargetInfo &target,
+                             int min_persistence_level);
+
+/**
  * CTE Core Runtime Container
  * Implements target management and tag/blob operations
  */

--- a/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
@@ -223,6 +223,7 @@ struct TargetInfo {
   clio::run::u64 remaining_space_;  // Remaining allocatable space in bytes
   clio::run::u64 max_capacity_;     // Total (max) capacity in bytes, fixed at register
   clio::run::bdev::PerfMetrics perf_metrics_;  // Performance metrics from bdev
+  clio::run::u32 expected_ttl_days_; // Predictive device TTL (defaults to 999999)
   clio::run::bdev::PersistenceLevel persistence_level_;
   // Underlying bdev type, captured at RegisterTarget time. Used by the
   // GPU metadata cache projection to decide whether a blob landed in a
@@ -239,6 +240,7 @@ struct TargetInfo {
         target_score_(0.0f),
         remaining_space_(0),
         max_capacity_(0),
+        expected_ttl_days_(999999),
         persistence_level_(clio::run::bdev::PersistenceLevel::kVolatile),
         bdev_type_(clio::run::bdev::BdevType::kFile) {}
 
@@ -253,6 +255,7 @@ struct TargetInfo {
         target_score_(0.0f),
         remaining_space_(0),
         max_capacity_(0),
+        expected_ttl_days_(999999),
         persistence_level_(clio::run::bdev::PersistenceLevel::kVolatile) {}
 #endif
 
@@ -269,6 +272,7 @@ struct TargetInfo {
         remaining_space_(other.remaining_space_),
         max_capacity_(other.max_capacity_),
         perf_metrics_(other.perf_metrics_),
+        expected_ttl_days_(other.expected_ttl_days_),
         persistence_level_(other.persistence_level_),
         bdev_type_(other.bdev_type_) {}
 
@@ -286,6 +290,7 @@ struct TargetInfo {
       remaining_space_ = other.remaining_space_;
       max_capacity_ = other.max_capacity_;
       perf_metrics_ = other.perf_metrics_;
+      expected_ttl_days_ = other.expected_ttl_days_;
       persistence_level_ = other.persistence_level_;
       bdev_type_ = other.bdev_type_;
     }

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -65,6 +65,27 @@
 
 namespace clio::cte::core {
 
+/**
+ * Decide whether a target should participate in blob placement.
+ *
+ * @param target Target metadata including predicted TTL and persistence.
+ * @param min_persistence_level Required minimum persistence tier.
+ * @return True if the target can safely accept the blob.
+ */
+bool IsTargetEligibleForBlob(const TargetInfo &target,
+                             int min_persistence_level) {
+  const clio::run::u32 ttl = target.expected_ttl_days_;
+  if (ttl > 7) {
+    return true;
+  }
+  if (ttl >= 1) {
+    return static_cast<int>(target.persistence_level_) <
+           static_cast<int>(clio::run::bdev::PersistenceLevel::kLongTerm) &&
+           static_cast<int>(target.persistence_level_) >= min_persistence_level;
+  }
+  return false;
+}
+
 // Bring chi namespace items into scope for CLIO_CUR_WORKER macro
 using clio::run::chi_cur_worker_key_;
 using clio::run::Worker;
@@ -747,6 +768,7 @@ clio::run::TaskResume Runtime::RegisterTarget(clio::run::shared_ptr<RegisterTarg
         total_size;  // Total (max) capacity, fixed for the life of the target
     target_info.perf_metrics_ =
         perf_metrics;  // Store the entire PerfMetrics structure
+    target_info.expected_ttl_days_ = stats_task->predicted_ttl_days_;
     target_info.persistence_level_ = GetPersistenceLevelForTarget(target_name);
     target_info.bdev_type_ = task->bdev_type_;
 
@@ -913,6 +935,7 @@ clio::run::TaskResume Runtime::StatTargets(clio::run::shared_ptr<StatTargetsTask
         if (target_info != nullptr) {
           target_info->perf_metrics_ = perf_metrics;
           target_info->remaining_space_ = remaining_size;
+          target_info->expected_ttl_days_ = stats_task->predicted_ttl_days_;
 
           float manual_score =
               GetManualScoreForTarget(target_info->target_name_.str());
@@ -937,9 +960,84 @@ clio::run::TaskResume Runtime::StatTargets(clio::run::shared_ptr<StatTargetsTask
               t.perf_metrics_ = target_info->perf_metrics_;
               t.remaining_space_ = target_info->remaining_space_;
               t.target_score_ = target_info->target_score_;
+              t.expected_ttl_days_ = target_info->expected_ttl_days_;
               break;
             }
           }
+        }
+      }
+
+      // Evacuation Check (Cordon & Drain)
+      // Per policy:
+      //   - If TTL < 1 day: Evacuate all blobs off this target immediately.
+      //   - If 1 <= TTL <= 7 days and it is a LongTerm device: Evacuate all blobs
+      //     off this target to move them to a healthy LongTerm target.
+      bool should_evacuate = false;
+      std::string target_name_str;
+      clio::run::PoolQuery target_query;
+      {
+        clio::run::ScopedCoRwReadLock read_lock(target_lock_);
+        TargetInfo *target_info = registered_targets_.find(target_id);
+        if (target_info != nullptr) {
+          target_name_str = target_info->target_name_.str();
+          target_query = target_info->target_query_;
+          clio::run::u32 ttl = target_info->expected_ttl_days_;
+          if (ttl < 1) {
+            should_evacuate = true;
+          } else if (ttl <= 7 && target_info->persistence_level_ ==
+                                     clio::run::bdev::PersistenceLevel::kLongTerm) {
+            should_evacuate = true;
+          }
+        }
+      }
+
+      if (should_evacuate) {
+        HLOG(kWarning,
+             "StatTargets: Target %s has degraded health. Evacuating all residing blobs...",
+             target_name_str.c_str());
+
+        // Find all blobs that have blocks on this target
+        std::vector<std::pair<TagId, std::string>> blobs_to_evacuate;
+        tag_blob_name_to_info_.for_each(
+            [&](const std::string &composite_key,
+                const std::shared_ptr<BlobInfo> &blob_info_sp) {
+              const BlobInfo &blob_info = *blob_info_sp;
+              for (const auto &block : blob_info.blocks_) {
+                if (block.bdev_client_.pool_id_ == target_id) {
+                  const size_t first_sep = composite_key.find('.');
+                  const size_t second_sep =
+                      (first_sep == std::string::npos)
+                          ? std::string::npos
+                          : composite_key.find('.', first_sep + 1);
+                  if (first_sep == std::string::npos ||
+                      second_sep == std::string::npos) {
+                    break;
+                  }
+                  TagId blob_tag_id(
+                      static_cast<clio::run::u32>(
+                          std::stoul(composite_key.substr(0, first_sep))),
+                      static_cast<clio::run::u32>(
+                          std::stoul(composite_key.substr(first_sep + 1,
+                                                          second_sep - first_sep - 1))));
+                  blobs_to_evacuate.push_back(
+                      std::make_pair(blob_tag_id,
+                                     composite_key.substr(second_sep + 1)));
+                  break;
+                }
+              }
+            },
+            ctp::priv::ForEachLock::kShared);
+
+        for (const auto &pair : blobs_to_evacuate) {
+          HLOG(kInfo, "StatTargets: Evacuating blob %s off failing target %s...",
+               pair.second.c_str(), target_name_str.c_str());
+
+          // Reorganize with the same score.
+          // Since the target has degraded TTL, new target selection (ExtendBlob)
+          // will automatically route this data to a healthy device.
+          auto reorg_task = client_.AsyncReorganizeBlob(
+              pair.first, pair.second, 0.99f, target_query);
+          CLIO_CO_AWAIT(reorg_task);
         }
       }
     }
@@ -3549,6 +3647,37 @@ clio::run::TaskResume Runtime::ExtendBlob(BlobInfo &blob_info, clio::run::u64 of
                        }),
         ordered_targets.end());
   }
+
+  // Filter by device health (TTL) using predictive failure model.
+  //
+  // Policy (per Luke Logan):
+  //   TTL > 7 days  → always accept the device regardless of data type.
+  //   TTL 1–7 days  → only accept if the data is volatile or nonvolatile
+  //                   (i.e., NOT long-term persistent). Short-lived data
+  //                   can still safely land on a degrading drive.
+  //   TTL < 1 day   → reject the device entirely; imminent failure.
+  ordered_targets.erase(
+      std::remove_if(
+          ordered_targets.begin(), ordered_targets.end(),
+          [min_persistence_level](const TargetInfo &t) {
+            const clio::run::u32 ttl = t.expected_ttl_days_;
+            if (ttl > 7) {
+              // Healthy device – always usable.
+              return false;
+            }
+            if (ttl >= 1) {
+              // Degrading device – only allow volatile / temporary data.
+              // Reject if caller requires long-term persistence.
+              return static_cast<int>(t.persistence_level_) >=
+                     static_cast<int>(
+                         clio::run::bdev::PersistenceLevel::kLongTerm);
+            }
+            // TTL < 1 day – device is effectively dead, always reject.
+            return true;
+          }),
+      ordered_targets.end());
+  HLOG(kDebug, "ExtendBlob: {} candidate target(s) after TTL health filter",
+       ordered_targets.size());
 
   if (ordered_targets.empty()) {
     error_code = 2;

--- a/context-transfer-engine/test/unit/test_cte_config_dpe.cc
+++ b/context-transfer-engine/test/unit/test_cte_config_dpe.cc
@@ -1,6 +1,7 @@
 #include "simple_test.h"
 #include <clio_cte/core/core_config.h>
 #include <clio_cte/core/core_dpe.h>
+#include <clio_cte/core/core_runtime.h>
 #include <fstream>
 #include <cstdlib>
 #include <filesystem>
@@ -660,6 +661,33 @@ TEST_CASE("MaxBwDpe SelectTargets - Score Filtering", "[cte][dpe]") {
   // Blob score is 0.3, should filter targets with score > 0.3
   std::vector<TargetInfo> result = dpe.SelectTargets(targets, 0.3f, 64 * 1024);
   REQUIRE(result.size() > 0);
+}
+
+TEST_CASE("IsTargetEligibleForBlob - TTL policy", "[cte][ttl]") {
+  TargetInfo healthy;
+  healthy.expected_ttl_days_ = 14;
+  healthy.persistence_level_ = clio::run::bdev::PersistenceLevel::kLongTerm;
+  REQUIRE(IsTargetEligibleForBlob(healthy,
+                                  static_cast<int>(
+                                      clio::run::bdev::PersistenceLevel::kLongTerm)));
+
+  TargetInfo degrading_short_lived;
+  degrading_short_lived.expected_ttl_days_ = 3;
+  degrading_short_lived.persistence_level_ =
+      clio::run::bdev::PersistenceLevel::kVolatile;
+  REQUIRE(IsTargetEligibleForBlob(
+      degrading_short_lived,
+      static_cast<int>(clio::run::bdev::PersistenceLevel::kVolatile)));
+  REQUIRE_FALSE(IsTargetEligibleForBlob(
+      degrading_short_lived,
+      static_cast<int>(clio::run::bdev::PersistenceLevel::kLongTerm)));
+
+  TargetInfo failing;
+  failing.expected_ttl_days_ = 0;
+  failing.persistence_level_ = clio::run::bdev::PersistenceLevel::kVolatile;
+  REQUIRE_FALSE(IsTargetEligibleForBlob(
+      failing,
+      static_cast<int>(clio::run::bdev::PersistenceLevel::kVolatile)));
 }
 
 TEST_CASE("DpeFactory CreateDpe - By Enum kRandom", "[cte][dpe]") {

--- a/prediction_server/models/ssd_rolling_model.pkl
+++ b/prediction_server/models/ssd_rolling_model.pkl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ab2e1b2aac7824f3ca1a5369b01015d67e624058bc94621c146c32413361bfa7
-size 5686
+oid sha256:68e9d2363a7dc373c6d60d6d46f0b6a0eb0a0bac66e2d53876f9f34d229fe5ea
+size 33857398

--- a/prediction_server/models/ssd_static_model.pkl
+++ b/prediction_server/models/ssd_static_model.pkl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ab2e1b2aac7824f3ca1a5369b01015d67e624058bc94621c146c32413361bfa7
-size 5686
+oid sha256:68e9d2363a7dc373c6d60d6d46f0b6a0eb0a0bac66e2d53876f9f34d229fe5ea
+size 33857398

--- a/prediction_server/server.py
+++ b/prediction_server/server.py
@@ -507,8 +507,12 @@ def drive_history(drive_id: str):
 
 if __name__ == "__main__":
     import argparse
+    import os
+    # Resolve the models directory relative to this script's location
+    default_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'models')
+    
     parser = argparse.ArgumentParser()
-    parser.add_argument('--model-dir', type=str, default='models')
+    parser.add_argument('--model-dir', type=str, default=default_dir)
     parser.add_argument('--port', type=int, default=8000)
     parser.add_argument('--db', type=str, default='drive_history.db')
     args = parser.parse_args()


### PR DESCRIPTION
Adds the bdev lifespan injection API, propagates predicted TTL into CTE target metadata, and updates the tiered allocation policy and unit tests. Also includes the prediction server updates and SSD model artifacts used by the tiered system.