### PR TITLE
fix(sycl): don't abort runtime server when no GPU is present

### DIFF
--- a/context-transport-primitives/include/clio_ctp/util/gpu_api.h
+++ b/context-transport-primitives/include/clio_ctp/util/gpu_api.h
@@ -288,6 +288,12 @@ class GpuApi {
     }
     return attributes.type == cudaMemoryTypeDevice;
 #elif CTP_ENABLE_SYCL
+    // On a host with no GPU no USM *device* allocation can exist, so any pointer
+    // is host memory. Short-circuit before touching SyclQueue(): constructing a
+    // sycl::queue throws when no SYCL device is present, and an unhandled throw
+    // inside a coroutine task aborts the whole runtime server (mirrors the
+    // CUDA/ROCm "failed query -> host pointer" degradation above).
+    if (!HasSyclGpuDevice()) return false;
     auto kind = sycl::get_pointer_type(static_cast<const void *>(ptr),
                                         SyclQueue().get_context());
     return kind == sycl::usm::alloc::device;
@@ -440,6 +446,32 @@ class GpuApi {
 #endif
 
 #if CTP_ENABLE_SYCL
+  /**
+   * True if at least one SYCL GPU device is visible. Cached on first use:
+   * enumerating platforms on every per-op IsDevicePointer call would be far too
+   * slow. This is the guard that keeps a GPU-enabled build running on a host
+   * with no GPU — see SyclQueue()/IsDevicePointer() for why constructing a queue
+   * unconditionally is fatal there.
+   */
+  static bool HasSyclGpuDevice() {
+    static const bool has = [] {
+      try {
+        return !sycl::device::get_devices(sycl::info::device_type::gpu).empty();
+      } catch (const sycl::exception &) {
+        return false;
+      }
+    }();
+    return has;
+  }
+
+  /**
+   * Shared SYCL queue backing the GPU host-side helpers (Memcpy, Free,
+   * Synchronize) and the device-pointer probe. Only ever call this when
+   * HasSyclGpuDevice() is true: sycl::gpu_selector_v (and even the default
+   * selector on this environment) throws "No device of requested type
+   * available" when no SYCL device is present, and an unhandled throw inside a
+   * coroutine task aborts the whole runtime server.
+   */
   static sycl::queue &SyclQueue() {
     static sycl::queue q{sycl::gpu_selector_v};
     return q;


### PR DESCRIPTION
## Summary
Fixes a SYCL-build server crash: on a host with **no visible SYCL device** (e.g. an Aurora login node with no GPU allocated), `GpuApi::IsDevicePointer()` constructed a `sycl::queue{sycl::gpu_selector_v}` via `SyclQueue()`, which **throws**. Since `IsDevicePointer` runs on every RAM-bdev read/write, the first `PutBlob`/`write` threw inside a coroutine task → `std::terminate()` → the runtime **server aborted mid-request**, cascading into failures of 9 CPU-only tests.

The CUDA/ROCm branches already degrade gracefully (failed pointer query → treat as host); this brings SYCL in line.

## Change
`context-transport-primitives/include/clio_ctp/util/gpu_api.h`:
- Add a cached `HasSyclGpuDevice()` helper.
- `IsDevicePointer()` (SYCL) now returns `false` **before** touching `SyclQueue()` when no GPU is present. On such a host no USM device allocation can exist, so any pointer is host memory and the GPU copy paths are never taken.

## Validation
Ran `~/bin/clio_core_gpu` on `aurora-uan-0010` (`sycl-debug` preset, `icpx` 2025.3.2), full `ctest -D Experimental`:
- **Before:** 194/205 passing (11 failures)
- **After:** 203/205 passing

The only remaining failures — `test_gpu_sycl` and `cr_gpu_kernel_stress_sycl` — require actual GPU hardware and are expected to fail on a GPU-less login node.

Closes #765.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
