### PR TITLE
feat(vfd): implement additional HDF5 VFD callbacks.

### DIFF
--- a/context-transfer-engine/adapter/vfd/H5FDclio.cc
+++ b/context-transfer-engine/adapter/vfd/H5FDclio.cc
@@ -110,6 +110,12 @@ static herr_t H5FD__clio_read(H5FD_t *_file, H5FD_mem_t type, hid_t fapl_id,
                                 haddr_t addr, size_t size, void *buf);
 static herr_t H5FD__clio_write(H5FD_t *_file, H5FD_mem_t type, hid_t fapl_id,
                                  haddr_t addr, size_t size, const void *buf);
+static herr_t H5FD__clio_get_handle(H5FD_t *_file, hid_t fapl,
+                                    void **file_handle);
+static herr_t H5FD__clio_flush(H5FD_t *_file, hid_t dxpl_id, bool closing);
+static herr_t H5FD__clio_truncate(H5FD_t *_file, hid_t dxpl_id, bool closing);
+static herr_t H5FD__clio_lock(H5FD_t *_file, bool rw);
+static herr_t H5FD__clio_unlock(H5FD_t *_file);
 
 static const H5FD_class_t H5FD_clio_g = {
     H5FD_CLASS_VERSION,   /* struct version       */
@@ -137,18 +143,18 @@ static const H5FD_class_t H5FD_clio_g = {
     NULL,                 /* free                 */
     H5FD__clio_get_eoa, /* get_eoa              */
     H5FD__clio_set_eoa, /* set_eoa              */
-    H5FD__clio_get_eof, /* get_eof              */
-    NULL,                 /* get_handle           */
-    H5FD__clio_read,    /* read                 */
-    H5FD__clio_write,   /* write                */
-    NULL,                 /* read_vector          */
-    NULL,                 /* write_vector         */
-    NULL,                 /* read_selection       */
-    NULL,                 /* write_selection      */
-    NULL,                 /* flush                */
-    NULL,                 /* truncate             */
-    NULL,                 /* lock                 */
-    NULL,                 /* unlock               */
+    H5FD__clio_get_eof,    /* get_eof            */
+    H5FD__clio_get_handle, /* get_handle         */
+    H5FD__clio_read,       /* read               */
+    H5FD__clio_write,      /* write              */
+    NULL,                  /* read_vector        */
+    NULL,                  /* write_vector       */
+    NULL,                  /* read_selection     */
+    NULL,                  /* write_selection    */
+    H5FD__clio_flush,      /* flush              */
+    H5FD__clio_truncate,   /* truncate           */
+    H5FD__clio_lock,       /* lock               */
+    H5FD__clio_unlock,     /* unlock             */
     NULL,                 /* del                  */
     NULL,                 /* ctl                  */
     H5FD_FLMAP_DICHOTOMY  /* fl_map               */
@@ -510,6 +516,120 @@ static herr_t H5FD__clio_write(H5FD_t *_file, H5FD_mem_t type, hid_t dxpl_id,
   }
   return SUCCEED;
 } /* end H5FD__clio_write() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__clio_get_handle
+ *
+ * Purpose:     Returns the POSIX file descriptor of the authoritative native
+ *              file, for consumers (tools, the core VFD) that expect a real OS
+ *              handle. Behaves like sec2.
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ *-------------------------------------------------------------------------
+ */
+static herr_t H5FD__clio_get_handle(H5FD_t *_file, hid_t fapl,
+                                    void **file_handle) {
+  (void)fapl;
+  H5FD_clio_t *file = (H5FD_clio_t *)_file;
+  if (!file_handle) {
+    return FAIL;
+  }
+  *file_handle = &(file->posix_fd);
+  return SUCCEED;
+} /* end H5FD__clio_get_handle() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__clio_flush
+ *
+ * Purpose:     Durability barrier: fsync the authoritative native file so a
+ *              successful H5Fflush/H5Dflush leaves no pending dirty state on
+ *              disk. Fail-closed if the fsync fails.
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ *-------------------------------------------------------------------------
+ */
+static herr_t H5FD__clio_flush(H5FD_t *_file, hid_t dxpl_id, bool closing) {
+  (void)dxpl_id;
+  (void)closing;
+  H5FD_clio_t *file = (H5FD_clio_t *)_file;
+  if (file->posix_fd >= 0 && fsync(file->posix_fd) < 0) {
+    return FAIL; /* never report a flush that did not persist */
+  }
+  return SUCCEED;
+} /* end H5FD__clio_flush() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__clio_truncate
+ *
+ * Purpose:     Truncate the authoritative native file to the end-of-address
+ *              marker so close-to-EOA yields the correct on-disk file size
+ *              (a byte-exact native image). Behaves like sec2.
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ *-------------------------------------------------------------------------
+ */
+static herr_t H5FD__clio_truncate(H5FD_t *_file, hid_t dxpl_id, bool closing) {
+  (void)dxpl_id;
+  (void)closing;
+  H5FD_clio_t *file = (H5FD_clio_t *)_file;
+  if (file->eof != file->eoa) {
+    if (file->posix_fd >= 0 &&
+        ftruncate(file->posix_fd, (off_t)file->eoa) < 0) {
+      return FAIL;
+    }
+    // Keep the CTE cache's logical size in step (best-effort; populate-only
+    // tier, see the write callback).
+    if (file->fd >= 0) {
+      CLIO_CTE_CFS->FtruncateFd(file->fd, (off_t)file->eoa);
+    }
+    file->eof = file->eoa;
+  }
+  return SUCCEED;
+} /* end H5FD__clio_truncate() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__clio_lock / H5FD__clio_unlock
+ *
+ * Purpose:     Advisory whole-file locking (flock) on the authoritative native
+ *              fd, for file locking / SWMR / concurrent-tool safety. Behaves
+ *              like sec2: non-blocking flock, and a filesystem that does not
+ *              support locking (ENOSYS) is not treated as an error.
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ *-------------------------------------------------------------------------
+ */
+static herr_t H5FD__clio_lock(H5FD_t *_file, bool rw) {
+  H5FD_clio_t *file = (H5FD_clio_t *)_file;
+  if (file->posix_fd < 0) {
+    return SUCCEED;
+  }
+  int lock_flags = (rw ? LOCK_EX : LOCK_SH) | LOCK_NB;
+  if (flock(file->posix_fd, lock_flags) < 0) {
+    if (errno == ENOSYS) {
+      return SUCCEED; /* locking unsupported here: not an error (sec2 parity) */
+    }
+    return FAIL;
+  }
+  return SUCCEED;
+} /* end H5FD__clio_lock() */
+
+static herr_t H5FD__clio_unlock(H5FD_t *_file) {
+  H5FD_clio_t *file = (H5FD_clio_t *)_file;
+  if (file->posix_fd < 0) {
+    return SUCCEED;
+  }
+  if (flock(file->posix_fd, LOCK_UN) < 0) {
+    if (errno == ENOSYS) {
+      return SUCCEED;
+    }
+    return FAIL;
+  }
+  return SUCCEED;
+} /* end H5FD__clio_unlock() */
 
 /*
  * Entry points for dynamic plugin loading.

--- a/context-transfer-engine/test/unit/adapters/vfd/test_vfd_adapter.cc
+++ b/context-transfer-engine/test/unit/adapters/vfd/test_vfd_adapter.cc
@@ -26,7 +26,13 @@
  */
 #include <hdf5.h>
 
+#include <fcntl.h>
+#include <sys/file.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
 #include <algorithm>
+#include <cerrno>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -366,6 +372,83 @@ int main() {
     CHECK(H5Lexists(rb, "a", H5P_DEFAULT) <= 0, "6: B has no cross-talk from A");
     CHECK(H5Fclose(ra) >= 0 && H5Fclose(rb) >= 0, "6: close both (read)");
     std::printf("[vfd-suite] ok 6: two files open simultaneously (no cross-talk)\n");
+  }
+
+  // === 7. flush callback + get_handle ====================================
+  // After H5Fflush the native file is a valid HDF5 image readable independently
+  // of the VFD (the flush callback ran and the write-through reached the fd).
+  // NOTE: this observes the *functional* barrier, not the fsync-to-platter --
+  // an in-process read hits the same page cache, so durability itself is not
+  // unit-observable. get_handle must hand back the authoritative POSIX fd.
+  {
+    const char *kClioFl = "clio::/tmp/clio_cte_vfd_flush.h5";
+    const char *kNativeFl = "/tmp/clio_cte_vfd_flush.h5";
+    std::remove(kNativeFl);
+    hid_t f = H5Fcreate(kClioFl, H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
+    CHECK(f >= 0, "7: create");
+    CHECK(WriteDset(f, "d", H5T_NATIVE_INT32, MakeI32(kSmall)), "7: write");
+    CHECK(H5Fflush(f, H5F_SCOPE_GLOBAL) >= 0, "7: H5Fflush (flush callback)");
+    // The HDF5 superblock signature must be on the fd now, read via plain POSIX.
+    int rfd = ::open(kNativeFl, O_RDONLY);
+    CHECK(rfd >= 0, "7: POSIX-open native file mid-session");
+    unsigned char sig[8] = {0};
+    ssize_t n = ::pread(rfd, sig, sizeof(sig), 0);
+    ::close(rfd);
+    const unsigned char kHdf5Sig[8] = {0x89, 'H', 'D', 'F',  '\r',
+                                       '\n', 0x1a, '\n'};
+    CHECK(n == 8 && std::memcmp(sig, kHdf5Sig, 8) == 0,
+          "7: valid HDF5 superblock on disk after H5Fflush");
+    // get_handle returns the authoritative POSIX fd -- verify it is THIS file's
+    // fd (same device+inode as the native path), not merely some valid fd.
+    void *vh = nullptr;
+    CHECK(H5Fget_vfd_handle(f, H5P_DEFAULT, &vh) >= 0, "7: H5Fget_vfd_handle");
+    CHECK(vh != nullptr, "7: handle non-null");
+    int gfd = *static_cast<int *>(vh);
+    struct stat gst, nst;
+    CHECK(gfd >= 0 && ::fstat(gfd, &gst) == 0, "7: get_handle fd is valid");
+    CHECK(::stat(kNativeFl, &nst) == 0 && gst.st_dev == nst.st_dev &&
+              gst.st_ino == nst.st_ino,
+          "7: get_handle fd points at the authoritative native file");
+    CHECK(H5Fclose(f) >= 0, "7: close");
+    std::printf("[vfd-suite] ok 7: flush callback + get_handle\n");
+  }
+
+  // NOTE: the truncate callback is exercised on every close (HDF5 sizes the
+  // file to EOA there) and is covered transitively -- a broken truncate would
+  // corrupt the image, which the round-trip / h5diff / tool-matrix sections
+  // catch. There is no clean *isolated* truncate assertion at this layer:
+  // HDF5's EOA is not exposed independently of the driver's own get_eof, and
+  // comparing on-disk size to sec2 is confounded by the metadata-aggregation
+  // feature flags (a separate change) that alter HDF5's allocation.
+
+  // === 8. lock excludes a concurrent opener; unlock releases =============
+  // Force HDF5 file locking on, so create takes an exclusive flock via the lock
+  // callback. flock conflicts across independent open descriptions (even same
+  // process), so an independent flock is denied while held and granted after
+  // the VFD unlocks on close.
+  {
+    const char *kClioLk = "clio::/tmp/clio_cte_vfd_lock.h5";
+    const char *kNativeLk = "/tmp/clio_cte_vfd_lock.h5";
+    std::remove(kNativeLk);
+    hid_t fapl_lk = H5Pcopy(fapl);
+    CHECK(fapl_lk >= 0, "8: H5Pcopy fapl");
+    CHECK(H5Pset_file_locking(fapl_lk, /*use*/ true, /*ignore_disabled*/ false) >= 0,
+          "8: force file locking on");
+    hid_t f = H5Fcreate(kClioLk, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_lk);
+    CHECK(f >= 0, "8: create (VFD takes exclusive lock)");
+    int p = ::open(kNativeLk, O_RDWR);
+    CHECK(p >= 0, "8: POSIX-open native file");
+    errno = 0;
+    int held = ::flock(p, LOCK_EX | LOCK_NB);
+    CHECK(held < 0 && (errno == EWOULDBLOCK || errno == EAGAIN),
+          "8: independent flock denied while the VFD holds the lock");
+    CHECK(H5Fclose(f) >= 0, "8: close (VFD unlocks)");
+    int freed = ::flock(p, LOCK_EX | LOCK_NB);
+    CHECK(freed == 0, "8: independent flock granted after the VFD unlocks");
+    ::flock(p, LOCK_UN);
+    ::close(p);
+    H5Pclose(fapl_lk);
+    std::printf("[vfd-suite] ok 8: lock excludes a concurrent opener; unlock releases\n");
   }
 
   H5Pclose(fapl);


### PR DESCRIPTION
This PR implements the VFD callback operations that  #718. left unimplemented, those being flush, truncate, get_handle, and lock/unlock. With these in place the CLIO driver covers mostly the same operational surface as HDF5's built-in default driver.

A few caveats:

- get_handle works but isn't advertised yet. The driver hands back a real POSIX descriptor, but HDF5 won't treat it as POSIX-compatible until the driver also reports the matching feature flag.
- Durability can't be fully proven in a unit test. flush fsyncs, but an in-process read hits the same page cache, so a test can't actually observe the bytes reaching the platter. Locking, by contrast, is fully testable: flock conflicts across independent file descriptors even within one process, so the test proves exclusion without needing a second process.
- truncate has no isolated test, since HDF5 doesn't expose its logical end-of-file independently of the driver, and comparing on-disk size against sec2 doesn't work because this driver currently produces a slightly smaller file than sec2 for identical content, as it doesn't yet advertise the metadata-aggregation feature flags that change how HDF5 lays data out. So truncate is left to indirect coverage in the tests.