### PR TITLE
fix(vol-compat): resolve hdf5.h for on-the-fly C tests in conda ctest

### DIFF
--- a/benchmarks/hdf5-ingest/vol_compat_suite.py
+++ b/benchmarks/hdf5-ingest/vol_compat_suite.py
@@ -420,6 +420,30 @@ def _dump_restart_diagnostics(proc, env):
         pass
 
 
+def _hdf5_prefix():
+    """Return the install prefix of the HDF5 that this suite links against, or
+    None. The suite is launched by ctest with an explicit interpreter path
+    (e.g. <conda>/bin/python3), so the HDF5 headers/libs it exercises live under
+    that interpreter's prefix (<conda>/include, <conda>/lib). Deriving the prefix
+    from sys.executable keeps the on-the-fly C compiler pointed at the same HDF5
+    as the h5py arms, instead of a hardcoded /usr/local that may not have it."""
+    prefix = os.path.dirname(os.path.dirname(os.path.abspath(sys.executable)))
+    if os.path.isfile(os.path.join(prefix, "include", "hdf5.h")):
+        return prefix
+    return None
+
+
+def _find_h5cc():
+    """Locate the h5cc wrapper, preferring one next to the running interpreter
+    (the HDF5 this suite actually uses) over anything on PATH."""
+    prefix = _hdf5_prefix()
+    if prefix:
+        cand = os.path.join(prefix, "bin", "h5cc")
+        if os.path.isfile(cand) and os.access(cand, os.X_OK):
+            return cand
+    return shutil.which("h5cc")
+
+
 def _compile_c(binp, srcp):
     """Compile a single C test, preferring the HDF5 wrapper h5cc and falling back
     to gcc + -lhdf5. Returns the CompletedProcess of whichever compiler ran, or
@@ -428,12 +452,18 @@ def _compile_c(binp, srcp):
     FileNotFoundError, which previously aborted the whole suite instead of letting
     the gcc fallback run."""
     comp = None
-    if shutil.which("h5cc"):
-        comp = subprocess.run(["h5cc", "-o", binp, srcp], capture_output=True,
+    h5cc = _find_h5cc()
+    if h5cc:
+        comp = subprocess.run([h5cc, "-o", binp, srcp], capture_output=True,
                               text=True, env=_env(False))
     if (comp is None or comp.returncode != 0) and shutil.which("gcc"):
-        comp = subprocess.run(["gcc", "-o", binp, srcp, "-I/usr/local/include",
-                               "-L/usr/local/lib", "-lhdf5"],
+        # Point gcc at the HDF5 under the running interpreter's prefix (the same
+        # one the h5py arms use); fall back to /usr/local for standalone runs.
+        prefix = _hdf5_prefix()
+        inc = os.path.join(prefix, "include") if prefix else "/usr/local/include"
+        lib = os.path.join(prefix, "lib") if prefix else "/usr/local/lib"
+        comp = subprocess.run(["gcc", "-o", binp, srcp, "-I" + inc,
+                               "-L" + lib, "-Wl,-rpath," + lib, "-lhdf5"],
                               capture_output=True, text=True, env=_env(False))
     return comp
 


### PR DESCRIPTION
## What

Fixes the `cte_hdf5_vol_compat_suite` ctest failure in conda builds, where the on-the-fly C tests (`c_iteration`, `c_safeflush`, `c_selection`, `telemetry`) failed to compile with `hdf5.h: No such file or directory`.

`benchmarks/hdf5-ingest/vol_compat_suite.py` compiled these with a hardcoded `-I/usr/local/include` gcc fallback and relied on `h5cc` being on `PATH`. In a conda ctest run neither holds:
- `hdf5.h` lives under the conda prefix (`<conda>/include`), not `/usr/local/include`.
- The conda `h5cc`'s backing compiler (`x86_64-conda-linux-gnu-cc`) is not on `PATH`, so `h5cc` returns 127.

## Change

`_compile_c` now:
- Derives the HDF5 prefix from `sys.executable` (ctest launches the suite with `<conda>/bin/python3`), verified by the presence of `<prefix>/include/hdf5.h`.
- Prefers an `h5cc` next to that interpreter, then falls back to gcc pointed at `<prefix>/include` and `<prefix>/lib` (with `-Wl,-rpath`).
- Falls back to `/usr/local` when no interpreter-prefix HDF5 is found (standalone runs).

## Testing

`ctest -R cte_hdf5_vol_compat_suite` now passes — **all 20/20 compat cases green** (previously 16/20, 4 COMPILE-FAIL).

## Note (not in this PR)

The same conda ctest run also surfaced ~26 `Subprocess aborted` failures caused by a POCO header/library ABI mismatch (1.11.0 headers vs 1.14.2 lib) — a stack smash in `SystemInfo::PredictDriveFailure`. That is an environment/packaging problem (mismatched POCO install), not a source bug, so it is documented in the issue rather than fixed here.

Closes #762

🤖 Generated with [Claude Code](https://claude.com/claude-code)
