### PR TITLE
feat(vfd): feature complete the CLIO HDF5 VFD

### DIFF
--- a/context-transfer-engine/adapter/vfd/H5FDclio.cc
+++ b/context-transfer-engine/adapter/vfd/H5FDclio.cc
@@ -720,9 +720,12 @@ static herr_t H5FD__clio_flush(H5FD_t *_file, hid_t dxpl_id, bool closing) {
   (void)dxpl_id;
   (void)closing;
   H5FD_clio_t *file = (H5FD_clio_t *)_file;
+  // Persist the authoritative native file; fail-closed so a flush that did not
+  // reach disk never reports success. Writes are write-through, so the native
+  // file is the only store holding data to flush.
   if (file->posix_fd >= 0 && fsync(file->posix_fd) < 0) {
     H5FD_CLIO_ERROR("fsync() in flush failed");
-    return FAIL; /* never report a flush that did not persist */
+    return FAIL;
   }
   return SUCCEED;
 } /* end H5FD__clio_flush() */

--- a/context-transfer-engine/adapter/vfd/H5FDclio.cc
+++ b/context-transfer-engine/adapter/vfd/H5FDclio.cc
@@ -69,6 +69,11 @@ hid_t H5FDclio_err_class_g = H5I_INVALID_HID;
 static hid_t H5FDclio_err_major_g = H5I_INVALID_HID;
 static hid_t H5FDclio_err_minor_g = H5I_INVALID_HID;
 
+/* Observability: number of times the vector callbacks have run. Exported (not
+ * static) so a test can confirm HDF5 actually took the vector I/O path. */
+unsigned long H5FDclio_read_vector_calls_g = 0;
+unsigned long H5FDclio_write_vector_calls_g = 0;
+
 /* Push a driver error onto HDF5's default error stack. Callbacks still return
  * FAIL/NULL to signal the failure to the library; this records a diagnosable
  * reason (incl. errno) that composes with HDF5's own stack and is surfaced by
@@ -100,19 +105,35 @@ static hid_t H5FDclio_err_minor_g = H5I_INVALID_HID;
 extern "C" {
 #endif
 
+/* Driver-specific file access properties: the tiering policy an application can
+ * set via its FAPL. POD (no pointers), so copy/free are trivial. Extensible --
+ * more knobs (e.g. cache page size / tiering policy) can be added when the CTE
+ * read tier makes them meaningful. */
+typedef struct H5FD_clio_fapl_t {
+  hbool_t cache_enabled; /* populate the CTE cache tier (default on) */
+} H5FD_clio_fapl_t;
+
+/* Default policy when a file is opened without a driver-specific FAPL
+ * (e.g. H5Pset_driver(fapl, driver, NULL)): cache on. */
+static const H5FD_clio_fapl_t H5FD_clio_fapl_default_g = {/*cache_enabled*/ 1};
+
 /* The description of a file belonging to this driver. */
 typedef struct H5FD_clio_t {
-  H5FD_t pub;      /* public stuff, must be first           */
-  haddr_t eoa;     /* end of allocated region               */
-  haddr_t eof;     /* end of file; current file size        */
-  int fd;          /* CTE cache handle (-1 if none this session) */
-  int posix_fd;    /* authoritative on-disk native file fd  */
-  char *filename_; /* the name of the file (NULL if empty)  */
-  unsigned flags;  /* the flags passed from H5Fcreate/H5Fopen */
+  H5FD_t pub;         /* public stuff, must be first           */
+  haddr_t eoa;        /* end of allocated region               */
+  haddr_t eof;        /* end of file; current file size        */
+  int fd;             /* CTE cache handle (-1 if none this session) */
+  int posix_fd;       /* authoritative on-disk native file fd  */
+  char *filename_;    /* the name of the file (NULL if empty)  */
+  unsigned flags;     /* the flags passed from H5Fcreate/H5Fopen */
+  H5FD_clio_fapl_t fa; /* driver-specific FAPL config for this file */
 } H5FD_clio_t;
 
 /* Prototypes */
 static herr_t H5FD__clio_term(void);
+static void *H5FD__clio_fapl_get(H5FD_t *_file);
+static void *H5FD__clio_fapl_copy(const void *_old_fa);
+static herr_t H5FD__clio_fapl_free(void *_fa);
 static H5FD_t *H5FD__clio_open(const char *name, unsigned flags,
                                  hid_t fapl_id, haddr_t maxaddr);
 static herr_t H5FD__clio_close(H5FD_t *_file);
@@ -126,12 +147,19 @@ static herr_t H5FD__clio_read(H5FD_t *_file, H5FD_mem_t type, hid_t fapl_id,
                                 haddr_t addr, size_t size, void *buf);
 static herr_t H5FD__clio_write(H5FD_t *_file, H5FD_mem_t type, hid_t fapl_id,
                                  haddr_t addr, size_t size, const void *buf);
+static herr_t H5FD__clio_read_vector(H5FD_t *_file, hid_t dxpl, uint32_t count,
+                                     H5FD_mem_t types[], haddr_t addrs[],
+                                     size_t sizes[], void *bufs[]);
+static herr_t H5FD__clio_write_vector(H5FD_t *_file, hid_t dxpl, uint32_t count,
+                                      H5FD_mem_t types[], haddr_t addrs[],
+                                      size_t sizes[], const void *bufs[]);
 static herr_t H5FD__clio_get_handle(H5FD_t *_file, hid_t fapl,
                                     void **file_handle);
 static herr_t H5FD__clio_flush(H5FD_t *_file, hid_t dxpl_id, bool closing);
 static herr_t H5FD__clio_truncate(H5FD_t *_file, hid_t dxpl_id, bool closing);
 static herr_t H5FD__clio_lock(H5FD_t *_file, bool rw);
 static herr_t H5FD__clio_unlock(H5FD_t *_file);
