### PR TITLE
fix(cte/kvhdf5): compile GPU test targets at C++20

### DIFF
--- a/context-transfer-engine/adapter/kvhdf5/test/CMakeLists.txt
+++ b/context-transfer-engine/adapter/kvhdf5/test/CMakeLists.txt
@@ -68,8 +68,14 @@ function(kvhdf5_add_gpu_test_target target)
             HSHM_ENABLE_CUDA=1
     )
 
+    # kvhdf5's device-facing headers use C++20 (std::span, the BlobBackend
+    # concept), matching the codebase-wide CMAKE_CXX_STANDARD 20. Pin CUDA to 20
+    # too so the .cu translation units compile them, regardless of any global
+    # CMAKE_CUDA_STANDARD (e.g. a build that forces 17).
     set_target_properties(${target} PROPERTIES
         CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}"
+        CUDA_STANDARD 20
+        CUDA_STANDARD_REQUIRED ON
         RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
     )
 


### PR DESCRIPTION
Fixes #758.

## Problem

The kvhdf5 GPU test `.cu` files pull in the adapter's device-facing headers, which use C++20 features: `std::span` (`tag_path.h`) and the `BlobBackend` concept used as `template<BlobBackend B>` (`cpu_dataset.h` via `blob_backend.h`). When the build configures CUDA at C++17 (e.g. `-DCMAKE_CUDA_STANDARD=17`), nvcc rejects these:

```
tag_path.h(46): error: namespace "std" has no member "span"
cpu_dataset.h(52): error: argument list for variable template "kvhdf5::BlobBackend" is missing
```

failing the `kvhdf5_e2e_tests` build (11 errors).

## Fix

Pin `CUDA_STANDARD 20` / `CUDA_STANDARD_REQUIRED ON` on the shared GPU test target recipe (`kvhdf5_add_gpu_test_target`) so the `.cu` translation units compile at C++20 regardless of the global `CMAKE_CUDA_STANDARD`. This matches the codebase-wide `CMAKE_CXX_STANDARD 20` and the CPU unit tests' existing `CXX_STANDARD 20`. Scoped to the two kvhdf5 GPU test binaries; the rest of the CUDA build is untouched.

## Verification

Clean rebuild via the GPU dev build script now compiles and links `kvhdf5_e2e_tests` (and `clio_contract_tests`, `kvhdf5_unit_tests`); the original 11 compile errors are gone. Remaining GPU test *runtime* failures on the build host are environmental (`nvidia-smi`: `Failed to initialize NVML` — no usable GPU), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)