### PR TITLE
fix(logging): route all log levels to stderr, not stdout

### DIFF
--- a/context-transport-primitives/include/clio_ctp/util/logging.h
+++ b/context-transport-primitives/include/clio_ctp/util/logging.h
@@ -223,7 +223,10 @@ class Logger {
 #if CTP_IS_HOST && !CTP_IS_DEVICE_PASS
     std::string msg = ctp::Formatter::format(fmt, std::forward<Args>(args)...);
     std::string out = ctp::Formatter::format("{}\n", msg);
-    std::cout << out;
+    // Logs go to stderr, never stdout: stdout is reserved for a program's actual
+    // data output (e.g. h5dump through the CTE VOL connector), which log lines
+    // would otherwise corrupt.
+    std::cerr << out;
     if (fout_) {
       fwrite(out.data(), 1, out.size(), fout_);
     }
@@ -248,15 +251,11 @@ class Logger {
         "{}{}:{} {} {} {} {}{}\n",
         color, path, line, level, tid, func, msg, reset);
 
-    // Route to appropriate output stream
-    // Debug, Info, and Success go to stdout; Warning/Error/Fatal go to stderr
-    if (LOG_CODE <= kSuccess) {
-      std::cout << out;
-      fflush(stdout);
-    } else {
-      std::cerr << out;
-      fflush(stderr);
-    }
+    // All log levels go to stderr. stdout is reserved for a program's actual
+    // data output — e.g. h5dump reading through the CTE HDF5 VOL connector emits
+    // the dumped dataset on stdout, and any log line written there corrupts it.
+    std::cerr << out;
+    fflush(stderr);
 
     // Write to file without color codes
     if (fout_) {


### PR DESCRIPTION
## Problem

`ctp::Logger` (`context-transport-primitives/include/clio_ctp/util/logging.h`) routed **Debug/Info/Success** to `std::cout` and only Warning/Error/Fatal to `std::cerr`. Client-side runtime logs (e.g. on `ClientInit`) therefore land on **stdout**, corrupting the data stream of any program that uses stdout for its output.

Most visibly, `h5dump` (and `h5py`/`neuroh5`) reading through the **`clio` HDF5 VOL connector** (`HDF5_VOL_CONNECTOR=clio`) get ~12 `INFO` lines interleaved into the dumped dataset, so the output can't be piped/diffed/parsed without stripping log lines first.

## Fix

Route **all** log levels to `std::cerr`. stdout is reserved for a program's actual data output; diagnostics belong on stderr. `Logger::Print()` is updated the same way.

## Verification

On a 4-node CTE cluster, a full-file `h5dump <case6.h5>` through the `clio` VOL connector is now **byte-identical to a native read with no stripping** (0 log lines on stdout), and the runtime `INFO` lines correctly appear on **stderr**.

Fixes #740