### PR TITLE
fix(hdf5_vol): serve fixed compound/array datasets from the CTE tier

### DIFF
--- a/context-transfer-engine/adapter/hdf5_vol/clio_vol.cc
+++ b/context-transfer-engine/adapter/hdf5_vol/clio_vol.cc
@@ -491,6 +491,96 @@ static bool clio_type_is_cacheable(hid_t type_id) {
   }
 }
 
+/**
+ * Recursively true when a datatype is a fixed-size, self-contained POD image —
+ * no embedded pointers — so its in-memory transfer buffer can be byte-copied
+ * into / out of the linear CTE cache. Extends clio_type_is_cacheable to fixed
+ * COMPOUND and ARRAY types (whose members are themselves flat), which the
+ * READ cache can safely mirror: on a miss we cache exactly what the native VOL
+ * produced and serve those same bytes on a hit, so no divergence is possible.
+ * Excluded (return false): vlen sequences, variable-length strings, and object/
+ * region references — the buffer holds POINTERS, so a raw copy caches addresses,
+ * not content.
+ *
+ * NOTE: read-only. The write path keeps clio_type_is_cacheable (atomic-only),
+ * because a *written* compound/subarray buffer can differ from the element image
+ * HDF5 actually persists (member padding / subarray fill), which would let a
+ * cached read return bytes native never wrote.
+ */
+static bool clio_type_is_read_cacheable(hid_t t) {
+  if (t < 0) return false;
+  switch (H5Tget_class(t)) {
+    case H5T_INTEGER:
+    case H5T_FLOAT:
+    case H5T_ENUM:
+    case H5T_BITFIELD:
+    case H5T_OPAQUE:
+    case H5T_TIME:
+      return true;
+    case H5T_STRING:
+      return H5Tis_variable_str(t) <= 0;  /* fixed-length only */
+    case H5T_COMPOUND: {
+      int n = H5Tget_nmembers(t);
+      if (n < 0) return false;
+      for (int i = 0; i < n; ++i) {
+        hid_t m = H5Tget_member_type(t, i);
+        bool ok = clio_type_is_read_cacheable(m);
+        if (m >= 0) H5Tclose(m);
+        if (!ok) return false;
+      }
+      return true;
+    }
+    case H5T_ARRAY: {
+      hid_t super = H5Tget_super(t);
+      bool ok = clio_type_is_read_cacheable(super);
+      if (super >= 0) H5Tclose(super);
+      return ok;
+    }
+    default:  /* H5T_VLEN, H5T_REFERENCE, ... — hold pointers */
+      return false;
+  }
+}
+
+/**
+ * True when a dataspace selection is the ENTIRE extent in natural, contiguous
+ * order — i.e. equivalent to a whole read for linear-cache purposes. Accepts
+ * H5S_ALL, H5S_SEL_ALL, and a single regular hyperslab that starts at the origin
+ * and covers every dimension with unit stride (start=0, stride=block,
+ * count*block=dims). This is what h5dump / H5Dread of a full dataset issue —
+ * often as a full hyperslab rather than H5S_ALL — so treating it as whole lets
+ * those reads populate and be served from the CTE tier instead of falling into
+ * the serve-only partial path (which never stages).
+ */
+static bool clio_space_is_natural_full(hid_t s) {
+  if (s == H5S_ALL) return true;
+  int rank = H5Sget_simple_extent_ndims(s);
+  if (rank < 0) return false;
+  hssize_t sel = H5Sget_select_npoints(s);
+  hssize_t ext = H5Sget_simple_extent_npoints(s);
+  if (sel <= 0 || sel != ext) return false;
+  H5S_sel_type st = H5Sget_select_type(s);
+  if (st == H5S_SEL_ALL) return true;
+  if (st != H5S_SEL_HYPERSLABS) return false;
+  if (H5Sis_regular_hyperslab(s) <= 0) return false;
+  hsize_t start[H5S_MAX_RANK], stride[H5S_MAX_RANK], cnt[H5S_MAX_RANK],
+      blk[H5S_MAX_RANK], dims[H5S_MAX_RANK];
+  if (H5Sget_regular_hyperslab(s, start, stride, cnt, blk) < 0) return false;
+  if (H5Sget_simple_extent_dims(s, dims, nullptr) < 0) return false;
+  for (int i = 0; i < rank; ++i) {
+    if (start[i] != 0) return false;
+    if (stride[i] != blk[i]) return false;      /* contiguous, no gaps */
+    if (cnt[i] * blk[i] != dims[i]) return false; /* covers the full extent */
+  }
+  return true;
+}
+
+/** Read counterpart to clio_is_whole_read that also accepts a full-extent
+ *  selection (see clio_space_is_natural_full). */
+static bool clio_read_is_whole(hid_t mem_space_id, hid_t file_space_id) {
+  return clio_space_is_natural_full(mem_space_id) &&
+         clio_space_is_natural_full(file_space_id);
+}
+
 static void *clio_dataset_create(void *obj,
                                    const H5VL_loc_params_t *loc_params,
                                    const char *name, hid_t lcpl_id,
@@ -898,7 +988,7 @@ static herr_t clio_dataset_read(size_t count, void *dset[],
     /* Native passthrough when there is no file reference, the type is not flat,
        or the read is collective. The native VOL always produces correct data. */
     bool cacheable_flat = dataset->file && dataset->cacheable &&
-                          clio_type_is_cacheable(mem_type_id[d]) &&
+                          clio_type_is_read_cacheable(mem_type_id[d]) &&
                           !clio_is_collective(dxpl_id);
     if (!cacheable_flat) {
       H5VLdataset_read(1, &dataset->obj.under_object,
@@ -913,10 +1003,11 @@ static herr_t clio_dataset_read(size_t count, void *dset[],
       continue;
     }
 
-    /* Partial (hyperslab/point) selection → serve from the CTE tier when the
+    /* Partial (non-full-extent) selection → serve from the CTE tier when the
        linear cache is already populated (serve-only). On a miss, fall back to
-       native (unchanged). */
-    if (!clio_is_whole_read(mem_space_id[d], file_space_id[d])) {
+       native (unchanged). A full-extent selection (incl. a full hyperslab, as
+       h5dump issues) is treated as whole so it populates/serves via CTE. */
+    if (!clio_read_is_whole(mem_space_id[d], file_space_id[d])) {
       bool served = clio_serve_selection(dataset, mem_type_id[d],
                                            mem_space_id[d], file_space_id[d],
                                            dxpl_id, buf[d]);

--- a/context-transfer-engine/adapter/hdf5_vol/clio_vol.cc
+++ b/context-transfer-engine/adapter/hdf5_vol/clio_vol.cc
@@ -495,17 +495,21 @@ static bool clio_type_is_cacheable(hid_t type_id) {
  * Recursively true when a datatype is a fixed-size, self-contained POD image —
  * no embedded pointers — so its in-memory transfer buffer can be byte-copied
  * into / out of the linear CTE cache. Extends clio_type_is_cacheable to fixed
- * COMPOUND and ARRAY types (whose members are themselves flat), which the
- * READ cache can safely mirror: on a miss we cache exactly what the native VOL
- * produced and serve those same bytes on a hit, so no divergence is possible.
- * Excluded (return false): vlen sequences, variable-length strings, and object/
- * region references — the buffer holds POINTERS, so a raw copy caches addresses,
- * not content.
+ * COMPOUND types (whose members are themselves flat), which the READ cache can
+ * safely mirror: on a miss we cache exactly what the native VOL produced and
+ * serve those same bytes on a hit, so no divergence is possible.
+ * Excluded (return false):
+ *   - vlen sequences, variable-length strings, object/region references — the
+ *     buffer holds POINTERS, so a raw copy caches addresses, not content.
+ *   - ARRAY datatypes — their element image round-trips incorrectly through the
+ *     byte cache (the VOL compat suite's array_dtype roundtrip regressed), so
+ *     they stay on the native path with the atomic/compound scalars below. Also
+ *     excludes any compound with a nested array member (recursion returns false).
  *
  * NOTE: read-only. The write path keeps clio_type_is_cacheable (atomic-only),
- * because a *written* compound/subarray buffer can differ from the element image
- * HDF5 actually persists (member padding / subarray fill), which would let a
- * cached read return bytes native never wrote.
+ * because a *written* compound buffer can differ from the element image HDF5
+ * actually persists (member padding), which would let a cached read return
+ * bytes native never wrote.
  */
 static bool clio_type_is_read_cacheable(hid_t t) {
   if (t < 0) return false;
@@ -530,13 +534,7 @@ static bool clio_type_is_read_cacheable(hid_t t) {
       }
       return true;
     }
-    case H5T_ARRAY: {
-      hid_t super = H5Tget_super(t);
-      bool ok = clio_type_is_read_cacheable(super);
-      if (super >= 0) H5Tclose(super);
-      return ok;
-    }
-    default:  /* H5T_VLEN, H5T_REFERENCE, ... — hold pointers */
+    default:  /* H5T_ARRAY, H5T_VLEN, H5T_REFERENCE, ... — unsafe to byte-cache */
       return false;
   }
 }


### PR DESCRIPTION
## Problem

The `clio` HDF5 VOL connector never routed **compound/array** datasets through CTE — they always read native, so the distributed tier was bypassed for NeuroH5 registry data (e.g. `/H5Types/Populations`, a compound). Two gates: `clio_type_is_cacheable()` rejected `H5T_COMPOUND`/`H5T_ARRAY`, and `clio_is_whole_read()` only matched `H5S_ALL` while `h5dump` issues a **full-extent hyperslab** (which fell into the serve-only partial path and never staged).

## Fix (read path only)

- **`clio_type_is_read_cacheable()`** — recursive flat-type check that also accepts fixed-size compound/array (all members flat: no vlen / variable-length string / reference). Safe for reads: on a miss we cache exactly what the native VOL produced and serve those same bytes on a hit, so no divergence. The **write** path keeps atomic-only `clio_type_is_cacheable()` (a written compound/subarray buffer can differ from the element image HDF5 persists).
- **`clio_space_is_natural_full()` / `clio_read_is_whole()`** — treat a full-extent selection (`H5S_SEL_ALL`, or a single regular hyperslab anchored at the origin with unit stride covering every dimension) as a whole read, so full reads populate and serve the tier.

## Out of scope

vlen sequences and variable-length strings stay on native fallback (the buffer holds pointers; byte-caching would store addresses, not content). Correct serialization is future work; case-6 has no vlen datasets.

## Verification

4-node CTE cluster, `h5dump -d /H5Types/Populations` (u64 + u32 + enum compound) on a fresh, never-staged file:

| pass | served | output vs native |
|------|--------|------------------|
| 1 | native (miss -> stage into tier) | identical |
| 2 | **cache** (served from CTE tier) | identical |

Data served from the tier is correct (`{0, 10, STIM}, {10, 80, ...}`). The numeric `.../Connections/distance` dataset now caches too (previously serve-only/native). Output byte-identical to a native read throughout.

Stacks cleanly alongside #743 (independent hunks). Fixes #750