+static herr_t H5FD__clio_del(const char *name, hid_t fapl);
 
 static const H5FD_class_t H5FD_clio_g = {
     H5FD_CLASS_VERSION,   /* struct version       */
@@ -143,10 +171,10 @@ static const H5FD_class_t H5FD_clio_g = {
     NULL,                 /* sb_size              */
     NULL,                 /* sb_encode            */
     NULL,                 /* sb_decode            */
-    0,                    /* fapl_size            */
-    NULL,                 /* fapl_get             */
-    NULL,                 /* fapl_copy            */
-    NULL,                 /* fapl_free            */
+    sizeof(H5FD_clio_fapl_t), /* fapl_size        */
+    H5FD__clio_fapl_get,      /* fapl_get         */
+    H5FD__clio_fapl_copy,     /* fapl_copy        */
+    H5FD__clio_fapl_free,     /* fapl_free        */
     0,                    /* dxpl_size            */
     NULL,                 /* dxpl_copy            */
     NULL,                 /* dxpl_free            */
@@ -161,17 +189,17 @@ static const H5FD_class_t H5FD_clio_g = {
     H5FD__clio_set_eoa, /* set_eoa              */
     H5FD__clio_get_eof,    /* get_eof            */
     H5FD__clio_get_handle, /* get_handle         */
-    H5FD__clio_read,       /* read               */
-    H5FD__clio_write,      /* write              */
-    NULL,                  /* read_vector        */
-    NULL,                  /* write_vector       */
+    H5FD__clio_read,        /* read              */
+    H5FD__clio_write,       /* write             */
+    H5FD__clio_read_vector, /* read_vector       */
+    H5FD__clio_write_vector,/* write_vector      */
     NULL,                  /* read_selection     */
     NULL,                  /* write_selection    */
     H5FD__clio_flush,      /* flush              */
     H5FD__clio_truncate,   /* truncate           */
     H5FD__clio_lock,       /* lock               */
     H5FD__clio_unlock,     /* unlock             */
-    NULL,                 /* del                  */
+    H5FD__clio_del,        /* del                  */
     NULL,                 /* ctl                  */
     H5FD_FLMAP_DICHOTOMY  /* fl_map               */
 };
@@ -255,9 +283,14 @@ static herr_t H5FD__clio_term(void) {
  */
 static H5FD_t *H5FD__clio_open(const char *name, unsigned flags,
                                  hid_t fapl_id, haddr_t maxaddr) {
-  (void)fapl_id;
   (void)maxaddr;
   clio::cte::core::CLIO_CTE_CLIENT_INIT();
+
+  // Driver-specific FAPL config: use the caller's policy if a driver-info block
+  // was set (H5Pset_fapl_clio), else the default (cache on).
+  const H5FD_clio_fapl_t *fa_in =
+      (const H5FD_clio_fapl_t *)H5Pget_driver_info(fapl_id);
+  H5FD_clio_fapl_t fa = fa_in ? *fa_in : H5FD_clio_fapl_default_g;
 
   /* Build the open flags */
   int o_flags = (H5F_ACC_RDWR & flags) ? O_RDWR : O_RDONLY;
@@ -289,9 +322,13 @@ static H5FD_t *H5FD__clio_open(const char *name, unsigned flags,
   // Today the handle is populated on write but NOT yet served on reads, so the
   // open is best-effort: a cache-open failure must not sink the open (the
   // authoritative native file already succeeded) -- fd == -1 just means "no
-  // cache this session".
-  int fd = CLIO_CTE_CFS->Open(name, o_flags, H5FD_CLIO_POSIX_CREATE_MODE_RW);
-  HLOG(kDebug, "");
+  // cache this session". Skipped entirely when the FAPL disables the cache
+  // (which avoids the current write-amplification of the populate-only tier).
+  int fd = -1;
+  if (fa.cache_enabled) {
+    fd = CLIO_CTE_CFS->Open(name, o_flags, H5FD_CLIO_POSIX_CREATE_MODE_RW);
+    HLOG(kDebug, "");
+  }
 
   /* Create the new file struct */
   H5FD_clio_t *file = (H5FD_clio_t *)calloc(1, sizeof(H5FD_clio_t));
@@ -315,6 +352,7 @@ static H5FD_t *H5FD__clio_open(const char *name, unsigned flags,
   file->fd = fd;
   file->posix_fd = posix_fd;
   file->flags = flags;
+  file->fa = fa;
 
   // EOF is the authoritative on-disk size (durable across reopen/append), not a
   // session-local counter or the cache's logical size.
@@ -395,11 +433,28 @@ static int H5FD__clio_cmp(const H5FD_t *_f1, const H5FD_t *_f2) {
 static herr_t H5FD__clio_query(const H5FD_t *_file,
                                  unsigned long *flags /* out */) {
   (void)_file;
-  // No feature flags are advertised yet (a dedicated change will advertise the
-  // sec2-compatible set). Returning 0 is conservative but disables HDF5's
-  // metadata-aggregation / data-sieve optimizations.
   if (flags) {
+    /* Advertise the I/O-optimization subset of sec2's feature set. Model A
+     * makes these honest: the backend is a real byte-addressable POSIX file, so
+     * HDF5's metadata aggregation / accumulation / data-sieve / small-data
+     * aggregation optimizations all apply. Returning 0 (the old behavior)
+     * silently disabled all of them.
+     *
+     * NOT set: H5FD_FEAT_POSIX_COMPAT_HANDLE and H5FD_FEAT_DEFAULT_VFD_COMPATIBLE
+     * -- the two "name-resolving" flags. Under either, H5F_open() resolves the
+     * file's canonical name by stat()/realpath() on the filename it was handed
+     * (H5F__build_actual_name), which for this driver is the clio::-marked path
+     * (e.g. clio::/tmp/foo.h5), NOT a real filesystem path -- so stat() fails
+     * and H5Fopen aborts. sec2's names are real paths; ours carry the marker, so
+     * these two can only be advertised once the name HDF5 sees is the bare
+     * (stripped) path. get_handle itself still works, and the on-disk image is a
+     * plain native HDF5 file readable by standard tools. */
     *flags = 0;
+    *flags |= H5FD_FEAT_AGGREGATE_METADATA;   /* metadata block aggregation */
+    *flags |= H5FD_FEAT_ACCUMULATE_METADATA;  /* metadata accumulation      */
+    *flags |= H5FD_FEAT_DATA_SIEVE;           /* data sieving               */
+    *flags |= H5FD_FEAT_AGGREGATE_SMALLDATA;  /* small raw-data aggregation */
+    *flags |= H5FD_FEAT_SUPPORTS_SWMR_IO;     /* flock + real file          */
   }
   return SUCCEED;
 } /* end H5FD__clio_query() */
@@ -459,6 +514,62 @@ static haddr_t H5FD__clio_get_eof(const H5FD_t *_file, H5FD_mem_t type) {
 } /* end H5FD__clio_get_eof() */
 
 /*-------------------------------------------------------------------------
+ * Shared byte-I/O primitives used by BOTH the scalar (read/write) and the
+ * vectored (read_vector/write_vector) callbacks, so their semantics cannot
+ * drift -- when the CTE read-cache tier eventually lands, it changes here once
+ * and both paths inherit it.
+ *
+ *   H5FD__clio_do_read: read SIZE bytes at ADDR from the authoritative native
+ *     file into BUF, zero-filling any tail past EOF (HDF5 treats the file as a
+ *     flat byte array). A genuine read error is fail-closed; a short read is EOF.
+ *     FUTURE (CTE read tier): consult the cache first and serve a hit from a fast
+ *     tier, falling back to native on a miss. That needs per-file tracking of
+ *     which byte ranges are populated -- the CFS chimod zero-fills holes and
+ *     reports a full read, so a naive lookup could return stale zeros. Until
+ *     then, reads come straight from the authoritative file.
+ *
+ *   H5FD__clio_do_write: write-through SIZE bytes at ADDR to the authoritative
+ *     native file (fail-closed on short/failed write), best-effort populate the
+ *     CTE cache tier when a handle exists (groundwork; not yet served on reads),
+ *     and advance the session end-of-file.
+ *-------------------------------------------------------------------------
+ */
+static herr_t H5FD__clio_do_read(H5FD_clio_t *file, haddr_t addr, size_t size,
+                                 void *buf) {
+  ssize_t got = pread(file->posix_fd, buf, size, static_cast<off_t>(addr));
+  if (getenv("CLIO_VFD_DEBUG"))
+    fprintf(stderr, "[vfd] READ  addr=%llu size=%llu got=%lld\n",
+            (unsigned long long)addr, (unsigned long long)size, (long long)got);
+  if (got < 0) {
+    H5FD_CLIO_ERROR("pread() of authoritative native file failed");
+    return FAIL;
+  }
+  if (static_cast<size_t>(got) < size) {
+    memset(static_cast<char *>(buf) + got, 0, size - static_cast<size_t>(got));
+  }
+  return SUCCEED;
+}
+
+static herr_t H5FD__clio_do_write(H5FD_clio_t *file, haddr_t addr, size_t size,
+                                  const void *buf) {
+  ssize_t put = pwrite(file->posix_fd, buf, size, static_cast<off_t>(addr));
+  if (getenv("CLIO_VFD_DEBUG"))
+    fprintf(stderr, "[vfd] WRITE addr=%llu size=%llu put=%lld\n",
+            (unsigned long long)addr, (unsigned long long)size, (long long)put);
+  if (put < 0 || static_cast<size_t>(put) < size) {
+    H5FD_CLIO_ERROR("pwrite() to authoritative native file failed/short");
+    return FAIL;
+  }
+  if (file->fd >= 0) {
+    CLIO_CTE_CFS->Pwrite(file->fd, buf, size, static_cast<off_t>(addr));
+  }
+  if ((haddr_t)(addr + size) > file->eof) {
+    file->eof = (haddr_t)(addr + size);
+  }
+  return SUCCEED;
+}
+
+/*-------------------------------------------------------------------------
  * Function:    H5FD__clio_read
  *
  * Purpose:     Reads SIZE bytes of data from FILE beginning at address ADDR
@@ -476,34 +587,7 @@ static herr_t H5FD__clio_read(H5FD_t *_file, H5FD_mem_t type, hid_t dxpl_id,
                                 haddr_t addr, size_t size, void *buf) {
   (void)dxpl_id;
   (void)type;
-  H5FD_clio_t *file = (H5FD_clio_t *)_file;
-
-  // FUTURE (CTE read tier): consult the cache first and serve a hit from a fast
-  // tier, falling back to the native file on a miss (and populating on the
-  // way). This needs per-file tracking of which byte ranges are populated --
-  // the CFS chimod zero-fills holes and reports them as a full read, so a naive
-  // cache lookup could hand back stale zeros. Until that exists, reads come
-  // straight from the authoritative native file so correctness never depends on
-  // the cache.
-  ssize_t count = pread(file->posix_fd, buf, size, static_cast<off_t>(addr));
-  if (getenv("CLIO_VFD_DEBUG"))
-    fprintf(stderr, "[vfd] READ  addr=%llu size=%llu got=%lld\n",
-            (unsigned long long)addr, (unsigned long long)size,
-            (long long)count);
-  HLOG(kDebug, "");
-
-  // Distinguish a genuine read error from EOF: a negative count is a failure
-  // and must NOT be masked as zero data; a short read (0 <= count < size) is
-  // EOF and the unread tail is zero-filled.
-  if (count < 0) {
-    H5FD_CLIO_ERROR("pread() of authoritative native file failed");
-    return FAIL;
-  }
-  size_t got = static_cast<size_t>(count);
-  if (got < size) {
-    memset(static_cast<char *>(buf) + got, 0, size - got);
-  }
-  return SUCCEED;
+  return H5FD__clio_do_read((H5FD_clio_t *)_file, addr, size, buf);
 } /* end H5FD__clio_read() */
 
 /*-------------------------------------------------------------------------
@@ -521,35 +605,83 @@ static herr_t H5FD__clio_write(H5FD_t *_file, H5FD_mem_t type, hid_t dxpl_id,
                                  haddr_t addr, size_t size, const void *buf) {
   (void)dxpl_id;
   (void)type;
+  return H5FD__clio_do_write((H5FD_clio_t *)_file, addr, size, buf);
+} /* end H5FD__clio_write() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__clio_read_vector / H5FD__clio_write_vector
+ *
+ * Purpose:     Vectored I/O: service a whole vector of (addr, size, buf)
+ *              elements in ONE driver call, rather than have HDF5 re-dispatch
+ *              each element through the scalar read/write callbacks (the VFL
+ *              emulation). Each element goes through the shared do_read/do_write
+ *              helpers, so the semantics match the scalar paths exactly. Note the
+ *              elements are still issued as individual pread/pwrites; coalescing
+ *              file-contiguous elements into a single preadv/pwritev is a
+ *              possible future optimization (worthwhile only for patterns with
+ *              contiguous runs, which HDF5's scattered vector I/O rarely has).
+ *
+ *              The `sizes` array may be shortened: a 0 entry (for i > 0) means
+ *              this and all subsequent elements reuse the last explicit size.
+ *              `addrs` and `bufs` always have `count` entries.
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ *-------------------------------------------------------------------------
+ */
+static herr_t H5FD__clio_read_vector(H5FD_t *_file, hid_t dxpl, uint32_t count,
+                                     H5FD_mem_t types[], haddr_t addrs[],
+                                     size_t sizes[], void *bufs[]) {
+  (void)dxpl;
+  (void)types;
   H5FD_clio_t *file = (H5FD_clio_t *)_file;
-
-  // Commit point: write-through to the authoritative native file, synchronously.
-  ssize_t count = pwrite(file->posix_fd, buf, size, static_cast<off_t>(addr));
-  if (getenv("CLIO_VFD_DEBUG"))
-    fprintf(stderr, "[vfd] WRITE addr=%llu size=%llu put=%lld\n",
-            (unsigned long long)addr, (unsigned long long)size,
-            (long long)count);
-  if (count < 0 || static_cast<size_t>(count) < size) {
-    H5FD_CLIO_ERROR("pwrite() to authoritative native file failed/short");
-    return FAIL;
+  H5FDclio_read_vector_calls_g++;
+  if (count == 0) {
+    return SUCCEED;
   }
-
-  // FUTURE (CTE tiering): populate the cache tier with these bytes. This is
-  // written today as groundwork but is NOT yet served on reads (see the read
-  // callback), so it is best-effort -- its failure never fails the
-  // authoritative write, and it is skipped when there is no cache handle.
-  if (file->fd >= 0) {
-    CLIO_CTE_CFS->Pwrite(file->fd, buf, size, static_cast<off_t>(addr));
-    HLOG(kDebug, "");
-  }
-
-  // Track end-of-file so get_eof stays accurate within a session (HDF5 checks
-  // it to validate file size).
-  if ((haddr_t)(addr + size) > file->eof) {
-    file->eof = (haddr_t)(addr + size);
+  size_t size = sizes[0];
+  bool size_fixed = false; /* once a 0 size is seen, reuse the last explicit */
+  for (uint32_t i = 0; i < count; i++) {
+    if (!size_fixed) {
+      if (i > 0 && sizes[i] == 0) {
+        size_fixed = true; /* size stays = the last explicit size */
+      } else {
+        size = sizes[i];
+      }
+    }
+    if (H5FD__clio_do_read(file, addrs[i], size, bufs[i]) < 0) {
+      return FAIL;
+    }
   }
   return SUCCEED;
-} /* end H5FD__clio_write() */
+} /* end H5FD__clio_read_vector() */
+
+static herr_t H5FD__clio_write_vector(H5FD_t *_file, hid_t dxpl, uint32_t count,
+                                      H5FD_mem_t types[], haddr_t addrs[],
+                                      size_t sizes[], const void *bufs[]) {
+  (void)dxpl;
+  (void)types;
+  H5FD_clio_t *file = (H5FD_clio_t *)_file;
+  H5FDclio_write_vector_calls_g++;
+  if (count == 0) {
+    return SUCCEED;
+  }
+  size_t size = sizes[0];
+  bool size_fixed = false;
+  for (uint32_t i = 0; i < count; i++) {
+    if (!size_fixed) {
+      if (i > 0 && sizes[i] == 0) {
+        size_fixed = true;
+      } else {
+        size = sizes[i];
+      }
+    }
+    if (H5FD__clio_do_write(file, addrs[i], size, bufs[i]) < 0) {
+      return FAIL;
+    }
+  }
+  return SUCCEED;
+} /* end H5FD__clio_write_vector() */
 
 /*-------------------------------------------------------------------------
  * Function:    H5FD__clio_get_handle
@@ -666,6 +798,95 @@ static herr_t H5FD__clio_unlock(H5FD_t *_file) {
   }
   return SUCCEED;
 } /* end H5FD__clio_unlock() */
+
+/*-------------------------------------------------------------------------
+ * Driver-specific FAPL memory management.
+ *
+ * These make the driver's FAPL a first-class, storable/copyable property so
+ * H5Pset_driver(fapl, driver, &config) round-trips the config (with
+ * fapl_size/get/copy/free all NULL, no driver-info could be carried at all).
+ * The struct is POD, so copy/free are trivial.
+ *-------------------------------------------------------------------------
+ */
+static void *H5FD__clio_fapl_get(H5FD_t *_file) {
+  H5FD_clio_t *file = (H5FD_clio_t *)_file;
+  H5FD_clio_fapl_t *fa = (H5FD_clio_fapl_t *)malloc(sizeof(H5FD_clio_fapl_t));
+  if (fa) {
+    *fa = file->fa;
+  }
+  return fa;
+}
+
+static void *H5FD__clio_fapl_copy(const void *_old_fa) {
+  H5FD_clio_fapl_t *fa = (H5FD_clio_fapl_t *)malloc(sizeof(H5FD_clio_fapl_t));
+  if (fa && _old_fa) {
+    *fa = *(const H5FD_clio_fapl_t *)_old_fa;
+  }
+  return fa;
+}
+
+static herr_t H5FD__clio_fapl_free(void *_fa) {
+  free(_fa);
+  return SUCCEED;
+}
+
+/*-------------------------------------------------------------------------
+ * Function:    H5Pset_fapl_clio
+ *
+ * Purpose:     Select the CLIO VFD on a file access property list and attach
+ *              the driver-specific tiering policy. The supported, HDF5-idiomatic
+ *              way to configure the driver (vs. H5Pset_driver with the raw id).
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t H5Pset_fapl_clio(hid_t fapl_id, hbool_t cache_enabled) {
+  if (H5Pisa_class(fapl_id, H5P_FILE_ACCESS) <= 0) {
+    H5FD_CLIO_ERROR("H5Pset_fapl_clio: not a file access property list");
+    return FAIL;
+  }
+  hid_t driver = H5FD_clio_init();
+  if (driver < 0) {
+    return FAIL;
+  }
+  H5FD_clio_fapl_t fa;
+  fa.cache_enabled = cache_enabled;
+  return H5Pset_driver(fapl_id, driver, &fa);
+}
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__clio_del
+ *
+ * Purpose:     Delete the file NAME (H5Fdelete). Removes BOTH stores so neither
+ *              is left orphaned: the authoritative on-disk native file
+ *              (fail-closed, like sec2) and the CTE cache tag (best-effort -- the
+ *              cache may have been disabled or never populated, in which case its
+ *              removal is a harmless no-op). Called without an open handle, so it
+ *              (re)initializes the CTE client and works purely by name.
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ *-------------------------------------------------------------------------
+ */
+static herr_t H5FD__clio_del(const char *name, hid_t fapl) {
+  (void)fapl;
+  clio::cte::core::CLIO_CTE_CLIENT_INIT();
+
+  // Drop the CTE cache tag first so it can never be orphaned behind a deleted
+  // native file. Best-effort: keyed by the same full name open() used, and
+  // absence (cache off / never populated) is a harmless no-op.
+  CLIO_CTE_CFS->RemovePath(name);
+
+  // Remove the authoritative native file at the stripped path. Fail-closed on
+  // error (sec2 parity) so a failed delete is reported, not masked.
+  std::string native_path = clio::cae::StripClioPrefix(name);
+  if (unlink(native_path.c_str()) < 0) {
+    H5FD_CLIO_ERROR("unlink() of authoritative native file failed");
+    return FAIL;
+  }
+  return SUCCEED;
+} /* end H5FD__clio_del() */
 
 /*
  * Entry points for dynamic plugin loading.

--- a/context-transfer-engine/adapter/vfd/H5FDclio.h
+++ b/context-transfer-engine/adapter/vfd/H5FDclio.h
@@ -50,6 +50,11 @@ extern "C" {
 #endif
 
 hid_t H5FD_clio_init();
+/* Select the CLIO VFD and attach its tiering policy.
+ *   cache_enabled: populate the CTE cache tier (false = native-only, which
+ *                  avoids the current write-amplification of the populate-only
+ *                  cache). */
+herr_t H5Pset_fapl_clio(hid_t fapl_id, hbool_t cache_enabled);
 
 H5PL_type_t H5PLget_plugin_type(void);
 const void* H5PLget_plugin_info(void);

--- a/context-transfer-engine/test/unit/adapters/vfd/test_vfd_adapter.cc
+++ b/context-transfer-engine/test/unit/adapters/vfd/test_vfd_adapter.cc
@@ -42,6 +42,7 @@
 #include "clio_runtime/clio_runtime.h"
 #include "clio_runtime/bdev/bdev_client.h"
 #include "clio_cte/core/core_client.h"
+#include "adapter/cfs/cfs_io.h"
 #include "adapter/vfd/H5FDclio.h"
 
 namespace {
@@ -481,6 +482,257 @@ int main() {
     CHECK(found_clio_err,
           "9: the driver pushed a diagnosable error onto the HDF5 stack");
     std::printf("[vfd-suite] ok 9: fail-closed error reporting\n");
+  }
+
+  // === 10. feature-flag effect: on-disk size matches sec2 =================
+  // With the metadata-aggregation feature flags advertised by query(), HDF5
+  // lays the file out the same way it does for sec2, so identical content yields
+  // an identical on-disk byte size. Before those flags the VFD produced a
+  // smaller, differently-aggregated file -- so this both proves the flags took
+  // effect and pins truncate/close sizing against the sec2 oracle. (Byte content
+  // isn't compared: HDF5 stamps object modification times, which differ by
+  // instant but not in size.)
+  {
+    const char *kSec2 = "/tmp/clio_cte_vfd_flagsec2.h5";
+    const char *kClioFf = "clio::/tmp/clio_cte_vfd_flagvfd.h5";
+    const char *kNativeFf = "/tmp/clio_cte_vfd_flagvfd.h5";
+    std::remove(kSec2);
+    std::remove(kNativeFf);
+    hid_t s = H5Fcreate(kSec2, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    CHECK(s >= 0 && WriteRich(s) && H5Fclose(s) >= 0, "10: sec2 write+close");
+    hid_t v = H5Fcreate(kClioFf, H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
+    CHECK(v >= 0 && WriteRich(v) && H5Fclose(v) >= 0, "10: VFD write+close");
+    struct stat ss, vs;
+    CHECK(::stat(kSec2, &ss) == 0 && ::stat(kNativeFf, &vs) == 0,
+          "10: stat both files");
+    CHECK(ss.st_size == vs.st_size,
+          "10: VFD on-disk size == sec2 (metadata-aggregation flags in effect)");
+    std::printf("[vfd-suite] ok 10: feature-flag effect (size parity with sec2)\n");
+  }
+
+  // === 11. SWMR I/O (validates the SUPPORTS_SWMR_IO feature flag) =========
+  // SWMR needs the latest file format + an extendible dataset. HDF5 accepts an
+  // SWMR-write transition only because the driver advertises SUPPORTS_SWMR_IO;
+  // then write-through + flush must make appended data visible to a *concurrent*
+  // SWMR reader (a separate handle on the same native file) after H5Drefresh.
+  // File locking is disabled on the FAPL (standard for SWMR): the writer's
+  // advisory flock would otherwise block the in-process reader -- same as sec2.
+  {
+    const char *kClioSwmr = "clio::/tmp/clio_cte_vfd_swmr.h5";
+    const char *kNativeSwmr = "/tmp/clio_cte_vfd_swmr.h5";
+    std::remove(kNativeSwmr);
+    hid_t fapl_sw = H5Pcopy(fapl);
+    CHECK(fapl_sw >= 0, "11: H5Pcopy");
+    CHECK(H5Pset_libver_bounds(fapl_sw, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) >= 0,
+          "11: set latest libver (required for SWMR)");
+    CHECK(H5Pset_file_locking(fapl_sw, /*use*/ false, /*ignore*/ true) >= 0,
+          "11: disable file locking for SWMR");
+
+    // Writer: create + unlimited chunked dataset seeded with 3 rows.
+    hid_t f = H5Fcreate(kClioSwmr, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_sw);
+    CHECK(f >= 0, "11: H5Fcreate (latest format)");
+    hsize_t dims[1] = {3}, maxd[1] = {H5S_UNLIMITED}, chunk[1] = {4};
+    hid_t sp = H5Screate_simple(1, dims, maxd);
+    hid_t dcpl = H5Pcreate(H5P_DATASET_CREATE);
+    H5Pset_chunk(dcpl, 1, chunk);
+    hid_t d = H5Dcreate2(f, "swmr", H5T_NATIVE_INT32, sp, H5P_DEFAULT, dcpl,
+                         H5P_DEFAULT);
+    int seed[3] = {10, 11, 12};
+    CHECK(d >= 0 && H5Dwrite(d, H5T_NATIVE_INT32, H5S_ALL, H5S_ALL, H5P_DEFAULT,
+                             seed) >= 0,
+          "11: seed write");
+    H5Pclose(dcpl);
+    H5Sclose(sp);
+
+    // Transition to SWMR write -- accepted only because the VFD advertises SWMR.
+    CHECK(H5Fstart_swmr_write(f) >= 0,
+          "11: H5Fstart_swmr_write (VFD accepts SWMR I/O)");
+
+    // Append 2 rows and flush (the SWMR barrier).
+    hsize_t newsize[1] = {5};
+    CHECK(H5Dset_extent(d, newsize) >= 0, "11: extend to 5 rows");
+    hid_t fsp = H5Dget_space(d);
+    hsize_t start[1] = {3}, cnt[1] = {2};
+    H5Sselect_hyperslab(fsp, H5S_SELECT_SET, start, nullptr, cnt, nullptr);
+    hid_t msp = H5Screate_simple(1, cnt, nullptr);
+    int more[2] = {13, 14};
+    CHECK(H5Dwrite(d, H5T_NATIVE_INT32, msp, fsp, H5P_DEFAULT, more) >= 0,
+          "11: append write");
+    H5Sclose(msp);
+    H5Sclose(fsp);
+    CHECK(H5Dflush(d) >= 0, "11: H5Dflush (SWMR barrier)");
+
+    // Concurrent SWMR reader (separate handle) must see all 5 rows after refresh.
+    hid_t rf = H5Fopen(kClioSwmr, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl_sw);
+    CHECK(rf >= 0, "11: SWMR reader open");
+    hid_t rd = H5Dopen2(rf, "swmr", H5P_DEFAULT);
+    CHECK(rd >= 0 && H5Drefresh(rd) >= 0, "11: reader open + refresh");
+    hid_t rsp = H5Dget_space(rd);
+    hsize_t cur[1] = {0};
+    H5Sget_simple_extent_dims(rsp, cur, nullptr);
+    int got[5] = {0, 0, 0, 0, 0};
+    const int exp[5] = {10, 11, 12, 13, 14};
+    bool ok = (cur[0] == 5) &&
+              H5Dread(rd, H5T_NATIVE_INT32, H5S_ALL, H5S_ALL, H5P_DEFAULT,
+                      got) >= 0 &&
+              std::memcmp(got, exp, sizeof(exp)) == 0;
+    H5Sclose(rsp);
+    H5Dclose(rd);
+    H5Fclose(rf);
+    CHECK(ok, "11: SWMR reader sees appended data via write-through + flush");
+
+    H5Dclose(d);
+    H5Fclose(f);
+    H5Pclose(fapl_sw);
+    std::printf("[vfd-suite] ok 11: SWMR I/O (write-through visible to reader)\n");
+  }
+
+  // === 12. driver FAPL: H5Pset_fapl_clio round-trip ======================
+  // The supported way to select the driver and carry config. Set the driver via
+  // the CLIO setter with the cache DISABLED (native-only path), confirm the FAPL
+  // actually carries the CLIO driver + a driver-info block (fapl_size/copy round
+  // the config), and that a full rich round-trip works through it.
+  {
+    hid_t fapl_nc = H5Pcreate(H5P_FILE_ACCESS);
+    CHECK(fapl_nc >= 0, "12: H5Pcreate");
+    CHECK(H5Pset_fapl_clio(fapl_nc, /*cache_enabled*/ 0) >= 0,
+          "12: H5Pset_fapl_clio (cache off)");
+    CHECK(H5Pget_driver(fapl_nc) == H5FD_clio_init(),
+          "12: FAPL driver is the CLIO VFD");
+    // The driver-info block must carry the exact config we set -- proving
+    // fapl_copy round-trips the value, not merely that a block exists. The probe
+    // layout matches H5FD_clio_fapl_t's first field; both values must survive.
+    struct ClioFaplProbe {
+      hbool_t cache_enabled;
+    };
+    const void *di0 = H5Pget_driver_info(fapl_nc);
+    CHECK(di0 != nullptr &&
+              static_cast<const ClioFaplProbe *>(di0)->cache_enabled == 0,
+          "12: FAPL round-trips cache_enabled=false");
+    hid_t fapl_c = H5Pcreate(H5P_FILE_ACCESS);
+    CHECK(fapl_c >= 0 && H5Pset_fapl_clio(fapl_c, /*cache_enabled*/ 1) >= 0,
+          "12: H5Pset_fapl_clio (cache on)");
+    const void *di1 = H5Pget_driver_info(fapl_c);
+    CHECK(di1 != nullptr &&
+              static_cast<const ClioFaplProbe *>(di1)->cache_enabled == 1,
+          "12: FAPL round-trips cache_enabled=true");
+    H5Pclose(fapl_c);
+    const char *kClioFapl = "clio::/tmp/clio_cte_vfd_fapl.h5";
+    std::remove("/tmp/clio_cte_vfd_fapl.h5");
+    hid_t f = H5Fcreate(kClioFapl, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_nc);
+    CHECK(f >= 0 && WriteRich(f) && H5Fclose(f) >= 0,
+          "12: write+close via setter");
+    hid_t f2 = H5Fopen(kClioFapl, H5F_ACC_RDONLY, fapl_nc);
+    CHECK(f2 >= 0 && VerifyRich(f2) && H5Fclose(f2) >= 0,
+          "12: rich round-trip via H5Pset_fapl_clio (cache off)");
+    H5Pclose(fapl_nc);
+
+    // The setter rejects a plist that is not a file access property list
+    // (suppress the auto-printer -- the rejection pushes an expected error).
+    hid_t not_fapl = H5Pcreate(H5P_DATASET_CREATE);
+    H5E_auto2_t of = nullptr;
+    void *od = nullptr;
+    H5Eget_auto2(H5E_DEFAULT, &of, &od);
+    H5Eset_auto2(H5E_DEFAULT, nullptr, nullptr);
+    herr_t bad = H5Pset_fapl_clio(not_fapl, 1);
+    H5Eset_auto2(H5E_DEFAULT, of, od);
+    CHECK(bad < 0, "12: H5Pset_fapl_clio rejects a non-FAPL plist");
+    H5Pclose(not_fapl);
+    std::printf("[vfd-suite] ok 12: driver FAPL (H5Pset_fapl_clio round-trip)\n");
+  }
+
+  // === 13. vectored I/O (read_vector / write_vector) =====================
+  // Force HDF5 down the vector path: request selection I/O on the transfer
+  // plist. With the driver's selection callbacks NULL but read_vector/
+  // write_vector implemented, HDF5 translates selection I/O to vector I/O.
+  // Confirm the vector callbacks actually ran (exported counters advanced) AND
+  // the data round-trips byte-clean.
+  {
+    extern unsigned long H5FDclio_read_vector_calls_g;
+    extern unsigned long H5FDclio_write_vector_calls_g;
+    const char *kClioVec = "clio::/tmp/clio_cte_vfd_vec.h5";
+    std::remove("/tmp/clio_cte_vfd_vec.h5");
+    hid_t dxpl = H5Pcreate(H5P_DATASET_XFER);
+    CHECK(dxpl >= 0 && H5Pset_selection_io(dxpl, H5D_SELECTION_IO_MODE_ON) >= 0,
+          "13: request selection I/O on the transfer plist");
+
+    const unsigned long w0 = H5FDclio_write_vector_calls_g;
+    const unsigned long r0 = H5FDclio_read_vector_calls_g;
+    std::vector<int32_t> w = MakeI32(kSmall);
+
+    hid_t f = H5Fcreate(kClioVec, H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
+    CHECK(f >= 0, "13: create");
+    hsize_t dims[1] = {kSmall};
+    hid_t sp = H5Screate_simple(1, dims, nullptr);
+    hid_t d = H5Dcreate2(f, "vec", H5T_NATIVE_INT32, sp, H5P_DEFAULT, H5P_DEFAULT,
+                         H5P_DEFAULT);
+    CHECK(d >= 0 && H5Dwrite(d, H5T_NATIVE_INT32, H5S_ALL, H5S_ALL, dxpl,
+                             w.data()) >= 0,
+          "13: H5Dwrite (selection/vector I/O)");
+    H5Dclose(d);
+    H5Sclose(sp);
+    CHECK(H5Fclose(f) >= 0, "13: close");
+
+    std::vector<int32_t> got(kSmall, 0);
+    hid_t f2 = H5Fopen(kClioVec, H5F_ACC_RDONLY, fapl);
+    hid_t d2 = H5Dopen2(f2, "vec", H5P_DEFAULT);
+    CHECK(d2 >= 0 && H5Dread(d2, H5T_NATIVE_INT32, H5S_ALL, H5S_ALL, dxpl,
+                             got.data()) >= 0,
+          "13: H5Dread (selection/vector I/O)");
+    H5Dclose(d2);
+    H5Fclose(f2);
+    H5Pclose(dxpl);
+
+    CHECK(std::memcmp(got.data(), w.data(), kSmall * sizeof(int32_t)) == 0,
+          "13: vectored round-trip byte-clean");
+    CHECK(H5FDclio_write_vector_calls_g > w0,
+          "13: write_vector was actually exercised");
+    CHECK(H5FDclio_read_vector_calls_g > r0,
+          "13: read_vector was actually exercised");
+    std::printf("[vfd-suite] ok 13: vectored I/O (read_vector/write_vector exercised)\n");
+  }
+
+  // === 14. del callback: H5Fdelete removes BOTH stores ====================
+  // A correct delete must leave NEITHER store orphaned: the authoritative native
+  // file AND the CTE cache tag. Create+write a file (populating both), confirm
+  // both exist, H5Fdelete through the VFD, then confirm both are gone (verified
+  // on the HDF5 side via stat/reopen and on the CLIO side via the CFS tag) so a
+  // deleted file leaves nothing behind in either the filesystem or CTE.
+  {
+    const char *kClioDel = "clio::/tmp/clio_cte_vfd_del.h5";
+    const char *kNativeDel = "/tmp/clio_cte_vfd_del.h5";
+    std::remove(kNativeDel);
+    hid_t f = H5Fcreate(kClioDel, H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
+    CHECK(f >= 0, "14: create");
+    CHECK(WriteDset(f, "d", H5T_NATIVE_INT32, MakeI32(kSmall)), "14: write");
+    CHECK(H5Fclose(f) >= 0, "14: close");
+
+    // Precondition: BOTH stores now exist.
+    struct stat nst;
+    CHECK(::stat(kNativeDel, &nst) == 0, "14: native file exists before delete");
+    struct stat cst;
+    CHECK(CLIO_CTE_CFS->StatPath(kClioDel, &cst) == 0,
+          "14: CTE cache tag exists before delete");
+
+    // Delete through the VFD (drives H5FD__clio_del via H5Fdelete).
+    CHECK(H5Fdelete(kClioDel, fapl) >= 0, "14: H5Fdelete succeeds");
+
+    // Postcondition (HDF5 side): native file gone; it no longer opens.
+    errno = 0;
+    CHECK(::stat(kNativeDel, &nst) != 0 && errno == ENOENT,
+          "14: native file removed after H5Fdelete");
+    H5E_auto2_t of = nullptr;
+    void *od = nullptr;
+    H5Eget_auto2(H5E_DEFAULT, &of, &od);
+    H5Eset_auto2(H5E_DEFAULT, nullptr, nullptr);
+    hid_t reopened = H5Fopen(kClioDel, H5F_ACC_RDONLY, fapl);
+    H5Eset_auto2(H5E_DEFAULT, of, od);
+    CHECK(reopened < 0, "14: deleted file no longer opens");
+
+    // Postcondition (CLIO side): the CTE cache tag is gone, not orphaned.
+    CHECK(CLIO_CTE_CFS->StatPath(kClioDel, &cst) != 0,
+          "14: CTE cache tag removed after H5Fdelete (not orphaned)");
+    std::printf("[vfd-suite] ok 14: del removes both native file and CTE tag\n");
   }
 
   H5Pclose(fapl);

--- a/context-transfer-engine/test/unit/adapters/vfd/test_vfd_adapter.cc
+++ b/context-transfer-engine/test/unit/adapters/vfd/test_vfd_adapter.cc
@@ -735,6 +735,58 @@ int main() {
     std::printf("[vfd-suite] ok 14: del removes both native file and CTE tag\n");
   }
 
+  // === 15. no-pending-dirty-state barrier: H5Fflush finalizes the image ======
+  // An independent sec2 reader (no VFD; the writer stays open and is never
+  // closed) reads the dataset back from the native file only AFTER H5Fflush: the
+  // read fails before the flush (HDF5 metadata still buffered) and succeeds
+  // after, so it is the flush -- not write-through alone -- that leaves a
+  // complete, consistent on-disk image. Consistency only, not fsync-to-platter:
+  // an in-process read hits the page cache. Locking is off so the reader is not
+  // blocked by the writer.
+  {
+    const char *kClioDur = "clio::/tmp/clio_cte_vfd_durable.h5";
+    const char *kNativeDur = "/tmp/clio_cte_vfd_durable.h5";
+    std::remove(kNativeDur);
+    std::vector<int32_t> w = MakeI32(kSmall);
+
+    hid_t wfapl = H5Pcopy(fapl);
+    CHECK(wfapl >= 0 && H5Pset_file_locking(wfapl, false, true) >= 0,
+          "15: writer FAPL (locking off)");
+    hid_t rfapl = H5Pcreate(H5P_FILE_ACCESS);
+    CHECK(rfapl >= 0 && H5Pset_file_locking(rfapl, false, true) >= 0,
+          "15: reader FAPL (locking off)");
+
+    hid_t f = H5Fcreate(kClioDur, H5F_ACC_TRUNC, H5P_DEFAULT, wfapl);
+    CHECK(f >= 0, "15: create");
+    CHECK(WriteDset(f, "durable", H5T_NATIVE_INT32, w), "15: write");
+
+    // Open the native file with sec2 (no VFD) and read the dataset back
+    // byte-clean; false if it is not yet a complete HDF5 image. The pre-flush
+    // call is expected to error, so suppress the auto-printer around it.
+    auto independent_read_ok = [&]() -> bool {
+      H5E_auto2_t af = nullptr;
+      void *ad = nullptr;
+      H5Eget_auto2(H5E_DEFAULT, &af, &ad);
+      H5Eset_auto2(H5E_DEFAULT, nullptr, nullptr);
+      hid_t rf = H5Fopen(kNativeDur, H5F_ACC_RDONLY, rfapl);
+      bool ok = rf >= 0 && ReadDsetEq(rf, "durable", H5T_NATIVE_INT32, w);
+      if (rf >= 0) H5Fclose(rf);
+      H5Eset_auto2(H5E_DEFAULT, af, ad);
+      return ok;
+    };
+
+    CHECK(!independent_read_ok(),
+          "15: pre-flush image is incomplete to an independent reader");
+    CHECK(H5Fflush(f, H5F_SCOPE_GLOBAL) >= 0, "15: H5Fflush (the barrier)");
+    CHECK(independent_read_ok(),
+          "15: post-flush data fully persisted + readable without the VFD");
+
+    CHECK(H5Fclose(f) >= 0, "15: close writer");
+    H5Pclose(rfapl);
+    H5Pclose(wfapl);
+    std::printf("[vfd-suite] ok 15: no-pending-dirty-state barrier (flush finalizes the image)\n");
+  }
+
   H5Pclose(fapl);
 
   // === 4. Native tool matrix on the VFD's file (NO VFD loaded) ============


### PR DESCRIPTION
This builds on the native write-through core and fills in the rest of what makes the CLIO VFD behave like a real, first-class HDF5 file driver (rather than a minimal byte shim). Four main things:

- Feature flags. query() now advertises the same I/O-optimization flags sec2 does (metadata aggregation/accumulation, data sieve, SWMR). Practical effect: HDF5 lays a file out the same way it would for the default driver, so the VFD's on-disk file is byte-size-identical to sec2 for the same content (and SWMR readers work).
- A real driver FAPL + H5Pset_fapl_clio. You can now select the driver the idiomatic HDF5 way and carry config with it. The one knob today is cache_enabled, which makes CTE cache population opt-in per file — so you can run pure native (sec2-equivalent, no CTE write traffic) or opt into the cache tier.
- Vectored I/O. read_vector/write_vector are implemented (with HDF5's size-array shortening convention), so HDF5's batched and selection-I/O paths hit one driver call instead of being emulated element-by-element. The scalar and vector paths share the same underlying read/write helpers, so their semantics can't drift.
- Delete. H5Fdelete now works and cleans up both stores — the authoritative native file and the CTE cache tag — so deleting a file never leaves an orphaned tag behind.

The VFD unit suite grew to 14 sections to cover all of this: size-parity vs sec2, a concurrent SWMR reader, FAPL round-trip (cache on/off), a forced-and-verified vector path, and delete-removes-both-stores. Everything passes green end-to-end.

The CTE cache is still populate-only - writes push into it but reads always come from the authoritative native file. The FAPL toggle and this PR set up the cache plumbing; actually serving reads from CTE (a range-tracked read tier) will be done later.