### PR TITLE
fix(kvhdf5): pin gray-scott GPU e2e test to gpu 0 (multi-GPU CUDA Error 700)

### DIFF
--- a/context-transfer-engine/adapter/kvhdf5/test/e2e/gray_scott_gpu_test.cu
+++ b/context-transfer-engine/adapter/kvhdf5/test/e2e/gray_scott_gpu_test.cu
@@ -115,6 +115,16 @@ TEST_CASE("GPU Gray-Scott end-to-end snapshots via dataset handle",
       ipc->GetGpuIpcManager()->GetGpuInfo(/*gpu_id=*/0);
   REQUIRE(gpu_info.gpu2cpu_queue != nullptr);
 
+  // Pin THIS host thread to the same GPU the datasets and snapshot kernels use
+  // (gpu 0). The shared CLIO runtime initialises every GPU on the node and
+  // leaves the current device set to the last one, so on a multi-GPU host the
+  // working grids below would otherwise be cudaMalloc'd on a different device
+  // than where GsSnapKernel launches — the dataset ctor's SetDevice(0) only
+  // runs later, mid-loop — making the kernel's read of `src` an illegal access
+  // (CUDA Error 700). Setting it up front keeps grids, dataset buffers, and
+  // launches all on gpu 0. (Single-GPU CI never exposed this.)
+  ctp::GpuApi::SetDevice(/*gpu_id=*/0);
+
   // ---- Working grids: 4 plain device buffers, ping-pong u/v. ----
   float *u_curr = nullptr, *u_next = nullptr, *v_curr = nullptr, *v_next = nullptr;
   REQUIRE(cudaMalloc(&u_curr, kBytes) == cudaSuccess);


### PR DESCRIPTION
## What

Pin the "GPU Gray-Scott end-to-end snapshots via dataset handle" e2e test to gpu 0 before it allocates its working grids:

```cpp
ctp::GpuApi::SetDevice(/*gpu_id=*/0);
```

## Why

On a **multi-GPU host** the test fails with **CUDA Error 700 (illegal memory access)**. The shared CLIO runtime initialises every GPU and leaves the current device set to the last one, so the grids get `cudaMalloc`'d on a non-zero GPU. The `GpuCteDataset` ctor's `SetDevice(0)` only runs later (mid-loop), so `GsSnapKernel` launches on gpu 0 and reads `src` (a grid on another device) → illegal access. `GsStepKernel` passed only because it ran before the device switch. Full root-cause analysis in the linked issue.

Single-GPU CI never exposed this. Found via the full `ctest -D Experimental` on TACC Frontera (4× RTX 5000, sm_75), pinned down with `compute-sanitizer` + a device `printf` (which confirmed the args were correct → device-placement bug, not corruption).

## Verification

- The isolated test now round-trips all 3 snapshots: `All tests passed (18 assertions in 1 test case)`.
- Full Debug `ctest -D Experimental` with GPU tests enabled on Frontera: all previously-passing tests remain green and this one now passes.

Closes #735
