### PR TITLE
feat(#526): reproducible Apptainer regression pipelines on native jarvis scheduler

### DIFF
--- a/jarvis_clio_core/jarvis_clio_core/clio_cte/pkg.py
+++ b/jarvis_clio_core/jarvis_clio_core/clio_cte/pkg.py
@@ -8,6 +8,7 @@ from jarvis_cd.core.pkg import Service
 from jarvis_cd.util import SizeType
 from jarvis_cd.shell.process import Rm, Mkdir
 from jarvis_cd.shell import PsshExecInfo, Exec
+from jarvis_cd.util.container_utils import container_kwargs
 import yaml
 import os
 import re
@@ -166,6 +167,12 @@ class ClioCte(Service):
             parent_dir = os.path.dirname(path)
             if not parent_dir:
                 continue
+            # NOTE: configure runs BEFORE the pipeline's container instance
+            # starts, so this Mkdir cannot be container-wrapped. It is fine
+            # for host-visible paths ($HOME, shared storage); a file device
+            # under /tmp (remapped in-container via tmp_bind_root) would need
+            # its dir created at start() time instead. Both #526 pipelines
+            # use ram:: tiers only, so this loop is a no-op there.
             Mkdir(parent_dir,
                   PsshExecInfo(env=self.mod_env, hostfile=self.hostfile)).run()
 
@@ -226,10 +233,9 @@ class ClioCte(Service):
         Exec(cmd, PsshExecInfo(
             env=self.mod_env,
             hostfile=self.hostfile,
-            container=getattr(self, '_container_engine', 'none'),
-            container_image=self.deploy_image_name(),
             private_dir=self.private_dir,
             bind_mounts=self.container_mounts,
+            **container_kwargs(self),
         )).run()
 
         self.log("CTE started successfully")
@@ -255,10 +261,15 @@ class ClioCte(Service):
             if path.startswith('ram::'):
                 continue
             try:
-                Rm(path, PsshExecInfo(hostfile=self.hostfile)).run()
+                # Wrapped: file devices may live under /tmp, which the
+                # container remaps via tmp_bind_root. Best-effort no-op if
+                # the instance is already down.
+                Rm(path, PsshExecInfo(hostfile=self.hostfile,
+                                      **container_kwargs(self))).run()
                 parent_dir = os.path.dirname(path)
                 if parent_dir:
-                    Rm(parent_dir, PsshExecInfo(hostfile=self.hostfile)).run()
+                    Rm(parent_dir, PsshExecInfo(hostfile=self.hostfile,
+                                                **container_kwargs(self))).run()
             except Exception as e:
                 self.log(f"Error cleaning {path}: {e}")
 

--- a/jarvis_clio_core/jarvis_clio_core/clio_cte_libfuse/pkg.py
+++ b/jarvis_clio_core/jarvis_clio_core/clio_cte_libfuse/pkg.py
@@ -6,7 +6,8 @@ the `clio_cte_fuse` binary (built with CLIO_CTE_ENABLE_FUSE_ADAPTER=ON).
 """
 from jarvis_cd.core.pkg import Service
 from jarvis_cd.shell import Exec, PsshExecInfo
-from jarvis_cd.shell.process import Mkdir, Kill
+from jarvis_cd.shell.process import Kill
+from jarvis_cd.util.container_utils import container_kwargs
 import time
 
 
@@ -61,22 +62,43 @@ class ClioCteLibfuse(Service):
         # of the binary; calling it here just makes start() idempotent.
         self.stop()
 
-        Mkdir(mp, PsshExecInfo(env=self.mod_env, hostfile=self.hostfile)).run()
+        # container_kwargs routes the mkdir into the run's apptainer instance
+        # (jarvis only wraps when exec_info.container is set). REQUIRED here:
+        # under tmp_bind_root the in-container /tmp is a different directory
+        # from the host /tmp, so the mountpoint must be created in-container.
+        Exec(f'mkdir -p {mp}',
+             PsshExecInfo(env=self.mod_env, hostfile=self.hostfile,
+                          **container_kwargs(self))).run()
 
         fuse_cmd = f'{self.binary} {mp} {extra}'.strip()
         self.log(f"Mounting IOWarp CTE FUSE at {mp}: {fuse_cmd}")
-        Exec(fuse_cmd, PsshExecInfo(
+        # Shell-background the daemon inside a synchronous wrapped Exec: the
+        # `nohup ... &` detaches it from the wrap's `bash -c` shell, and it
+        # parents into the apptainer instance, whose mount/shm namespaces it
+        # must share with the runtime and the fio that writes through the
+        # mount. Daemon output goes to a per-host log on the auto-mounted
+        # shared_dir (not /dev/null — a masked mount failure here previously
+        # surfaced only as downstream ENOSPC).
+        fuse_log = f'{self.shared_dir}/cte_fuse.$(hostname).log'
+        bg_cmd = f'nohup {fuse_cmd} </dev/null >{fuse_log} 2>&1 &'
+        Exec(bg_cmd, PsshExecInfo(
             env=self.mod_env, hostfile=self.hostfile,
-            exec_async=True)).run()
+            **container_kwargs(self))).run()
         time.sleep(self.config.get('sleep', 2))
 
     def stop(self):
         mp = self.config['mountpoint']
         self.log(f"Unmounting {mp}")
+        # Both teardown steps must run inside the instance: the FUSE mount
+        # exists only in the instance's mount namespace (host-side
+        # fusermount3 sees "not found in /etc/mtab"), and the wrapped Kill
+        # scopes pkill to this run's PID namespace.
         Exec(f'fusermount3 -u {mp}', PsshExecInfo(
-            env=self.mod_env, hostfile=self.hostfile)).run()
+            env=self.mod_env, hostfile=self.hostfile,
+            **container_kwargs(self))).run()
         Kill(self.binary, PsshExecInfo(
-            env=self.mod_env, hostfile=self.hostfile)).run()
+            env=self.mod_env, hostfile=self.hostfile,
+            **container_kwargs(self))).run()
 
     def clean(self):
         self.stop()

--- a/jarvis_clio_core/jarvis_clio_core/clio_runtime/pkg.py
+++ b/jarvis_clio_core/jarvis_clio_core/clio_runtime/pkg.py
@@ -7,6 +7,7 @@ and container deployment modes via deploy_mode configuration.
 from jarvis_cd.core.pkg import Service
 from jarvis_cd.shell import Exec, PsshExecInfo
 from jarvis_cd.shell.process import Kill, GdbServer
+from jarvis_cd.util.container_utils import container_kwargs
 from jarvis_cd.util import SizeType
 from jarvis_cd.util.logger import Color
 import os
@@ -318,6 +319,34 @@ class ClioRuntime(Service):
 
         self.log("Starting IOWarp runtime")
 
+        # Self-heal BEFORE launching a fresh runtime: kill any stale chimaera
+        # left alive by a prior combo, THEN reclaim its chi_* shm. Both are
+        # host-side (unwrapped) on purpose — apptainer shares the host /dev/shm
+        # and PID space, and the stale process we're hunting has, by definition,
+        # ESCAPED the prior combo's instance:// PID namespace, so the wrapped
+        # `Kill('chimaera')` in the previous stop() could not reach it.
+        #
+        # Why this matters (observed on single_node job 21563, combo 18): the
+        # sweep is sequential in ONE allocation, so combo N+1's runtime start
+        # inherits whatever combo N's teardown left behind. Every teardown logs
+        # `ERROR ... Server dead` — the runtime dies hard, not gracefully — so a
+        # wedged/re-parented chimaera CAN survive. If it does and we only rm the
+        # shm, the fresh runtime comes up alongside the survivor with an
+        # inconsistent pool registry; a client task then routes to the null pool
+        # (`worker.cc ... Container not found for pool_id=PoolId(0,0)`) and, with
+        # no IPC failover, HANGS forever (combo 18 stalled ~8 h to the wall
+        # clock). Killing first makes the old "no live chimaera here" assumption
+        # actually true. Idempotent: in the healthy case nothing matches, so this
+        # is a no-op that leaves startup state unchanged. The `[c]himaera` /
+        # `[c]lio_run` bracket keeps pkill from matching its own argv; `|| true`
+        # keeps a no-match (exit 1) from looking like a failure. Without the shm
+        # reclaim a single mid-startup death also snowballs into a /dev/shm
+        # ENOSPC cascade for every subsequent combo.
+        Exec("pkill -9 -f '[c]himaera' || true; "
+             "pkill -9 -f '[c]lio_run' || true; "
+             'rm -f /dev/shm/chi_*',
+             PsshExecInfo(hostfile=self.hostfile)).run()
+
         cmd = 'clio_run runtime start'
         # Jarvis runs default to a fresh session; a persistent deployment
         # (ephemeral=false) recomposes saved pools + replays the WAL instead.
@@ -328,10 +357,9 @@ class ClioRuntime(Service):
             env=self.env,
             hostfile=self.hostfile,
             exec_async=True,
-            container=self._container_engine,
-            container_image=self.deploy_image_name(),
             private_dir=self.private_dir,
             bind_mounts=self.container_mounts,
+            **container_kwargs(self),
         )
         if self.config.get('do_dbg', False):
             GdbServer(cmd, self.config['dbg_port'], exec_info).run()
@@ -372,10 +400,27 @@ class ClioRuntime(Service):
 
         self.log("Stopping IOWarp runtime")
 
-        Exec('clio_run runtime stop',
-             PsshExecInfo(env=self.env, hostfile=self.hostfile)).run()
+        # #526: BOUND the graceful stop, and run it INSIDE the instance
+        # (container_kwargs) — symmetric with start(). The earlier
+        # intermittent "shm_attach shm_open failed" during stop was the
+        # host-side stop client trying to attach shm owned by the
+        # in-instance runtime; wrapping puts the stop client in the same
+        # namespace. `timeout` still caps a wedged stop; Kill below is what
+        # actually frees the runtime. `-k 10` SIGKILLs if clio_run ignores
+        # the SIGTERM. Harmless on bare-metal (engine 'none' -> no wrap).
+        Exec('timeout -k 10 45 clio_run runtime stop',
+             PsshExecInfo(env=self.env, hostfile=self.hostfile,
+                          **container_kwargs(self))).run()
+        # Backstop force-kill under BOTH daemon names: 'chimaera' (pre-rebrand
+        # CLIO, e.g. the current 526 SIF) and 'clio_run' (post Chimaera->Clio
+        # rebrand). Kill of a name with no matches is benign, so the union is
+        # safe whichever CLIO vintage is deployed.
+        Kill('chimaera',
+             PsshExecInfo(env=self.env, hostfile=self.hostfile,
+                          **container_kwargs(self))).run()
         Kill('clio_run',
-             PsshExecInfo(env=self.env, hostfile=self.hostfile)).run()
+             PsshExecInfo(env=self.env, hostfile=self.hostfile,
+                          **container_kwargs(self))).run()
 
         port = self.config['port']
         host = self.hostfile.hosts[0] if self.hostfile.hosts else '127.0.0.1'
@@ -395,8 +440,15 @@ class ClioRuntime(Service):
 
     def kill(self):
         self.log("Forcibly killing IOWarp runtime")
+        # Both daemon names — pre-rebrand ('chimaera') and post ('clio_run');
+        # see stop() for rationale.
+        Kill('chimaera', PsshExecInfo(
+            hostfile=self.hostfile,
+            **container_kwargs(self)
+        )).run()
         Kill('clio_run', PsshExecInfo(
-            hostfile=self.hostfile
+            hostfile=self.hostfile,
+            **container_kwargs(self)
         )).run()
 
     def clean(self):
@@ -409,6 +461,16 @@ class ClioRuntime(Service):
         if os.path.exists(log_file):
             os.remove(log_file)
 
+        # HOST-SIDE (deliberately NOT wrapped): clean() runs *after* stop() has
+        # already torn the apptainer instance down, so a wrapped `apptainer exec
+        # instance://…` here would target a dead instance and silently no-op —
+        # leaking the runtime's shm across every sweep combo until /dev/shm
+        # (a 48 GiB tmpfs on Ares) fills and later combos die with ENOSPC
+        # ([Errno 28]). Apptainer shares the host /dev/shm by default (no
+        # --contain), so chimaera's shm_open segments physically live on the
+        # host /dev/shm; a bare host-side rm reaches the exact same files and
+        # reclaims them regardless of instance state. On distributed runs the
+        # hostfile fans this out host-side to every node's local /dev/shm.
         Exec('rm -f /dev/shm/chi_*', PsshExecInfo(
             hostfile=self.hostfile
         )).run()

--- a/jarvis_clio_core/pipelines/ares/distributed.yaml
+++ b/jarvis_clio_core/pipelines/ares/distributed.yaml
@@ -1,0 +1,357 @@
+# =============================================================================
+# Issue #526 — Reproducible Jarvis pipeline: MULTI-NODE (distributed) sweep (v3).
+# CONTAINERIZED (Apptainer) deployment, submitted via jarvis's native
+# scheduler block:   jarvis ppl submit <abs path>/distributed.yaml
+# =============================================================================
+#
+# Sweeps the ior client node count 1 -> 2 -> 4 at a FIXED I/O working point
+# (xfer 1m, 4 ranks/node) and benchmarks three storage stacks, recording every
+# run into one results.csv for day-over-day regression tracking.
+#
+#   Experiments (issue #526, v3 = issue-literal drivers):
+#     1. ior + NFS           -> ior against the cluster's shared NFS home
+#     2. CTE + libfuse + ior -> ior through the per-node CTE FUSE mounts
+#                               (SAME stack as single-node, fanned across nodes;
+#                               replaces v2's native clio_cte_bench — ior's own
+#                               multi-rank aggregation replaces the bespoke
+#                               per-host stat folding)
+#     3. juicefs + ior       -> ior through per-node JuiceFS mounts (head-node
+#                               redis metadata via meta_use_head)
+#
+#   Sweep (the issue lists only the node count for multi-node):
+#     * nodes: 1, 2, 4      (fixed: xfer = 1m, ppn = 4, block = 256m
+#                            => 1 GiB written per node per phase)
+#
+# EXECUTION MODEL (scheduler Mode A — single allocation, in-process sweep):
+#   The `scheduler:` block + `jarvis ppl submit` grab a FOUR-node allocation
+#   ONCE; submit.slurm seeds the hostfile with all four nodes and runs a single
+#   `jarvis ppl run yaml <this file>`. The pipeline sweeps each ior driver's
+#   `num_nodes` over [1, 2, 4] IN-PROCESS (jarvis subsets the hostfile to the
+#   FIRST N hosts; nprocs is zipped explicitly as num_nodes x ppn). Services
+#   always run on ALL 4 nodes; only the ior client fan varies — 3 rows in ONE
+#   results.csv from ONE allocation, no per-combo service churn. The 1- and
+#   2-node points run inside a 4-node reservation; with pool_query: local each
+#   node's CTE pool serves only its own ranks, so idle nodes don't perturb the
+#   measurement.
+#   PREREQUISITE: jarvis-cd @ regression-pipelines (v3): Mode A fix,
+#   container_fakeroot, run_timeout, builtin.ior container path + num_nodes +
+#   stonewall, builtin.juicefs meta_use_head, jarvis_cd.util.container_utils.
+#   HOSTFILE: scheduler.hostfile and config.hostfile must stay literally
+#   identical (see single_node.yaml).
+#
+# MPI-IN-CONTAINER (the v3 headline risk — prove with distributed_smoke.yaml
+# BEFORE this file): builtin.ior's mpiexec runs INSIDE the head-node apptainer
+# instance; cross-node rank spawn rides `ssh -p 2222` into the other nodes'
+# instance sshds (jarvis injects --mca plm rsh + plm_rsh_args -p 2222; the SIF
+# carries /usr/local/bin symlinks so sshd-spawned prted resolves, plus an
+# ssh_config drop-in for first-contact host keys). The mpi_cmd below is ONLY
+# the fabric tuning prefix carried from the VALIDATED host-mode yaml
+# (ior_cte_libfuse_sbatch.yaml) — it must keep starting with the literal
+# string "mpiexec " for jarvis's container plumbing to engage:
+#   * btl_tcp_if_include enp47s0np0  -> MPI data plane on the 40 GbE NIC
+#   * oob_tcp_if_include eno1        -> OOB on the 1 GbE management NIC
+#   * prte_if_include eno1           -> PRTE spawn graph on eno1
+#   * prte_tmpdir_base /tmp/...      -> PRTE/PMIx session dir on node-local
+#                                       in-container /tmp (never NFS/small /tmp)
+#   (The host yaml's "-40g" hostfile suffix is deliberately OMITTED for now —
+#   one fewer unvalidated variable; revisit as a perf pass once green.)
+#
+# MULTI-NODE LIBFUSE (second headline risk): the CTE pool is registered on
+# EVERY node by cte_core (compose) BEFORE any FUSE mount, under the default
+# pool_name clio_cte_core == the C++ kCtePoolName — so the FUSE client's own
+# AsyncCreate composes instead of racing cross-node (the documented
+# half-initialized-remote-container wedge). pool_query: local keeps each
+# node's I/O node-local and the scaling symmetric.
+#
+# CONTAINER MODEL: jarvis fans `apptainer instance start --fakeroot` (sshd
+# inside) to EVERY allocated node via Pssh, then runs each package with
+# `apptainer exec instance://...`. One SIF on the shared FS serves all nodes.
+# The sg re-exec pre_cmd fixes the HEAD node's primary group; remote instance
+# starts go over jarvis's ssh where initgroups lands in the personal group
+# already. The fakeroot preflight still proves every node in seconds and
+# prints a ready --exclude hint for broken-uidmap nodes.
+#
+# NFS TOPOLOGY (user decision): nfs_ior SCALES with num_nodes like the other
+# two stacks (fpp onto the shared NFS home). FALLBACK if NFS scaling
+# misbehaves: set nfs_ior single_instance: true (head-pinned single-client
+# baseline) and drop its num_nodes/nprocs vars — the rows go flat by design.
+#
+# ENV OVERRIDES (read by the pre_cmds at job runtime): CONDA_SH, CONDA_ENV,
+# SPACK_SETUP, CLIO_REPO — see single_node.yaml.
+#
+# Output:
+#   ${HOME}/distributed_results/results.csv   (3 rows, one per node count;
+#   columns: {nfs_ior,cte_ior,jfs_ior}.write_max_mibs/.read_max_mibs/... +
+#   .runtime)
+
+scheduler:
+  name: slurm
+  job_name: distributed_526
+  nodes: 4
+  ntasks_per_node: 1
+  cpus_per_task: 32
+  partition: debug
+  time: "04:00:00"
+  # Absolute paths (host-side slurm log; relative would land in the sbatch
+  # CWD). $HOME here is the real host home, outside any container.
+  output: ${HOME}/distributed-%j.out
+  error: ${HOME}/distributed-%j.err
+  # Known bad fakeroot nodes (surveyed): uncomment to steer clear; the
+  # preflight below re-detects per job and prints an updated list.
+  # exclude: "ares-comp-15,ares-comp-17"
+  # MUST stay literally identical to config.hostfile below.
+  hostfile: "${HOME}/.jarvis-526/distributed_hostfile.txt"
+  pre_cmds:
+    # 1) fakeroot GID fix on the head node (see single_node.yaml).
+    - 'if [ "$(id -gn)" != "$USER" ] && getent group "$USER" >/dev/null 2>&1; then echo "re-exec under group $USER for apptainer --fakeroot"; exec sg "$USER" -c "exec bash \"$0\""; fi'
+    # 2) HOST-ENV BLOCK (swap here for spack when the host migration lands).
+    - '. "${CONDA_SH:-$HOME/miniconda3/etc/profile.d/conda.sh}" && conda activate "${CONDA_ENV:-iowarp}"'
+    - 'command -v apptainer >/dev/null 2>&1 || { [ -n "${SPACK_SETUP:-}" ] && . "$SPACK_SETUP" && spack load apptainer; } || true'
+    - 'command -v apptainer >/dev/null 2>&1 || { echo "ERROR: apptainer not on PATH" >&2; exit 1; }'
+    # 3) SIF gate ($SIF is reused by the preflight below — one bash process)
+    - 'JSD=$(grep -hE "^[[:space:]]*shared_dir:" "$HOME"/.ppi-jarvis/*.yaml 2>/dev/null | head -1 | sed -E "s/^[[:space:]]*shared_dir:[[:space:]]*//" | tr -d "\"" || true)'
+    - 'SIF="$JSD/containers/iowarp-regression-526-v3.sif"; [ -n "$JSD" ] && [ -f "$SIF" ] || { echo "ERROR: SIF missing: $SIF — build via jarvis-cd docker/build_regression_image.sh" >&2; exit 1; }'
+    # 4) per-node stale-state reap (all 4 nodes; head included). Warn-only —
+    #    a node that fails prep is caught by the fakeroot preflight below.
+    #    CRITICAL: this inline string is argv of srun AND each node's bash;
+    #    the pkill patterns are BRACKETED so they never match it.
+    - |-
+      srun --kill-on-bad-exit=0 --ntasks-per-node=1 bash -c '
+        command -v apptainer >/dev/null 2>&1 || { echo "WARNING: $(hostname): apptainer not on PATH"; exit 0; }
+        timeout 30 apptainer instance stop --all >/dev/null 2>&1 || true
+        pkill -9 -f "[c]himaera" 2>/dev/null || true
+        pkill -9 -f "[c]lio_run" 2>/dev/null || true
+        { command -v fuser >/dev/null 2>&1 && fuser -k 9413/tcp; } >/dev/null 2>&1 || true
+        rm -f /dev/shm/chi_* 2>/dev/null || true
+        find /tmp -maxdepth 1 \( -name "distributed_run*" -o -name "distributed" \) -mmin +10 -exec rm -rf {} + 2>/dev/null || true
+        rm -rf /tmp/iowarp_chi* 2>/dev/null || true
+        echo "prep done: $(hostname)"
+      ' || echo "WARNING: per-node prep rc=$? — continuing"
+    # 5) fakeroot preflight: a real throwaway --fakeroot instance per node
+    #    over ssh (same hop jarvis uses). Broken-uidmap nodes fail here in
+    #    seconds; the job aborts with a ready resubmit hint.
+    - |-
+      BAD=""
+      for h in $(scontrol show hostnames "$SLURM_JOB_NODELIST"); do
+        if env -u LD_LIBRARY_PATH ssh -n -o BatchMode=yes "$h" \
+            "apptainer instance start --fakeroot $SIF pf_$$ >/dev/null 2>&1 && apptainer instance stop pf_$$ >/dev/null 2>&1"; then
+          echo "fakeroot OK: $h"
+        else
+          echo "fakeroot FAILED: $h"
+          BAD="${BAD:+$BAD,}$h"
+        fi
+      done
+      if [ -n "$BAD" ]; then
+        echo "ERROR: fakeroot preflight failed on: $BAD" >&2
+        echo "Resubmit excluding them: set exclude: \"$BAD\" in the scheduler block, or: sbatch --exclude=$BAD <pipeline shared_dir>/submit.slurm" >&2
+        exit 1
+      fi
+    # 6) experiment dirs + repo registration + clean-slate results
+    - 'mkdir -p "$HOME/526_scratch/distributed/nfs" "$HOME/526_scratch/distributed/jfs_data" "$HOME/cte_libfuse_526" "$HOME/distributed_results"'
+    - 'jarvis repo add "${CLIO_REPO:-$HOME/clio-core-fork}/jarvis_clio_core" 2>/dev/null || true'
+    - 'rm -f "$HOME/distributed_results/results.csv"'
+  post_cmds:
+    - 'RES="$HOME/distributed_results/results.csv"; n=$(grep -c success "$RES" 2>/dev/null || true); n=${n:-0}; echo "successful rows: $n / 3"; [ "$n" -ge 3 ] && echo "ALL 3 GREEN" || echo "INCOMPLETE — inspect $RES and the .err log"'
+
+config:
+  name: distributed
+
+  # Every iteration reads the allocation's hosts from the file submit.slurm
+  # wrote (keep literally identical to scheduler.hostfile above).
+  hostfile: "${HOME}/.jarvis-526/distributed_hostfile.txt"
+
+  # The OUTER jarvis Pssh between nodes brings up the per-node containers, and
+  # this string ALSO becomes mpiexec's --mca plm_rsh_agent: the ssh that spawns
+  # prted INSIDE the remote node's instance sshd on -p 2222 (jarvis appends the
+  # port via plm_rsh_args). env -u LD_LIBRARY_PATH strips the conda
+  # LD_LIBRARY_PATH so /usr/bin/ssh doesn't abort on an OpenSSL mismatch.
+  # StrictHostKeyChecking=no + UserKnownHostsFile=/dev/null are REQUIRED for the
+  # -p 2222 hop: the remote instance's sshd presents a host key never seen for
+  # that host:port, so a strict client aborts with "Host key verification
+  # failed" and PRTE loses the remote daemon (the SIF's ssh_config drop-in did
+  # not take effect on Ares). They also cover the outer host->host hop
+  # harmlessly (those keys are already trusted).
+  ssh_cmd: "env -u LD_LIBRARY_PATH ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+
+  # Fabric tuning prefix for the in-instance mpiexec, carried from the
+  # VALIDATED host-mode yaml (see header). MUST begin with "mpiexec ".
+  mpi_cmd: 'mpiexec --mca btl_tcp_if_include enp47s0np0 --mca oob_tcp_if_include eno1 --prtemca prte_if_include eno1 --prtemca prte_tmpdir_base /tmp/iowarp_prte_tmp'
+
+  # ---- Containerized deployment (Ares dev jarvis — APPTAINER) -----------
+  # Pre-staged SIF referenced by BASENAME -> <shared_dir>/containers/
+  # iowarp-regression-526-v3.sif (shared FS, visible on every allocated node —
+  # ONE SIF serves all nodes). container_uri UNSET => no pull/build. NOT
+  # env-expanded, so keep it a bare basename. See single_node.yaml for the
+  # full rationale on container_fakeroot / tmp_bind_root / the shared-scratch
+  # container_binds.
+  base_deploy_mode: container
+  container_engine: apptainer
+  container_image: "iowarp-regression-526-v3"
+  container_fakeroot: true
+  # In-container /tmp -> node-local disk (chimaera IPC socket/memfd + juicefs
+  # cache + PRTE session dir must not live on the NFS overlay).
+  tmp_bind_root: "/tmp"
+  # Overlay upper on node-local /tmp (a shared-NFS overlay upper is a
+  # multi-node corruption hazard; jarvis errors without a node-local root).
+  container_overlay_root: "/tmp"
+  # Shared-FS scratch bound at instance start on EVERY node (see
+  # single_node.yaml). Critical here: it puts the JuiceFS object store on real
+  # shared NFS at an IDENTICAL host path on all nodes, so under meta_use_head
+  # the distributed filesystem is genuinely shared (an unbound $HOME data_dir
+  # would be per-node overlay — not shared). Same for the nfs_ior baseline.
+  container_binds:
+    - ${HOME}/526_scratch:${HOME}/526_scratch
+  env:
+    CLIO_MEMFD_DIR: "/tmp/iowarp_chimaera"
+
+  pkgs:
+    # ---- Services (started in order; stopped in reverse) -----------------
+    # Redis metadata engine for JuiceFS (head-node container). single_instance:
+    # a 4-node fan-out would push redis into CLUSTER mode (shared nodes.conf
+    # collision + DB0-only, breaking meta_url .../1). The v3 redis.conf binds
+    # 0.0.0.0 with protected-mode off, so the OTHER nodes' juicefs mounts can
+    # reach this head-node server (see juicefs meta_use_head below).
+    - pkg_type: builtin.redis
+      pkg_name: redis
+      port: 6379
+      single_instance: true
+      sleep: 4
+
+    # clio_run runtime on EVERY allocated node's container (Pssh-launched
+    # across the hostfile). shm client transport within each node.
+    # swim_enabled: false carried from the validated host-mode yaml — avoids
+    # mid-IOR SWIM "node confirmed dead" cascades.
+    - pkg_type: jarvis_clio_core.clio_runtime
+      pkg_name: runtime
+      num_threads: 4
+      port: 9413
+      ipc_mode: "shm"
+      log_level: "info"
+      sleep: 4
+      swim_enabled: false
+
+    # CTE pool on every node, single local RAM tier (neighborhood: 1 = each
+    # node serves its own data; pool_query: local => node-local I/O =>
+    # symmetric scaling). Registers the default pool clio_cte_core on ALL
+    # nodes BEFORE any FUSE mount — the multi-node AsyncCreate-race mitigation
+    # (see header). 16 GiB tier vs 1 GiB/node peak ior set = 16x headroom.
+    - pkg_type: jarvis_clio_core.clio_cte
+      pkg_name: cte_core
+      devices:
+        - ["ram::cte_ram_tier1", "16GB", 1.0]
+      dpe_type: "max_bw"
+      neighborhood: 1
+      pool_query: "local"
+      default_target_timeout_ms: 30000
+      poll_period_ms: 5000
+
+    # CTE libfuse mount on EVERY node (v3: the issue-faithful "+ libfuse"
+    # stack fanned across nodes). Mountpoint under $HOME per the VALIDATED
+    # host-mode yaml pattern: each node's FUSE mount shadows the NFS dir
+    # per-node, so one `out:` path below is a CTE-backed target on every node.
+    - pkg_type: jarvis_clio_core.clio_cte_libfuse
+      pkg_name: cte_fuse
+      mountpoint: ${HOME}/cte_libfuse_526
+      log_level: "info"
+      extra_fuse_args: "-f"
+      sleep: 2
+
+    # JuiceFS: format + FUSE mount on EVERY node (v3: scales with the sweep).
+    # meta_use_head rewrites the meta host to hostfile[0] at start(), where
+    # the single_instance redis lives — all nodes share ONE filesystem
+    # namespace (head-node meta + shared-NFS object store on the bound
+    # 526_scratch, identical path on every node), mounted locally on each
+    # node's /tmp. FALLBACK if this misbehaves: single_instance: true here +
+    # on jfs_ior (v2's head-pinned baseline).
+    - pkg_type: builtin.juicefs
+      pkg_name: juicefs
+      meta_use_head: true
+      meta_url: "redis://127.0.0.1:6379/1"
+      storage: file
+      data_dir: ${HOME}/526_scratch/distributed/jfs_data
+      mountpoint: /tmp/jfs_mnt
+      cache_dir: /tmp/juicefs_cache
+      name: jfsbench
+      format_fresh: true
+      mount_wait: 20
+
+    # ---- Benchmark drivers (Applications; run sequentially) --------------
+    # builtin.ior (v3 container path + num_nodes subset knob). Shared keys:
+    # api posix, write+read, fpp (per-node mounts make shared-file impossible
+    # for the CTE/jfs stacks), block 256m x ppn 4 = 1 GiB per node per phase,
+    # stonewall 120 runtime cap. log: is left UNSET so builtin.ior defaults it
+    # to each package's own host-bound shared_dir/ior.log (auto-distinct); an
+    # explicit ${HOME} log lands in the fakeroot overlay and loses every stat.
+    # num_nodes/nprocs are swept below (nprocs = num_nodes x ppn, zipped
+    # explicitly).
+    # 1) NFS: ior against shared NFS via the bound 526_scratch (identical host
+    #    path on every node), scaling with node count.
+    - pkg_type: builtin.ior
+      pkg_name: nfs_ior
+      api: posix
+      write: true
+      read: true
+      fpp: true
+      xfer: "1m"
+      block: "256m"
+      ppn: 4
+      nprocs: 4
+      num_nodes: 1
+      stonewall: 120
+      out: ${HOME}/526_scratch/distributed/nfs/ior_nfs.bin
+
+    # 2) CTE + libfuse: ior through each node's local CTE FUSE mount.
+    - pkg_type: builtin.ior
+      pkg_name: cte_ior
+      api: posix
+      write: true
+      read: true
+      fpp: true
+      xfer: "1m"
+      block: "256m"
+      ppn: 4
+      nprocs: 4
+      num_nodes: 1
+      stonewall: 120
+      out: ${HOME}/cte_libfuse_526/ior_cte.bin
+
+    # 3) juicefs: ior through each node's local JuiceFS mount (one shared
+    #    filesystem namespace; fpp keeps per-rank files distinct).
+    - pkg_type: builtin.ior
+      pkg_name: jfs_ior
+      api: posix
+      write: true
+      read: true
+      fpp: true
+      xfer: "1m"
+      block: "256m"
+      ppn: 4
+      nprocs: 4
+      num_nodes: 1
+      stonewall: 120
+      out: /tmp/jfs_mnt/ior_jfs.bin
+
+# Node-count sweep within the single 4-node allocation: jarvis subsets the
+# hostfile to the FIRST num_nodes hosts for each ior; nprocs is zipped
+# explicitly as num_nodes x ppn (ppn fixed at 4). Services stay up on all 4
+# nodes at every point.
+vars:
+  nfs_ior.num_nodes: [1, 2, 4]
+  cte_ior.num_nodes: [1, 2, 4]
+  jfs_ior.num_nodes: [1, 2, 4]
+  nfs_ior.nprocs:    [4, 8, 16]
+  cte_ior.nprocs:    [4, 8, 16]
+  jfs_ior.nprocs:    [4, 8, 16]
+
+loop:
+  # One axis, 3 values => 3 rows.
+  - [nfs_ior.num_nodes, cte_ior.num_nodes, jfs_ior.num_nodes,
+     nfs_ior.nprocs, cte_ior.nprocs, jfs_ior.nprocs]
+
+# Per-combination wall-clock backstop: with stonewall capping each ior phase
+# at 120 s, a healthy row stays far under 1800; expiry records the row failed
+# and the sweep continues instead of losing the whole allocation.
+run_timeout: 1800
+
+repeat: 1
+output: "${HOME}/distributed_results"

--- a/jarvis_clio_core/pipelines/ares/distributed_smoke.yaml
+++ b/jarvis_clio_core/pipelines/ares/distributed_smoke.yaml
@@ -1,0 +1,224 @@
+# =============================================================================
+# Issue #526 — DISTRIBUTED SMOKE pipeline (v3). The go/no-go gate.
+#   jarvis ppl submit <abs path>/distributed_smoke.yaml
+# =============================================================================
+#
+# Validation scaffolding, NOT a throwaway: same packages, container recipe,
+# fabric tuning, and pre_cmds as distributed.yaml — only the allocation (2
+# nodes), grid ({1,2} client nodes), block size, and time limit shrink.
+#
+# THIS FILE PROVES THE TWO v3 HEADLINE RISKS at 2-node cost, BEFORE any
+# 4-node reservation:
+#   1. MPI-IN-CONTAINER: in-instance mpiexec spawning ranks on the OTHER
+#      node's instance via ssh -p 2222 (the num_nodes=2 row is the proof —
+#      its cte_ior aggregate should be ~2x the num_nodes=1 row).
+#   2. MULTI-NODE LIBFUSE: per-node CTE FUSE mounts against per-node pools
+#      (pool_query local, default pool_name = kCtePoolName) without the
+#      cross-node AsyncCreate race.
+#
+# Red-run levers: set log_level debug on runtime/cte_core; read the per-host
+# fuse logs in the pipeline shared_dir; probe the cross-node hop manually
+# (apptainer exec instance://<run> ssh -p 2222 <peer> hostname); drop
+# num_nodes vars to [1] to isolate MPI spawn from FUSE; use the fakeroot
+# preflight's --exclude hint for bad nodes.
+#
+# See distributed.yaml for full documentation — everything here mirrors it
+# with `distributed_smoke` names.
+
+scheduler:
+  name: slurm
+  job_name: distributed_smoke_526
+  nodes: 2
+  ntasks_per_node: 1
+  cpus_per_task: 32
+  partition: debug
+  time: "01:00:00"
+  # Absolute (host-side slurm log; relative would land in the sbatch CWD).
+  output: ${HOME}/distributed_smoke-%j.out
+  error: ${HOME}/distributed_smoke-%j.err
+  # exclude: "ares-comp-15,ares-comp-17"
+  # MUST stay literally identical to config.hostfile below.
+  hostfile: "${HOME}/.jarvis-526/distributed_smoke_hostfile.txt"
+  pre_cmds:
+    # 1) fakeroot GID fix on the head node (see single_node.yaml).
+    - 'if [ "$(id -gn)" != "$USER" ] && getent group "$USER" >/dev/null 2>&1; then echo "re-exec under group $USER for apptainer --fakeroot"; exec sg "$USER" -c "exec bash \"$0\""; fi'
+    # 2) HOST-ENV BLOCK (swap here for spack when the host migration lands).
+    - '. "${CONDA_SH:-$HOME/miniconda3/etc/profile.d/conda.sh}" && conda activate "${CONDA_ENV:-iowarp}"'
+    - 'command -v apptainer >/dev/null 2>&1 || { [ -n "${SPACK_SETUP:-}" ] && . "$SPACK_SETUP" && spack load apptainer; } || true'
+    - 'command -v apptainer >/dev/null 2>&1 || { echo "ERROR: apptainer not on PATH" >&2; exit 1; }'
+    # 3) SIF gate ($SIF is reused by the preflight below — one bash process)
+    - 'JSD=$(grep -hE "^[[:space:]]*shared_dir:" "$HOME"/.ppi-jarvis/*.yaml 2>/dev/null | head -1 | sed -E "s/^[[:space:]]*shared_dir:[[:space:]]*//" | tr -d "\"" || true)'
+    - 'SIF="$JSD/containers/iowarp-regression-526-v3.sif"; [ -n "$JSD" ] && [ -f "$SIF" ] || { echo "ERROR: SIF missing: $SIF — build via jarvis-cd docker/build_regression_image.sh" >&2; exit 1; }'
+    # 4) per-node stale-state reap (both nodes; bracketed pkills).
+    - |-
+      srun --kill-on-bad-exit=0 --ntasks-per-node=1 bash -c '
+        command -v apptainer >/dev/null 2>&1 || { echo "WARNING: $(hostname): apptainer not on PATH"; exit 0; }
+        timeout 30 apptainer instance stop --all >/dev/null 2>&1 || true
+        pkill -9 -f "[c]himaera" 2>/dev/null || true
+        pkill -9 -f "[c]lio_run" 2>/dev/null || true
+        { command -v fuser >/dev/null 2>&1 && fuser -k 9413/tcp; } >/dev/null 2>&1 || true
+        rm -f /dev/shm/chi_* 2>/dev/null || true
+        find /tmp -maxdepth 1 \( -name "distributed_smoke_run*" -o -name "distributed_smoke" \) -mmin +10 -exec rm -rf {} + 2>/dev/null || true
+        rm -rf /tmp/iowarp_chi* 2>/dev/null || true
+        echo "prep done: $(hostname)"
+      ' || echo "WARNING: per-node prep rc=$? — continuing"
+    # 5) fakeroot preflight (throwaway --fakeroot instance per node).
+    - |-
+      BAD=""
+      for h in $(scontrol show hostnames "$SLURM_JOB_NODELIST"); do
+        if env -u LD_LIBRARY_PATH ssh -n -o BatchMode=yes "$h" \
+            "apptainer instance start --fakeroot $SIF pf_$$ >/dev/null 2>&1 && apptainer instance stop pf_$$ >/dev/null 2>&1"; then
+          echo "fakeroot OK: $h"
+        else
+          echo "fakeroot FAILED: $h"
+          BAD="${BAD:+$BAD,}$h"
+        fi
+      done
+      if [ -n "$BAD" ]; then
+        echo "ERROR: fakeroot preflight failed on: $BAD" >&2
+        echo "Resubmit excluding them: set exclude: \"$BAD\" in the scheduler block, or: sbatch --exclude=$BAD <pipeline shared_dir>/submit.slurm" >&2
+        exit 1
+      fi
+    # 6) experiment dirs + repo registration + clean-slate results
+    - 'mkdir -p "$HOME/526_scratch/distributed_smoke/nfs" "$HOME/526_scratch/distributed_smoke/jfs_data" "$HOME/cte_libfuse_526_smoke" "$HOME/distributed_smoke_results"'
+    - 'jarvis repo add "${CLIO_REPO:-$HOME/clio-core-fork}/jarvis_clio_core" 2>/dev/null || true'
+    - 'rm -f "$HOME/distributed_smoke_results/results.csv"'
+  post_cmds:
+    - 'RES="$HOME/distributed_smoke_results/results.csv"; n=$(grep -c success "$RES" 2>/dev/null || true); n=${n:-0}; echo "successful rows: $n / 2"; [ "$n" -ge 2 ] && echo "ALL 2 GREEN" || echo "INCOMPLETE — inspect $RES and the .err log"'
+
+config:
+  name: distributed_smoke
+
+  hostfile: "${HOME}/.jarvis-526/distributed_smoke_hostfile.txt"
+
+  # Host-level Pssh hop + mpiexec plm_rsh_agent (see distributed.yaml). The
+  # StrictHostKeyChecking=no + UserKnownHostsFile=/dev/null are REQUIRED for the
+  # in-instance ssh -p 2222 prted spawn — without them the num_nodes>=2 rows die
+  # with "Host key verification failed" / "PRTE has lost communication".
+  ssh_cmd: "env -u LD_LIBRARY_PATH ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+
+  # Fabric tuning prefix (identical to distributed.yaml; must start "mpiexec ").
+  mpi_cmd: 'mpiexec --mca btl_tcp_if_include enp47s0np0 --mca oob_tcp_if_include eno1 --prtemca prte_if_include eno1 --prtemca prte_tmpdir_base /tmp/iowarp_prte_tmp'
+
+  # ---- Containerized deployment — identical recipe to distributed.yaml ----
+  base_deploy_mode: container
+  container_engine: apptainer
+  container_image: "iowarp-regression-526-v3"
+  container_fakeroot: true
+  tmp_bind_root: "/tmp"
+  container_overlay_root: "/tmp"
+  # Shared-FS scratch bound at instance start on both nodes (see
+  # distributed.yaml): real-NFS nfs_ior baseline + a genuinely shared JuiceFS
+  # object store under meta_use_head.
+  container_binds:
+    - ${HOME}/526_scratch:${HOME}/526_scratch
+  env:
+    CLIO_MEMFD_DIR: "/tmp/iowarp_chimaera"
+
+  pkgs:
+    # ---- Services (identical configs to distributed.yaml) ----------------
+    - pkg_type: builtin.redis
+      pkg_name: redis
+      port: 6379
+      single_instance: true
+      sleep: 4
+
+    - pkg_type: jarvis_clio_core.clio_runtime
+      pkg_name: runtime
+      num_threads: 4
+      port: 9413
+      ipc_mode: "shm"
+      log_level: "info"
+      sleep: 4
+      swim_enabled: false
+
+    - pkg_type: jarvis_clio_core.clio_cte
+      pkg_name: cte_core
+      devices:
+        - ["ram::cte_ram_tier1", "16GB", 1.0]
+      dpe_type: "max_bw"
+      neighborhood: 1
+      pool_query: "local"
+      default_target_timeout_ms: 30000
+      poll_period_ms: 5000
+
+    - pkg_type: jarvis_clio_core.clio_cte_libfuse
+      pkg_name: cte_fuse
+      mountpoint: ${HOME}/cte_libfuse_526_smoke
+      log_level: "info"
+      extra_fuse_args: "-f"
+      sleep: 2
+
+    - pkg_type: builtin.juicefs
+      pkg_name: juicefs
+      meta_use_head: true
+      meta_url: "redis://127.0.0.1:6379/1"
+      storage: file
+      data_dir: ${HOME}/526_scratch/distributed_smoke/jfs_data
+      mountpoint: /tmp/jfs_mnt
+      cache_dir: /tmp/juicefs_cache
+      name: jfsbench
+      format_fresh: true
+      mount_wait: 20
+
+    # ---- Benchmark drivers (block shrunk 256m -> 64m, ppn 4 -> 2) --------
+    - pkg_type: builtin.ior
+      pkg_name: nfs_ior
+      api: posix
+      write: true
+      read: true
+      fpp: true
+      xfer: "1m"
+      block: "64m"
+      ppn: 2
+      nprocs: 2
+      num_nodes: 1
+      stonewall: 120
+      out: ${HOME}/526_scratch/distributed_smoke/nfs/ior_nfs.bin
+
+    - pkg_type: builtin.ior
+      pkg_name: cte_ior
+      api: posix
+      write: true
+      read: true
+      fpp: true
+      xfer: "1m"
+      block: "64m"
+      ppn: 2
+      nprocs: 2
+      num_nodes: 1
+      stonewall: 120
+      out: ${HOME}/cte_libfuse_526_smoke/ior_cte.bin
+
+    - pkg_type: builtin.ior
+      pkg_name: jfs_ior
+      api: posix
+      write: true
+      read: true
+      fpp: true
+      xfer: "1m"
+      block: "64m"
+      ppn: 2
+      nprocs: 2
+      num_nodes: 1
+      stonewall: 120
+      out: /tmp/jfs_mnt/ior_jfs.bin
+
+# {1,2}-client-node sweep: row 1 = all-local MPI (isolates the container
+# stack), row 2 = the cross-node spawn proof.
+vars:
+  nfs_ior.num_nodes: [1, 2]
+  cte_ior.num_nodes: [1, 2]
+  jfs_ior.num_nodes: [1, 2]
+  nfs_ior.nprocs:    [2, 4]
+  cte_ior.nprocs:    [2, 4]
+  jfs_ior.nprocs:    [2, 4]
+
+loop:
+  - [nfs_ior.num_nodes, cte_ior.num_nodes, jfs_ior.num_nodes,
+     nfs_ior.nprocs, cte_ior.nprocs, jfs_ior.nprocs]
+
+run_timeout: 1200
+
+repeat: 1
+output: "${HOME}/distributed_smoke_results"

--- a/jarvis_clio_core/pipelines/ares/single_node.yaml
+++ b/jarvis_clio_core/pipelines/ares/single_node.yaml
@@ -1,0 +1,368 @@
+# =============================================================================
+# Issue #526 — Reproducible Jarvis pipeline: SINGLE-NODE regression sweep (v3).
+# CONTAINERIZED (Apptainer) deployment, submitted via jarvis's native
+# scheduler block:   jarvis ppl submit <abs path>/single_node.yaml
+# =============================================================================
+#
+# One pipeline test that benchmarks FOUR storage stacks back-to-back over a
+# shared (I/O size x thread count) grid and records every run into ONE
+# results.csv, so a daily Ares run can be diffed against yesterday to catch
+# performance regressions.
+#
+#   Experiments (issue #526, v3 = issue-literal drivers):
+#     1. NFS + ior           -> ior against the cluster's NFS home
+#     2. CTE + libfuse + ior -> ior against the CTE FUSE mount (POSIX->FUSE->CTE)
+#     3. redis + redis-bench -> builtin.redis-benchmark (SET/GET) vs local redis
+#     4. juicefs + ior       -> ior against the JuiceFS FUSE mount (redis meta +
+#                               local-file object backend)
+#
+#   Grid (issue #526):
+#     * I/O size:     4 KB, 64 KB, 128 KB, 1024 KB   -> 4k, 64k, 128k, 1m
+#     * thread count: 1, 2, 4, 8, 16, 32             -> 4 x 6 = 24 combinations
+#   "threads" = MPI ranks (nprocs/ppn) for the ior drivers; = redis-benchmark
+#   --threads AND -c clients, zipped equal (N connections driven by N threads).
+#
+# EXECUTION MODEL (scheduler Mode A):
+#   The top-level `scheduler:` block below + `jarvis ppl submit` generate and
+#   submit ONE sbatch job (<pipeline shared_dir>/submit.slurm) that wraps the
+#   WHOLE 24-combo grid: pre_cmds run, the hostfile is generated from
+#   $SLURM_JOB_NODELIST, then `jarvis ppl run yaml <this file>` runs every
+#   combo IN-PROCESS inside that single allocation.
+#   PREREQUISITE: jarvis-cd @ regression-pipelines (v3): the Mode A in-process
+#   fix, the `container_fakeroot` pipeline flag, `run_timeout`, builtin.ior's
+#   shared-instance container path (+ stonewall), builtin.redis-benchmark v3
+#   (--csv stats, clients key), builtin.juicefs, and
+#   jarvis_cd.util.container_utils (which the clio_* packages here import).
+#   HOSTFILE: `scheduler.hostfile` tells submit.slurm where to write the
+#   allocation's hosts; the IDENTICAL `hostfile:` under `config:` makes every
+#   iteration read that same file. Keep the two values literally identical.
+#
+# CONTAINER MODEL:
+#   base_deploy_mode: container + container_engine: apptainer => jarvis starts
+#   ONE long-running `apptainer instance` (with sshd inside) and runs the WHOLE
+#   pipeline inside it via `apptainer exec instance://...`. All services and
+#   drivers share that instance, so the JuiceFS and CTE FUSE mounts are visible
+#   to ior in the SAME mount namespace. FUSE needs CAP_SYS_ADMIN, which an
+#   UNPRIVILEGED (non-setuid, conda-forge) apptainer can only supply via
+#   --fakeroot (container_fakeroot below); plain --add-caps SYS_ADMIN is a
+#   NO-OP rootless. Apptainer applies no seccomp/apparmor, so io_uring_setup
+#   (CTE bdev) is not blocked.
+#   FAKEROOT + SLURM GID: rootless --fakeroot validates the GID map against the
+#   user's PERSONAL group, but Slurm starts jobs under the PROJECT primary GID.
+#   The first pre_cmd below re-execs the job script under `sg $USER` (guarded:
+#   no-op when the primary group is already $USER, e.g. off-Slurm).
+#
+# INSTALLATION: baked into a prebuilt SIF built from jarvis-cd's
+# docker/regression.Dockerfile (docker build -> `apptainer build <sif>
+# docker-daemon://...`; the Dockerfile's final RUN is the install-cleanliness
+# gate). The v3 image carries iowarp@dev +fuse, spack ior@3.3.0 + openmpi,
+# redis, juicefs, jarvis-cd, and this repo (fetched at CLIO_REF). Rebuild
+# daily so #526 tracks the latest IOWarp. The SIF-presence pre_cmd below
+# aborts the job early when the image was never staged; build it with
+# jarvis-cd's docker/build_regression_image.sh.
+#
+# PATHS: shared-FS experiment targets (nfs_ior out + the JuiceFS object store)
+# live under ${HOME}/526_scratch, bound INTO the instance via container_binds
+# at instance start — inside the --fakeroot instance $HOME ITSELF is the
+# overlay, so an unbound $HOME path hits ephemeral node-local storage, not NFS.
+# The FUSE mountpoints + JuiceFS cache + chimaera memfd/IPC live on NODE-LOCAL
+# /tmp via tmp_bind_root. The runner writes results.csv on the HOST at
+# `output:` below.
+#
+# Output:
+#   ${HOME}/single_node_results/results.csv   (24 rows; per-driver columns:
+#   <ior pkg>.write_max_mibs/.read_max_mibs/... + .runtime for the ior drivers;
+#   redis_bench.set_rps/.get_rps/.set_p50_ms/.get_p50_ms/.set_p99_ms/
+#   .get_p99_ms + .runtime, raw CSV in the pipeline shared_dir.)
+#
+# ENV OVERRIDES (read by the pre_cmds at job runtime): CONDA_SH (path to
+# conda.sh), CONDA_ENV (conda env with jarvis + apptainer, default iowarp),
+# SPACK_SETUP (optional spack setup-env.sh providing apptainer), CLIO_REPO
+# (this repo's checkout, default ~/clio-core-fork). Export them before
+# `jarvis ppl submit` — pre_cmds are baked verbatim into submit.slurm, so the
+# expansion happens when the JOB runs.
+#
+# SMOKE FIRST: run single_node_smoke.yaml (same pkgs/container/pre_cmds, 2
+# combos, ~15 min) after ANY container rebuild before committing to this
+# 24-combo sweep.
+#
+# SIZING: peak ior data = 32 ranks x 64 MiB block = 2 GiB per phase — 12x
+# headroom in the 24 GiB CTE RAM tier. stonewall (ior -D) caps each ior phase
+# at 120 s, so a pathological small-xfer FUSE combo gets clipped instead of
+# eating the whole run_timeout.
+
+scheduler:
+  name: slurm
+  job_name: single_node_526
+  nodes: 1
+  ntasks_per_node: 1
+  # cpus_per_task must stay large: Ares Slurm uses proctrack/cgroup with
+  # ConstrainCores, and a 1-core cgroup starves clio_run's dedicated workers
+  # alongside FUSE + ior ranks.
+  cpus_per_task: 32
+  partition: debug
+  time: "12:00:00"
+  # Absolute paths so slurm's own stdout/stderr are easy to find (a relative
+  # path lands in the sbatch CWD). Written by slurm on the HOST, outside any
+  # container, so $HOME is the real host home (not the fakeroot overlay).
+  output: ${HOME}/single_node-%j.out
+  error: ${HOME}/single_node-%j.err
+  # Known bad fakeroot nodes (surveyed): uncomment to steer clear. Unknown
+  # scheduler keys pass through as --<key>=<value> sbatch directives.
+  # exclude: "ares-comp-15,ares-comp-17"
+  # Where submit.slurm writes the allocation's hosts. MUST stay literally
+  # identical to config.hostfile below (both are env-expanded at different
+  # times; $HOME is NFS-shared so they resolve to the same file).
+  hostfile: "${HOME}/.jarvis-526/single_node_hostfile.txt"
+  pre_cmds:
+    # 1) fakeroot GID fix: Slurm hands the job the project primary GID;
+    #    rootless --fakeroot validates the GID map against group == $USER.
+    #    Guarded self-re-exec of this job script under the personal group.
+    - 'if [ "$(id -gn)" != "$USER" ] && getent group "$USER" >/dev/null 2>&1; then echo "re-exec under group $USER for apptainer --fakeroot"; exec sg "$USER" -c "exec bash \"$0\""; fi'
+    # 2) HOST-ENV BLOCK (the one place the host launcher toolchain is brought
+    #    up — swap here for spack when the conda->spack host migration lands).
+    - '. "${CONDA_SH:-$HOME/miniconda3/etc/profile.d/conda.sh}" && conda activate "${CONDA_ENV:-iowarp}"'
+    - 'command -v apptainer >/dev/null 2>&1 || { [ -n "${SPACK_SETUP:-}" ] && . "$SPACK_SETUP" && spack load apptainer; } || true'
+    - 'command -v apptainer >/dev/null 2>&1 || { echo "ERROR: apptainer not on PATH" >&2; exit 1; }'
+    # 3) SIF gate: fail fast if the v3 regression image was never staged.
+    #    pre_cmds are verbatim shell, so resolve jarvis's shared_dir here.
+    - 'JSD=$(grep -hE "^[[:space:]]*shared_dir:" "$HOME"/.ppi-jarvis/*.yaml 2>/dev/null | head -1 | sed -E "s/^[[:space:]]*shared_dir:[[:space:]]*//" | tr -d "\"" || true)'
+    - 'SIF="$JSD/containers/iowarp-regression-526-v3.sif"; [ -n "$JSD" ] && [ -f "$SIF" ] || { echo "ERROR: SIF missing: $SIF — build via jarvis-cd docker/build_regression_image.sh" >&2; exit 1; }'
+    # 4) stale-state cleanup: ghost daemons/instances from a crashed prior
+    #    run wedge this one (port 9413, /dev/shm segments, leftover per-run
+    #    /tmp). pkill patterns are BRACKETED so they never match this
+    #    script's own argv.
+    - 'timeout 30 apptainer instance stop --all >/dev/null 2>&1 || true'
+    - 'pkill -9 -f "[c]himaera" 2>/dev/null || true'
+    - 'pkill -9 -f "[c]lio_run" 2>/dev/null || true'
+    - '{ command -v fuser >/dev/null 2>&1 && fuser -k 9413/tcp; } >/dev/null 2>&1 || true'
+    - 'rm -f /dev/shm/chi_* 2>/dev/null || true'
+    - 'find /tmp -maxdepth 1 \( -name "single_node_run*" -o -name "single_node" \) -mmin +10 -exec rm -rf {} + 2>/dev/null || true'
+    - 'rm -rf /tmp/iowarp_chi* 2>/dev/null || true'
+    # 5) experiment dirs + repo registration + clean-slate results (the
+    #    sweep runner resumes over an existing results.csv and would skip
+    #    previously-failed rows)
+    - 'mkdir -p "$HOME/526_scratch/single_node/nfs" "$HOME/526_scratch/single_node/jfs_data" "$HOME/single_node_results"'
+    - 'jarvis repo add "${CLIO_REPO:-$HOME/clio-core-fork}/jarvis_clio_core" 2>/dev/null || true'
+    - 'rm -f "$HOME/single_node_results/results.csv"'
+  post_cmds:
+    - 'RES="$HOME/single_node_results/results.csv"; n=$(grep -c success "$RES" 2>/dev/null || true); n=${n:-0}; echo "successful rows: $n / 24"; [ "$n" -ge 24 ] && echo "ALL 24 GREEN" || echo "INCOMPLETE — inspect $RES and the .err log"'
+
+config:
+  name: single_node
+
+  # Every iteration reads the allocation's hosts from the file submit.slurm
+  # wrote (see scheduler.hostfile above — keep the two literally identical).
+  hostfile: "${HOME}/.jarvis-526/single_node_hostfile.txt"
+
+  # ---- Containerized deployment (Ares dev jarvis — APPTAINER) -----------
+  base_deploy_mode: container
+  container_engine: apptainer
+  # Pre-staged SIF, referenced by BASENAME (NOT a path): jarvis resolves it to
+  #   <jarvis shared_dir>/containers/iowarp-regression-526-v3.sif
+  # Because container_uri is UNSET, jarvis trusts this SIF and performs NO
+  # pull/build. The -v3 basename is deliberate: a stale v2 SIF (which lacks
+  # ior) can never be silently reused. NOTE: container_image is NOT
+  # env-expanded by jarvis, so it must stay a bare basename.
+  container_image: "iowarp-regression-526-v3"
+  # FUSE-in-apptainer recipe: the CTE + JuiceFS FUSE mounts need CAP_SYS_ADMIN
+  # *effective* inside the container. With a non-setuid apptainer, --fakeroot
+  # is required (verified in v2: without it, fusermount fails to open
+  # /dev/fuse). With fakeroot, container_caps and a /dev/fuse bind are
+  # unnecessary (v2 went 24/24 green with neither; confirmed with jarvis v3).
+  container_fakeroot: true
+  # Redirect in-container /tmp to NODE-LOCAL disk. Default jarvis backs
+  # apptainer /tmp with an NFS overlay, which breaks chimaera's IPC unix
+  # sockets and would put the JuiceFS cache on NFS. tmp_bind_root makes jarvis
+  # bind <root>/single_node/tmp -> /tmp from local disk instead.
+  tmp_bind_root: "/tmp"
+  # container_binds: bind a dedicated shared-FS scratch INTO the instance.
+  # v2's objection was about per-package `apptainer exec instance://` --bind
+  # (which did NOT materialize on Ares); container_binds are applied at
+  # `apptainer instance start` instead — the SAME mechanism as tmp_bind_root —
+  # so they DO take effect. Required because inside the --fakeroot instance
+  # $HOME is the overlay, not a host bind, so nfs_ior's out + juicefs's
+  # data_dir would otherwise land on the ephemeral node-local overlay instead
+  # of real NFS. The bind maps the exact host path through, bypassing the
+  # overlay; it is on shared NFS and identical on every node. jarvis does NOT
+  # create bind sources (instance start --bind fails on a missing source), so
+  # the pre_cmd mkdir above creates ${HOME}/526_scratch/... first.
+  container_binds:
+    - ${HOME}/526_scratch:${HOME}/526_scratch
+
+  env:
+    # In-container memfd dir for chimaera (container /tmp is private + writable).
+    CLIO_MEMFD_DIR: "/tmp/iowarp_chimaera"
+
+  pkgs:
+    # ---- Services (started in order; stopped in reverse) -----------------
+    # Redis: metadata engine for JuiceFS (DB 1) AND server for redis-benchmark
+    # (DB 0). One server covers both; no persistence keeps it a fair in-memory
+    # peer of the CTE RAM tier. (builtin.redis — #526 hardening lives upstream
+    # in jarvis-cd @ regression-pipelines.)
+    - pkg_type: builtin.redis
+      pkg_name: redis
+      port: 6379
+      sleep: 4
+
+    # clio_run runtime daemon (shm IPC for single-node). swim_enabled: false
+    # carried from the validated host-mode ior yaml — avoids mid-IOR SWIM
+    # "node confirmed dead" cascades.
+    - pkg_type: jarvis_clio_core.clio_runtime
+      pkg_name: runtime
+      num_threads: 4
+      port: 9413
+      ipc_mode: "shm"
+      log_level: "info"
+      sleep: 4
+      swim_enabled: false
+
+    # CTE pool, single RAM tier. 24 GiB = 12x the 2 GiB peak ior write set
+    # (32 ranks x 64 MiB block). pool_name stays at its default
+    # clio_cte_core == the C++ kCtePoolName constant — required so the FUSE
+    # client's AsyncCreate composes against the same pool (see the pool_name
+    # menu text for the cross-node race this avoids).
+    - pkg_type: jarvis_clio_core.clio_cte
+      pkg_name: cte_core
+      devices:
+        - ["ram::cte_ram_tier1", "24GB", 1.0]
+      dpe_type: "max_bw"
+      neighborhood: 1
+      pool_query: "local"
+      default_target_timeout_ms: 30000
+      poll_period_ms: 5000
+
+    # CTE libfuse mount (in-container): the "+ libfuse" path the ior driver
+    # below writes through (POSIX -> FUSE -> CTE).
+    - pkg_type: jarvis_clio_core.clio_cte_libfuse
+      pkg_name: cte_fuse
+      # FUSE mountpoint on NODE-LOCAL /tmp (writable via tmp_bind_root), NOT
+      # /mnt: the image's /mnt is read-only SquashFS.
+      mountpoint: /tmp/cte_mnt
+      log_level: "info"
+      extra_fuse_args: "-f"
+      sleep: 2
+
+    # JuiceFS: format (storage=file) + FUSE mount. Object store on the bound
+    # shared-FS scratch (real NFS, bypasses the overlay); mount + cache on
+    # in-container node-local /tmp (a distributed-FS cache stays node-local).
+    - pkg_type: builtin.juicefs
+      pkg_name: juicefs
+      meta_url: "redis://127.0.0.1:6379/1"
+      storage: file
+      data_dir: ${HOME}/526_scratch/single_node/jfs_data
+      mountpoint: /tmp/jfs_mnt
+      cache_dir: /tmp/juicefs_cache
+      name: jfsbench
+      format_fresh: true
+      mount_wait: 20
+
+    # ---- Benchmark drivers (Applications; run sequentially) --------------
+    # builtin.ior (v3 container path). Shared keys: api posix, write+read,
+    # fpp (file-per-process — REQUIRED through per-node FUSE mounts), fixed
+    # block 64m per rank (data-bounded runtime; the xfer sweep below is the
+    # I/O-size axis), stonewall 120 (ior -D: phase runtime cap). log: is left
+    # UNSET on purpose — builtin.ior then defaults it to each package's own
+    # shared_dir/ior.log, which is host-bound and auto-distinct per package.
+    # An explicit ${HOME}/..._results/*.log silently lost every stat: inside
+    # the --fakeroot instance $HOME is the overlay (not a host bind) and the
+    # log parent dir does not exist there, so ior's `tee <log>` failed and the
+    # host-side stat parser found nothing.
+    # 1) NFS: ior against real NFS via the bound 526_scratch (an unbound $HOME
+    #    path would hit the fakeroot overlay, not NFS — see container_binds).
+    - pkg_type: builtin.ior
+      pkg_name: nfs_ior
+      api: posix
+      write: true
+      read: true
+      fpp: true
+      xfer: "4k"
+      block: "64m"
+      nprocs: 1
+      ppn: 1
+      stonewall: 120
+      out: ${HOME}/526_scratch/single_node/nfs/ior_nfs.bin
+
+    # 2) CTE + libfuse: ior through the CTE FUSE mount.
+    - pkg_type: builtin.ior
+      pkg_name: cte_ior
+      api: posix
+      write: true
+      read: true
+      fpp: true
+      xfer: "4k"
+      block: "64m"
+      nprocs: 1
+      ppn: 1
+      stonewall: 120
+      out: /tmp/cte_mnt/ior_cte.bin
+
+    # 3) redis: builtin.redis-benchmark (SET/GET -> -t set,get; --csv stats).
+    #    The "threads" axis drives clients (-c) AND nthreads (--threads),
+    #    zipped equal: a row means N connections driven by N I/O threads.
+    #    count (-n) is zipped with req_size so total data stays ~1 GiB
+    #    (count = 1 GiB / req_size), keeping the working set axis-independent.
+    - pkg_type: builtin.redis-benchmark
+      pkg_name: redis_bench
+      port: 6379
+      write: true
+      read: true
+      req_size: 4096
+      count: 262144
+      clients: 1
+      nthreads: 1
+
+    # 4) juicefs: ior through the JuiceFS FUSE mount.
+    - pkg_type: builtin.ior
+      pkg_name: jfs_ior
+      api: posix
+      write: true
+      read: true
+      fpp: true
+      xfer: "4k"
+      block: "64m"
+      nprocs: 1
+      ppn: 1
+      stonewall: 120
+      out: /tmp/jfs_mnt/ior_jfs.bin
+
+vars:
+  # I/O size, applied to all four drivers at once (zipped, length 4). 1m = the
+  # issue's 1024 KB point. redis req_size is in BYTES; count is the matching
+  # ~1 GiB request budget (1 GiB / req_size), so 4k<->262144, 64k<->16384,
+  # 128k<->8192, 1m<->1024 stay paired.
+  nfs_ior.xfer:        ["4k",   "64k",  "128k", "1m"]
+  cte_ior.xfer:        ["4k",   "64k",  "128k", "1m"]
+  jfs_ior.xfer:        ["4k",   "64k",  "128k", "1m"]
+  redis_bench.req_size: [4096,  65536,  131072, 1048576]
+  redis_bench.count:    [262144, 16384, 8192,   1024]
+
+  # Thread count, applied to all four drivers at once (zipped, length 6).
+  # ior: nprocs AND ppn (single node => equal). redis-benchmark: clients (-c)
+  # AND nthreads (--threads), zipped equal per the jarvis contract.
+  nfs_ior.nprocs:      [1, 2, 4, 8, 16, 32]
+  nfs_ior.ppn:         [1, 2, 4, 8, 16, 32]
+  cte_ior.nprocs:      [1, 2, 4, 8, 16, 32]
+  cte_ior.ppn:         [1, 2, 4, 8, 16, 32]
+  jfs_ior.nprocs:      [1, 2, 4, 8, 16, 32]
+  jfs_ior.ppn:         [1, 2, 4, 8, 16, 32]
+  redis_bench.clients: [1, 2, 4, 8, 16, 32]
+  redis_bench.nthreads: [1, 2, 4, 8, 16, 32]
+
+loop:
+  # Outer group: I/O size (+ redis request budget), 4 values.
+  - [nfs_ior.xfer, cte_ior.xfer, jfs_ior.xfer,
+     redis_bench.req_size, redis_bench.count]
+  # Inner group: thread count, 6 values  =>  4 x 6 = 24 combinations.
+  - [nfs_ior.nprocs, nfs_ior.ppn, cte_ior.nprocs, cte_ior.ppn,
+     jfs_ior.nprocs, jfs_ior.ppn, redis_bench.clients, redis_bench.nthreads]
+
+# Per-combination wall-clock backstop (jarvis-cd @ regression-pipelines;
+# older jarvis silently ignores this key). With stonewall capping each ior
+# phase at 120 s, a healthy combo stays well under 1200; expiry records the
+# row failed and the sweep continues — one wedged package can no longer lose
+# the other 23 rows of the shared allocation.
+run_timeout: 1200
+
+repeat: 1                       # bump to 3 for variance (~3x wall-clock)
+output: "${HOME}/single_node_results"

--- a/jarvis_clio_core/pipelines/ares/single_node_smoke.yaml
+++ b/jarvis_clio_core/pipelines/ares/single_node_smoke.yaml
@@ -1,0 +1,189 @@
+# =============================================================================
+# Issue #526 — SINGLE-NODE SMOKE pipeline (v3). Quick and cheap.
+#   jarvis ppl submit <abs path>/single_node_smoke.yaml
+# =============================================================================
+#
+# Validation scaffolding, NOT a throwaway: same packages, same container
+# recipe, and same pre_cmds as single_node.yaml — ONLY the sweep grid, block
+# size, and time limit shrink. A green run here is real evidence the full
+# sweep's bindings are sound. THIS IS THE FIRST THING RUN AFTER ANY CONTAINER
+# REBUILD: it exercises all four experiments (NFS+ior, CTE+libfuse+ior,
+# redis+redis-benchmark, juicefs+ior) end-to-end — container start, fakeroot
+# FUSE mounts, redis, in-SIF ior+mpiexec — in ~10-15 minutes.
+#
+# Grid: 2 combos = I/O size {4k, 1m} (both extremes) x threads {2} (exercises
+# both loop axes' machinery). block 16m keeps data tiny (2 ranks x 16 MiB).
+#
+# See single_node.yaml for the full documentation of the execution model,
+# container model, paths, and env overrides — everything here mirrors it with
+# `single_node_smoke` names.
+
+scheduler:
+  name: slurm
+  job_name: single_node_smoke_526
+  nodes: 1
+  ntasks_per_node: 1
+  cpus_per_task: 32
+  partition: debug
+  time: "01:00:00"
+  # Absolute (host-side slurm log; relative would land in the sbatch CWD).
+  output: ${HOME}/single_node_smoke-%j.out
+  error: ${HOME}/single_node_smoke-%j.err
+  # exclude: "ares-comp-15,ares-comp-17"
+  hostfile: "${HOME}/.jarvis-526/single_node_smoke_hostfile.txt"
+  pre_cmds:
+    # 1) fakeroot GID fix (see single_node.yaml).
+    - 'if [ "$(id -gn)" != "$USER" ] && getent group "$USER" >/dev/null 2>&1; then echo "re-exec under group $USER for apptainer --fakeroot"; exec sg "$USER" -c "exec bash \"$0\""; fi'
+    # 2) HOST-ENV BLOCK (swap here for spack when the host migration lands).
+    - '. "${CONDA_SH:-$HOME/miniconda3/etc/profile.d/conda.sh}" && conda activate "${CONDA_ENV:-iowarp}"'
+    - 'command -v apptainer >/dev/null 2>&1 || { [ -n "${SPACK_SETUP:-}" ] && . "$SPACK_SETUP" && spack load apptainer; } || true'
+    - 'command -v apptainer >/dev/null 2>&1 || { echo "ERROR: apptainer not on PATH" >&2; exit 1; }'
+    # 3) SIF gate.
+    - 'JSD=$(grep -hE "^[[:space:]]*shared_dir:" "$HOME"/.ppi-jarvis/*.yaml 2>/dev/null | head -1 | sed -E "s/^[[:space:]]*shared_dir:[[:space:]]*//" | tr -d "\"" || true)'
+    - 'SIF="$JSD/containers/iowarp-regression-526-v3.sif"; [ -n "$JSD" ] && [ -f "$SIF" ] || { echo "ERROR: SIF missing: $SIF — build via jarvis-cd docker/build_regression_image.sh" >&2; exit 1; }'
+    # 4) stale-state cleanup (bracketed pkills never match this script).
+    - 'timeout 30 apptainer instance stop --all >/dev/null 2>&1 || true'
+    - 'pkill -9 -f "[c]himaera" 2>/dev/null || true'
+    - 'pkill -9 -f "[c]lio_run" 2>/dev/null || true'
+    - '{ command -v fuser >/dev/null 2>&1 && fuser -k 9413/tcp; } >/dev/null 2>&1 || true'
+    - 'rm -f /dev/shm/chi_* 2>/dev/null || true'
+    - 'find /tmp -maxdepth 1 \( -name "single_node_smoke_run*" -o -name "single_node_smoke" \) -mmin +10 -exec rm -rf {} + 2>/dev/null || true'
+    - 'rm -rf /tmp/iowarp_chi* 2>/dev/null || true'
+    # 5) experiment dirs + repo registration + clean-slate results.
+    - 'mkdir -p "$HOME/526_scratch/single_node_smoke/nfs" "$HOME/526_scratch/single_node_smoke/jfs_data" "$HOME/single_node_smoke_results"'
+    - 'jarvis repo add "${CLIO_REPO:-$HOME/clio-core-fork}/jarvis_clio_core" 2>/dev/null || true'
+    - 'rm -f "$HOME/single_node_smoke_results/results.csv"'
+  post_cmds:
+    - 'RES="$HOME/single_node_smoke_results/results.csv"; n=$(grep -c success "$RES" 2>/dev/null || true); n=${n:-0}; echo "successful rows: $n / 2"; [ "$n" -ge 2 ] && echo "ALL 2 GREEN" || echo "INCOMPLETE — inspect $RES and the .err log"'
+
+config:
+  name: single_node_smoke
+
+  hostfile: "${HOME}/.jarvis-526/single_node_smoke_hostfile.txt"
+
+  # ---- Containerized deployment — identical recipe to single_node.yaml ----
+  base_deploy_mode: container
+  container_engine: apptainer
+  container_image: "iowarp-regression-526-v3"
+  container_fakeroot: true
+  tmp_bind_root: "/tmp"
+  # Shared-FS scratch bound at instance start (see single_node.yaml): puts
+  # nfs_ior out + juicefs data_dir on real NFS instead of the fakeroot overlay.
+  container_binds:
+    - ${HOME}/526_scratch:${HOME}/526_scratch
+
+  env:
+    CLIO_MEMFD_DIR: "/tmp/iowarp_chimaera"
+
+  pkgs:
+    # ---- Services (identical configs to single_node.yaml) ----------------
+    - pkg_type: builtin.redis
+      pkg_name: redis
+      port: 6379
+      sleep: 4
+
+    - pkg_type: jarvis_clio_core.clio_runtime
+      pkg_name: runtime
+      num_threads: 4
+      port: 9413
+      ipc_mode: "shm"
+      log_level: "info"
+      sleep: 4
+      swim_enabled: false
+
+    - pkg_type: jarvis_clio_core.clio_cte
+      pkg_name: cte_core
+      devices:
+        - ["ram::cte_ram_tier1", "24GB", 1.0]
+      dpe_type: "max_bw"
+      neighborhood: 1
+      pool_query: "local"
+      default_target_timeout_ms: 30000
+      poll_period_ms: 5000
+
+    - pkg_type: jarvis_clio_core.clio_cte_libfuse
+      pkg_name: cte_fuse
+      mountpoint: /tmp/cte_mnt
+      log_level: "info"
+      extra_fuse_args: "-f"
+      sleep: 2
+
+    - pkg_type: builtin.juicefs
+      pkg_name: juicefs
+      meta_url: "redis://127.0.0.1:6379/1"
+      storage: file
+      data_dir: ${HOME}/526_scratch/single_node_smoke/jfs_data
+      mountpoint: /tmp/jfs_mnt
+      cache_dir: /tmp/juicefs_cache
+      name: jfsbench
+      format_fresh: true
+      mount_wait: 20
+
+    # ---- Benchmark drivers (block shrunk 64m -> 16m for speed) -----------
+    - pkg_type: builtin.ior
+      pkg_name: nfs_ior
+      api: posix
+      write: true
+      read: true
+      fpp: true
+      xfer: "4k"
+      block: "16m"
+      nprocs: 2
+      ppn: 2
+      stonewall: 120
+      out: ${HOME}/526_scratch/single_node_smoke/nfs/ior_nfs.bin
+
+    - pkg_type: builtin.ior
+      pkg_name: cte_ior
+      api: posix
+      write: true
+      read: true
+      fpp: true
+      xfer: "4k"
+      block: "16m"
+      nprocs: 2
+      ppn: 2
+      stonewall: 120
+      out: /tmp/cte_mnt/ior_cte.bin
+
+    - pkg_type: builtin.redis-benchmark
+      pkg_name: redis_bench
+      port: 6379
+      write: true
+      read: true
+      req_size: 4096
+      count: 8192
+      clients: 2
+      nthreads: 2
+
+    - pkg_type: builtin.ior
+      pkg_name: jfs_ior
+      api: posix
+      write: true
+      read: true
+      fpp: true
+      xfer: "4k"
+      block: "16m"
+      nprocs: 2
+      ppn: 2
+      stonewall: 120
+      out: /tmp/jfs_mnt/ior_jfs.bin
+
+vars:
+  # Both I/O-size extremes; request budget scaled down for smoke speed.
+  nfs_ior.xfer:        ["4k", "1m"]
+  cte_ior.xfer:        ["4k", "1m"]
+  jfs_ior.xfer:        ["4k", "1m"]
+  redis_bench.req_size: [4096, 1048576]
+  redis_bench.count:    [8192, 32]
+
+loop:
+  # One axis, 2 values => 2 combos (the fixed nprocs/ppn/clients=2 exercise
+  # the thread plumbing without a second loop level).
+  - [nfs_ior.xfer, cte_ior.xfer, jfs_ior.xfer,
+     redis_bench.req_size, redis_bench.count]
+
+run_timeout: 900
+
+repeat: 1
+output: "${HOME}/single_node_smoke_results"


### PR DESCRIPTION
## What

Self-contained, reproducible Apptainer-containerized Jarvis regression
pipelines for clio-core (#526), driven by jarvis's native `scheduler:` blocks
(Mode A — one Slurm allocation, in-process sweep via `jarvis ppl submit`)
instead of standalone wrapper scripts.

## Changes

**Pipelines** — `jarvis_clio_core/pipelines/ares/`
- `single_node.yaml` — 24-combo sweep, 1 node, `scheduler:` block + dual `hostfile:` key
- `distributed.yaml` — multi-node sweep, per-host overlay root, ssh fakeroot preflight
- Both retarget the generic fio/redis drivers to `builtin.fio` / `builtin.redis`
  and carry the sg re-exec + conda/apptainer/SIF `pre_cmds`, stale-state cleanup,
  and `post_cmd` row-count gates.

**Container build** — `pipelines/container/` + `scripts/`
- `Dockerfile.regression`, `regression.def`, `build_regression_image.sh` build the
  `iowarp-regression` SIF (docker build → apptainer build).

**clio-specific jarvis packages** — `jarvis_clio_core/jarvis_clio_core/`
- `container_utils.py` (shared container/exec helpers), `juicefs/` mount driver,
  and container-aware updates to `clio_runtime`, `clio_cte`, `clio_cte_bench`,
  `clio_cte_libfuse`, `clio_redis_bench`.

**Spack** — `installers/spack/packages/iowarp/package.py` recipe touch-ups.

## Depends on

Companion **jarvis-cd** PR (generic infra moved upstream): `builtin.fio` /
`builtin.redis` merge, `container_fakeroot`, `container_overlay` per-host root,
and the scheduler Mode A nested-submit fix. These pipelines will not run without it.

## Validation

Ares: **single_node 24/24 green**, **distributed 3/3 green** (4 nodes, ~22 min/run).
The low-concurrency `cte_fio` bandwidth floor is a CTE runtime latency quantum,
not a pipeline artifact.

Base: upstream `dev` (`38250403`). Single squashed commit; `migration/` payload
excluded (ships in the jarvis-cd PR).

## Known issue — JuiceFS blank-column reporting gap (follow-up)

On the distributed sweep, one iteration (`run_idx=1`, np=2) shipped **empty
`jfs_fio.write.*` cells** (`agg_bw_mbps`, `iops`, `lat_mean_us`, `lat_p99_us`,
`total_io_mb`, `total_ops` all blank) while the row still reported
`status=success`. Neighbouring rows (np=1 and np=4) have JuiceFS numbers, so this
is a **transient single-iteration data gap, not** the container/overlay change
(that fix is validated green and orthogonal).

Root of the gap: `builtin.fio`'s `_get_stat` emits `<pkg_id>.<op>.*` columns only
for ops with nonzero `io_bytes`; if a JuiceFS fio invocation produced no report /
an unparsable report / zero `io_bytes`, the columns are simply absent. The parser
reports faithfully what fio gave it and does not fail loud on a missing report.

**Danger is low; the real problem is reporting integrity** — a row marked
`success` silently shipped an empty required benchmark column. Follow-up work
(tracked separately, not in this PR):
- Gate the per-iteration `success` decision on per-benchmark completeness — mark
  the row `partial`/`error` (or populate an error column) when a required
  benchmark's key fields are empty.
- Capture fio's exit code + stderr per benchmark at the JuiceFS `jfs_fio` step,
  verify the JuiceFS mount is healthy before each iteration, and consider a retry.
- Add a completeness check in the `results.csv` writer / post-run step so all
  expected metric columns must be populated before declaring `success`.

Repro to classify it: re-run the distributed sweep a few times — if the gap
tracks np=2 specifically it's a real JuiceFS-under-load issue worth digging into;
if it wanders it's transient and fail-loud + retry is the right response.