### PR TITLE
fix(shm): size MPSC ring for realistic async fan-out (#768 deadlock)

### DIFF
--- a/context-transport-primitives/include/clio_ctp/lightbeam/shm_mpsc_transport.h
+++ b/context-transport-primitives/include/clio_ctp/lightbeam/shm_mpsc_transport.h
@@ -32,9 +32,24 @@
 namespace ctp::lbm {
 
 // --- Tunables ---------------------------------------------------------------
-// Default transfer space when the caller does not specify one (128KB total,
-// minus the header, is available as ring capacity).
-static constexpr size_t kShmMpscDefaultSegmentSize = 128 * 1024;
+// Default transfer space when the caller does not specify one (minus the
+// header, this is the ring capacity).
+//
+// Sizing note (issue #768 deadlock): the ring holds
+// (segment / kShmMpscChunkSize) fixed slots, which bounds the number of
+// in-flight messages per direction. SendBytes()/WaitSlotFree() BLOCK when the
+// ring is full (they only bail if the peer process dies). A client that issues
+// N async ops before waiting (e.g. cr_cli_cfs fires 16 AsyncAppend, cr_cli_cfs
+// rename fires 12 renames + 12 readdirs) needs the ring to hold ~N messages in
+// EACH direction: with too few slots the client blocks in SendIn (request ring
+// full) while the worker blocks in SendOut (response ring full) and neither
+// drains the other -> a bidirectional deadlock (reproduced under boost
+// coroutines in the deps-cpu container). 128KB gave only 4 slots. 1MB gives 32
+// slots, comfortably above the runtime's realistic per-thread async fan-out
+// (>=16-24 outstanding), which restores forward progress. (A fully
+// deadlock-proof design would make SendOut non-blocking/deferred; tracked
+// separately.)
+static constexpr size_t kShmMpscDefaultSegmentSize = 1024 * 1024;
 // Per-chunk cap: SendBytes/RecvBytes move at most this many bytes per xfer slot.
 static constexpr size_t kShmMpscChunkSize = 32 * 1024;
 // Number of in-flight transfer slots the ring tracks (bounds concurrency).


### PR DESCRIPTION
## Summary

Fixes the `cr_cli_cfs` (#140) timeout in the `boost (docker deps-cpu)` CI job — the last red on the 762 line after the readdir-corruption fix (#bb530381). Targets 762 so its boost-docker goes green with both fixes.

## Root cause: bidirectional SHM MPSC ring deadlock

`cr_cli_cfs` hangs under SHM + boost coroutines in the constrained deps-cpu container (reproduced in-container; backtraces below). The client fires **16 `AsyncAppend` ops before waiting** (`test_cfs.cc:548`, `kNum=16`). The SHM MPSC ring held only `128 KB / 32 KB = 4` in-flight slots, and `SendBytes`/`WaitSlotFree` **block** when the ring is full (they only bail if the peer process *dies*, `shm_mpsc_transport.h:467`). So:

- **Client** blocks in `SendIn → Send → WaitSlotFree` — the worker's request ring is full.
- **Worker** blocks in `SendOut → Send → WaitSlotFree` — the client's response ring is full.
- Neither drains the other's ring while blocked → **cyclic deadlock**.

Captured backtraces at the hang:
```
client: steady_clock::now → ShmMpscTransport::Send → IpcCpu2Cpu::SendIn<AppendTask> → Client::AsyncAppend
server: steady_clock::now → ShmMpscTransport::Send → IpcCpu2Cpu::SendOut → Worker::EndTask → Worker::Run
```
(3 of 4 workers idle in `SuspendMe`). It only surfaces in the constrained container because the timing lines the two full rings up; native has more slack.

## Fix

Raise the default ring segment 128 KB → **1 MB** (4 → 32 slots), comfortably above the runtime's realistic per-thread async fan-out (`cr_cli_cfs` 16-deep; `cr_cli_cfs_rename` D4 24-deep). This lets a full batch plus its responses be in flight in both directions, restoring forward progress.

This is a low-risk sizing change; a fully deadlock-proof design (non-blocking / deferred `SendOut` so a worker never spins on a full client ring) is the ideal follow-up and is noted in the code comment.

## Validation (in the deps-cpu container, boost coroutines, forced `CLIO_IPC_MODE=SHM`)

- `cr_cli_cfs`: **4/4 pass** (was a hard hang/timeout).
- MPSC transport unit tests: **8/8 pass**.
- `cr_cli_cfs_rename` passes here too once combined with the readdir demux fix already on 762.

Issue #768.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
