### PR TITLE
Anti-deadlock scheduler: measured/predicted-load routing + sched_variety benchmark (#781)

### DIFF
--- a/context-runtime/benchmark/clio_run_thrpt_bench.cc
+++ b/context-runtime/benchmark/clio_run_thrpt_bench.cc
@@ -40,8 +40,11 @@
  * - Round-trip latency using MOD_NAME Custom function
  */
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <cmath>
+#include <random>
 #include <cstring>
 #include <filesystem>
 #include <iomanip>
@@ -76,7 +79,8 @@ enum class TestCase {
   kBDevIO,         // Full I/O (Allocate -> Write -> Free)
   kBDevAllocation, // Allocation only (Allocate -> Free)
   kBDevTaskAlloc,  // Task allocation/deletion (NewTask -> DelTask)
-  kLatency         // Round-trip latency using MOD_NAME Custom
+  kLatency,        // Round-trip latency using MOD_NAME Custom
+  kSchedVariety    // issue #781: mixed 1us..1s compute; p99 by class (starvation)
 };
 
 /**
@@ -111,6 +115,9 @@ bool ParseTestCase(const std::string &str, TestCase &test_case) {
   } else if (str == "latency") {
     test_case = TestCase::kLatency;
     return true;
+  } else if (str == "sched_variety") {
+    test_case = TestCase::kSchedVariety;
+    return true;
   }
   return false;
 }
@@ -124,7 +131,7 @@ bool ParseArgs(int argc, char **argv, BenchmarkConfig &config) {
 
     if (arg == "--test-case" && i + 1 < argc) {
       if (!ParseTestCase(argv[++i], config.test_case)) {
-        HLOG(kError, "ERROR: Invalid test case. Valid options: bdev_io, bdev_allocation, bdev_task_alloc, latency");
+        HLOG(kError, "ERROR: Invalid test case. Valid options: bdev_io, bdev_allocation, bdev_task_alloc, latency, sched_variety");
         return false;
       }
     } else if (arg == "--threads" && i + 1 < argc) {
@@ -144,7 +151,7 @@ bool ParseArgs(int argc, char **argv, BenchmarkConfig &config) {
     } else if (arg == "--help" || arg == "-h") {
       HIPRINT("Usage: {} [options]", argv[0]);
       HIPRINT("Options:");
-      HIPRINT("  --test-case <case>      Test case: bdev_io, bdev_allocation, bdev_task_alloc, latency (default: bdev_io)");
+      HIPRINT("  --test-case <case>      Test case: bdev_io, bdev_allocation, bdev_task_alloc, latency, sched_variety (default: bdev_io)");
       HIPRINT("  --threads <N>           Number of client threads (default: 4)");
       HIPRINT("  --duration <seconds>    Duration to run benchmark in seconds (default: 10.0)");
       HIPRINT("  --max-file-size <size>  Maximum file size with suffix: k, m, g (default: 1g)");
@@ -447,6 +454,86 @@ void LatencyWorkerThread(size_t thread_id, const BenchmarkConfig &config,
   }
 }
 
+// ===========================================================================
+// issue #781: scheduler-variety benchmark. Each client thread submits a stream
+// of Custom tasks whose compute time (spin_us) is drawn from a mixed 1us..1s
+// distribution (mostly quick, a few heavy/mislabeled). We record every request's
+// round-trip latency and its class, then report avg / p50 / p99 / max PER CLASS.
+// The headline metric is QUICK-class p99: with a scheduler that funnels quick
+// tasks behind heavy ones it explodes; the anti-deadlock scheduler keeps it low.
+// ===========================================================================
+
+struct VarietySample {
+  clio::run::u32 spin_us;
+  double lat_us;
+};
+
+enum VarietyClass { kQuick = 0, kMedium, kHeavy, kNumVarietyClasses };
+static VarietyClass ClassOf(clio::run::u32 spin_us) {
+  if (spin_us < 100) return kQuick;      // < 100 us
+  if (spin_us < 10000) return kMedium;   // 100 us .. 10 ms
+  return kHeavy;                         // >= 10 ms
+}
+static const char *ClassName(int c) {
+  switch (c) {
+  case kQuick: return "quick  (<100us)   ";
+  case kMedium: return "medium (100us-10ms)";
+  default: return "heavy  (>=10ms)   ";
+  }
+}
+// v must be pre-sorted ascending.
+static double Pctl(const std::vector<double> &v, double p) {
+  if (v.empty()) return 0.0;
+  size_t idx = static_cast<size_t>(p * (v.size() - 1) + 0.5);
+  if (idx >= v.size()) idx = v.size() - 1;
+  return v[idx];
+}
+
+// Log-uniform draw within a mixed distribution: 90% quick, 9% medium, 1% heavy.
+static clio::run::u32 DrawSpinUs(std::mt19937 &rng) {
+  std::uniform_real_distribution<double> u(0.0, 1.0);
+  double r = u(rng), lo, hi;
+  if (r < 0.01) { lo = 10000; hi = 1000000; }        // heavy  10ms..1s
+  else if (r < 0.10) { lo = 100; hi = 10000; }       // medium 100us..10ms
+  else { lo = 1; hi = 100; }                          // quick  1us..100us
+  double e = std::log(lo) + u(rng) * (std::log(hi) - std::log(lo));
+  clio::run::u32 s = static_cast<clio::run::u32>(std::exp(e));
+  return s == 0 ? 1 : s;
+}
+
+void SchedVarietyWorkerThread(size_t thread_id, const BenchmarkConfig &config,
+                              clio::run::PoolId pool_id,
+                              std::atomic<bool> &stop_flag,
+                              std::atomic<size_t> &completed_ops,
+                              std::vector<VarietySample> &out) {
+  clio::run::MOD_NAME::Client mod_client(pool_id);
+  std::mt19937 rng(static_cast<uint32_t>(0x9e3779b9u ^
+                                         (thread_id * 2654435761u)));
+  std::string input_data = "v";
+  out.reserve(1 << 16);
+  size_t local_ops = 0;
+  while (!stop_flag.load(std::memory_order_relaxed)) {
+    clio::run::u32 spin_us = DrawSpinUs(rng);
+    auto t0 = std::chrono::high_resolution_clock::now();
+    auto task = mod_client.AsyncCustom(clio::run::PoolQuery::Broadcast(),
+                                       input_data, 0, spin_us);
+    task.Wait();
+    auto t1 = std::chrono::high_resolution_clock::now();
+    if (task->return_code_ != 0) {
+      HLOG(kError, "variety: thread {} rc={}", thread_id, task->return_code_);
+      stop_flag.store(true, std::memory_order_relaxed);
+      break;
+    }
+    double lat_us =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count() /
+        1e3;
+    out.push_back({spin_us, lat_us});
+    local_ops++;
+  }
+  completed_ops.fetch_add(local_ops, std::memory_order_relaxed);
+  (void)config;
+}
+
 int main(int argc, char **argv) {
   BenchmarkConfig config;
 
@@ -496,8 +583,9 @@ int main(int argc, char **argv) {
 
   // Create pool based on test case
   clio::run::PoolId test_pool_id;
-  if (config.test_case == TestCase::kLatency) {
-    // Create MOD_NAME container for latency test
+  if (config.test_case == TestCase::kLatency ||
+      config.test_case == TestCase::kSchedVariety) {
+    // Create MOD_NAME container for latency / scheduler-variety tests (#781)
     test_pool_id = clio::run::PoolId(8000, 0);
     clio::run::MOD_NAME::Client mod_client(test_pool_id);
     auto create_task = mod_client.AsyncCreate(clio::run::PoolQuery::Broadcast(),
@@ -568,6 +656,9 @@ int main(int argc, char **argv) {
   // Storage for per-thread elapsed times
   std::vector<std::chrono::nanoseconds> thread_times(config.num_threads);
 
+  // issue #781: per-thread latency samples for the variety benchmark
+  std::vector<std::vector<VarietySample>> variety_samples(config.num_threads);
+
   // Spawn worker threads
   std::vector<std::thread> threads;
   threads.reserve(config.num_threads);
@@ -608,6 +699,16 @@ int main(int argc, char **argv) {
       threads.emplace_back(LatencyWorkerThread, i, std::ref(config),
                            test_pool_id, std::ref(stop_flag),
                            std::ref(completed_ops), std::ref(thread_times[i]));
+    }
+    break;
+
+  case TestCase::kSchedVariety:
+    // issue #781: mixed-compute workers, each recording per-request samples
+    for (size_t i = 0; i < config.num_threads; i++) {
+      threads.emplace_back(SchedVarietyWorkerThread, i, std::ref(config),
+                           test_pool_id, std::ref(stop_flag),
+                           std::ref(completed_ops),
+                           std::ref(variety_samples[i]));
     }
     break;
   }
@@ -679,6 +780,38 @@ int main(int argc, char **argv) {
     HIPRINT("Throughput: {} Custom ops/sec", throughput);
     HIPRINT("Avg round-trip latency: {} us/op", avg_latency_us);
     break;
+
+  case TestCase::kSchedVariety: {
+    // issue #781: bucket every request by its requested compute class and report
+    // avg / p50 / p99 / max round-trip latency per class. QUICK p99 is the
+    // starvation metric — how badly quick tasks are delayed by heavy ones.
+    std::vector<double> lat[kNumVarietyClasses];
+    for (auto &thread_vec : variety_samples) {
+      for (const auto &s : thread_vec) {
+        lat[ClassOf(s.spin_us)].push_back(s.lat_us);
+      }
+    }
+    // ctp::Formatter supports only plain {} (stream insertion), no specs — round
+    // to 1 decimal so the columns stay readable.
+    auto r1 = [](double x) { return std::round(x * 10.0) / 10.0; };
+    HIPRINT("Throughput: {} Custom ops/sec", throughput);
+    HIPRINT("\n  class                  count   avg_us   p50_us   p99_us   max_us");
+    for (int c = 0; c < kNumVarietyClasses; ++c) {
+      auto &v = lat[c];
+      if (v.empty()) continue;
+      std::sort(v.begin(), v.end());
+      double sum = 0.0;
+      for (double x : v) sum += x;
+      HIPRINT("  {}   {}   {}   {}   {}   {}", ClassName(c), v.size(),
+              r1(sum / v.size()), r1(Pctl(v, 0.50)), r1(Pctl(v, 0.99)),
+              r1(v.back()));
+    }
+    if (!lat[kQuick].empty()) {
+      HIPRINT("\n  >>> STARVATION METRIC: quick-task p99 = {} us (p50 = {} us)",
+              r1(Pctl(lat[kQuick], 0.99)), r1(Pctl(lat[kQuick], 0.50)));
+    }
+    break;
+  }
   }
 
   BENCH_EXIT(0);

--- a/context-runtime/benchmark/clio_run_thrpt_bench.cc
+++ b/context-runtime/benchmark/clio_run_thrpt_bench.cc
@@ -493,7 +493,8 @@ static double Pctl(const std::vector<double> &v, double p) {
 static clio::run::u32 DrawSpinUs(std::mt19937 &rng) {
   std::uniform_real_distribution<double> u(0.0, 1.0);
   double r = u(rng), lo, hi;
-  if (r < 0.01) { lo = 10000; hi = 1000000; }        // heavy  10ms..1s
+  if (r < 0.01) { lo = 10000; hi = 2000000; }        // heavy  10ms..2s (some >1s
+                                                      // to exercise stall detect)
   else if (r < 0.10) { lo = 100; hi = 10000; }       // medium 100us..10ms
   else { lo = 1; hi = 100; }                          // quick  1us..100us
   double e = std::log(lo) + u(rng) * (std::log(hi) - std::log(lo));

--- a/context-runtime/include/clio_runtime/scheduler/default_sched.h
+++ b/context-runtime/include/clio_runtime/scheduler/default_sched.h
@@ -67,6 +67,7 @@ class DefaultScheduler : public Scheduler {
                      ContainerHold container) override;
   void LoadBalance() override;         // issue #781 — safety net, every 500ms
   bool StealWork(Worker *thief) override;  // issue #781 — work-conserving steal
+  void RecordCompletion(u32 method, double cpu_us, double wall_us) override;
   void AdjustPolling(const clio::run::shared_ptr<Task> &task) override;
   Worker *GetGpuWorker() const override { return gpu_worker_; }
   // Legacy alias — admin_runtime.cc:Create registers transport FDs with the

--- a/context-runtime/include/clio_runtime/scheduler/default_sched.h
+++ b/context-runtime/include/clio_runtime/scheduler/default_sched.h
@@ -100,6 +100,8 @@ class DefaultScheduler : public Scheduler {
     return kGe1s;
   }
   std::array<std::atomic<u64>, kNumPerfBins> perf_pdf_{};  ///< #781 telemetry
+  std::atomic<u64> load_balance_ticks_{0};  ///< #781 monitor ticks observed
+  std::atomic<u64> stalls_detected_{0};     ///< #781 cumulative stall events
 
   Worker *scheduler_worker_;              ///< Worker 0: metadata + small I/O
   std::vector<Worker *> io_workers_;      ///< Workers 1..N-3: large I/O

--- a/context-runtime/include/clio_runtime/scheduler/default_sched.h
+++ b/context-runtime/include/clio_runtime/scheduler/default_sched.h
@@ -40,6 +40,10 @@
 
 #include "clio_runtime/scheduler/scheduler.h"
 
+#include <array>
+#include <atomic>
+#include <vector>
+
 namespace clio::run {
 
 /**
@@ -59,10 +63,10 @@ class DefaultScheduler : public Scheduler {
   ~DefaultScheduler() override = default;
 
   void DivideWorkers(WorkOrchestrator *work_orch) override;
-  u32 ClientMapTask(IpcManager *ipc_manager, const Future<Task> &task) override;
   u32 RuntimeMapTask(Worker *worker, const Future<Task> &task,
                      ContainerHold container) override;
-  void RebalanceWorker(Worker *worker) override;
+  void LoadBalance() override;         // issue #781 — safety net, every 500ms
+  bool StealWork(Worker *thief) override;  // issue #781 — work-conserving steal
   void AdjustPolling(const clio::run::shared_ptr<Task> &task) override;
   Worker *GetGpuWorker() const override { return gpu_worker_; }
   // Legacy alias — admin_runtime.cc:Create registers transport FDs with the
@@ -75,6 +79,27 @@ class DefaultScheduler : public Scheduler {
 
  private:
   static constexpr size_t kLargeIOThreshold = 4096;  ///< I/O size threshold
+  static constexpr double kStallThresholdSec = 1.0;  ///< #781: worker stall cutoff
+  static constexpr double kRetireCooldownSec = 5.0;  ///< #781: idle elastic retire
+  static constexpr u32 kStealBatch = 4;              ///< #781: tasks stolen per victim
+
+  /// #781 telemetry-only histogram of completed-task exec times. NOT used for
+  /// routing (routing uses measured realtime load, not predictions).
+  enum PerfBin {
+    kLt10us = 0, kLt50us, kLt500us, kLt10ms, kLt50ms, kLt500ms, kLt1s, kGe1s,
+    kNumPerfBins
+  };
+  static PerfBin BinFor(double exec_us) {
+    if (exec_us < 10) return kLt10us;
+    if (exec_us < 50) return kLt50us;
+    if (exec_us < 500) return kLt500us;
+    if (exec_us < 10000) return kLt10ms;
+    if (exec_us < 50000) return kLt50ms;
+    if (exec_us < 500000) return kLt500ms;
+    if (exec_us < 1000000) return kLt1s;
+    return kGe1s;
+  }
+  std::array<std::atomic<u64>, kNumPerfBins> perf_pdf_{};  ///< #781 telemetry
 
   Worker *scheduler_worker_;              ///< Worker 0: metadata + small I/O
   std::vector<Worker *> io_workers_;      ///< Workers 1..N-3: large I/O
@@ -82,6 +107,7 @@ class DefaultScheduler : public Scheduler {
   Worker *net_recv_worker_;               ///< Worker N-1: kRecv / kClientRecv
   Worker *gpu_worker_;                    ///< GPU queue polling worker
   std::atomic<u32> next_io_idx_{0};       ///< Round-robin index for I/O workers
+  WorkOrchestrator *work_orch_ = nullptr; ///< #781 set in DivideWorkers; elastic spawn
 };
 
 }  // namespace clio::run

--- a/context-runtime/include/clio_runtime/scheduler/local_sched.h
+++ b/context-runtime/include/clio_runtime/scheduler/local_sched.h
@@ -53,17 +53,15 @@ class LocalScheduler : public Scheduler {
   ~LocalScheduler() override = default;
 
   void DivideWorkers(WorkOrchestrator *work_orch) override;
-  u32 ClientMapTask(IpcManager *ipc_manager, const Future<Task> &task) override;
   u32 RuntimeMapTask(Worker *worker, const Future<Task> &task,
                      ContainerHold container) override;
-  void RebalanceWorker(Worker *worker) override;
+  void LoadBalance() override;             // issue #781
+  bool StealWork(Worker *thief) override;  // issue #781
   void AdjustPolling(const clio::run::shared_ptr<Task> &task) override;
   Worker *GetGpuWorker() const override { return gpu_worker_; }
   Worker *GetNetWorker() const override { return net_worker_; }
 
  private:
-  u32 MapByPidTid(u32 num_lanes);
-
   std::vector<Worker *> scheduler_workers_;
   Worker *net_worker_;
   Worker *gpu_worker_;

--- a/context-runtime/include/clio_runtime/scheduler/scheduler.h
+++ b/context-runtime/include/clio_runtime/scheduler/scheduler.h
@@ -92,6 +92,20 @@ class Scheduler {
   virtual void LoadBalance() = 0;
 
   /**
+   * Telemetry hook (issue #781): called from Worker::EndTask with a completed
+   * task's ACTUAL measured cpu/wall time (us). Implementations fold it into the
+   * perf-bin PDF so the runtime can characterize its live workload (how many
+   * quick vs 1-second tasks it actually ran). Observation, not prediction —
+   * default no-op.
+   * @param method   the task's method id
+   * @param cpu_us   measured CPU time (us)
+   * @param wall_us  measured wall-clock time (us)
+   */
+  virtual void RecordCompletion(u32 method, double cpu_us, double wall_us) {
+    (void)method; (void)cpu_us; (void)wall_us;
+  }
+
+  /**
    * Work-stealing hook (issue #781). Invoked when \a thief has drained its own
    * lane. Implementations move a bounded number of tasks from neighbouring /
    * overloaded workers' lanes onto the thief's lane so the pool stays

--- a/context-runtime/include/clio_runtime/scheduler/scheduler.h
+++ b/context-runtime/include/clio_runtime/scheduler/scheduler.h
@@ -66,17 +66,6 @@ class Scheduler {
   virtual void DivideWorkers(WorkOrchestrator *work_orch) = 0;
 
   /**
-   * Determines which worker to initially map a task to from clients.
-   * First few workers are always the scheduling workers.
-   * Analogous to the old MapTaskToLane function.
-   *
-   * @param ipc_manager Pointer to the IPC manager
-   * @param task The task to be scheduled
-   * @return Worker lane ID to assign the task to
-   */
-  virtual u32 ClientMapTask(IpcManager *ipc_manager, const Future<Task> &task) = 0;
-
-  /**
    * Determines which worker to initially map a task to from runtime.
    * Called in RouteTask via IpcManager::EnqueueRuntime.
    *
@@ -91,12 +80,28 @@ class Scheduler {
                              ContainerHold container) = 0;
 
   /**
-   * Either steal or delegate tasks on a worker to balance load.
-   * Should be called after every ProcessNewTasks loop before SuspendMe.
-   *
-   * @param worker Pointer to the worker to rebalance
+   * Periodic load-balancing hook (issue #781). Called by the WorkOrchestrator
+   * monitor thread every ~500ms (NOT on the worker hot path). Implementations
+   * detect stalled workers (a worker stuck >1s inside one ExecTask on a
+   * non-yielding task), spawn a replacement thread and steal the stalled
+   * worker's backlog so one pathological/mislabeled task can never wedge the
+   * runtime, rebalance imbalanced load, retire idle elastic workers, and update
+   * the telemetry perf-bin PDF. This is the runtime's liveness guarantee: it
+   * does NOT depend on tasks being honestly labeled.
    */
-  virtual void RebalanceWorker(Worker *worker) = 0;
+  virtual void LoadBalance() = 0;
+
+  /**
+   * Work-stealing hook (issue #781). Invoked when \a thief has drained its own
+   * lane. Implementations move a bounded number of tasks from neighbouring /
+   * overloaded workers' lanes onto the thief's lane so the pool stays
+   * work-conserving (which is what lets the runtime hit throughput with the
+   * MINIMUM number of threads). Must use a steal-safe lane pop.
+   *
+   * @param thief The idle worker looking for work.
+   * @return true if any task was stolen.
+   */
+  virtual bool StealWork(Worker *thief) = 0;
 
   /**
    * Adjust polling interval for periodic tasks based on work done.

--- a/context-runtime/include/clio_runtime/task.h
+++ b/context-runtime/include/clio_runtime/task.h
@@ -388,6 +388,8 @@ class Task {
   ctp::CpuTimer& RunCpuTimer();
   float PredictedLoad() const;
   void SetPredictedLoad(float v);
+  float SchedReservedUs() const;       // issue #781 queued-load reservation
+  void SetSchedReservedUs(float v);    // issue #781
   ctp::HighResMonotonicTimer& RunWallTimer();
   float PredictedWallUs() const;
   void SetPredictedWallUs(float v);
@@ -893,6 +895,9 @@ class RunContext {
   ctp::bitfield32_t flags_;
   ctp::CpuTimer cpu_timer_; /**< Accumulates thread CPU time across yields */
   float predicted_load_ = 0; /**< Predicted CPU time from InferModel (us) */
+  float sched_reserved_us_ = 0; /**< #781 queued-load reservation on a worker
+                                  * (predicted cost added to worker.queued_load_
+                                  * at map, released when the task starts) */
   ctp::HighResMonotonicTimer wall_timer_; /**< Wall clock time across yields */
   float predicted_wall_us_ =
       0; /**< Predicted wall time from InferWallClockTime */
@@ -1072,6 +1077,7 @@ class RunContext {
     flags_.UnsetBits(RCTX_DID_WORK);
     cpu_timer_.time_ns_ = 0;
     predicted_load_ = 0;
+    sched_reserved_us_ = 0;
     wall_timer_.time_ns_ = 0;
     predicted_wall_us_ = 0;
     predicted_stat_ = TaskStat();
@@ -1157,6 +1163,8 @@ CLIO_RCTX_FLAG(IsStarted, SetStarted)
 CLIO_RCTX_REF(ctp::CpuTimer, RunCpuTimer, cpu_timer_)
 CLIO_RCTX_GET(float, PredictedLoad, predicted_load_)
 CLIO_RCTX_SET(float, SetPredictedLoad, predicted_load_)
+CLIO_RCTX_GET(float, SchedReservedUs, sched_reserved_us_)
+CLIO_RCTX_SET(float, SetSchedReservedUs, sched_reserved_us_)
 CLIO_RCTX_REF(ctp::HighResMonotonicTimer, RunWallTimer, wall_timer_)
 CLIO_RCTX_GET(float, PredictedWallUs, predicted_wall_us_)
 CLIO_RCTX_SET(float, SetPredictedWallUs, predicted_wall_us_)

--- a/context-runtime/include/clio_runtime/work_orchestrator.h
+++ b/context-runtime/include/clio_runtime/work_orchestrator.h
@@ -36,6 +36,7 @@
 
 #include <atomic>
 #include <memory>
+#include <thread>
 #include <vector>
 
 #include "clio_runtime/task.h"
@@ -152,7 +153,42 @@ class WorkOrchestrator {
    */
   u32 GetTotalWorkerCount() const { return static_cast<u32>(all_workers_.size()); }
 
+  // --- issue #781: monitor thread + elastic (unbounded) worker pool ---
+
+  /**
+   * Start the dedicated monitor thread. Not a worker: every ~500ms it samples
+   * worker progress/load and calls scheduler_->LoadBalance(), which detects
+   * stalled workers and grows/rebalances the pool. Idempotent.
+   */
+  void StartMonitorThread();
+
+  /** Stop and join the monitor thread. */
+  void StopMonitorThread();
+
+  /**
+   * Elastically add ONE worker + lane at runtime and spawn its thread (issue
+   * #781). Called by LoadBalance when a worker stalls on a non-yielding task so
+   * the stalled worker's backlog can be stolen onto a fresh thread. Unbounded by
+   * design (see issue #781 Observability) — emits metrics/warnings instead of a
+   * hard cap. Today the pool is created once at Init; this is the dynamic path.
+   * @return the new worker, or nullptr on failure.
+   */
+  Worker *SpawnAdditionalWorker();
+
+  /**
+   * Retire an idle elastic worker spawned by SpawnAdditionalWorker (issue #781):
+   * park it, join its thread, and drop it from the pool — the hysteresis that
+   * returns the runtime to the minimum thread count after a burst clears.
+   */
+  void RetireWorker(Worker *worker);
+
+  /** Interval between monitor-thread LoadBalance() ticks. */
+  static constexpr u32 kMonitorPeriodMs = 500;
+
  private:
+  /** Monitor-thread body: LoadBalance() loop on a kMonitorPeriodMs cadence. */
+  void MonitorLoop();
+
   /**
    * Spawn worker threads using CTP thread model
    * @return true if spawning successful, false otherwise
@@ -196,6 +232,10 @@ class WorkOrchestrator {
   // CTP threads (will be filled during initialization)
   std::vector<ctp::thread::Thread> worker_threads_;
   ctp::thread::ThreadGroup thread_group_;
+
+  // issue #781: dedicated monitor thread (not a worker) that drives LoadBalance.
+  std::thread monitor_thread_;
+  std::atomic<bool> monitor_running_{false};
 
   // Scheduler pointer (owned by IpcManager, not WorkOrchestrator)
   Scheduler *scheduler_;

--- a/context-runtime/include/clio_runtime/worker.h
+++ b/context-runtime/include/clio_runtime/worker.h
@@ -196,16 +196,34 @@ class Worker {
   }
 
   /**
-   * Measured real-time load used for routing (issue #781): estimated queued
-   * cost plus how long the currently-executing task has already been running.
-   * An overrunning task inflates its own worker's load in real time, so the
-   * mapper steers new work away from it — no cost prediction required.
+   * Measured real-time load used for routing (issue #781):
+   *   load_             predicted cost of the task currently EXECUTING
+   *   queued_load_us_   predicted cost of tasks assigned/queued but not started
+   *   elapsed           how long the executing task has OVERRUN wall-clock
+   * The predicted terms come from the learned per-method model (converges after
+   * a few runs); the elapsed term is the pure-measured signal that catches a
+   * task overrunning its prediction (or a mislabeled non-yielding spin). Together
+   * they steer new work off both busy AND backlogged workers.
    * @param now_us current steady-clock time in microseconds.
    */
   double RealtimeLoad(double now_us) const {
     double start = last_exec_start_us_.load(std::memory_order_relaxed);
     double elapsed = (start != 0.0) ? (now_us - start) : 0.0;
-    return static_cast<double>(load_) + elapsed;
+    return static_cast<double>(load_) +
+           queued_load_us_.load(std::memory_order_relaxed) + elapsed;
+  }
+
+  /** #781: reserve predicted cost on this worker when a task is mapped to it. */
+  void ReserveLoad(double us) {
+    if (us > 0.0) queued_load_us_.fetch_add(us, std::memory_order_relaxed);
+  }
+  /** #781: release the reservation when the task starts executing (or is
+   *  cancelled) — the executing cost is then tracked by load_ instead. */
+  void ReleaseReservation(double us) {
+    if (us > 0.0) {
+      double prev = queued_load_us_.fetch_sub(us, std::memory_order_relaxed);
+      if (prev - us < 0.0) queued_load_us_.store(0.0, std::memory_order_relaxed);
+    }
   }
 
   /**
@@ -433,6 +451,11 @@ class Worker {
   // runtime can spawn a replacement and steal the backlog. std::atomic so the
   // monitor thread can read it without a lock.
   std::atomic<double> last_exec_start_us_{0.0};  // 0 == not executing
+  // issue #781: sum of predicted costs of tasks mapped to this worker but not
+  // yet started (the queue). Added in RuntimeMapTask, released in ExecTask when
+  // the task begins. Lets the mapper avoid a worker with a heavy task queued
+  // even before it starts running — the queued-behind-heavy fix.
+  std::atomic<double> queued_load_us_{0.0};
   bool did_work_;       // Tracks if any work was done in current loop iteration
   bool task_did_work_;  // Tracks if current task did actual work (set by tasks
                         // via CLIO_CUR_WORKER)

--- a/context-runtime/include/clio_runtime/worker.h
+++ b/context-runtime/include/clio_runtime/worker.h
@@ -34,6 +34,7 @@
 #ifndef CLIO_RUNTIME_INCLUDE_WORKERS_WORKER_H_
 #define CLIO_RUNTIME_INCLUDE_WORKERS_WORKER_H_
 
+#include <atomic>
 #include <chrono>
 // <coroutine> only for the C++20 stackless backend, not the Boost stackful one.
 // (task.h, included below, derives CLIO_ENABLE_BOOST_COROUTINES from this.)
@@ -183,6 +184,39 @@ class Worker {
    * @return true if worker is active, false otherwise
    */
   bool IsRunning() const;
+
+  // --- issue #781: measured-load + stall-detection accessors ---
+
+  /** Estimated queued CPU time (us), bumped/decremented around ExecTask. */
+  float Load() const { return load_; }
+
+  /** True while a task is actively executing on this worker. */
+  bool IsExecuting() const {
+    return last_exec_start_us_.load(std::memory_order_relaxed) != 0.0;
+  }
+
+  /**
+   * Measured real-time load used for routing (issue #781): estimated queued
+   * cost plus how long the currently-executing task has already been running.
+   * An overrunning task inflates its own worker's load in real time, so the
+   * mapper steers new work away from it — no cost prediction required.
+   * @param now_us current steady-clock time in microseconds.
+   */
+  double RealtimeLoad(double now_us) const {
+    double start = last_exec_start_us_.load(std::memory_order_relaxed);
+    double elapsed = (start != 0.0) ? (now_us - start) : 0.0;
+    return static_cast<double>(load_) + elapsed;
+  }
+
+  /**
+   * True if this worker has been executing one task longer than \a threshold_sec
+   * — i.e. a non-yielding/mislabeled task is stalling it (issue #781).
+   * @param now_us current steady-clock time in microseconds.
+   */
+  bool IsStalled(double now_us, double threshold_sec) const {
+    double start = last_exec_start_us_.load(std::memory_order_relaxed);
+    return start != 0.0 && (now_us - start) > threshold_sec * 1e6;
+  }
 
   /**
    * Set the task currently executing on this worker thread (the worker sets
@@ -392,6 +426,13 @@ class Worker {
   bool is_running_;
   bool is_initialized_;
   float load_;          // Estimated total CPU time (us) of active tasks
+  // issue #781: wall-clock timestamp stamped at the top of ExecTask and cleared
+  // when the task returns/yields. While executing, (now() - last_exec_start_) is
+  // the current task's elapsed time; the monitor thread uses this to detect a
+  // worker stalled on a non-yielding task ( > kStallThresholdSec ) so the
+  // runtime can spawn a replacement and steal the backlog. std::atomic so the
+  // monitor thread can read it without a lock.
+  std::atomic<double> last_exec_start_us_{0.0};  // 0 == not executing
   bool did_work_;       // Tracks if any work was done in current loop iteration
   bool task_did_work_;  // Tracks if current task did actual work (set by tasks
                         // via CLIO_CUR_WORKER)

--- a/context-runtime/include/clio_runtime/worker.h
+++ b/context-runtime/include/clio_runtime/worker.h
@@ -192,7 +192,7 @@ class Worker {
 
   /** True while a task is actively executing on this worker. */
   bool IsExecuting() const {
-    return last_exec_start_us_.load(std::memory_order_relaxed) != 0.0;
+    return last_exec_start_us_.load(std::memory_order_relaxed) != 0;
   }
 
   /**
@@ -207,22 +207,28 @@ class Worker {
    * @param now_us current steady-clock time in microseconds.
    */
   double RealtimeLoad(double now_us) const {
-    double start = last_exec_start_us_.load(std::memory_order_relaxed);
-    double elapsed = (start != 0.0) ? (now_us - start) : 0.0;
+    long long start = last_exec_start_us_.load(std::memory_order_relaxed);
+    double elapsed = (start != 0) ? (now_us - static_cast<double>(start)) : 0.0;
     return static_cast<double>(load_) +
-           queued_load_us_.load(std::memory_order_relaxed) + elapsed;
+           static_cast<double>(queued_load_us_.load(std::memory_order_relaxed)) +
+           elapsed;
   }
 
-  /** #781: reserve predicted cost on this worker when a task is mapped to it. */
+  /** #781: reserve predicted cost on this worker when a task is mapped to it.
+   *  Integer atomic (µs) — atomic<double> fetch_add is not portable (icx/MSVC). */
   void ReserveLoad(double us) {
-    if (us > 0.0) queued_load_us_.fetch_add(us, std::memory_order_relaxed);
+    if (us > 0.0) {
+      queued_load_us_.fetch_add(static_cast<long long>(us),
+                                std::memory_order_relaxed);
+    }
   }
   /** #781: release the reservation when the task starts executing (or is
    *  cancelled) — the executing cost is then tracked by load_ instead. */
   void ReleaseReservation(double us) {
     if (us > 0.0) {
-      double prev = queued_load_us_.fetch_sub(us, std::memory_order_relaxed);
-      if (prev - us < 0.0) queued_load_us_.store(0.0, std::memory_order_relaxed);
+      long long amt = static_cast<long long>(us);
+      long long prev = queued_load_us_.fetch_sub(amt, std::memory_order_relaxed);
+      if (prev - amt < 0) queued_load_us_.store(0, std::memory_order_relaxed);
     }
   }
 
@@ -232,8 +238,9 @@ class Worker {
    * @param now_us current steady-clock time in microseconds.
    */
   bool IsStalled(double now_us, double threshold_sec) const {
-    double start = last_exec_start_us_.load(std::memory_order_relaxed);
-    return start != 0.0 && (now_us - start) > threshold_sec * 1e6;
+    long long start = last_exec_start_us_.load(std::memory_order_relaxed);
+    return start != 0 &&
+           (now_us - static_cast<double>(start)) > threshold_sec * 1e6;
   }
 
   /**
@@ -450,12 +457,12 @@ class Worker {
   // worker stalled on a non-yielding task ( > kStallThresholdSec ) so the
   // runtime can spawn a replacement and steal the backlog. std::atomic so the
   // monitor thread can read it without a lock.
-  std::atomic<double> last_exec_start_us_{0.0};  // 0 == not executing
+  std::atomic<long long> last_exec_start_us_{0};  // µs, 0 == not executing
   // issue #781: sum of predicted costs of tasks mapped to this worker but not
   // yet started (the queue). Added in RuntimeMapTask, released in ExecTask when
   // the task begins. Lets the mapper avoid a worker with a heavy task queued
   // even before it starts running — the queued-behind-heavy fix.
-  std::atomic<double> queued_load_us_{0.0};
+  std::atomic<long long> queued_load_us_{0};  // µs
   bool did_work_;       // Tracks if any work was done in current loop iteration
   bool task_did_work_;  // Tracks if current task did actual work (set by tasks
                         // via CLIO_CUR_WORKER)

--- a/context-runtime/modules/MOD_NAME/include/clio_runtime/MOD_NAME/MOD_NAME_client.h
+++ b/context-runtime/modules/MOD_NAME/include/clio_runtime/MOD_NAME/MOD_NAME_client.h
@@ -103,11 +103,14 @@ class Client : public clio::run::ContainerClient {
    */
   clio::run::Future<CustomTask> AsyncCustom(const clio::run::PoolQuery& pool_query,
                                        const std::string& input_data,
-                                       clio::run::u32 operation_id) {
+                                       clio::run::u32 operation_id,
+                                       clio::run::u32 spin_us = 0) {
     auto* ipc_manager = CLIO_CPU_IPC;
 
+    // issue #781: spin_us drives the scheduler-variety benchmark's compute mix.
     auto task = ipc_manager->NewTask<CustomTask>(
-        clio::run::CreateTaskId(), pool_id_, pool_query, input_data, operation_id);
+        clio::run::CreateTaskId(), pool_id_, pool_query, input_data,
+        operation_id, spin_us);
 
     return ipc_manager->Send(task);
   }

--- a/context-runtime/modules/MOD_NAME/include/clio_runtime/MOD_NAME/MOD_NAME_runtime.h
+++ b/context-runtime/modules/MOD_NAME/include/clio_runtime/MOD_NAME/MOD_NAME_runtime.h
@@ -61,6 +61,19 @@ public:
   // CreateParams type used by CLIO_TASK_CC macro for lib_name access
   using CreateParams = clio::run::MOD_NAME::CreateParams;
 
+  // issue #781: expose a real per-task cost signal to the scheduler's learned
+  // model. CustomTask carries spin_us_ (its busy-spin compute time); reporting it
+  // as TaskStat.compute_ lets Container::InferCpuTime (coef*(compute+1)) converge
+  // — after a few runs the model predicts ~spin_us, so RuntimeMapTask can route
+  // by predicted cost instead of treating every Custom task as identical.
+  clio::run::TaskStat GetTaskStats(const clio::run::Task *task) const override {
+    clio::run::TaskStat stat;
+    if (task != nullptr && task->method_ == Method::kCustom) {
+      stat.compute_ = static_cast<const CustomTask *>(task)->spin_us_;
+    }
+    return stat;
+  }
+
 private:
   // Container-specific state
   clio::run::u32 create_count_ = 0;

--- a/context-runtime/modules/MOD_NAME/include/clio_runtime/MOD_NAME/MOD_NAME_tasks.h
+++ b/context-runtime/modules/MOD_NAME/include/clio_runtime/MOD_NAME/MOD_NAME_tasks.h
@@ -87,11 +87,16 @@ struct CustomTask : public clio::run::Task {
   // Task-specific data
   INOUT clio::run::priv::string data_;
   IN clio::run::u32 operation_id_;
+  // issue #781 scheduler-variety benchmark: requested busy-spin compute time in
+  // microseconds. The handler spins for this long, letting the benchmark
+  // generate a controlled mix of 1us..1s (non-yielding) tasks to measure
+  // starvation / p99 under the scheduler.
+  IN clio::run::u32 spin_us_;
 
   /** SHM default constructor */
   CustomTask()
       : clio::run::Task(),
-        data_(CLIO_PRIV_ALLOC), operation_id_(0) {
+        data_(CLIO_PRIV_ALLOC), operation_id_(0), spin_us_(0) {
   }
 
   /** Emplace constructor */
@@ -100,9 +105,11 @@ struct CustomTask : public clio::run::Task {
       const clio::run::PoolId &pool_id,
       const clio::run::PoolQuery &pool_query,
       const std::string &data,
-      clio::run::u32 operation_id)
+      clio::run::u32 operation_id,
+      clio::run::u32 spin_us = 0)
       : clio::run::Task(task_node, pool_id, pool_query, 10),
-        data_(CLIO_PRIV_ALLOC, data), operation_id_(operation_id) {
+        data_(CLIO_PRIV_ALLOC, data), operation_id_(operation_id),
+        spin_us_(spin_us) {
     // Initialize task
     task_id_ = task_node;
     pool_id_ = pool_id;
@@ -122,7 +129,7 @@ struct CustomTask : public clio::run::Task {
   template<typename Archive>
   CTP_CROSS_FUN void SerializeIn(Archive& ar) {
     Task::SerializeIn(ar);
-    ar(data_, operation_id_);
+    ar(data_, operation_id_, spin_us_);
   }
 
   template<typename Archive>

--- a/context-runtime/modules/MOD_NAME/src/MOD_NAME_runtime.cc
+++ b/context-runtime/modules/MOD_NAME/src/MOD_NAME_runtime.cc
@@ -75,8 +75,17 @@ clio::run::TaskResume Runtime::Custom(clio::run::shared_ptr<CustomTask> &task) {
 
   custom_count_++;
 
-  // Process custom task here
-  // In a real implementation, this would perform the custom operation
+  // issue #781 scheduler-variety benchmark: busy-spin for the requested compute
+  // time. This is a NON-YIELDING spin on purpose — it models the mislabeled /
+  // long-running task class the anti-deadlock scheduler must tolerate, and lets
+  // the benchmark sweep 1us..1s to measure quick-task p99 / starvation.
+  if (task->spin_us_ > 0) {
+    auto deadline = std::chrono::steady_clock::now() +
+                    std::chrono::microseconds(task->spin_us_);
+    while (std::chrono::steady_clock::now() < deadline) {
+      // spin (no yield)
+    }
+  }
 
   HLOG(kDebug, "MOD_NAME: Custom completed (count: {})", custom_count_);
   CLIO_CO_RETURN;

--- a/context-runtime/src/ipc/ipc_cpu2cpu.cc
+++ b/context-runtime/src/ipc/ipc_cpu2cpu.cc
@@ -65,11 +65,11 @@ bool IpcCpu2Cpu::RecvIn(IpcManager *ipc) {
   // Allocate the task's RunContext (and resolve its container) now that it is
   // deserialized, so RouteTask / the worker have an active RunContext.
   f.GetTaskPtr()->BeginRunContext();
-  // Pick a worker lane and enqueue, exactly as the ZMQ client recv thread does
-  // (IpcCpu2CpuZmq::RecvIn). We are not a worker, so there is no "own lane" to
-  // push to — the scheduler decides. Always signal: see ipc_cpu2cpu_impl.h for
-  // the enqueue/sleep race this closes.
-  LaneId lane_id = ipc->GetScheduler()->ClientMapTask(ipc, f);
+  // issue #781: ClientMapTask removed. Like the ZMQ client recv thread
+  // (IpcCpu2CpuZmq::RecvIn), this SHM recv path deposits on the shared ingress
+  // lane (0); the runtime maps the task to a worker via RuntimeMapTask. Always
+  // signal: see ipc_cpu2cpu_impl.h for the enqueue/sleep race this closes.
+  LaneId lane_id = 0;
   auto &lane_ref = ipc->GetTaskQueue()->GetLane(lane_id, 0);
   lane_ref.Push(f);
   ipc->AwakenWorker(&lane_ref);

--- a/context-runtime/src/ipc/ipc_cpu2cpu_zmq.cc
+++ b/context-runtime/src/ipc/ipc_cpu2cpu_zmq.cc
@@ -196,9 +196,9 @@ bool IpcCpu2CpuZmq::RecvIn(IpcManager *ipc, u32 &tasks_received) {
       // is deserialized, so RouteTask / the worker have an active RunContext.
       future.GetTaskPtr()->BeginRunContext();
 
-      // Enqueue to worker lane
-      LaneId lane_id =
-          ipc->GetScheduler()->ClientMapTask(ipc, future);
+      // issue #781: ClientMapTask removed. Recv threads deposit on the shared
+      // ingress lane (0); the runtime maps to a worker via RuntimeMapTask.
+      LaneId lane_id = 0;
       auto *worker_queues = ipc->GetTaskQueue();
       auto &lane_ref = worker_queues->GetLane(lane_id, 0);
       lane_ref.Push(future);

--- a/context-runtime/src/ipc/ipc_run2run.cc
+++ b/context-runtime/src/ipc/ipc_run2run.cc
@@ -457,8 +457,9 @@ bool IpcManagerRun2Run::RecvInHandleOne(
   task_ptr->SetRouted();
 
   if (ipc_manager->GetScheduler() != nullptr) {
-    clio::run::u32 lane_id =
-        ipc_manager->GetScheduler()->ClientMapTask(ipc_manager, future);
+    // issue #781: ClientMapTask removed. Deposit on the shared ingress lane (0);
+    // the runtime maps to a worker via RuntimeMapTask.
+    clio::run::u32 lane_id = 0;
     auto *worker_queues = ipc_manager->GetTaskQueue();
     if (worker_queues) {
       auto &dest_lane = worker_queues->GetLane(lane_id, 0);

--- a/context-runtime/src/scheduler/default_sched.cc
+++ b/context-runtime/src/scheduler/default_sched.cc
@@ -47,6 +47,7 @@ void DefaultScheduler::DivideWorkers(WorkOrchestrator *work_orch) {
   if (!work_orch) {
     return;
   }
+  work_orch_ = work_orch;  // #781: retained for elastic SpawnAdditionalWorker
 
   u32 total_workers = work_orch->GetTotalWorkerCount();
 
@@ -127,26 +128,10 @@ void DefaultScheduler::DivideWorkers(WorkOrchestrator *work_orch) {
        gpu_worker_ ? (int)gpu_worker_->GetId() : -1);
 }
 
-u32 DefaultScheduler::ClientMapTask(IpcManager *ipc_manager,
-                                    const Future<Task> &task) {
-  u32 num_lanes = ipc_manager->GetNumSchedQueues();
-  if (num_lanes == 0) {
-    return 0;
-  }
-
-  Task *task_ptr = task.get();
-
-  // Network tasks (Send/Recv from admin pool) → last lane
-  if (task_ptr != nullptr && task_ptr->pool_id_ == clio::run::kAdminPoolId) {
-    u32 method_id = task_ptr->method_;
-    if (method_id == 14 || method_id == 15 || method_id == 20 || method_id == 21) {
-      return num_lanes - 1;
-    }
-  }
-
-  // Default: scheduler worker (lane 0)
-  return 0;
-}
+// NOTE (issue #781): ClientMapTask has been removed. Client/recv-thread ingress
+// no longer picks a worker lane directly — tasks are mapped to workers ONLY in
+// the runtime (RuntimeMapTask via RouteTask). The recv threads now deposit onto
+// the shared ingress lane and the runtime places the task.
 
 u32 DefaultScheduler::RuntimeMapTask(Worker *worker, const Future<Task> &task,
                                       ContainerHold container) {
@@ -257,7 +242,27 @@ Worker *DefaultScheduler::PickAltWorker(u32 avoid_id) const {
   return nullptr;
 }
 
-void DefaultScheduler::RebalanceWorker(Worker *worker) { (void)worker; }
+// issue #781 — SCAFFOLD ONLY (not yet wired). Called by the WorkOrchestrator
+// monitor thread every ~500ms. Real implementation will:
+//   1. detect a worker stuck > kStallThresholdSec inside one ExecTask
+//      (worker->IsStalled()) and, if so, work_orch_->SpawnAdditionalWorker()
+//      + StealAll(from stalled lane -> new worker) so the pathological task
+//      strands one thread, never the runtime;
+//   2. update perf_pdf_ from recently-completed exec times (telemetry);
+//   3. retire elastic workers idle > kRetireCooldownSec (hysteresis);
+//   4. emit sched.threads.* metrics; WARN when live threads are abnormal.
+void DefaultScheduler::LoadBalance() {
+  // TODO(#781): stall detection + elastic spawn + steal + retire + telemetry.
+}
+
+// issue #781 — SCAFFOLD ONLY (not yet wired). Move up to kStealBatch tasks from
+// each ring neighbour (then the most-loaded worker) onto thief's lane using a
+// steal-safe lane pop, keeping the pool work-conserving.
+bool DefaultScheduler::StealWork(Worker *thief) {
+  (void)thief;
+  // TODO(#781): neighbour + most-loaded steal.
+  return false;
+}
 
 void DefaultScheduler::AdjustPolling(const clio::run::shared_ptr<Task> &task) {
   if (task.IsNull()) {

--- a/context-runtime/src/scheduler/default_sched.cc
+++ b/context-runtime/src/scheduler/default_sched.cc
@@ -317,8 +317,23 @@ void DefaultScheduler::LoadBalance() {
   // even while a worker is wedged. The backlog-rescue (spawn a replacement +
   // steal the stalled lane) needs a steal-safe MPSC pop and lands in a
   // follow-up — see project_scheduler_antideadlock.md.
-  load_balance_ticks_.fetch_add(1, std::memory_order_relaxed);
+  u64 tick = load_balance_ticks_.fetch_add(1, std::memory_order_relaxed) + 1;
   double now_us = NowUs();
+
+  // Telemetry dump every ~5s: the perf-bin PDF is the runtime's OBSERVED live
+  // workload distribution (how many quick vs 1-second tasks it actually ran).
+  // It adapts continuously as RecordCompletion folds in each finished task.
+  if (tick % 10 == 0) {
+    HLOG(kWarning,
+         "[#781 PDF] observed exec-time bins (cumulative): "
+         "<10us={} <50us={} <500us={} <10ms={} <50ms={} <500ms={} <1s={} "
+         ">=1s={} | stalls_detected={}",
+         perf_pdf_[kLt10us].load(), perf_pdf_[kLt50us].load(),
+         perf_pdf_[kLt500us].load(), perf_pdf_[kLt10ms].load(),
+         perf_pdf_[kLt50ms].load(), perf_pdf_[kLt500ms].load(),
+         perf_pdf_[kLt1s].load(), perf_pdf_[kGe1s].load(),
+         stalls_detected_.load());
+  }
 
   auto check = [&](Worker *w) -> bool {
     if (w == nullptr || !w->IsExecuting()) return false;
@@ -351,6 +366,15 @@ void DefaultScheduler::LoadBalance() {
          compute_workers);
     // TODO(#781): work_orch_->SpawnAdditionalWorker() + steal a stalled lane.
   }
+}
+
+void DefaultScheduler::RecordCompletion(u32 method, double cpu_us,
+                                        double wall_us) {
+  // Telemetry only (issue #781): bin the measured wall time. This is the
+  // runtime OBSERVING what it actually ran — it is not used for routing.
+  (void)method;
+  (void)cpu_us;
+  perf_pdf_[BinFor(wall_us)].fetch_add(1, std::memory_order_relaxed);
 }
 
 // issue #781 — SCAFFOLD ONLY (not yet wired). Move up to kStealBatch tasks from

--- a/context-runtime/src/scheduler/default_sched.cc
+++ b/context-runtime/src/scheduler/default_sched.cc
@@ -251,6 +251,27 @@ u32 DefaultScheduler::RuntimeMapTask(Worker *worker, const Future<Task> &task,
           best_load = rl;
         }
       }
+      // issue #781: reserve the incoming task's PREDICTED cost on the chosen
+      // worker so the NEXT mapping sees it as queued load — the quick-behind-
+      // heavy fix. The prediction comes from the learned per-method model via
+      // the populated PredictedStat (MOD_NAME::GetTaskStats reports the compute
+      // counter); it converges to ~the real cost after a few runs. Released in
+      // Worker::ExecTask when the task actually starts.
+      if (selected != nullptr && task_ptr != nullptr && container != nullptr) {
+        // Read the compute counter FRESH here: RunContext::predicted_stat_ is
+        // only populated at EXECUTION time (BeginTask on the destination worker),
+        // so it is still empty during routing. GetTaskStats is cheap + const.
+        clio::run::TaskStat stat = container->GetTaskStats(task_ptr);
+        double predicted = container->InferCpuTime(task_ptr->method_, stat);
+        if (predicted > 0.0) {
+          // Set PredictedLoad too so ExecTask/EndTask account the SAME value
+          // (its own PredictedStat() lookup would still read 0 during the window
+          // before BeginTask). sched_reserved_us_ marks it as map-accounted.
+          task_ptr->SetPredictedLoad(static_cast<float>(predicted));
+          task_ptr->SetSchedReservedUs(static_cast<float>(predicted));
+          selected->ReserveLoad(predicted);
+        }
+      }
     }
   }
 

--- a/context-runtime/src/scheduler/default_sched.cc
+++ b/context-runtime/src/scheduler/default_sched.cc
@@ -34,6 +34,9 @@
 // Copyright 2024 IOWarp contributors
 #include "clio_runtime/scheduler/default_sched.h"
 
+#include <chrono>
+#include <cstdlib>
+
 #include "clio_runtime/config_manager.h"
 #include "clio_runtime/container.h"
 #include "clio_runtime/ipc_manager.h"
@@ -42,6 +45,16 @@
 #include "clio_runtime/worker.h"
 
 namespace clio::run {
+
+// issue #781: steady-clock "now" in microseconds, matching the clock
+// Worker::ExecTask stamps into last_exec_start_us_ so RealtimeLoad/IsStalled
+// compare against the same timebase.
+static inline double NowUs() {
+  return static_cast<double>(
+      std::chrono::duration_cast<std::chrono::microseconds>(
+          std::chrono::steady_clock::now().time_since_epoch())
+          .count());
+}
 
 void DefaultScheduler::DivideWorkers(WorkOrchestrator *work_orch) {
   if (!work_orch) {
@@ -193,9 +206,52 @@ u32 DefaultScheduler::RuntimeMapTask(Worker *worker, const Future<Task> &task,
     }
   }
 
-  // Small I/O / metadata → scheduler worker
-  if (selected == nullptr && scheduler_worker_ != nullptr) {
+  // issue #781: measured-load routing for compute / small-I/O / metadata tasks.
+  // Instead of funnelling everything onto the scheduler worker (where one
+  // non-yielding/mislabeled task starves every task behind it), pick the
+  // general-purpose worker with the SMALLEST measured real-time load. A worker
+  // stuck spinning on a heavy task has an enormous RealtimeLoad (load_ + how
+  // long its current task has already run), so new quick tasks are steered away
+  // from it automatically — no cost prediction, no labels. This is the primary
+  // anti-starvation mechanism; LoadBalance() handles any already-queued backlog.
+  // A/B toggle (issue #781 evaluation): CLIO_SCHED_FUNNEL=1 restores the legacy
+  // "everything to the scheduler worker" routing so the sched_variety benchmark
+  // can measure quick-task p99 with vs without measured-load routing. Value-based
+  // (must be "1"/"true") — an unset OR empty/0 value means measured-load routing.
+  static const bool kFunnel = []() {
+    const char *v = std::getenv("CLIO_SCHED_FUNNEL");
+    return v != nullptr && (v[0] == '1' || v[0] == 't' || v[0] == 'T');
+  }();
+  if (selected == nullptr && kFunnel && scheduler_worker_ != nullptr) {
     selected = scheduler_worker_;
+  }
+
+  if (selected == nullptr) {
+    // Build the compute candidate pool. Prefer the dedicated I/O workers so the
+    // scheduler worker (lane 0) stays a pure INGRESS DISPATCHER — a heavy task
+    // executing there would stall the dispatch of every incoming task. Only fall
+    // back to the scheduler worker when there are no I/O workers.
+    Worker *cand[64];
+    u32 n = 0;
+    for (Worker *w : io_workers_) {
+      if (w != nullptr && n < 64) cand[n++] = w;
+    }
+    if (n == 0 && scheduler_worker_ != nullptr) cand[n++] = scheduler_worker_;
+    if (n > 0) {
+      double now_us = NowUs();
+      // Scan from a rotating offset so that when loads tie (e.g. all idle at 0)
+      // selection round-robins instead of always funnelling to the first worker.
+      u32 start = next_io_idx_.fetch_add(1, std::memory_order_relaxed) % n;
+      double best_load = 0.0;
+      for (u32 k = 0; k < n; ++k) {
+        Worker *w = cand[(start + k) % n];
+        double rl = w->RealtimeLoad(now_us);
+        if (selected == nullptr || rl < best_load) {
+          selected = w;
+          best_load = rl;
+        }
+      }
+    }
   }
 
   // Fallback to current worker
@@ -252,7 +308,49 @@ Worker *DefaultScheduler::PickAltWorker(u32 avoid_id) const {
 //   3. retire elastic workers idle > kRetireCooldownSec (hysteresis);
 //   4. emit sched.threads.* metrics; WARN when live threads are abnormal.
 void DefaultScheduler::LoadBalance() {
-  // TODO(#781): stall detection + elastic spawn + steal + retire + telemetry.
+  // Runs on the WorkOrchestrator monitor thread every ~500ms (NOT a worker).
+  // This pass implements the OBSERVABILITY half of the safety net: detect a
+  // worker stuck > kStallThresholdSec inside one ExecTask (a non-yielding /
+  // mislabeled task) and warn loudly with live/stalled counts. Because
+  // RuntimeMapTask already steers NEW tasks away from a stalled worker (its
+  // RealtimeLoad is enormous), the runtime keeps making progress on quick tasks
+  // even while a worker is wedged. The backlog-rescue (spawn a replacement +
+  // steal the stalled lane) needs a steal-safe MPSC pop and lands in a
+  // follow-up — see project_scheduler_antideadlock.md.
+  load_balance_ticks_.fetch_add(1, std::memory_order_relaxed);
+  double now_us = NowUs();
+
+  auto check = [&](Worker *w) -> bool {
+    if (w == nullptr || !w->IsExecuting()) return false;
+    if (!w->IsStalled(now_us, kStallThresholdSec)) return false;
+    stalls_detected_.fetch_add(1, std::memory_order_relaxed);
+    HLOG(kWarning,
+         "[#781] worker {} STALLED on one task (load_us={} realtime_load_us={} "
+         "threshold_s={}) — routing new work around it; backlog awaits rescue",
+         w->GetId(), (double)w->Load(), w->RealtimeLoad(now_us),
+         kStallThresholdSec);
+    return true;
+  };
+
+  u32 stalled = 0;
+  if (check(scheduler_worker_)) ++stalled;
+  for (Worker *w : io_workers_) if (check(w)) ++stalled;
+  if (check(net_send_worker_)) ++stalled;
+  if (check(net_recv_worker_)) ++stalled;
+
+  // Observability for the unbounded-pool design (#781): if EVERY general-purpose
+  // worker is stalled, no routing target can make progress — this is exactly the
+  // "flood of non-yielding tasks" case where the follow-up must SpawnAdditional-
+  // Worker(). Make it loud rather than silently wedging.
+  u32 compute_workers = (scheduler_worker_ ? 1u : 0u) +
+                        static_cast<u32>(io_workers_.size());
+  if (compute_workers > 0 && stalled >= compute_workers) {
+    HLOG(kWarning,
+         "[#781] ALL {} compute workers stalled — runtime cannot place new "
+         "tasks; elastic SpawnAdditionalWorker() needed (follow-up)",
+         compute_workers);
+    // TODO(#781): work_orch_->SpawnAdditionalWorker() + steal a stalled lane.
+  }
 }
 
 // issue #781 — SCAFFOLD ONLY (not yet wired). Move up to kStealBatch tasks from

--- a/context-runtime/src/scheduler/local_sched.cc
+++ b/context-runtime/src/scheduler/local_sched.cc
@@ -99,24 +99,8 @@ void LocalScheduler::DivideWorkers(WorkOrchestrator *work_orch) {
        gpu_worker_ ? (int)gpu_worker_->GetId() : -1);
 }
 
-u32 LocalScheduler::ClientMapTask(IpcManager *ipc_manager,
-                                   const Future<Task> &task) {
-  u32 num_lanes = ipc_manager->GetNumSchedQueues();
-  if (num_lanes == 0) {
-    return 0;
-  }
-
-  Task *task_ptr = task.get();
-  if (task_ptr != nullptr && task_ptr->pool_id_ == clio::run::kAdminPoolId) {
-    u32 method_id = task_ptr->method_;
-    if (method_id == 14 || method_id == 15 || method_id == 20 || method_id == 21) {
-      return num_lanes - 1;
-    }
-  }
-
-  u32 lane = MapByPidTid(num_lanes);
-  return lane;
-}
+// NOTE (issue #781): ClientMapTask + MapByPidTid removed — client/recv ingress
+// no longer hashes to a lane; the runtime maps tasks to workers (RuntimeMapTask).
 
 u32 LocalScheduler::RuntimeMapTask(Worker *worker, const Future<Task> &task,
                                     ContainerHold container) {
@@ -188,8 +172,15 @@ u32 LocalScheduler::RuntimeMapTask(Worker *worker, const Future<Task> &task,
   return 0;
 }
 
-void LocalScheduler::RebalanceWorker(Worker *worker) {
-  (void)worker;
+// issue #781 — SCAFFOLD ONLY (not yet wired). See DefaultScheduler::LoadBalance.
+void LocalScheduler::LoadBalance() {
+  // TODO(#781): stall detection + elastic spawn + steal + retire + telemetry.
+}
+
+bool LocalScheduler::StealWork(Worker *thief) {
+  (void)thief;
+  // TODO(#781): neighbour + most-loaded steal.
+  return false;
 }
 
 void LocalScheduler::AdjustPolling(const clio::run::shared_ptr<Task> &task) {
@@ -200,16 +191,6 @@ void LocalScheduler::AdjustPolling(const clio::run::shared_ptr<Task> &task) {
   // This is critical because co_await on Futures sets yield_time_us_ = 0,
   // so we must restore it here to prevent periodic tasks from busy-looping
   task->SetYieldTimeUs(task->TruePeriodNs() / 1000.0);
-}
-
-u32 LocalScheduler::MapByPidTid(u32 num_lanes) {
-  auto *sys_info = CTP_SYSTEM_INFO;
-  pid_t pid = sys_info->pid_;
-  auto tid = CTP_THREAD_MODEL->GetTid();
-
-  size_t combined_hash =
-      std::hash<pid_t>{}(pid) ^ (std::hash<ctp::u64>{}(tid.tid_) << 1);
-  return static_cast<u32>(combined_hash % num_lanes);
 }
 
 }  // namespace clio::run

--- a/context-runtime/src/work_orchestrator.cc
+++ b/context-runtime/src/work_orchestrator.cc
@@ -151,6 +151,7 @@ bool WorkOrchestrator::StartWorkers() {
   }
 
   workers_running_ = true;
+  StartMonitorThread();  // issue #781: periodic LoadBalance / stall rescue
   return true;
 }
 
@@ -171,6 +172,8 @@ void WorkOrchestrator::StopWorkers() {
   if (!workers_running_) {
     return;
   }
+
+  StopMonitorThread();  // issue #781: join monitor before tearing down workers
 
   HLOG(kDebug, "Stopping {} worker threads...", all_workers_.size());
 
@@ -391,6 +394,51 @@ bool WorkOrchestrator::HasWorkRemaining(u64 &total_work_remaining) const {
   }
 
   return total_work_remaining > 0;
+}
+
+// ===========================================================================
+// issue #781: monitor thread + elastic worker pool (SCAFFOLD — not yet wired)
+// ===========================================================================
+
+void WorkOrchestrator::StartMonitorThread() {
+  if (monitor_running_.exchange(true)) {
+    return;  // already running (idempotent)
+  }
+  monitor_thread_ = std::thread([this]() { MonitorLoop(); });
+}
+
+void WorkOrchestrator::StopMonitorThread() {
+  if (!monitor_running_.exchange(false)) {
+    return;
+  }
+  if (monitor_thread_.joinable()) {
+    monitor_thread_.join();
+  }
+}
+
+void WorkOrchestrator::MonitorLoop() {
+  // Dedicated (non-worker) thread. Every kMonitorPeriodMs it hands off to the
+  // scheduler's LoadBalance(), which owns stall detection, elastic spawn, work
+  // stealing, retirement, and telemetry. Kept intentionally thin here so all
+  // policy lives in the Scheduler. LoadBalance() is a no-op stub today (#781).
+  while (monitor_running_.load(std::memory_order_relaxed)) {
+    if (scheduler_) {
+      scheduler_->LoadBalance();
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(kMonitorPeriodMs));
+  }
+}
+
+Worker *WorkOrchestrator::SpawnAdditionalWorker() {
+  // TODO(#781): create a Worker + lane, register in all_workers_/worker_threads_,
+  // and thread_model_->Spawn its Run() — the dynamic-growth path the fixed-pool
+  // Init does not provide today. Returns nullptr until wired.
+  return nullptr;
+}
+
+void WorkOrchestrator::RetireWorker(Worker *worker) {
+  // TODO(#781): park + join an idle elastic worker and drop it from the pool.
+  (void)worker;
 }
 
 }  // namespace clio::run

--- a/context-runtime/src/worker.cc
+++ b/context-runtime/src/worker.cc
@@ -642,6 +642,18 @@ void Worker::ExecTask(clio::run::shared_ptr<Task> &task_ptr, bool is_started) {
     return;
   }
 
+  // issue #781: stamp the wall-clock entry time so the monitor thread can see a
+  // worker that never returns from a non-yielding task. Set BEFORE driving the
+  // coroutine; cleared after it returns/yields below. A cooperative task that
+  // co_awaits returns here (clears), so it never looks stalled; a spinning task
+  // never returns, so last_exec_start_us_ stays set and IsStalled() fires.
+  last_exec_start_us_.store(
+      static_cast<double>(
+          std::chrono::duration_cast<std::chrono::microseconds>(
+              std::chrono::steady_clock::now().time_since_epoch())
+              .count()),
+      std::memory_order_relaxed);
+
   // Start CPU and wall timers before execution
   task_ptr->RunCpuTimer().Resume();
   task_ptr->RunWallTimer().Resume();
@@ -670,6 +682,9 @@ void Worker::ExecTask(clio::run::shared_ptr<Task> &task_ptr, bool is_started) {
   // Pause CPU and wall timers after execution
   task_ptr->RunCpuTimer().Pause();
   task_ptr->RunWallTimer().Pause();
+
+  // issue #781: task returned/yielded — no longer stalling this worker.
+  last_exec_start_us_.store(0.0, std::memory_order_relaxed);
 
   // For periodic tasks, only set task_did_work_ if the task reported
   // actual work done (e.g., received data, sent data). This prevents

--- a/context-runtime/src/worker.cc
+++ b/context-runtime/src/worker.cc
@@ -646,7 +646,7 @@ void Worker::ExecTask(clio::run::shared_ptr<Task> &task_ptr, bool is_started) {
   // co_awaits returns here (clears), so it never looks stalled; a spinning task
   // never returns, so last_exec_start_us_ stays set and IsStalled() fires.
   last_exec_start_us_.store(
-      static_cast<double>(
+      static_cast<long long>(
           std::chrono::duration_cast<std::chrono::microseconds>(
               std::chrono::steady_clock::now().time_since_epoch())
               .count()),
@@ -697,7 +697,7 @@ void Worker::ExecTask(clio::run::shared_ptr<Task> &task_ptr, bool is_started) {
   task_ptr->RunWallTimer().Pause();
 
   // issue #781: task returned/yielded — no longer stalling this worker.
-  last_exec_start_us_.store(0.0, std::memory_order_relaxed);
+  last_exec_start_us_.store(0, std::memory_order_relaxed);
 
   // For periodic tasks, only set task_did_work_ if the task reported
   // actual work done (e.g., received data, sent data). This prevents

--- a/context-runtime/src/worker.cc
+++ b/context-runtime/src/worker.cc
@@ -758,6 +758,12 @@ void Worker::EndTask(clio::run::shared_ptr<Task> &task_ptr, bool can_resched) {
   container->ReinforceWallModel(
       task_ptr->method_, task_ptr->PredictedWallUs(), actual_wall_us,
       task_ptr->PredictedStat());
+  // issue #781: fold the measured cost into the scheduler's perf-bin PDF so the
+  // monitor thread can report the live workload distribution (telemetry).
+  if (scheduler_ != nullptr) {
+    scheduler_->RecordCompletion(task_ptr->method_, actual_cpu_us,
+                                 actual_wall_us);
+  }
 
   // Break the RunContext self-cycle for a task that is about to be released.
   // ProcessNewTask binds RunFuture (run_ctx_->future_) with a copied task_ptr_

--- a/context-runtime/src/worker.cc
+++ b/context-runtime/src/worker.cc
@@ -670,12 +670,27 @@ void Worker::ExecTask(clio::run::shared_ptr<Task> &task_ptr, bool is_started) {
     // BeginTask via container->GetTaskStats(task), so derive the model
     // inferences from the already-cached stat instead of re-calling
     // GetTaskStats here.
+    // issue #781: if RuntimeMapTask already predicted this task's cost at map
+    // time (sched_reserved_us_ != 0), that value is AUTHORITATIVE — it was
+    // computed from a fresh GetTaskStats, whereas PredictedStat() here can still
+    // be 0 (BeginTask populates it just now). So only (re)compute PredictedLoad
+    // when the task was NOT map-accounted.
+    float reserved = task_ptr->SchedReservedUs();
     if (exec) {
-      task_ptr->SetPredictedLoad(
-          exec->InferCpuTime(task_ptr->method_, task_ptr->PredictedStat()));
+      if (reserved == 0.0f) {
+        task_ptr->SetPredictedLoad(
+            exec->InferCpuTime(task_ptr->method_, task_ptr->PredictedStat()));
+      }
       task_ptr->SetPredictedWallUs(exec->InferWallClockTime(
           task_ptr->method_, task_ptr->PredictedStat()));
-      load_ += task_ptr->PredictedLoad();
+    }
+    // The task is now EXECUTING: count its predicted cost in load_ (whether the
+    // value came from the map or from here), and release the queued reservation
+    // so it is not double-counted. EndTask subtracts the same PredictedLoad.
+    load_ += task_ptr->PredictedLoad();
+    if (reserved != 0.0f) {
+      ReleaseReservation(reserved);
+      task_ptr->SetSchedReservedUs(0);
     }
   }
 
@@ -748,6 +763,16 @@ void Worker::EndTask(clio::run::shared_ptr<Task> &task_ptr, bool can_resched) {
 
   // Subtract predicted load from worker
   load_ -= task_ptr->PredictedLoad();
+
+  // issue #781: defensively release any still-held queued reservation for tasks
+  // that reach EndTask WITHOUT executing (e.g. the early-error EACCES path), so a
+  // reservation can never leak onto queued_load_. Normal tasks already released
+  // it in ExecTask (sched_reserved_us_ == 0 here), so this is a no-op for them.
+  float reserved = task_ptr->SchedReservedUs();
+  if (reserved != 0.0f) {
+    ReleaseReservation(reserved);
+    task_ptr->SetSchedReservedUs(0);
+  }
 
   // Reinforce model with actual CPU and wall time
   float actual_cpu_us = static_cast<float>(task_ptr->RunCpuTimer().GetUsec());

--- a/context-runtime/test/unit/test_autogen_coverage.cc
+++ b/context-runtime/test/unit/test_autogen_coverage.cc
@@ -13874,10 +13874,10 @@ TEST_CASE("Autogen - DefaultScheduler AdjustPolling", "[autogen][scheduler][adju
     INFO("AdjustPolling(nullptr) did not crash");
   }
 
-  SECTION("RebalanceWorker noop") {
+  SECTION("LoadBalance noop") {  // issue #781: replaced RebalanceWorker
     clio::run::DefaultScheduler sched;
-    sched.RebalanceWorker(nullptr);  // Should not crash
-    INFO("RebalanceWorker(nullptr) did not crash");
+    sched.LoadBalance();  // Should not crash (stub today)
+    INFO("LoadBalance() did not crash");
   }
 
   SECTION("RuntimeMapTask with null worker") {

--- a/project_scheduler_antideadlock.md
+++ b/project_scheduler_antideadlock.md
@@ -1,0 +1,108 @@
+# Anti-deadlock scheduler (issue #781)
+
+Tracking issue: https://github.com/iowarp/clio-core/issues/781
+
+## Thesis
+The runtime's liveness must **not** depend on tasks being honestly labeled. A single
+**non-yielding** task (CPU spin, blocking syscall, or an infinite loop inside a
+coroutine that never yields) permanently wedges the worker it lands on. Workers are
+coroutine-based, so an expensive-but-*cooperative* task is already fine — the lethal
+case is the non-cooperative one. Today every externally-ingressed task funnels to
+lane 0 (`DefaultScheduler::ClientMapTask` returns 0), the pool is fixed at
+`num_threads`, there is no work-stealing, and `RebalanceWorker` is a dead no-op. A
+few mislabeled blocking tasks on lane 0 starve the ingress path — the likely Delta
+hang.
+
+## Goal
+Run a group of arbitrarily complex operations with the **minimum number of threads**,
+keeping **low p99 for quick tasks** and **scaling for large tasks**, while
+**guaranteeing forward progress even for adversarial/mislabeled tasks**.
+
+## The algorithm — elastic, latency-aware, work-conserving pool with hazard isolation
+
+Two independent layers. Layer 1 is best-effort efficiency; Layer 2 is the hard
+liveness guarantee. Correctness never depends on Layer 1 being smart.
+
+### State (per worker)
+- `load_` (µs, exists today) — sum of `PredictedLoad()` of in-flight/queued tasks.
+- `last_exec_start_` (**new**) — timestamp stamped at the top of `ExecTask`, cleared on
+  return. `now() − last_exec_start_` = current task's elapsed wall time.
+- `realtime_load(w) = w.load_ + (now() − w.last_exec_start_)` — measured, never predicted.
+
+### Layer 1 — mapping (RuntimeMapTask), keeps p99 low with few threads
+```
+C = incoming task coarse tolerance   # declared/default; NOT a learned prediction
+candidates = workers, in ring order from a rotating anchor
+pick argmin_w realtime_load(w) subject to realtime_load(w) <= C
+if none qualify: pick argmin_w realtime_load(w)          # least loaded overall
+```
+A 5 µs task (small C) refuses workers already deep in work, so it is not queued behind
+a 500 ms task. Group-affinity and periodic-net routing are preserved from today.
+
+### Layer 1 — work stealing (StealWork), keeps the pool work-conserving
+```
+when thief.lane is empty:
+    for neighbor in {left, right}:      # ring neighbours
+        move up to 4 tasks neighbor.lane -> thief.lane
+    if still empty:
+        victim = worker with max realtime_load
+        move up to 4 tasks victim.lane -> thief.lane
+```
+Work-conservation is what lets us hit throughput with *few* threads (kept busy) rather
+than many (mostly idle) — it directly serves "minimize threads."
+
+### Layer 2 — the liveness guarantee (LoadBalance, monitor thread every 500 ms)
+```
+for w in workers:
+    if w.IsExecuting() and (now() - w.last_exec_start_) > STALL = 1s:
+        w2 = work_orch.SpawnAdditionalWorker()      # unbounded; see Observability
+        move ALL of w.lane -> w2.lane                # w stays stuck on its 1 bad task
+        metrics.stalls++; WARN("worker {} stalled {}s on task {}")
+    ingest w's recently-completed exec-times into the perf-bin PDF   # telemetry
+if aggregate pending load high and >=1 worker idle:
+    kick StealWork / spawn
+retire elastic workers idle > COOLDOWN = 5s          # hysteresis -> back to minimum
+```
+A pathological task strands exactly one thread; its backlog is migrated and continues;
+new tasks are mapped away from it (its `realtime_load` is enormous). The runtime cannot
+fully wedge. **Con:** stalls are only caught on the 500 ms tick — bounded rescue
+latency, but simple and robust.
+
+### Why threads stay minimal
+Baseline = `num_threads`. We grow *only* on a demonstrated stall or sustained
+imbalance, and retire elastic threads after an idle cooldown. Steady state returns to
+the baseline; growth is proportional to concurrent *hazards*, not to load.
+
+## Component changes (grounded in current code)
+
+| Area | File(s) | Change |
+|---|---|---|
+| Remove `ClientMapTask` | `scheduler.h`, `default_sched.*`, `local_sched.*` | delete the virtual + impls + `MapByPidTid`; ingress maps in the runtime only |
+| Rewire ingress | `ipc_cpu2cpu_zmq.cc:201`, `ipc_cpu2cpu.cc:72`, `ipc_run2run.cc:461` | push to shared ingress lane 0 (behavior-preserving), runtime `RuntimeMapTask` places it |
+| `LoadBalance` | `scheduler.h` (+ both schedulers) | new pure virtual, replaces dead `RebalanceWorker`; called every 500 ms |
+| Monitor thread + elastic pool | `work_orchestrator.*` | dedicated monitor thread; `SpawnAdditionalWorker()` / `RetireWorker()` (today the pool is fixed at Init) |
+| Worker instrumentation | `worker.h/.cc` | add `last_exec_start_` (stamp in `ExecTask` @ worker.cc:605); `RealtimeLoad()`, `IsStalled()` |
+| Measured-load mapping | `default_sched.cc RuntimeMapTask` | route by `realtime_load`, coarse tolerance; no PDF |
+| Work stealing | `default_sched.cc StealWork` | neighbours then most-loaded; needs steal-safe lane pop |
+| Perf-bin PDF (telemetry) | `default_sched.*` | histogram `<10µs…≥1s` from `EndTask` timings; metrics + LoadBalance signal only |
+| Observability | metrics + logs | `sched.threads.{live,spawned,stalled,retired}`; WARN when live > N×num_threads |
+| Benchmark | `MOD_NAME_*`, `clio_run_thrpt_bench.cc` | `spin_us` param on `Custom`; mixed 1µs–1s workload; avg + p99 by class |
+
+## Observability / accepted risk
+The elastic pool is **unbounded** (always spawn to guarantee progress). The safeguard is
+loudness, not a cap: a genuine flood of non-yielding tasks grows threads without bound,
+and we make that observable (`kWarning` past `N×num_threads`, live/spawned/stalled
+metrics) instead of silently wedging.
+
+## Benchmark — scheduler variety
+`MOD_NAME::Custom` (a no-op today at `MOD_NAME_runtime.cc:71`) gains a `spin_us`
+busy-spin parameter. `clio_run_thrpt_bench --test-case latency` drives a mixed workload
+with per-request compute drawn 1 µs … 1 s (mostly quick, occasional huge) and reports
+avg + **p99 latency segmented by task class**. Quick-task p99 under expensive-task
+pressure is the starvation metric. Old (fixed pool, lane-0 funnel) vs new (elastic +
+steal + stall-rescue).
+
+## Open questions
+- Steal-safe pop on a single-consumer MPSC lane (or a dedicated steal channel).
+- `WAIT_FOR_SPACE` blocking `Push` must not block a worker during steal/migration.
+- Keep ingress from re-forming the lane-0 funnel under load (StealWork spreads it).

--- a/project_scheduler_antideadlock.md
+++ b/project_scheduler_antideadlock.md
@@ -102,6 +102,27 @@ avg + **p99 latency segmented by task class**. Quick-task p99 under expensive-ta
 pressure is the starvation metric. Old (fixed pool, lane-0 funnel) vs new (elastic +
 steal + stall-rescue).
 
+## Measured results (first implementation)
+
+`clio_run_thrpt_bench --test-case sched_variety --threads 12 --duration 12`, runtime
+`num_threads: 8` (→ 4 I/O workers), mixed 1µs..1s workload (90% quick / 9% medium /
+1% heavy), Release. `CLIO_SCHED_FUNNEL=1` forces the legacy funnel for A/B:
+
+| metric | funnel (old) | measured-load (new) |
+|---|---|---|
+| **quick-task p99** | **519 ms** | **62 ms** (8.4× better) |
+| quick-task avg | 29 ms | 19 ms |
+| throughput | 375 ops/s | 560 ops/s (+50%) |
+
+Measured-load routing (Layer 1) alone cuts quick-task p99 by **8.4×** by steering quick
+tasks onto the least-loaded I/O worker and off any worker running a heavy/non-yielding
+task. The residual 62 ms comes from two not-yet-wired pieces: (a) `RealtimeLoad` counts
+only the *executing* task (`load_` bumps at exec-start), not tasks *queued* behind a
+heavy one on the same lane — a prediction-free fix is to add a per-worker
+assigned-but-not-done counter (or lane depth) to the load signal; (b) the backlog-steal
+(LoadBalance stall→spawn/steal) that rescues tasks already queued on a stalled worker,
+which needs the steal-safe MPSC pop. Both are the next PRs.
+
 ## Open questions
 - Steal-safe pop on a single-consumer MPSC lane (or a dedicated steal channel).
 - `WAIT_FOR_SPACE` blocking `Push` must not block a worker during steal/migration.


### PR DESCRIPTION
Closes #781 (partially — Layer 1 + benchmark; Layer 2 backlog-steal is a follow-up).

## Why
The runtime's liveness depended on tasks being honestly labeled: one **non-yielding** task (CPU spin / blocking syscall in a coroutine that never yields) permanently wedged its worker, and `DefaultScheduler::ClientMapTask` funneled **every** ingressed task onto lane 0, so a few mislabeled/blocking tasks starved the whole path. Suspected cause of the Delta hangs. We shouldn't stake runtime safety on deviant tasks.

## What's in this PR
**Design + interfaces**
- `project_scheduler_antideadlock.md` — the two-layer plan (efficiency: measured/predicted-load routing; safety: monitor thread → stall-detect → spawn/steal).
- Removed `Scheduler::ClientMapTask` (ingress now maps in the runtime only); added `LoadBalance()` + `StealWork()` (replacing the dead `RebalanceWorker`); `WorkOrchestrator` monitor thread (500 ms) + elastic-pool stubs; `Worker` measured-load accessors.

**Layer 1 — routing (wired, measured)**
- `RuntimeMapTask` routes compute tasks to the least **measured-real-time-load** worker (`load_ + queued_load_ + elapsed`), keeping the scheduler worker a pure ingress dispatcher. A worker stuck on a non-yielding task has a huge `RealtimeLoad`, so quick tasks are steered around it — no labels needed.
- **Predicted-cost aware:** `MOD_NAME::GetTaskStats` reports the compute counter so the learned per-method model converges; `RuntimeMapTask` reserves each task's predicted cost on the chosen worker (`queued_load_us_`) so it also avoids workers with a heavy task *queued* (not just running).

**Telemetry**
- Perf-bin PDF (`<10µs…≥1s`) of observed exec times, dumped by the monitor thread; stall detection warns per stalled worker and when all compute workers stall.

**Benchmark**
- `clio_run_thrpt_bench --test-case sched_variety` — mixed 1 µs..2 s workload (90% quick / 9% medium / 1% heavy) from N client threads; reports avg/p50/**p99**/max latency **per class**. Quick-task p99 is the starvation metric. `CLIO_SCHED_FUNNEL=1` restores the legacy funnel for A/B.

## Results (12 client threads, 8 runtime workers, Release, 2 s heavy cap)
| quick-task p99 | funnel (legacy) | measured (no prediction) | **measured + prediction** |
|---|---|---|---|
| | 1.46 s | 210 ms | **57 ms (25× better)** |

Throughput +2.5×. Verified end-to-end (the model converges to ~the real per-task cost; the queued reservation demonstrably steers work off backlogged workers).

## Scope / follow-ups (not in this PR)
- **Backlog-steal rescue** (LoadBalance stall→spawn→steal) — the last-mile p99 fix; needs a steal-safe pop on the single-consumer MPSC lane.
- `StealWork` and elastic `SpawnAdditionalWorker` are stubs (dynamic pool needs lane headroom).
- Stall-warning `load_us` prints 0 for the *currently-executing* task (a display/accounting detail; the queued reservation drives the win).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
