### PR TITLE
Add I/O emulation mode to CTE PutBlob/GetBlob

### DIFF
--- a/context-runtime/modules/bdev/include/clio_runtime/bdev/bdev_runtime.h
+++ b/context-runtime/modules/bdev/include/clio_runtime/bdev/bdev_runtime.h
@@ -74,9 +74,59 @@ class Runtime : public clio::run::Container {
   void AggregateOut(clio::run::u32 method, clio::run::shared_ptr<clio::run::Task> &orig_task,
                  const clio::run::shared_ptr<clio::run::Task>& replica_task) override;
 
+ public:
+  // ---------------------------------------------------------------------
+  // Perf-stats persistence (issue #747).
+  //
+  // The bdev's real performance knowledge lives in two places: the
+  // PerfMetrics snapshot (bandwidth/latency/iops) and the runtime's learned
+  // per-method wall-clock model coefficients (method_model_wall_[kRead/
+  // kWrite]) that GetStats derives its bandwidth numbers from. Both are
+  // saved to a small per-bdev stats file so a restarted session starts from
+  // the previous session's estimates instead of re-learning from the 1.0
+  // model seed. Files live under $CLIO_BDEV_STATS_DIR (default
+  // <home>/.clio/bdev_perf), keyed by the sanitized pool name.
+  //
+  // The file helpers are static so they can be unit-tested without a
+  // running container.
+  // ---------------------------------------------------------------------
+
+  /** Resolve the stats-file path for a bdev pool name. */
+  static std::string MakePerfStatsPath(const std::string &pool_name);
+
+  /**
+   * Write a perf-stats file (small text format, tmp+rename).
+   * @param path Destination file
+   * @param metrics Perf metrics snapshot
+   * @param model_wall_read Learned wall-model coefficient for kRead
+   * @param model_wall_write Learned wall-model coefficient for kWrite
+   * @return true on success
+   */
+  static bool SavePerfStatsFile(const std::string &path,
+                                const PerfMetrics &metrics,
+                                float model_wall_read, float model_wall_write);
+
+  /**
+   * Read a perf-stats file previously written by SavePerfStatsFile.
+   * @param path Source file
+   * @param metrics Output metrics (only overwritten on success)
+   * @param model_wall_read Output kRead wall coefficient
+   * @param model_wall_write Output kWrite wall coefficient
+   * @return true if the file existed and parsed
+   */
+  static bool LoadPerfStatsFile(const std::string &path, PerfMetrics &metrics,
+                                float &model_wall_read,
+                                float &model_wall_write);
+
  private:
+  /** Load persisted stats into perf_metrics_ + the wall model (Create). */
+  void LoadPerfStats();
+
+  /** Persist current stats, throttled to one write per ~10s (GetStats). */
+  void SavePerfStats(bool force);
+
   Client client_;
-  BdevType bdev_type_;                            
+  BdevType bdev_type_;
 
   std::unique_ptr<BdevTransport> transport_;
 
@@ -85,8 +135,13 @@ class Runtime : public clio::run::Container {
   std::atomic<clio::run::u64> total_bytes_read_;
   std::atomic<clio::run::u64> total_bytes_written_;
   std::chrono::high_resolution_clock::time_point start_time_;
-  
+
   PerfMetrics perf_metrics_;
+
+  // Perf-stats persistence state (issue #747)
+  std::string perf_stats_path_;
+  std::chrono::steady_clock::time_point last_perf_save_{};
+  static constexpr double kPerfSaveThrottleSec = 10.0;
 
   size_t GetWorkerID(clio::run::RunContext& rctx);
 

--- a/context-runtime/modules/bdev/src/bdev_runtime.cc
+++ b/context-runtime/modules/bdev/src/bdev_runtime.cc
@@ -12,15 +12,154 @@
 #include <clio_ctp/serialize/msgpack_wrapper.h>
 
 #include <algorithm>
+#include <cctype>
 #include <cmath>
 #include <cstdio>
 #include <cstring>
+#include <filesystem>
+#include <fstream>
 #include <limits>
 #include <thread>
 
 #include "clio_ctp/util/timer.h"
 
 namespace clio::run::bdev {
+
+// ---------------------------------------------------------------------------
+// Perf-stats persistence (issue #747)
+// ---------------------------------------------------------------------------
+
+namespace {
+constexpr const char *kPerfStatsHeader = "clio_bdev_perf_v1";
+}  // namespace
+
+std::string Runtime::MakePerfStatsPath(const std::string &pool_name) {
+  // Master off-switch: CLIO_BDEV_PERSIST_STATS=0 disables persistence
+  // entirely (e.g. benchmarks that must start from a cold model).
+  if (ctp::SystemInfo::Getenv("CLIO_BDEV_PERSIST_STATS") == "0") {
+    return std::string();
+  }
+  std::string dir = ctp::SystemInfo::Getenv("CLIO_BDEV_STATS_DIR");
+  if (dir.empty()) {
+    std::string home = ctp::SystemInfo::GetHomeDir();
+    if (home.empty()) {
+      return std::string();  // nowhere to persist
+    }
+    dir = home + "/.clio/bdev_perf";
+  }
+  // Sanitize the pool name (it may be a filesystem path or "ram::name")
+  // into a flat file name.
+  std::string name = pool_name;
+  for (char &c : name) {
+    if (!std::isalnum(static_cast<unsigned char>(c)) && c != '.' && c != '-') {
+      c = '_';
+    }
+  }
+  return dir + "/" + name + ".perf";
+}
+
+bool Runtime::SavePerfStatsFile(const std::string &path,
+                                const PerfMetrics &metrics,
+                                float model_wall_read,
+                                float model_wall_write) {
+  if (path.empty()) return false;
+  try {
+    namespace fs = std::filesystem;
+    fs::create_directories(fs::path(path).parent_path());
+    // Write to a tmp file then rename so a crash mid-write never leaves a
+    // truncated stats file for the next session to trip over.
+    const std::string tmp = path + ".tmp";
+    {
+      std::ofstream ofs(tmp, std::ios::trunc);
+      if (!ofs.is_open()) return false;
+      ofs << kPerfStatsHeader << "\n"
+          << "read_bandwidth_mbps " << metrics.read_bandwidth_mbps_ << "\n"
+          << "write_bandwidth_mbps " << metrics.write_bandwidth_mbps_ << "\n"
+          << "read_latency_us " << metrics.read_latency_us_ << "\n"
+          << "write_latency_us " << metrics.write_latency_us_ << "\n"
+          << "iops " << metrics.iops_ << "\n"
+          << "model_wall_read " << model_wall_read << "\n"
+          << "model_wall_write " << model_wall_write << "\n";
+      if (!ofs.good()) return false;
+    }
+    std::error_code ec;
+    fs::remove(path, ec);  // Windows rename does not overwrite
+    fs::rename(tmp, path, ec);
+    return !ec;
+  } catch (const std::exception &) {
+    return false;
+  }
+}
+
+bool Runtime::LoadPerfStatsFile(const std::string &path, PerfMetrics &metrics,
+                                float &model_wall_read,
+                                float &model_wall_write) {
+  if (path.empty()) return false;
+  std::ifstream ifs(path);
+  if (!ifs.is_open()) return false;
+  std::string header;
+  if (!std::getline(ifs, header) || header != kPerfStatsHeader) {
+    return false;
+  }
+  PerfMetrics m;
+  float wall_read = 0.0f;
+  float wall_write = 0.0f;
+  std::string key;
+  double value = 0.0;
+  while (ifs >> key >> value) {
+    if (key == "read_bandwidth_mbps") m.read_bandwidth_mbps_ = value;
+    else if (key == "write_bandwidth_mbps") m.write_bandwidth_mbps_ = value;
+    else if (key == "read_latency_us") m.read_latency_us_ = value;
+    else if (key == "write_latency_us") m.write_latency_us_ = value;
+    else if (key == "iops") m.iops_ = value;
+    else if (key == "model_wall_read") wall_read = static_cast<float>(value);
+    else if (key == "model_wall_write") wall_write = static_cast<float>(value);
+    // Unknown keys are ignored (forward compatibility).
+  }
+  metrics = m;
+  model_wall_read = wall_read;
+  model_wall_write = wall_write;
+  return true;
+}
+
+void Runtime::LoadPerfStats() {
+  perf_stats_path_ = MakePerfStatsPath(pool_name_);
+  PerfMetrics m;
+  float wall_read = 0.0f;
+  float wall_write = 0.0f;
+  if (!LoadPerfStatsFile(perf_stats_path_, m, wall_read, wall_write)) {
+    return;  // first session for this bdev — keep configured defaults
+  }
+  perf_metrics_ = m;
+  // Seed the learned wall-clock model so InferWallClockTime (which GetStats
+  // derives its bandwidth from) starts warm instead of at the 1.0 seed.
+  if (wall_read > 0.0f && Method::kRead < method_model_wall_.size()) {
+    method_model_wall_[Method::kRead] = wall_read;
+  }
+  if (wall_write > 0.0f && Method::kWrite < method_model_wall_.size()) {
+    method_model_wall_[Method::kWrite] = wall_write;
+  }
+  HLOG(kInfo,
+       "bdev '{}': restored perf stats from {} (read {} MB/s, write {} MB/s)",
+       pool_name_, perf_stats_path_, perf_metrics_.read_bandwidth_mbps_,
+       perf_metrics_.write_bandwidth_mbps_);
+}
+
+void Runtime::SavePerfStats(bool force) {
+  if (perf_stats_path_.empty()) return;
+  auto now = std::chrono::steady_clock::now();
+  if (!force &&
+      std::chrono::duration<double>(now - last_perf_save_).count() <
+          kPerfSaveThrottleSec) {
+    return;
+  }
+  last_perf_save_ = now;
+  float wall_read = (Method::kRead < method_model_wall_.size())
+                        ? method_model_wall_[Method::kRead] : 0.0f;
+  float wall_write = (Method::kWrite < method_model_wall_.size())
+                         ? method_model_wall_[Method::kWrite] : 0.0f;
+  SavePerfStatsFile(perf_stats_path_, perf_metrics_, wall_read, wall_write);
+}
 
 clio::run::TaskStat Runtime::GetTaskStats(const clio::run::Task *task) const {
   if (!task) return clio::run::TaskStat();
@@ -84,6 +223,12 @@ clio::run::TaskResume Runtime::Create(clio::run::shared_ptr<CreateTask> &task) {
   total_writes_ = 0;
   total_bytes_read_ = 0;
   total_bytes_written_ = 0;
+
+  // Restore persisted performance stats from a previous session (issue
+  // #747) so the latency-bandwidth model does not have to be re-estimated
+  // on every startup. Overrides the configured defaults when a stats file
+  // exists.
+  LoadPerfStats();
 
   task->return_code_ = 0;
   CLIO_CO_RETURN;
@@ -218,6 +363,24 @@ clio::run::TaskResume Runtime::GetStats(clio::run::shared_ptr<GetStatsTask> &tas
     task->remaining_size_ = 0;
   }
 
+  // Cache the derived metrics and persist them (throttled) so the next
+  // session starts from this one's estimates (issue #747). Merge field-wise:
+  // a zero derived value (model not warmed up yet) must not clobber a
+  // configured/restored stat.
+  if (task->metrics_.read_bandwidth_mbps_ > 0.0) {
+    perf_metrics_.read_bandwidth_mbps_ = task->metrics_.read_bandwidth_mbps_;
+  }
+  if (task->metrics_.write_bandwidth_mbps_ > 0.0) {
+    perf_metrics_.write_bandwidth_mbps_ = task->metrics_.write_bandwidth_mbps_;
+  }
+  if (task->metrics_.read_latency_us_ > 0.0) {
+    perf_metrics_.read_latency_us_ = task->metrics_.read_latency_us_;
+  }
+  if (task->metrics_.write_latency_us_ > 0.0) {
+    perf_metrics_.write_latency_us_ = task->metrics_.write_latency_us_;
+  }
+  SavePerfStats(/*force=*/false);
+
   task->return_code_ = 0;
   CLIO_CO_RETURN;
   CLIO_TASK_BODY_END
@@ -225,6 +388,9 @@ clio::run::TaskResume Runtime::GetStats(clio::run::shared_ptr<GetStatsTask> &tas
 
 clio::run::TaskResume Runtime::Destroy(clio::run::shared_ptr<DestroyTask> &task) {
   CLIO_TASK_BODY_BEGIN
+  // Final perf-stats save (unthrottled) so the next session inherits
+  // everything learned in this one (issue #747).
+  SavePerfStats(/*force=*/true);
   if (transport_) {
     transport_->Destroy();
     transport_.reset();

--- a/context-transfer-engine/core/include/clio_cte/core/core_client.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_client.h
@@ -281,6 +281,7 @@ class Client : public clio::run::ContainerClient {
    * @param flags Operation flags
    * @param blob_data Shared memory pointer for output
    * @param pool_query Pool query for task routing (default: Dynamic)
+   * @param context Context for I/O emulation control (issue #747)
    */
   clio::run::Future<GetBlobTask> AsyncGetBlob(
       const TagId &tag_id,
@@ -288,12 +289,13 @@ class Client : public clio::run::ContainerClient {
       clio::run::u64 offset, clio::run::u64 size,
       clio::run::u32 flags,
       ctp::ipc::ShmPtr<> blob_data,
-      const clio::run::PoolQuery &pool_query = clio::run::PoolQuery::Dynamic()) {
+      const clio::run::PoolQuery &pool_query = clio::run::PoolQuery::Dynamic(),
+      const Context &context = Context()) {
     auto *ipc_manager = CLIO_CPU_IPC;
 
     auto task = ipc_manager->NewTask<GetBlobTask>(
         clio::run::CreateTaskId(), pool_id_, pool_query, tag_id,
-        blob_name, offset, size, flags, blob_data);
+        blob_name, offset, size, flags, blob_data, context);
 
     return ipc_manager->Send(task);
   }
@@ -305,9 +307,10 @@ class Client : public clio::run::ContainerClient {
       clio::run::u64 offset, clio::run::u64 size,
       clio::run::u32 flags,
       ctp::ipc::ShmPtr<> blob_data,
-      const clio::run::PoolQuery &pool_query = clio::run::PoolQuery::Dynamic()) {
+      const clio::run::PoolQuery &pool_query = clio::run::PoolQuery::Dynamic(),
+      const Context &context = Context()) {
     return AsyncGetBlob(tag_id, blob_name.c_str(), offset, size,
-                        flags, blob_data, pool_query);
+                        flags, blob_data, pool_query, context);
   }
 
   /**

--- a/context-transfer-engine/core/include/clio_cte/core/core_runtime.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_runtime.h
@@ -650,6 +650,25 @@ private:
                            size_t data_size, size_t data_offset_in_blob, clio::run::u32 &error_code);
 
   /**
+   * Model the wall time of a data transfer over the blocks overlapping
+   * [offset, offset+size) WITHOUT performing it (I/O emulation, issue #747).
+   * Bytes are aggregated per target; each target contributes
+   * latency + bytes/bandwidth from its measured PerfMetrics (fallback
+   * constants when a target is unknown or reports zero), and the result is
+   * the max across targets — blocks on different targets transfer
+   * concurrently, blocks on the same target serialize on the device.
+   * @param blocks Block layout of the blob (snapshot or live under the
+   *        write token)
+   * @param offset Transfer start offset within the blob
+   * @param size Transfer size in bytes
+   * @param is_write true = use write latency/bandwidth, false = read
+   * @return Modeled duration in nanoseconds (0 if no blocks overlap)
+   */
+  clio::run::u64 EstimateIoTimeNs(const clio::run::priv::vector<BlobBlock> &blocks,
+                                  clio::run::u64 offset, clio::run::u64 size,
+                                  bool is_write);
+
+  /**
    * Log telemetry data for CTE operations
    * @param op Operation type
    * @param off Offset within blob

--- a/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
@@ -998,6 +998,18 @@ struct Context {
   clio::run::u64 preallocate_;  // Preallocate this many bytes for GPU block storage
                           // (0 = disabled)
 
+  // I/O emulation (issue #747). When emulate_ is set, PutBlob/GetBlob skip
+  // the data-transfer phase (and all WAL logging) and instead estimate how
+  // long the I/O WOULD have taken from the targets' latency-bandwidth model,
+  // returned in emulated_time_ns_. Metadata effects (blob creation, block
+  // allocation, tag sizes, access stats) still happen, so tier capacities
+  // and placement decisions stay realistic — but emulated blob bytes are
+  // never written (reads of them return whatever the recycled blocks hold).
+  // Built for training RL data-organization policies without paying for the
+  // actual I/O.
+  bool emulate_;                    // IN: skip real I/O, model the time
+  clio::run::u64 emulated_time_ns_;  // OUT: modeled duration of the skipped I/O
+
 #if CTP_ENABLE_COMPRESS
   int dynamic_compress_;  // 0 - skip, 1 - static, 2 - dynamic
   int compress_lib_;      // The compression library to apply (0-10)
@@ -1027,7 +1039,9 @@ struct Context {
   CTP_CROSS_FUN Context()
       : persistence_target_(-1),
         min_persistence_level_(0),
-        preallocate_(0)
+        preallocate_(0),
+        emulate_(false),
+        emulated_time_ns_(0)
 #if CTP_ENABLE_COMPRESS
         ,
         dynamic_compress_(0),
@@ -1052,7 +1066,8 @@ struct Context {
 
   template <class Archive>
   CTP_CROSS_FUN void serialize(Archive &ar) {
-    ar.range(persistence_target_, min_persistence_level_, preallocate_);
+    ar.range(persistence_target_, min_persistence_level_, preallocate_,
+             emulate_, emulated_time_ns_);
 #if CTP_ENABLE_COMPRESS
     ar.range(dynamic_compress_, compress_lib_, compress_preset_, target_psnr_,
              psnr_chance_, max_performance_, consumer_node_, data_type_,
@@ -1065,6 +1080,13 @@ struct Context {
   CTP_CROSS_FUN static Context Preallocate(clio::run::u64 size) {
     Context ctx;
     ctx.preallocate_ = size;
+    return ctx;
+  }
+
+  /** Convenience: a context with I/O emulation enabled (issue #747). */
+  CTP_CROSS_FUN static Context Emulate() {
+    Context ctx;
+    ctx.emulate_ = true;
     return ctx;
   }
 };
@@ -1345,7 +1367,13 @@ struct PutBlobTask : public clio::run::Task {
     ar(tag_id_, blob_name_, offset_, size_, blob_data_,
        score_, context_, flags_, gpu_page_idx_, submit_ts_ns_);
     ar.PopPod();
-    ar.bulk(blob_data_, size_, BULK_XFER);
+    // Emulated puts (issue #747) never write the payload, so don't ship it
+    // over the wire either — the whole point is to not pay for the I/O.
+    // context_ is (de)serialized above, so both the save and load sides
+    // agree on whether the bulk follows.
+    if (!context_.emulate_) {
+      ar.bulk(blob_data_, size_, BULK_XFER);
+    }
   }
 
   /**
@@ -1417,6 +1445,7 @@ struct GetBlobTask : public clio::run::Task {
    */
   static constexpr clio::run::u32 kNoPageIdx = ~static_cast<clio::run::u32>(0);
   IN clio::run::u32 gpu_page_idx_;
+  INOUT Context context_;  // Emulation control + modeled time (issue #747)
 
   // SHM constructor
   CTP_CROSS_FUN GetBlobTask()
@@ -1427,7 +1456,8 @@ struct GetBlobTask : public clio::run::Task {
         size_(0),
         flags_(0),
         blob_data_(ctp::ipc::ShmPtr<>::GetNull()),
-        gpu_page_idx_(kNoPageIdx) {}
+        gpu_page_idx_(kNoPageIdx),
+        context_() {}
 
   // Emplace constructor
   CTP_CROSS_FUN explicit GetBlobTask(const clio::run::TaskId &task_id,
@@ -1436,7 +1466,8 @@ struct GetBlobTask : public clio::run::Task {
                                       const TagId &tag_id,
                                       const std::string &blob_name,
                                       clio::run::u64 offset, clio::run::u64 size,
-                                      clio::run::u32 flags, ctp::ipc::ShmPtr<> blob_data)
+                                      clio::run::u32 flags, ctp::ipc::ShmPtr<> blob_data,
+                                      const Context &context = Context())
       : clio::run::Task(task_id, pool_id, pool_query, Method::kGetBlob),
         tag_id_(tag_id),
         blob_name_(CLIO_PRIV_ALLOC, blob_name),
@@ -1444,7 +1475,8 @@ struct GetBlobTask : public clio::run::Task {
         size_(size),
         flags_(flags),
         blob_data_(blob_data),
-        gpu_page_idx_(kNoPageIdx) {
+        gpu_page_idx_(kNoPageIdx),
+        context_(context) {
     task_id_ = task_id;
     pool_id_ = pool_id;
     method_ = Method::kGetBlob;
@@ -1489,7 +1521,8 @@ struct GetBlobTask : public clio::run::Task {
                                       const TagId &tag_id,
                                       const char *blob_name, clio::run::u64 offset,
                                       clio::run::u64 size, clio::run::u32 flags,
-                                      ctp::ipc::ShmPtr<> blob_data)
+                                      ctp::ipc::ShmPtr<> blob_data,
+                                      const Context &context = Context())
       : clio::run::Task(task_id, pool_id, pool_query, Method::kGetBlob),
         tag_id_(tag_id),
         blob_name_(CLIO_PRIV_ALLOC, blob_name),
@@ -1497,7 +1530,8 @@ struct GetBlobTask : public clio::run::Task {
         size_(size),
         flags_(flags),
         blob_data_(blob_data),
-        gpu_page_idx_(kNoPageIdx) {
+        gpu_page_idx_(kNoPageIdx),
+        context_(context) {
     task_id_ = task_id;
     pool_id_ = pool_id;
     method_ = Method::kGetBlob;
@@ -1513,9 +1547,13 @@ struct GetBlobTask : public clio::run::Task {
     ar.PushPod(blob_name_.UsingSso());
     Task::SerializeIn(ar);
     ar(tag_id_, blob_name_, offset_, size_, flags_, blob_data_,
-       gpu_page_idx_);
+       gpu_page_idx_, context_);
     ar.PopPod();
-    ar.bulk(blob_data_, size_, BULK_EXPOSE);
+    // Emulated gets (issue #747) return no data, so the caller's buffer
+    // does not need to be exposed for the response.
+    if (!context_.emulate_) {
+      ar.bulk(blob_data_, size_, BULK_EXPOSE);
+    }
   }
 
   /**
@@ -1524,7 +1562,13 @@ struct GetBlobTask : public clio::run::Task {
   template <typename Archive>
   CTP_CROSS_FUN void SerializeOut(Archive &ar) {
     Task::SerializeOut(ar);
-    ar.bulk(blob_data_, size_, BULK_XFER);
+    // context_ is INOUT: carries emulated_time_ns_ back (issue #747). An
+    // emulated get read nothing, so no data bulk follows — the caller's
+    // buffer is left untouched and the wire cost is metadata-only.
+    ar(context_);
+    if (!context_.emulate_) {
+      ar.bulk(blob_data_, size_, BULK_XFER);
+    }
   }
 
   /** Fix up priv::string SSO pointer after cudaMemcpy D→H */
@@ -1545,6 +1589,7 @@ struct GetBlobTask : public clio::run::Task {
     flags_ = other->flags_;
     blob_data_ = other->blob_data_;
     gpu_page_idx_ = other->gpu_page_idx_;
+    context_ = other->context_;
   }
 
   /**
@@ -1731,7 +1776,11 @@ struct PodPutBlobTask : public clio::run::Task {
     Task::SerializeIn(ar);
     ar(tag_id_, blob_name_, offset_, size_, blob_data_, score_, context_,
        flags_, gpu_page_idx_, submit_ts_ns_);
-    ar.bulk(blob_data_, size_, BULK_XFER);
+    // Emulated puts never write the payload — skip the wire transfer too
+    // (issue #747; see PutBlobTask::SerializeIn).
+    if (!context_.emulate_) {
+      ar.bulk(blob_data_, size_, BULK_XFER);
+    }
   }
 
   template <typename Archive>
@@ -1776,6 +1825,7 @@ struct PodGetBlobTask : public clio::run::Task {
   IN ctp::ipc::ShmPtr<> blob_data_;
   static constexpr clio::run::u32 kNoPageIdx = ~static_cast<clio::run::u32>(0);
   IN clio::run::u32 gpu_page_idx_;
+  INOUT Context context_;  // Emulation control + modeled time (issue #747)
 
   // SHM constructor
   CTP_CROSS_FUN PodGetBlobTask()
@@ -1786,14 +1836,16 @@ struct PodGetBlobTask : public clio::run::Task {
         size_(0),
         flags_(0),
         blob_data_(ctp::ipc::ShmPtr<>::GetNull()),
-        gpu_page_idx_(kNoPageIdx) {}
+        gpu_page_idx_(kNoPageIdx),
+        context_() {}
 
   // GPU-compatible emplace constructor (const char* blob name, no allocator)
   CTP_CROSS_FUN explicit PodGetBlobTask(
       const clio::run::TaskId &task_id, const clio::run::PoolId &pool_id,
       const clio::run::PoolQuery &pool_query, const TagId &tag_id,
       const char *blob_name, clio::run::u64 offset, clio::run::u64 size,
-      clio::run::u32 flags, ctp::ipc::ShmPtr<> blob_data)
+      clio::run::u32 flags, ctp::ipc::ShmPtr<> blob_data,
+      const Context &context = Context())
       : clio::run::Task(task_id, pool_id, pool_query, Method::kPodGetBlob),
         tag_id_(tag_id),
         blob_name_(blob_name),
@@ -1801,7 +1853,8 @@ struct PodGetBlobTask : public clio::run::Task {
         size_(size),
         flags_(flags),
         blob_data_(blob_data),
-        gpu_page_idx_(kNoPageIdx) {
+        gpu_page_idx_(kNoPageIdx),
+        context_(context) {
     task_id_ = task_id;
     pool_id_ = pool_id;
     method_ = Method::kPodGetBlob;
@@ -1816,9 +1869,10 @@ struct PodGetBlobTask : public clio::run::Task {
                           const clio::run::PoolQuery &pool_query,
                           const TagId &tag_id, const std::string &blob_name,
                           clio::run::u64 offset, clio::run::u64 size,
-                          clio::run::u32 flags, ctp::ipc::ShmPtr<> blob_data)
+                          clio::run::u32 flags, ctp::ipc::ShmPtr<> blob_data,
+                          const Context &context = Context())
       : PodGetBlobTask(task_id, pool_id, pool_query, tag_id, blob_name.c_str(),
-                       offset, size, flags, blob_data) {}
+                       offset, size, flags, blob_data, context) {}
 #endif
 
   /** Destructor — frees blob_data_ when this task owns the buffer (see
@@ -1837,14 +1891,23 @@ struct PodGetBlobTask : public clio::run::Task {
   template <typename Archive>
   CTP_CROSS_FUN void SerializeIn(Archive &ar) {
     Task::SerializeIn(ar);
-    ar(tag_id_, blob_name_, offset_, size_, flags_, blob_data_, gpu_page_idx_);
-    ar.bulk(blob_data_, size_, BULK_EXPOSE);
+    ar(tag_id_, blob_name_, offset_, size_, flags_, blob_data_, gpu_page_idx_,
+       context_);
+    // Emulated gets return no data — no buffer expose needed (issue #747).
+    if (!context_.emulate_) {
+      ar.bulk(blob_data_, size_, BULK_EXPOSE);
+    }
   }
 
   template <typename Archive>
   CTP_CROSS_FUN void SerializeOut(Archive &ar) {
     Task::SerializeOut(ar);
-    ar.bulk(blob_data_, size_, BULK_XFER);
+    // context_ is INOUT: carries emulated_time_ns_ back (issue #747). No
+    // data bulk on the emulated path — the caller's buffer stays untouched.
+    ar(context_);
+    if (!context_.emulate_) {
+      ar.bulk(blob_data_, size_, BULK_XFER);
+    }
   }
 
   // No FixupAfterCopy — fixed_string is position-independent.
@@ -1858,6 +1921,7 @@ struct PodGetBlobTask : public clio::run::Task {
     flags_ = other->flags_;
     blob_data_ = other->blob_data_;
     gpu_page_idx_ = other->gpu_page_idx_;
+    context_ = other->context_;
   }
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -1152,7 +1152,9 @@ clio::run::TaskResume Runtime::PutBlobImpl(clio::run::shared_ptr<TaskT> &task) {
       task->return_code_ = 2;
       CLIO_CO_RETURN;
     }
-    if (blob_data.IsNull()) {
+    // Emulated puts (issue #747) skip the data write AND its wire transfer,
+    // so on a cross-node receiver blob_data_ is legitimately null.
+    if (blob_data.IsNull() && !task->context_.emulate_) {
       task->return_code_ = 3;
       CLIO_CO_RETURN;
     }
@@ -1259,8 +1261,12 @@ clio::run::TaskResume Runtime::PutBlobImpl(clio::run::shared_ptr<TaskT> &task) {
         (tail_write && old_num_blocks > 0) ? (old_blob_size - old_last_blk_size)
                                            : 0;
 
-    // WAL: log all current blocks (full replacement semantics)
-    if (!blob_txn_logs_.empty() && !blob_info_ptr->blocks_.empty()) {
+    // WAL: log all current blocks (full replacement semantics).
+    // Skipped in emulation mode (issue #747): emulated puts are training
+    // traffic, not recoverable state — no data was written, so replaying
+    // their block layout after a crash would resurrect garbage.
+    if (!task->context_.emulate_ && !blob_txn_logs_.empty() &&
+        !blob_info_ptr->blocks_.empty()) {
       clio::run::u32 wid = CLIO_CUR_WORKER->GetWorkerStats().worker_id_;
       TxnExtendBlob txn;
       txn.tag_major_ = tag_id.major_;
@@ -1279,40 +1285,52 @@ clio::run::TaskResume Runtime::PutBlobImpl(clio::run::shared_ptr<TaskT> &task) {
                                                        txn);
     }
 
-    // Step 2.5: Zero any hole created by writing past the old end-of-blob
-    // (sparse write). Newly allocated space is NOT guaranteed to be zero — the
-    // bdev recycles freed blocks, so a fresh block can hold stale data — and
-    // POSIX requires allocated-but-unwritten bytes to read as zeros. Only the
-    // gap [old_blob_size, offset) needs it; sequential appends (offset ==
-    // old_blob_size) and overwrites (offset < old_blob_size) create no hole.
-    if (offset > old_blob_size) {
-      clio::run::u64 hole = offset - old_blob_size;
-      auto *ipc_mgr = CLIO_IPC;
-      ctp::ipc::FullPtr<char> zbuf = ipc_mgr->AllocateBuffer(hole);
-      if (zbuf.IsNull()) {
-        task->return_code_ = 6;
-        CLIO_CO_RETURN;
+    if (task->context_.emulate_) {
+      // I/O emulation (issue #747): the placement above (DPE selection +
+      // block allocation) is real so tier capacities stay honest, but the
+      // data transfer is skipped — model its wall time from the selected
+      // targets' latency-bandwidth metrics instead. The blob's bytes are
+      // never written; reads return whatever the recycled blocks hold.
+      task->context_.emulated_time_ns_ =
+          EstimateIoTimeNs(blob_info_ptr->blocks_, offset, size,
+                           /*is_write=*/true);
+    } else {
+      // Step 2.5: Zero any hole created by writing past the old end-of-blob
+      // (sparse write). Newly allocated space is NOT guaranteed to be zero —
+      // the bdev recycles freed blocks, so a fresh block can hold stale data
+      // — and POSIX requires allocated-but-unwritten bytes to read as zeros.
+      // Only the gap [old_blob_size, offset) needs it; sequential appends
+      // (offset == old_blob_size) and overwrites (offset < old_blob_size)
+      // create no hole.
+      if (offset > old_blob_size) {
+        clio::run::u64 hole = offset - old_blob_size;
+        auto *ipc_mgr = CLIO_IPC;
+        ctp::ipc::FullPtr<char> zbuf = ipc_mgr->AllocateBuffer(hole);
+        if (zbuf.IsNull()) {
+          task->return_code_ = 6;
+          CLIO_CO_RETURN;
+        }
+        std::memset(zbuf.ptr_, 0, hole);
+        clio::run::u32 zero_result = 0;
+        CLIO_CO_AWAIT(ModifyExistingData(blob_info_ptr->blocks_,
+                                    zbuf.shm_.template Cast<void>(), hole,
+                                    old_blob_size, zero_result, hint_idx,
+                                    hint_off));
+        ipc_mgr->FreeBuffer(zbuf);
+        if (zero_result != 0) {
+          task->return_code_ = 20 + zero_result;
+          CLIO_CO_RETURN;
+        }
       }
-      std::memset(zbuf.ptr_, 0, hole);
-      clio::run::u32 zero_result = 0;
-      CLIO_CO_AWAIT(ModifyExistingData(blob_info_ptr->blocks_,
-                                  zbuf.shm_.template Cast<void>(), hole,
-                                  old_blob_size, zero_result, hint_idx,
-                                  hint_off));
-      ipc_mgr->FreeBuffer(zbuf);
-      if (zero_result != 0) {
-        task->return_code_ = 20 + zero_result;
-        CLIO_CO_RETURN;
-      }
-    }
 
-    // Step 3: ModifyExistingData — write data to blocks
-    clio::run::u32 write_result = 0;
-    CLIO_CO_AWAIT(ModifyExistingData(blob_info_ptr->blocks_, blob_data, size, offset,
-                                write_result, hint_idx, hint_off));
-    if (write_result != 0) {
-      task->return_code_ = 20 + write_result;
-      CLIO_CO_RETURN;
+      // Step 3: ModifyExistingData — write data to blocks
+      clio::run::u32 write_result = 0;
+      CLIO_CO_AWAIT(ModifyExistingData(blob_info_ptr->blocks_, blob_data, size,
+                                  offset, write_result, hint_idx, hint_off));
+      if (write_result != 0) {
+        task->return_code_ = 20 + write_result;
+        CLIO_CO_RETURN;
+      }
     }
 
 #if CTP_ENABLE_COMPRESS
@@ -1382,6 +1400,63 @@ clio::run::TaskResume Runtime::PutBlobImpl(clio::run::shared_ptr<TaskT> &task) {
   CLIO_TASK_BODY_END
 }
 
+clio::run::u64 Runtime::EstimateIoTimeNs(
+    const clio::run::priv::vector<BlobBlock> &blocks, clio::run::u64 offset,
+    clio::run::u64 size, bool is_write) {
+  // Fallbacks when a target is unknown or reports zeroed metrics — same
+  // defaults the bdev module seeds for un-benchmarked devices.
+  static constexpr double kFallbackReadBwMbps = 100.0;
+  static constexpr double kFallbackWriteBwMbps = 80.0;
+  static constexpr double kFallbackReadLatUs = 1000.0;
+  static constexpr double kFallbackWriteLatUs = 1200.0;
+
+  // Aggregate the transfer bytes per target. Blocks are laid out
+  // sequentially in the blob, so walk them accumulating each block's
+  // overlap with [offset, offset+size).
+  std::unordered_map<clio::run::PoolId, clio::run::u64> bytes_per_target;
+  const clio::run::u64 end = offset + size;
+  clio::run::u64 cur = 0;
+  for (size_t i = 0; i < blocks.size() && cur < end; ++i) {
+    const BlobBlock &blk = blocks[i];
+    const clio::run::u64 blk_start = cur;
+    const clio::run::u64 blk_end = cur + blk.size_;
+    cur = blk_end;
+    const clio::run::u64 lo = std::max(blk_start, offset);
+    const clio::run::u64 hi = std::min(blk_end, end);
+    if (hi > lo) {
+      bytes_per_target[blk.bdev_client_.pool_id_] += hi - lo;
+    }
+  }
+  if (bytes_per_target.empty()) {
+    return 0;
+  }
+
+  // Per target: latency + bytes/bandwidth. Targets transfer concurrently
+  // (the real Put/Get issues all block I/Os and waits for them), so the
+  // modeled duration is the max across targets.
+  double max_ns = 0.0;
+  {
+    clio::run::ScopedCoRwReadLock read_lock(target_lock_);
+    for (const auto &entry : bytes_per_target) {
+      double lat_us = is_write ? kFallbackWriteLatUs : kFallbackReadLatUs;
+      double bw_mbps = is_write ? kFallbackWriteBwMbps : kFallbackReadBwMbps;
+      TargetInfo *tinfo = registered_targets_.find(entry.first);
+      if (tinfo != nullptr) {
+        const clio::run::bdev::PerfMetrics &pm = tinfo->perf_metrics_;
+        double lat = is_write ? pm.write_latency_us_ : pm.read_latency_us_;
+        double bw = is_write ? pm.write_bandwidth_mbps_ : pm.read_bandwidth_mbps_;
+        if (lat > 0.0) lat_us = lat;
+        if (bw > 0.0) bw_mbps = bw;
+      }
+      const double bytes = static_cast<double>(entry.second);
+      // bandwidth is in MB/s with MB = 1024*1024 (matches bdev GetStats math)
+      const double ns = lat_us * 1e3 + (bytes / (bw_mbps * 1048576.0)) * 1e9;
+      max_ns = std::max(max_ns, ns);
+    }
+  }
+  return static_cast<clio::run::u64>(max_ns);
+}
+
 template <typename TaskT>
 clio::run::TaskResume Runtime::GetBlobImpl(clio::run::shared_ptr<TaskT> &task) {
   CLIO_TASK_BODY_BEGIN
@@ -1434,13 +1509,21 @@ clio::run::TaskResume Runtime::GetBlobImpl(clio::run::shared_ptr<TaskT> &task) {
     // stable copy. #680 read-vs-write safety.
     clio::run::priv::vector<BlobBlock> blocks_snapshot(blob_info_ptr->blocks_);
 
-    // Step 2: Read data from blob blocks (no lock held during I/O)
-    clio::run::u32 read_result = 0;
-    CLIO_CO_AWAIT(ReadData(blocks_snapshot, blob_data_ptr, size, offset,
-                      read_result));
-    if (read_result != 0) {
-      task->return_code_ = read_result;
-      CLIO_CO_RETURN;
+    // Step 2: Read data from blob blocks (no lock held during I/O).
+    // In emulation mode (issue #747) the read is skipped entirely — the
+    // caller's buffer is left untouched and no WAL/bdev traffic happens;
+    // the modeled wall time is returned via context_.emulated_time_ns_.
+    if (task->context_.emulate_) {
+      task->context_.emulated_time_ns_ =
+          EstimateIoTimeNs(blocks_snapshot, offset, size, /*is_write=*/false);
+    } else {
+      clio::run::u32 read_result = 0;
+      CLIO_CO_AWAIT(ReadData(blocks_snapshot, blob_data_ptr, size, offset,
+                        read_result));
+      if (read_result != 0) {
+        task->return_code_ = read_result;
+        CLIO_CO_RETURN;
+      }
     }
 
     // Step 3: Update timestamp (no lock needed - just updating values, not

--- a/context-transfer-engine/test/unit/CMakeLists.txt
+++ b/context-transfer-engine/test/unit/CMakeLists.txt
@@ -80,6 +80,12 @@ add_executable(test_data_organizer
     test_data_organizer.cc
 )
 
+# I/O emulation (issue #747): Context::emulate_ on PutBlob/GetBlob (modeled
+# time, buffer untouched, WAL skipped) + bdev perf-stats persistence.
+add_executable(test_io_emulation
+    test_io_emulation.cc
+)
+
 # BDEV leak stress: PutBlob/DelBlob loop for a wall-clock minute, then assert
 # the bdev used capacity is 0 and the runtime leak-checker heap counter is flat.
 add_executable(test_bdev_leak_stress
@@ -312,6 +318,18 @@ target_link_libraries(test_data_organizer
     clio::run::admin_runtime      # Admin module runtime (required for runtime mode)
     clio::run::admin_client       # Admin module client
     clio::run::bdev_runtime       # Bdev module runtime (required for runtime mode)
+    clio::run::bdev_client        # Bdev client for BdevType enum
+    ctp::cxx                    # ClioCtp library
+    ${CMAKE_THREAD_LIBS_INIT}    # Threading support
+)
+
+# Link test_io_emulation - using simple_test.h framework (NOT Catch2)
+target_link_libraries(test_io_emulation
+    clio_cte_core_runtime         # CTE core runtime library
+    clio_cte_core_client          # CTE core client library
+    clio::run::admin_runtime      # Admin module runtime (required for runtime mode)
+    clio::run::admin_client       # Admin module client
+    clio::run::bdev_runtime       # Bdev module runtime (perf-stats persistence helpers)
     clio::run::bdev_client        # Bdev client for BdevType enum
     ctp::cxx                    # ClioCtp library
     ${CMAKE_THREAD_LIBS_INIT}    # Threading support
@@ -719,6 +737,20 @@ set_tests_properties(
         ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CLIO_TEST_DATA_DIR=${CMAKE_BINARY_DIR};CLIO_BIND_ADDR=127.0.0.1"
 )
 
+# Add I/O emulation tests (issue #747)
+# NOTE: like the reorganize tests, the cases share global fixture state, so
+# they run together in a single process.
+add_test(NAME cte_io_emulation_all
+    COMMAND test_io_emulation)
+
+set_tests_properties(
+    cte_io_emulation_all
+    PROPERTIES
+        TIMEOUT 300  # 5 minute timeout
+        LABELS "unit;emulation;cte"
+        ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CLIO_TEST_DATA_DIR=${CMAKE_BINARY_DIR};CLIO_BIND_ADDR=127.0.0.1"
+)
+
 # ---------------------------------------------------------------------------
 # CLIO_FORCE_NET stress variants (one per CTE task-path test binary)
 # Route every non-Local task through the loopback run-to-run network path so
@@ -820,6 +852,7 @@ set_tests_properties(
     cte_block_reuse_all
     cte_reorganize_all
     cte_data_organizer_all
+    cte_io_emulation_all
     PROPERTIES LABELS "msan_skip"
 )
 
@@ -859,6 +892,7 @@ set_tests_properties(
     cte_block_reuse_all
     cte_reorganize_all
     cte_data_organizer_all
+    cte_io_emulation_all
     PROPERTIES
         RESOURCE_LOCK "clio_runtime"
         FIXTURES_REQUIRED "clio_test_cleanup_fixture"
@@ -903,6 +937,7 @@ set_property(TEST
     cte_block_reuse_all
     cte_reorganize_all
     cte_data_organizer_all
+    cte_io_emulation_all
     APPEND PROPERTY ENVIRONMENT "CLIO_PORT=10500"
 )
 # All cte_functional_* tests run test_core_functionality (9 test cases, each
@@ -930,7 +965,7 @@ set_tests_properties(
 # ------------------------------------------------------------------------------
 # Install Targets
 # ------------------------------------------------------------------------------
-set(_CTE_TEST_TARGETS cte_core_unit_tests cte_core_functionality_simple_tests test_core_functionality test_query test_cte_config_dpe test_tag_operations test_core_client_config test_core_runtime_coverage test_tiered_storage_stress test_tiered_storage_dram_default test_blob_block_reuse test_reorganize_blob test_data_organizer)
+set(_CTE_TEST_TARGETS cte_core_unit_tests cte_core_functionality_simple_tests test_core_functionality test_query test_cte_config_dpe test_tag_operations test_core_client_config test_core_runtime_coverage test_tiered_storage_stress test_tiered_storage_dram_default test_blob_block_reuse test_reorganize_blob test_data_organizer test_io_emulation)
 # (The legacy test_cte_gpu_coroutine / test_gpu_core / test_gpu_create targets
 # and their ctest registrations were removed along with the GPU runtime. CTE
 # GPU coverage now lives in test_cte_devmem_putget (cte_devmem_putget_cuda).)

--- a/context-transfer-engine/test/unit/test_io_emulation.cc
+++ b/context-transfer-engine/test/unit/test_io_emulation.cc
@@ -1,0 +1,409 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * I/O EMULATION TEST (issue #747)
+ *
+ * Exercises Context::emulate_ on PutBlob/GetBlob:
+ * - Emulated PutBlob allocates real placement (metadata/capacity effects)
+ *   but skips the data write and returns a modeled duration in ns.
+ * - Emulated GetBlob leaves the caller's buffer untouched and returns a
+ *   modeled duration in ns; a subsequent real GetBlob still works.
+ * - Bdev perf-stats persistence: file round trip via the static helpers,
+ *   and stats files appearing under CLIO_BDEV_STATS_DIR from the running
+ *   bdevs.
+ */
+
+#include <clio_runtime/clio_runtime.h>
+#include <clio_runtime/bdev/bdev_runtime.h>
+#include <clio_cte/core/core_client.h>
+#include <clio_cte/core/core_tasks.h>
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <thread>
+#include <vector>
+
+#include "simple_test.h"
+
+namespace fs = std::filesystem;
+
+static std::string chi_test_data_dir() {
+  const char *d = clio::run::env::GetCompat("TEST_DATA_DIR");
+  return (d && *d) ? d : ".";
+}
+
+static constexpr clio::run::u64 kBlobSize = 1 * 1024 * 1024;  // 1MB
+
+/**
+ * Test fixture: two-tier CTE; bdev perf stats directed into the test dir.
+ */
+class IoEmulationTestFixture {
+ public:
+  std::string config_path_;
+  std::string file_storage_path_;
+  std::string bdev_stats_dir_;
+  bool initialized_ = false;
+
+  IoEmulationTestFixture() {
+    INFO("=== Initializing IoEmulation Test ===");
+
+    config_path_ = chi_test_data_dir() + "/io_emulation_config.yaml";
+    file_storage_path_ = chi_test_data_dir() + "/io_emulation_storage.bin";
+    bdev_stats_dir_ = chi_test_data_dir() + "/io_emulation_bdev_perf";
+
+    Cleanup();
+    CreateConfigFile();
+
+    ctp::SystemInfo::Setenv("CLIO_SERVER_CONF", config_path_.c_str(), 1);
+    // Redirect bdev perf-stats persistence into the test directory so the
+    // persistence assertions below can inspect it (and so this test never
+    // pollutes the user's ~/.clio/bdev_perf).
+    ctp::SystemInfo::Setenv("CLIO_BDEV_STATS_DIR", bdev_stats_dir_.c_str(), 1);
+
+    bool success = clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, true);
+    REQUIRE(success);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    success = clio::cte::core::CLIO_CTE_CLIENT_INIT();
+    REQUIRE(success);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    initialized_ = true;
+    INFO("=== IoEmulation Test Environment Ready ===");
+  }
+
+  ~IoEmulationTestFixture() {
+    INFO("=== Cleaning up IoEmulation Test ===");
+    Cleanup();
+  }
+
+  void Cleanup() {
+    std::error_code ec;
+    if (fs::exists(config_path_)) fs::remove(config_path_, ec);
+    if (fs::exists(file_storage_path_)) fs::remove(file_storage_path_, ec);
+    fs::remove_all(bdev_stats_dir_, ec);
+  }
+
+  void CreateConfigFile() {
+    std::ofstream config_file(config_path_);
+    REQUIRE(config_file.is_open());
+
+    config_file << R"(
+# IoEmulation Test Configuration
+# - 16MB DRAM (fast tier, score 1.0)
+# - 64MB File (slow tier, score 0.2)
+
+runtime:
+  num_threads: 2
+  queue_depth: 1024
+  first_busy_wait: 10000
+  max_sleep: 50000
+
+compose:
+  - mod_name: clio_cte_core
+    pool_name: clio_cte
+    pool_query: local
+    pool_id: 512.0
+
+    performance:
+      stat_targets_period_ms: 1000
+
+    targets:
+      neighborhood: 1
+      default_target_timeout_ms: 30000
+      poll_period_ms: 1000
+
+    storage:
+      # Fast tier: 16MB DRAM (score 1.0)
+      - path: "ram::io_emulation_dram"
+        bdev_type: "ram"
+        capacity_limit: "16MB"
+        score: 1.0
+
+      # Slow tier: 64MB File (score 0.2)
+      - path: ")" << file_storage_path_ << R"("
+        bdev_type: "file"
+        capacity_limit: "64MB"
+        score: 0.2
+
+    dpe:
+      dpe_type: "max_bw"
+)";
+
+    config_file.close();
+    INFO("Created config file: " << config_path_);
+  }
+};
+
+// Global fixture instance
+static IoEmulationTestFixture *g_fixture = nullptr;
+
+/**
+ * Test: emulated PutBlob returns a modeled duration; placement is real
+ */
+TEST_CASE("IoEmulation - Emulated PutBlob", "[emulation][put][noleak]") {
+  REQUIRE(g_fixture != nullptr);
+  REQUIRE(g_fixture->initialized_);
+
+  auto *cte_client = CLIO_CTE_CLIENT;
+  REQUIRE(cte_client != nullptr);
+
+  clio::cte::core::Tag tag("emulation_test_tag");
+  clio::cte::core::TagId tag_id = tag.GetTagId();
+  std::string blob_name = "emulated_put_blob";
+
+  auto shm_buffer = CLIO_IPC->AllocateBuffer(kBlobSize);
+  REQUIRE(!shm_buffer.IsNull());
+  std::memset(shm_buffer.ptr_, 'E', kBlobSize);
+
+  auto put_task = cte_client->AsyncPutBlob(
+      tag_id, blob_name, 0, kBlobSize,
+      shm_buffer.shm_.template Cast<void>(), 1.0f,
+      clio::cte::core::Context::Emulate(), 0);
+  put_task.Wait();
+
+  REQUIRE(put_task->GetReturnCode() == 0);
+  clio::run::u64 put_ns = put_task->context_.emulated_time_ns_;
+  INFO("emulated PutBlob time: " << put_ns << " ns");
+  REQUIRE(put_ns > 0);
+
+  // Metadata effects are real: the blob exists at the requested size...
+  auto size_task = cte_client->AsyncGetBlobSize(tag_id, blob_name);
+  size_task.Wait();
+  REQUIRE(size_task->GetReturnCode() == 0);
+  REQUIRE(size_task->size_ == kBlobSize);
+
+  // ...and a real GetBlob over the emulated blob succeeds (blocks are
+  // allocated) even though the content was never written.
+  auto read_buffer = CLIO_IPC->AllocateBuffer(kBlobSize);
+  REQUIRE(!read_buffer.IsNull());
+  auto get_task = cte_client->AsyncGetBlob(
+      tag_id, blob_name, 0, kBlobSize, 0,
+      read_buffer.shm_.template Cast<void>());
+  get_task.Wait();
+  REQUIRE(get_task->GetReturnCode() == 0);
+
+  CLIO_IPC->FreeBuffer(shm_buffer);
+  CLIO_IPC->FreeBuffer(read_buffer);
+  INFO("SUCCESS: emulated PutBlob");
+}
+
+/**
+ * Test: emulated GetBlob models the time and leaves the buffer untouched
+ */
+TEST_CASE("IoEmulation - Emulated GetBlob", "[emulation][get][noleak]") {
+  REQUIRE(g_fixture != nullptr);
+  REQUIRE(g_fixture->initialized_);
+
+  auto *cte_client = CLIO_CTE_CLIENT;
+  REQUIRE(cte_client != nullptr);
+
+  clio::cte::core::Tag tag("emulation_test_tag");
+  clio::cte::core::TagId tag_id = tag.GetTagId();
+  std::string blob_name = "real_blob_for_emulated_get";
+
+  // REAL put with a known pattern
+  auto shm_buffer = CLIO_IPC->AllocateBuffer(kBlobSize);
+  REQUIRE(!shm_buffer.IsNull());
+  std::memset(shm_buffer.ptr_, 'R', kBlobSize);
+  auto put_task = cte_client->AsyncPutBlob(
+      tag_id, blob_name, 0, kBlobSize,
+      shm_buffer.shm_.template Cast<void>(), 1.0f,
+      clio::cte::core::Context(), 0);
+  put_task.Wait();
+  REQUIRE(put_task->GetReturnCode() == 0);
+  // A real put must not report an emulated time
+  REQUIRE(put_task->context_.emulated_time_ns_ == 0);
+
+  // EMULATED get: sentinel-filled buffer must come back untouched
+  auto read_buffer = CLIO_IPC->AllocateBuffer(kBlobSize);
+  REQUIRE(!read_buffer.IsNull());
+  std::memset(read_buffer.ptr_, 'S', kBlobSize);
+
+  auto eget_task = cte_client->AsyncGetBlob(
+      tag_id, blob_name, 0, kBlobSize, 0,
+      read_buffer.shm_.template Cast<void>(),
+      clio::run::PoolQuery::Dynamic(), clio::cte::core::Context::Emulate());
+  eget_task.Wait();
+  REQUIRE(eget_task->GetReturnCode() == 0);
+  clio::run::u64 get_ns = eget_task->context_.emulated_time_ns_;
+  INFO("emulated GetBlob time: " << get_ns << " ns");
+  REQUIRE(get_ns > 0);
+
+  bool untouched = true;
+  const char *rb = reinterpret_cast<const char *>(read_buffer.ptr_);
+  for (size_t i = 0; i < kBlobSize; ++i) {
+    if (rb[i] != 'S') {
+      untouched = false;
+      break;
+    }
+  }
+  REQUIRE(untouched);
+
+  // A REAL get afterwards still returns the original pattern
+  auto get_task = cte_client->AsyncGetBlob(
+      tag_id, blob_name, 0, kBlobSize, 0,
+      read_buffer.shm_.template Cast<void>());
+  get_task.Wait();
+  REQUIRE(get_task->GetReturnCode() == 0);
+  bool pattern_ok = true;
+  for (size_t i = 0; i < kBlobSize; ++i) {
+    if (rb[i] != 'R') {
+      pattern_ok = false;
+      break;
+    }
+  }
+  REQUIRE(pattern_ok);
+
+  CLIO_IPC->FreeBuffer(shm_buffer);
+  CLIO_IPC->FreeBuffer(read_buffer);
+  INFO("SUCCESS: emulated GetBlob");
+}
+
+/**
+ * Test: bdev perf-stats file save/load round trip (static helpers)
+ */
+TEST_CASE("IoEmulation - Perf Stats File Round Trip", "[emulation][perf]") {
+  using clio::run::bdev::PerfMetrics;
+  using BdevRuntime = clio::run::bdev::Runtime;
+
+  std::string path =
+      g_fixture->bdev_stats_dir_ + "/round_trip_test.perf";
+
+  PerfMetrics out;
+  out.read_bandwidth_mbps_ = 1234.5;
+  out.write_bandwidth_mbps_ = 987.6;
+  out.read_latency_us_ = 42.0;
+  out.write_latency_us_ = 84.0;
+  out.iops_ = 5000.0;
+
+  REQUIRE(BdevRuntime::SavePerfStatsFile(path, out, 3.5f, 7.25f));
+
+  PerfMetrics in;
+  float wall_read = 0.0f;
+  float wall_write = 0.0f;
+  REQUIRE(BdevRuntime::LoadPerfStatsFile(path, in, wall_read, wall_write));
+  REQUIRE(std::abs(in.read_bandwidth_mbps_ - 1234.5) < 1e-6);
+  REQUIRE(std::abs(in.write_bandwidth_mbps_ - 987.6) < 1e-6);
+  REQUIRE(std::abs(in.read_latency_us_ - 42.0) < 1e-6);
+  REQUIRE(std::abs(in.write_latency_us_ - 84.0) < 1e-6);
+  REQUIRE(std::abs(in.iops_ - 5000.0) < 1e-6);
+  REQUIRE(std::abs(wall_read - 3.5f) < 1e-6f);
+  REQUIRE(std::abs(wall_write - 7.25f) < 1e-6f);
+
+  // Missing file / bad header are rejected
+  PerfMetrics dummy;
+  REQUIRE(!BdevRuntime::LoadPerfStatsFile(
+      g_fixture->bdev_stats_dir_ + "/nope.perf", dummy, wall_read,
+      wall_write));
+
+  // Path derivation sanitizes non-path pool names under the stats dir
+  std::string p = BdevRuntime::MakePerfStatsPath("ram::some_device");
+  REQUIRE(p.rfind(g_fixture->bdev_stats_dir_, 0) == 0);
+  REQUIRE(p.find("::") == std::string::npos);
+
+  INFO("SUCCESS: perf stats file round trip");
+}
+
+/**
+ * Test: the running bdevs persist their stats under CLIO_BDEV_STATS_DIR
+ */
+TEST_CASE("IoEmulation - Perf Stats Persisted By Runtime",
+          "[emulation][perf][persist]") {
+  REQUIRE(g_fixture != nullptr);
+  REQUIRE(g_fixture->initialized_);
+
+  // StatTargets (period 1000ms in this config) drives bdev GetStats, whose
+  // first invocation persists a stats file per bdev (throttle starts
+  // expired). Wait a few periods, then look for at least one file.
+  bool found = false;
+  for (int attempt = 0; attempt < 20 && !found; ++attempt) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    std::error_code ec;
+    if (fs::exists(g_fixture->bdev_stats_dir_, ec)) {
+      for (const auto &entry :
+           fs::directory_iterator(g_fixture->bdev_stats_dir_, ec)) {
+        if (entry.path().extension() == ".perf") {
+          found = true;
+          INFO("found persisted stats: " << entry.path().string());
+          break;
+        }
+      }
+    }
+  }
+  REQUIRE(found);
+  INFO("SUCCESS: bdev perf stats persisted");
+}
+
+/**
+ * Test: cleanup blobs and tag
+ */
+TEST_CASE("IoEmulation - Cleanup", "[emulation][cleanup]") {
+  REQUIRE(g_fixture != nullptr);
+  REQUIRE(g_fixture->initialized_);
+
+  auto *cte_client = CLIO_CTE_CLIENT;
+  REQUIRE(cte_client != nullptr);
+
+  clio::cte::core::Tag tag("emulation_test_tag");
+  clio::cte::core::TagId tag_id = tag.GetTagId();
+
+  auto del1 = cte_client->AsyncDelBlob(tag_id, "emulated_put_blob");
+  del1.Wait();
+  auto del2 = cte_client->AsyncDelBlob(tag_id, "real_blob_for_emulated_get");
+  del2.Wait();
+  auto del_tag = cte_client->AsyncDelTag("emulation_test_tag");
+  del_tag.Wait();
+
+  INFO("Cleanup complete");
+}
+
+int main(int argc, char **argv) {
+  g_fixture = new IoEmulationTestFixture();
+
+  std::string filter = (argc > 1) ? argv[1] : "";
+  int result = SimpleTest::run_all_tests(filter);
+
+  delete g_fixture;
+  g_fixture = nullptr;
+
+  SIMPLE_TEST_PROCESS_EXIT(result);
+  return result;  // unreachable on Windows
+}


### PR DESCRIPTION
## Summary
- New `Context::emulate_` flag on PutBlob/GetBlob (GetBlob tasks gain an `INOUT Context` — they had none). When set, the data-transfer phase is skipped and the modeled duration of the skipped I/O is returned in nanoseconds via `context_.emulated_time_ns_` (`Context::Emulate()` convenience included).
- **What emulation keeps vs skips**: placement is real (DPE selection + block allocation, so tier capacities, blob sizes, and access stats stay honest); skipped are the hole zero-fill, the data write/read, **all WAL logging**, and — on the network path — the payload bulk transfers in both directions (an emulated op costs metadata-only wire bytes).
- `Runtime::EstimateIoTimeNs` models the transfer: bytes aggregated per target over the overlapping blocks, `latency + bytes/bandwidth` from each target's measured `PerfMetrics`, max across targets (concurrent targets, serialized same-target blocks), with bdev-default fallbacks for unbenchmarked devices.
- **Bdev perf-stats persistence**: each bdev now saves its `PerfMetrics` *and* the learned wall-clock model coefficients (`method_model_wall_[kRead/kWrite]` — what `GetStats` actually derives bandwidth from) to `$CLIO_BDEV_STATS_DIR` (default `~/.clio/bdev_perf`), restoring them in `Create` so performance is not re-estimated every session. Saves are throttled (10 s) in `GetStats` and forced in `Destroy`; `CLIO_BDEV_PERSIST_STATS=0` disables.

## Motivation
Fixes #747. Training an RL data-organization classifier requires many PutBlob/GetBlob cycles; actually performing the I/O is expensive and unnecessary. Stacked on #744 (`738-data-organizer-infra`).

## Test plan
- [x] New `test_io_emulation` (ctest `cte_io_emulation_all`): emulated put returns modeled ns with real metadata effects; emulated get returns modeled ns and leaves a sentinel-filled buffer untouched while a subsequent real get still returns the original data; perf-stats file save/load round trip + path sanitization; stats files appear under `CLIO_BDEV_STATS_DIR` from the running bdevs — **5/5 on both the SHM path and `CLIO_FORCE_NET=1`** (force-net caught the OUT-bulk clobbering the client buffer; fixed by conditional bulks)
- [x] Regression: `test_data_organizer` 6/6, `cte_core_unit_tests` 5/5 (SHM + force-net), `test_blob_block_reuse` 1/1 (SHM + force-net), `test_cte_config_dpe` 69/69; `test_tag_operations` shows only the pre-existing reorganize flake also present on clean main
- [x] No new compiler warnings
- [x] BSD 3-Clause headers on new files

## Breaking changes
None functionally. `GetBlobTask`/`PodGetBlobTask` wire format gains a `Context` (internal protocol; all in-repo users updated, client APIs are backward-compatible via defaulted parameters). Bdev stats persistence is on by default — set `CLIO_BDEV_PERSIST_STATS=0` for benchmarks that must start from a cold model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)