### PR TITLE
CTE shared-memory metadata cache: zero-IPC client reads (#783)

### DIFF
--- a/context-runtime/include/clio_runtime/config_manager.h
+++ b/context-runtime/include/clio_runtime/config_manager.h
@@ -382,7 +382,12 @@ class ConfigManager : public ctp::BaseConfig {
   // costs only the pages actually touched. NOTE: on a host whose /dev/shm is
   // smaller than the live set, touching past the tmpfs limit raises SIGBUS,
   // not ENOMEM. See CalculateMetadataSegmentSize().
-  size_t metadata_segment_size_ = ctp::Unit<size_t>::Gigabytes(8);
+  // 0 means "auto-calculate" — CalculateMetadataSegmentSize() supplies the
+  // default. Initialising this to a non-zero size would make the explicit
+  // override branch there permanently true and the documented sentinel a lie;
+  // it only worked because LoadDefault() resets it to 0. Set via the
+  // `metadata_segment_size` key under `runtime` in the config file.
+  size_t metadata_segment_size_ = 0;
 
   u32 port_ = 9413;
   // If true (CLIO_EPHEMERAL / --ephemeral), skip the default compose at startup.

--- a/context-runtime/include/clio_runtime/config_manager.h
+++ b/context-runtime/include/clio_runtime/config_manager.h
@@ -175,6 +175,17 @@ class ConfigManager : public ctp::BaseConfig {
   size_t CalculateQueueSegmentSize() const;
 
   /**
+   * Calculate the runtime-wide metadata segment size (issue #783).
+   *
+   * Backs the CTE shared-memory metadata cache. The reservation is large and
+   * sparse: it is never pre-faulted, so untouched pages cost nothing. Sizing is
+   * therefore about the address-space reservation, not RAM.
+   *
+   * @return Calculated size in bytes, or the explicit size if one is configured
+   */
+  size_t CalculateMetadataSegmentSize() const;
+
+  /**
    * Get memory segment size
    * @param segment Memory segment identifier
    * @return Size in bytes
@@ -366,6 +377,12 @@ class ConfigManager : public ctp::BaseConfig {
 
   size_t main_segment_size_ = ctp::Unit<size_t>::Gigabytes(1);
   size_t client_data_segment_size_ = ctp::Unit<size_t>::Megabytes(256);
+  // issue #783: metadata segment. Deliberately huge and never pre-faulted --
+  // shm_open + ftruncate + mmap is lazily populated, so the 8 GB reservation
+  // costs only the pages actually touched. NOTE: on a host whose /dev/shm is
+  // smaller than the live set, touching past the tmpfs limit raises SIGBUS,
+  // not ENOMEM. See CalculateMetadataSegmentSize().
+  size_t metadata_segment_size_ = ctp::Unit<size_t>::Gigabytes(8);
 
   u32 port_ = 9413;
   // If true (CLIO_EPHEMERAL / --ephemeral), skip the default compose at startup.
@@ -377,6 +394,7 @@ class ConfigManager : public ctp::BaseConfig {
   std::string main_segment_name_ = "chi_main_segment_${USER}";
   std::string client_data_segment_name_ = "chi_client_data_segment_${USER}";
   std::string queue_segment_name_ = "chi_queue_segment_${USER}";
+  std::string metadata_segment_name_ = "chi_metadata_segment_${USER}";
 
   // Networking configuration
   std::string hostfile_path_ = "";

--- a/context-runtime/include/clio_runtime/ipc_manager.h
+++ b/context-runtime/include/clio_runtime/ipc_manager.h
@@ -337,6 +337,17 @@ class IpcManager {
   /** Client-side: record the directory offset learned from ClientConnect. */
   void SetMetadataDirOffset(u64 off) { metadata_dir_off_ = off; }
 
+  /**
+   * PID of the runtime this process talks to (its own pid when this IS the
+   * runtime). Clients use it to reconstruct per-pool SHM segment names, e.g.
+   * a RAM bdev's data segment (issue #783), without those names having to be
+   * published anywhere.
+   */
+  int GetRuntimePid() const {
+    return runtime_pid_ != 0 ? runtime_pid_
+                             : static_cast<int>(ctp::SystemInfo::GetPid());
+  }
+
   /** Pid-based allocator ids of this runtime's SHM segments (pid.1 main,
    *  pid.2 queue, pid.3 metadata). Reported to clients via ClientConnect so
    *  they attach the right allocators instead of assuming (1,0)/(2,0). */

--- a/context-runtime/include/clio_runtime/ipc_manager.h
+++ b/context-runtime/include/clio_runtime/ipc_manager.h
@@ -302,12 +302,26 @@ class IpcManager {
     return main_allocator_;
   }
 
+  /**
+   * Returns the runtime-wide metadata allocator (issue #783), or nullptr if
+   * the metadata segment is not attached. Callers MUST null-check: the segment
+   * is optional, and a client that failed to attach it simply falls back to
+   * the RPC path rather than failing.
+   */
+  CLIO_TASK_ALLOC_T *GetMetadataAllocator() { return metadata_allocator_; }
+
+  /** True if the metadata segment is available for shared-memory caching. */
+  bool HasMetadataSegment() const { return metadata_allocator_ != nullptr; }
+
   /** Pid-based allocator ids of this runtime's SHM segments (pid.1 main,
-   *  pid.2 queue). Reported to clients via ClientConnect so they attach the
-   *  right allocators instead of assuming (1,0)/(2,0). */
+   *  pid.2 queue, pid.3 metadata). Reported to clients via ClientConnect so
+   *  they attach the right allocators instead of assuming (1,0)/(2,0). */
   ctp::ipc::AllocatorId GetMainAllocatorId() const { return main_allocator_id_; }
   ctp::ipc::AllocatorId GetQueueAllocatorId() const {
     return queue_allocator_id_;
+  }
+  ctp::ipc::AllocatorId GetMetadataAllocatorId() const {
+    return metadata_allocator_id_;
   }
 
   /**
@@ -1366,6 +1380,20 @@ class IpcManager {
 
   // Queue allocator pointer — ArenaAllocator for all TaskQueue structures
   CLIO_QUEUE_ALLOC_T *queue_allocator_ = nullptr;
+
+  // issue #783: runtime-wide metadata segment. Large (default 8 GB), sparse,
+  // never pre-faulted. Owned by the runtime; the CTE shared-memory metadata
+  // cache is its first consumer. Clients attach it read-write but by
+  // convention write only lock words -- metadata itself is runtime-owned.
+  ctp::ipc::PosixShmMmap metadata_backend_;
+
+  // Allocator ID for metadata segment
+  ctp::ipc::AllocatorId metadata_allocator_id_;
+
+  // Metadata allocator. BuddyAllocator (same as main) because the CTE cache
+  // does variable-size allocation with frees, which an ArenaAllocator cannot
+  // service.
+  CLIO_TASK_ALLOC_T *metadata_allocator_ = nullptr;
 
   // Number of workers for which queues are allocated
   u32 num_workers_ = 0;

--- a/context-runtime/include/clio_runtime/ipc_manager.h
+++ b/context-runtime/include/clio_runtime/ipc_manager.h
@@ -313,6 +313,30 @@ class IpcManager {
   /** True if the metadata segment is available for shared-memory caching. */
   bool HasMetadataSegment() const { return metadata_allocator_ != nullptr; }
 
+  /**
+   * Directory of well-known roots in the metadata segment (issue #783), or
+   * nullptr when unavailable. Resolved in THIS process from the offset the
+   * server published, so it is valid for clients too.
+   */
+  MetadataDirectory *GetMetadataDirectory() {
+    if (metadata_allocator_ == nullptr || metadata_dir_off_ == 0) {
+      return nullptr;
+    }
+    auto *dir = reinterpret_cast<MetadataDirectory *>(
+        reinterpret_cast<char *>(metadata_allocator_) + metadata_dir_off_);
+    if (dir->version_ != MetadataDirectory::kVersion) {
+      return nullptr;  // unknown layout -> decline rather than guess
+    }
+    return dir;
+  }
+
+  /** Offset of the metadata directory; 0 when unavailable. Sent to clients in
+   *  the ClientConnect handshake. */
+  u64 GetMetadataDirOffset() const { return metadata_dir_off_; }
+
+  /** Client-side: record the directory offset learned from ClientConnect. */
+  void SetMetadataDirOffset(u64 off) { metadata_dir_off_ = off; }
+
   /** Pid-based allocator ids of this runtime's SHM segments (pid.1 main,
    *  pid.2 queue, pid.3 metadata). Reported to clients via ClientConnect so
    *  they attach the right allocators instead of assuming (1,0)/(2,0). */
@@ -1394,6 +1418,10 @@ class IpcManager {
   // does variable-size allocation with frees, which an ArenaAllocator cannot
   // service.
   CLIO_TASK_ALLOC_T *metadata_allocator_ = nullptr;
+
+  // Offset of the MetadataDirectory within metadata_allocator_. Set by the
+  // server when it builds the segment, and by clients from ClientConnect.
+  u64 metadata_dir_off_ = 0;
 
   // Number of workers for which queues are allocated
   u32 num_workers_ = 0;

--- a/context-runtime/include/clio_runtime/types.h
+++ b/context-runtime/include/clio_runtime/types.h
@@ -627,12 +627,52 @@ enum MemorySegment {
 struct MetadataDirectory {
   static constexpr u32 kVersion = 1;
 
+  /** Max distinct module caches registrable. CTE alone can have many pools. */
+  static constexpr u32 kMaxEntries = 32;
+
+  /**
+   * One registered cache root, keyed by the owning pool.
+   *
+   * Keying by pool is REQUIRED, not cosmetic: CTE is a multi-pool module, and
+   * an earlier single-slot version let each new pool's Create overwrite the
+   * slot. Clients then attached whichever pool created its cache last and
+   * silently read a different pool's metadata -- every lookup missed.
+   */
+  struct Entry {
+    u64 pool_id_;   /**< PoolId::ToU64(); 0 = empty slot */
+    u64 root_off_;  /**< offset of the module's cache root */
+  };
+
   u32 version_;
-  u32 reserved_;
-  /** Offset of the CTE ShmMetadataCacheRoot, or 0 when CTE is not caching. */
-  u64 cte_cache_root_off_;
-  /** Spare slots so a new consumer does not change the layout. */
-  u64 reserved_slots_[6];
+  u32 num_entries_;
+  Entry entries_[kMaxEntries];
+
+  /** Register (or update) a pool's cache root. Returns false if full. */
+  bool RegisterRoot(u64 pool_id, u64 root_off) {
+    for (u32 i = 0; i < num_entries_ && i < kMaxEntries; ++i) {
+      if (entries_[i].pool_id_ == pool_id) {
+        entries_[i].root_off_ = root_off;  // re-created pool: update in place
+        return true;
+      }
+    }
+    if (num_entries_ >= kMaxEntries) {
+      return false;
+    }
+    entries_[num_entries_].pool_id_ = pool_id;
+    entries_[num_entries_].root_off_ = root_off;
+    ++num_entries_;
+    return true;
+  }
+
+  /** Look up a pool's cache root, or 0 if that pool is not caching. */
+  u64 FindRoot(u64 pool_id) const {
+    for (u32 i = 0; i < num_entries_ && i < kMaxEntries; ++i) {
+      if (entries_[i].pool_id_ == pool_id) {
+        return entries_[i].root_off_;
+      }
+    }
+    return 0;
+  }
 };
 
 // Input/Output parameter macros

--- a/context-runtime/include/clio_runtime/types.h
+++ b/context-runtime/include/clio_runtime/types.h
@@ -596,7 +596,13 @@ CTP_GPU_FUN ctp::ipc::RoundRobinAllocator *GetSharedAllocGpu();
 enum MemorySegment {
   kMainSegment = 0,
   kClientDataSegment = 1,
-  kQueueSegment = 2
+  kQueueSegment = 2,
+  // issue #783: runtime-wide metadata segment. Large (default 8 GB) and
+  // sparsely populated -- it is never pre-faulted, so only touched pages cost
+  // RAM. Owned by the runtime as a whole (not by any one ChiMod); the CTE
+  // shared-memory metadata cache is its first consumer. Clients map it
+  // read-write, but by convention only ever write lock words.
+  kMetadataSegment = 3
 };
 
 // Input/Output parameter macros

--- a/context-runtime/include/clio_runtime/types.h
+++ b/context-runtime/include/clio_runtime/types.h
@@ -605,6 +605,36 @@ enum MemorySegment {
   kMetadataSegment = 3
 };
 
+/**
+ * Directory of well-known roots inside the metadata segment (issue #783).
+ *
+ * WHY THIS EXISTS: the CTE cache root offset was originally handed to clients
+ * on the CreateTask OUT path, which only works for the process that actually
+ * causes the pool to be created. Any later client -- and in practice EVERY
+ * client, because compose creates the CTE pool at startup -- calls
+ * GetOrCreatePool, hits the existing pool, never runs the ChiMod's Create, and
+ * so receives a zero offset. A discovery path must not depend on being the
+ * first caller.
+ *
+ * The directory is allocated once by IpcManager as the FIRST object in the
+ * metadata segment, and its offset is handed to every client in the
+ * ClientConnect handshake alongside the allocator ids. Modules publish their
+ * roots here by offset (never by pointer -- clients map the segment at a
+ * different base address).
+ *
+ * POD and fixed-layout: no virtuals, no pointers.
+ */
+struct MetadataDirectory {
+  static constexpr u32 kVersion = 1;
+
+  u32 version_;
+  u32 reserved_;
+  /** Offset of the CTE ShmMetadataCacheRoot, or 0 when CTE is not caching. */
+  u64 cte_cache_root_off_;
+  /** Spare slots so a new consumer does not change the layout. */
+  u64 reserved_slots_[6];
+};
+
 // Input/Output parameter macros
 #define IN
 #define OUT

--- a/context-runtime/modules/admin/include/clio_runtime/admin/admin_tasks.h
+++ b/context-runtime/modules/admin/include/clio_runtime/admin/admin_tasks.h
@@ -798,6 +798,11 @@ struct ClientConnectTask : public clio::run::Task {
   // rather than assuming (1,0)/(2,0).
   OUT ctp::ipc::AllocatorId main_alloc_id_;
   OUT ctp::ipc::AllocatorId queue_alloc_id_;
+  // issue #783: offset of the MetadataDirectory inside the metadata segment,
+  // or 0 when the runtime has no metadata segment. Sent here rather than on a
+  // per-module Create path so discovery does not depend on which client
+  // happened to create a pool first.
+  OUT clio::run::u64 metadata_dir_off_;
 
   // GPU queue info (populated by server if GPUs are present)
   OUT clio::run::u32 num_gpus_;  ///< Number of GPU devices
@@ -863,7 +868,8 @@ struct ClientConnectTask : public clio::run::Task {
   CTP_CROSS_FUN void SerializeOut(Archive &ar) {
     Task::SerializeOut(ar);
     ar(response_, server_generation_, server_pid_, worker_queues_off_,
-       main_alloc_id_, queue_alloc_id_, num_gpus_, gpu_queue_depth_);
+       main_alloc_id_, queue_alloc_id_, num_gpus_, gpu_queue_depth_,
+       metadata_dir_off_);
     ar(num_worker_tids_);
     for (clio::run::u32 i = 0; i < kMaxWorkerTids; ++i) {
       ar(worker_tids_[i]);
@@ -889,6 +895,7 @@ struct ClientConnectTask : public clio::run::Task {
     worker_queues_off_ = other->worker_queues_off_;
     main_alloc_id_ = other->main_alloc_id_;
     queue_alloc_id_ = other->queue_alloc_id_;
+    metadata_dir_off_ = other->metadata_dir_off_;
     num_gpus_ = other->num_gpus_;
     gpu_queue_depth_ = other->gpu_queue_depth_;
     memcpy(cpu2gpu_queue_off_, other->cpu2gpu_queue_off_,

--- a/context-runtime/modules/admin/src/admin_runtime.cc
+++ b/context-runtime/modules/admin/src/admin_runtime.cc
@@ -591,6 +591,8 @@ clio::run::TaskResume Runtime::ClientConnect(clio::run::shared_ptr<ClientConnect
   // correct allocators (segments are no longer the hardcoded (1,0)/(2,0)).
   task->main_alloc_id_ = CLIO_IPC->GetMainAllocatorId();
   task->queue_alloc_id_ = CLIO_IPC->GetQueueAllocatorId();
+  // issue #783: tell the client where the metadata-segment directory lives.
+  task->metadata_dir_off_ = CLIO_IPC->GetMetadataDirOffset();
 
   // #642: publish worker OS thread ids so SHM clients can address each worker's
   // "clio-<server_pid>-<worker_tid>" MPSC receive server.

--- a/context-runtime/modules/bdev/include/clio_runtime/bdev/transports/mem_bdev_transport.h
+++ b/context-runtime/modules/bdev/include/clio_runtime/bdev/transports/mem_bdev_transport.h
@@ -93,7 +93,24 @@ class MemBdevTransport : public BdevTransport {
   /** Create the shared-memory backing for a node-local RAM device. */
   void InitShmBacking(const clio::run::PoolId &pool_id);
 
+  /**
+   * True if this page's START lies inside the shared mapping.
+   *
+   * Deliberately NOT "the whole 1 GiB page fits": a device smaller than one
+   * page has a partial page 0, and requiring the full page rejected it --
+   * which silently pushed every RAM bdev back to the private heap and broke
+   * direct payload reads. Callers clamp their access within the device
+   * capacity, and the mapping is sized to cover it (see kBackendHeaderSlack).
+   */
+  bool ShmPageInBounds(size_t page_idx) const {
+    if (kRamPageSize != 0 && page_idx > shm_usable_ / kRamPageSize) {
+      return false;  // guards the multiply below from overflowing
+    }
+    return page_idx * kRamPageSize < shm_usable_;
+  }
+
   ctp::ipc::PosixShmMmap shm_backend_;
+  size_t shm_usable_ = 0;  /**< bytes of device space actually mapped */
   char *shm_base_ = nullptr;       /**< byte 0 of device space, or nullptr */
   ShmRamHeader *shm_header_ = nullptr;
   bool shm_backed_ = false;

--- a/context-runtime/modules/bdev/include/clio_runtime/bdev/transports/mem_bdev_transport.h
+++ b/context-runtime/modules/bdev/include/clio_runtime/bdev/transports/mem_bdev_transport.h
@@ -8,8 +8,12 @@
 
 #include <clio_runtime/bdev/transports/bdev_transport.h>
 #include <clio_runtime/bdev/transports/block_allocator.h>
-#include <mutex>
+// Must follow the runtime headers above: posix_shm_mmap.h needs the memory
+// backend base types they pull in.
+#include <clio_ctp/memory/backend/posix_shm_mmap.h>
 #include <limits>
+#include <mutex>
+#include <string>
 
 namespace clio::run::bdev {
 
@@ -44,6 +48,56 @@ class MemBdevTransport : public BdevTransport {
   bool force_sync_gpu_{false};
 
   static constexpr size_t kRamPageSize = 1ULL << 30; // 1 GiB pages
+
+ public:
+  /**
+   * Header at the start of a RAM bdev's shared-memory segment (issue #783).
+   *
+   * Lets a client sanity-check a segment it attached by NAME before trusting
+   * any offset in it. POD, fixed layout, no pointers.
+   */
+  struct ShmRamHeader {
+    static constexpr clio::run::u32 kVersion = 1;
+    clio::run::u32 version_;
+    clio::run::u32 ready_;      /**< 0 until the mapping is usable */
+    clio::run::u64 capacity_;   /**< bytes of addressable device space */
+    clio::run::u64 data_off_;   /**< offset from header start to byte 0 */
+    clio::run::u64 reserved_[5];
+  };
+
+  /**
+   * Deterministic segment name for a node-local RAM bdev.
+   *
+   * Derived purely from (runtime pid, pool id) so a client can construct it
+   * from information it already has -- the server pid from ClientConnect and
+   * the target pool id carried in each cached block descriptor. That removes
+   * any need to publish a name or a page table separately.
+   */
+  static std::string ShmSegmentName(clio::run::u32 server_pid,
+                                    const clio::run::PoolId &pool_id) {
+    return "clio_rambdev_" + std::to_string(server_pid) + "_" +
+           std::to_string(pool_id.major_) + "_" +
+           std::to_string(pool_id.minor_);
+  }
+
+ private:
+  // issue #783: when this is a node-local kRam device, its bytes live in a
+  // dedicated shared-memory segment so client processes can read blob payloads
+  // directly instead of paying a round-trip.
+  //
+  // The whole capacity is mapped as ONE contiguous sparse region rather than a
+  // page table: these segments are memfd-backed, so an untouched reservation
+  // costs nothing, and a flat mapping means a reader resolves a block offset
+  // with an addition instead of chasing an index. kRamPageSize is retained
+  // only to keep the existing paged call sites unchanged.
+  /** Create the shared-memory backing for a node-local RAM device. */
+  void InitShmBacking(const clio::run::PoolId &pool_id);
+
+  ctp::ipc::PosixShmMmap shm_backend_;
+  char *shm_base_ = nullptr;       /**< byte 0 of device space, or nullptr */
+  ShmRamHeader *shm_header_ = nullptr;
+  bool shm_backed_ = false;
+  std::string shm_name_;
 
   // A lazily-allocated RAM page. A kPinned pool allocates page-locked host
   // memory through GpuApi (cudaMallocHost / hipHostMalloc / sycl::malloc_host)

--- a/context-runtime/modules/bdev/src/transports/mem_bdev_transport.cc
+++ b/context-runtime/modules/bdev/src/transports/mem_bdev_transport.cc
@@ -44,7 +44,15 @@ void MemBdevTransport::InitShmBacking(const clio::run::PoolId &pool_id) {
     shm_name_ = ShmSegmentName(pid, pool_id);
     // Reserve header + full capacity in one sparse mapping. memfd reservations
     // are lazily faulted, so this costs only the bytes actually written.
-    size_t total = sizeof(ShmRamHeader) + static_cast<size_t>(ram_capacity_);
+    // Ask for the device capacity PLUS slack for the backend's own header.
+    // The backend carves that out of the region, so data_capacity_ comes back
+    // smaller than requested (measured: exactly 65536 less). Without the slack
+    // the last 64 KB of the device maps to nothing, and the original code
+    // indexed into it -- an out-of-bounds write that Linux tolerated and
+    // Windows turned into a SIGSEGV in cte_tiered_storage_all.
+    static constexpr size_t kBackendHeaderSlack = 1024 * 1024;
+    size_t total = sizeof(ShmRamHeader) + static_cast<size_t>(ram_capacity_) +
+                   kBackendHeaderSlack;
     ctp::ipc::MemoryBackendId bid(pid, pool_id.major_);
     if (!shm_backend_.shm_init(bid, ctp::Unit<size_t>::Bytes(total),
                                shm_name_)) {
@@ -58,18 +66,42 @@ void MemBdevTransport::InitShmBacking(const clio::run::PoolId &pool_id) {
     if (base == nullptr) {
       return;
     }
+    // Trust the backend's reported capacity, not the size we asked for. The
+    // backend carves out its own header (kBackendHeaderSize) and a platform
+    // may hand back a smaller view than requested -- on Windows the metadata
+    // segment failed outright with "MapViewOfFile: Access is denied" at a
+    // similar size. Indexing to the REQUESTED capacity in that case walks off
+    // the end of the mapping, which is what segfaulted cte_tiered_storage_all
+    // on Windows while going unnoticed on Linux.
+    // Use what the backend ACTUALLY mapped, which is less than requested: it
+    // carves out its own header, and a platform may return a shorter view.
+    // Do NOT reject a short mapping -- an all-or-nothing check disables SHM
+    // backing entirely and sends every page to the 1 GiB private-heap path,
+    // which OOM-killed the bdev suite. Pages past the end fall back
+    // individually via ShmPageInBounds().
+    size_t usable = shm_backend_.data_capacity_;
+    if (usable <= sizeof(ShmRamHeader)) {
+      HLOG(kWarning,
+           "[#783] RAM bdev '{}': mapping unusably small ({} bytes) -- "
+           "private heap",
+           shm_name_, usable);
+      shm_backend_.shm_destroy();
+      return;
+    }
     shm_header_ = reinterpret_cast<ShmRamHeader *>(base);
     std::memset(shm_header_, 0, sizeof(ShmRamHeader));
     shm_header_->version_ = ShmRamHeader::kVersion;
     shm_header_->capacity_ = ram_capacity_;
     shm_header_->data_off_ = sizeof(ShmRamHeader);
     shm_base_ = base + sizeof(ShmRamHeader);
+    shm_usable_ = usable - sizeof(ShmRamHeader);
     // ready_ LAST, so a client that sees ready_ == 1 knows the mapping behind
     // it is fully described.
     shm_header_->ready_ = 1;
     shm_backed_ = true;
-    HLOG(kInfo, "[#783] RAM bdev '{}' is shared-memory backed ({} bytes)",
-         shm_name_, ram_capacity_);
+    HLOG(kInfo,
+         "[#783] RAM bdev '{}' is shared-memory backed ({} of {} bytes mapped)",
+         shm_name_, shm_usable_, ram_capacity_);
   } catch (const std::exception &e) {
     HLOG(kWarning, "[#783] RAM bdev shm backing failed: {}", e.what());
     shm_backed_ = false;
@@ -123,8 +155,20 @@ void MemBdevTransport::FreeBlocks(int worker_id, const std::vector<Block>& block
 char* MemBdevTransport::EnsureRamPage(size_t page_idx) {
   // SHM-backed devices need no per-page allocation at all: the whole capacity
   // is one sparse mapping, so a page is just an offset into it.
+  //
+  // The bounds check is NOT redundant: without it an offset past the mapping
+  // returns a pointer the caller happily memcpy's into. That is a silent
+  // out-of-bounds write, and it is what crashed Windows CI.
   if (shm_backed_ && shm_base_ != nullptr) {
-    return shm_base_ + page_idx * kRamPageSize;
+    if (ShmPageInBounds(page_idx)) {
+      return shm_base_ + page_idx * kRamPageSize;
+    }
+    HLOG(kWarning,
+         "[#783] RAM bdev '{}': page {} is outside the {}-byte mapping -- "
+         "using private heap for it",
+         shm_name_, page_idx, shm_usable_);
+    // Fall through to the private-heap path rather than hand back a bad
+    // pointer; correctness first, the fast path is only an optimization.
   }
   std::lock_guard<std::mutex> lock(ram_pages_mu_);
   if (page_idx >= ram_pages_.size()) {
@@ -154,7 +198,7 @@ char* MemBdevTransport::EnsureRamPage(size_t page_idx) {
 }
 
 char* MemBdevTransport::GetRamPage(size_t page_idx) const {
-  if (shm_backed_ && shm_base_ != nullptr) {
+  if (shm_backed_ && shm_base_ != nullptr && ShmPageInBounds(page_idx)) {
     return shm_base_ + page_idx * kRamPageSize;
   }
   std::lock_guard<std::mutex> lock(ram_pages_mu_);

--- a/context-runtime/modules/bdev/src/transports/mem_bdev_transport.cc
+++ b/context-runtime/modules/bdev/src/transports/mem_bdev_transport.cc
@@ -7,6 +7,7 @@
 #include <clio_runtime/clio_runtime.h>
 #include <clio_runtime/worker.h>
 #include <clio_runtime/work_orchestrator.h>
+#include <clio_runtime/bdev/bdev_runtime.h>
 #include <clio_ctp/util/gpu_api.h>
 #include <cstdlib>
 
@@ -22,10 +23,73 @@ bool MemBdevTransport::Init(const CreateParams& params,
   size_t num_workers = work_orchestrator ? work_orchestrator->GetWorkerCount() : 16;
   allocator_.Init(num_workers, ram_capacity_, params.alignment_);
 
+  // issue #783: back a plain RAM device with shared memory so client processes
+  // can read blob payloads directly.
+  //
+  // kPinned is deliberately excluded: its pages come from cudaMallocHost and
+  // cannot be SHM-backed, so it keeps the private-heap path.
+  //
+  // BEST-EFFORT. If the segment cannot be created the device still works
+  // exactly as before on the private heap; only the client fast path is lost.
+  if (bdev_type_ == BdevType::kRam && runtime != nullptr) {
+    InitShmBacking(runtime->pool_id_);
+  }
+
   return true;
 }
 
+void MemBdevTransport::InitShmBacking(const clio::run::PoolId &pool_id) {
+  try {
+    auto pid = static_cast<clio::run::u32>(ctp::SystemInfo::GetPid());
+    shm_name_ = ShmSegmentName(pid, pool_id);
+    // Reserve header + full capacity in one sparse mapping. memfd reservations
+    // are lazily faulted, so this costs only the bytes actually written.
+    size_t total = sizeof(ShmRamHeader) + static_cast<size_t>(ram_capacity_);
+    ctp::ipc::MemoryBackendId bid(pid, pool_id.major_);
+    if (!shm_backend_.shm_init(bid, ctp::Unit<size_t>::Bytes(total),
+                               shm_name_)) {
+      HLOG(kWarning,
+           "[#783] RAM bdev '{}': shm_init failed ({} bytes) -- falling back "
+           "to private heap, client direct reads disabled",
+           shm_name_, total);
+      return;
+    }
+    char *base = reinterpret_cast<char *>(shm_backend_.data_);
+    if (base == nullptr) {
+      return;
+    }
+    shm_header_ = reinterpret_cast<ShmRamHeader *>(base);
+    std::memset(shm_header_, 0, sizeof(ShmRamHeader));
+    shm_header_->version_ = ShmRamHeader::kVersion;
+    shm_header_->capacity_ = ram_capacity_;
+    shm_header_->data_off_ = sizeof(ShmRamHeader);
+    shm_base_ = base + sizeof(ShmRamHeader);
+    // ready_ LAST, so a client that sees ready_ == 1 knows the mapping behind
+    // it is fully described.
+    shm_header_->ready_ = 1;
+    shm_backed_ = true;
+    HLOG(kInfo, "[#783] RAM bdev '{}' is shared-memory backed ({} bytes)",
+         shm_name_, ram_capacity_);
+  } catch (const std::exception &e) {
+    HLOG(kWarning, "[#783] RAM bdev shm backing failed: {}", e.what());
+    shm_backed_ = false;
+    shm_base_ = nullptr;
+    shm_header_ = nullptr;
+  }
+}
+
 void MemBdevTransport::Destroy() {
+  if (shm_backed_) {
+    // Mark unusable before tearing the mapping down so a client that is
+    // mid-attach refuses rather than reading a dying segment.
+    if (shm_header_ != nullptr) {
+      shm_header_->ready_ = 0;
+    }
+    shm_header_ = nullptr;
+    shm_base_ = nullptr;
+    shm_backed_ = false;
+    shm_backend_.shm_destroy();
+  }
   std::lock_guard<std::mutex> lock(ram_pages_mu_);
   for (RamPage &page : ram_pages_) {
     FreeRamPage(page);
@@ -57,6 +121,11 @@ void MemBdevTransport::FreeBlocks(int worker_id, const std::vector<Block>& block
 }
 
 char* MemBdevTransport::EnsureRamPage(size_t page_idx) {
+  // SHM-backed devices need no per-page allocation at all: the whole capacity
+  // is one sparse mapping, so a page is just an offset into it.
+  if (shm_backed_ && shm_base_ != nullptr) {
+    return shm_base_ + page_idx * kRamPageSize;
+  }
   std::lock_guard<std::mutex> lock(ram_pages_mu_);
   if (page_idx >= ram_pages_.size()) {
     ram_pages_.resize(page_idx + 1);
@@ -85,6 +154,9 @@ char* MemBdevTransport::EnsureRamPage(size_t page_idx) {
 }
 
 char* MemBdevTransport::GetRamPage(size_t page_idx) const {
+  if (shm_backed_ && shm_base_ != nullptr) {
+    return shm_base_ + page_idx * kRamPageSize;
+  }
   std::lock_guard<std::mutex> lock(ram_pages_mu_);
   if (page_idx >= ram_pages_.size()) return nullptr;
   return ram_pages_[page_idx].data;

--- a/context-runtime/src/config_manager.cc
+++ b/context-runtime/src/config_manager.cc
@@ -38,6 +38,7 @@
 #include "clio_runtime/config_manager.h"
 #include "clio_runtime/task.h"
 #include "clio_runtime/ipc_manager.h"
+#include <cctype>
 #include <cstdlib>
 #include <filesystem>
 
@@ -45,6 +46,83 @@
 CLIO_RUN_DEFINE_GLOBAL_PTR_VAR_CC(clio::run::ConfigManager, g_config_manager);
 
 namespace clio::run {
+
+namespace {
+
+/**
+ * Parse a shared-memory segment size from YAML.
+ *
+ * Accepts either a bare byte count (`metadata_segment_size: 1073741824`) or a
+ * size string with a unit suffix (`metadata_segment_size: "1g"`), matching how
+ * the CTE spells storage capacities. A value of 0 means "use the built-in
+ * default" — the same sentinel LoadDefault() installs.
+ *
+ * Returns false and leaves `out` untouched when the value cannot be parsed, so
+ * the caller keeps its default. Deliberately does NOT delegate an unknown
+ * suffix to ctp::ConfigParse::ParseSize, which calls exit(1) on one: a typo in
+ * a config file should not take the runtime down, and the recognised suffixes
+ * are checked here first.
+ */
+bool ParseSegmentSizeNode(const YAML::Node &node, const char *key,
+                          size_t &out) {
+  std::string text;
+  try {
+    text = node.as<std::string>();
+  } catch (const std::exception &) {
+    HLOG(kError, "Config: {} is not a scalar value; ignoring", key);
+    return false;
+  }
+  if (text.empty()) {
+    HLOG(kError, "Config: {} is empty; ignoring", key);
+    return false;
+  }
+
+  // Locate the unit suffix (first character that is not part of the number).
+  size_t i = 0;
+  if (text[i] == '+' || text[i] == '-') ++i;
+  size_t digits_begin = i;
+  while (i < text.size() && ((text[i] >= '0' && text[i] <= '9') ||
+                             text[i] == '.')) {
+    ++i;
+  }
+  if (i == digits_begin) {
+    HLOG(kError, "Config: {} = '{}' has no numeric part; ignoring", key, text);
+    return false;
+  }
+  if (text[0] == '-') {
+    HLOG(kError, "Config: {} = '{}' is negative; ignoring", key, text);
+    return false;
+  }
+
+  std::string suffix;
+  for (size_t j = i; j < text.size(); ++j) {
+    if (!std::isspace(static_cast<unsigned char>(text[j]))) {
+      suffix += static_cast<char>(std::tolower(
+          static_cast<unsigned char>(text[j])));
+    }
+  }
+  // Bare number, or a unit ParseSize understands (it keys off the first
+  // character, so "gb"/"gigabytes" resolve the same as "g").
+  const bool suffix_ok =
+      suffix.empty() || suffix[0] == 'b' || suffix[0] == 'k' ||
+      suffix[0] == 'm' || suffix[0] == 'g' || suffix[0] == 't' ||
+      suffix[0] == 'p';
+  if (!suffix_ok) {
+    HLOG(kError, "Config: {} = '{}' has an unrecognised unit '{}'; ignoring "
+         "(expected one of b, k, m, g, t, p)", key, text, suffix);
+    return false;
+  }
+
+  // "b"/"bytes" is a bare byte count; ParseSize treats an unrecognised
+  // leading 'b' as a fatal unit, so strip it and let the empty-suffix path
+  // handle it.
+  const std::string for_parse =
+      (!suffix.empty() && suffix[0] == 'b') ? text.substr(0, i) : text;
+  out = static_cast<size_t>(ctp::ConfigParse::ParseSize(for_parse));
+  return true;
+}
+
+}  // namespace
 
 // Constructor and destructor removed - handled by CTP singleton pattern
 
@@ -311,6 +389,22 @@ void ConfigManager::ParseYAML(YAML::Node &yaml_conf) {
     // Task load prediction model learning rate
     if (runtime["learning_rate"]) {
       learning_rate_ = runtime["learning_rate"].as<float>();
+    }
+
+    // Size of the runtime-wide metadata segment (issue #783), which backs the
+    // CTE's shared-memory tag/blob maps. Accepts a byte count or a size string
+    // ("8g", "512MB"); 0 restores the built-in default.
+    //
+    // This needs to be tunable because the 8 GB default is more than some
+    // hosts can back. On Windows CI, CreateFileMapping cannot reserve it and
+    // the runtime falls back to the no-cache path, silently disabling the
+    // feature — with no way to ask for a smaller segment instead.
+    if (runtime["metadata_segment_size"]) {
+      size_t parsed = 0;
+      if (ParseSegmentSizeNode(runtime["metadata_segment_size"],
+                               "metadata_segment_size", parsed)) {
+        metadata_segment_size_ = parsed;
+      }
     }
 
     // Note: stack_size parameter removed (was never used)

--- a/context-runtime/src/config_manager.cc
+++ b/context-runtime/src/config_manager.cc
@@ -211,6 +211,9 @@ ConfigManager::GetSharedMemorySegmentName(MemorySegment segment,
   case kQueueSegment:
     segment_name = queue_segment_name_;
     break;
+  case kMetadataSegment:
+    segment_name = metadata_segment_name_;
+    break;
   default:
     return "";
   }
@@ -250,6 +253,8 @@ void ConfigManager::LoadDefault() {
   // Set default shared memory segment names with environment variables
   main_segment_name_ = "chi_main_segment_${USER}";
   client_data_segment_name_ = "chi_client_data_segment_${USER}";
+  metadata_segment_name_ = "chi_metadata_segment_${USER}";
+  metadata_segment_size_ = 0;  // 0 means auto-calculate
 
   // Set default hostfile path (empty means no networking/distributed mode)
   hostfile_path_ = "";
@@ -457,6 +462,20 @@ size_t ConfigManager::CalculateMainSegmentSize() const {
   // Main segment holds task data (FutureShm, BuddyAllocator metadata) — no queues
   // Use 1 GB default for task/data allocations
   return ctp::Unit<size_t>::Gigabytes(1);
+}
+
+size_t ConfigManager::CalculateMetadataSegmentSize() const {
+  // If metadata_segment_size is explicitly set (non-zero), use it
+  if (metadata_segment_size_ > 0) {
+    return metadata_segment_size_;
+  }
+
+  // Default 8 GB. This is an address-space reservation, not an allocation: the
+  // segment is never pre-faulted, so only pages the runtime actually writes
+  // consume RAM. Sized generously because the CTE metadata cache (issue #783)
+  // holds one entry per live tag and blob, and growing the segment later would
+  // invalidate every client's mapping.
+  return ctp::Unit<size_t>::Gigabytes(8);
 }
 
 size_t ConfigManager::CalculateQueueSegmentSize() const {

--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -715,6 +715,8 @@ void IpcManager::ServerFinalize() {
 
   // Clear main allocator pointer
   main_allocator_ = nullptr;
+  // issue #783: metadata segment is runtime-owned; clients only detach.
+  metadata_allocator_ = nullptr;
 
   // Leak scan while the SHM segments are still mapped (alloc_vector_ is not
   // cleared here). This is the reliable trigger for the IpcManager leak scan:
@@ -878,12 +880,69 @@ bool IpcManager::ServerInitShm() {
       return false;
     }
 
-    // Reserve segment indices 0-2 of this pid's allocator-id space: index 1 is
-    // the main segment and index 2 is the queue segment (see above). Runtime
-    // data segments created on demand by IncreaseClientShm (for AllocateBuffer
-    // / FutureShm) start at index 3 so their AllocatorId never collides with
-    // main/queue. Clients use a different pid, so they keep starting at 0.
-    shm_count_.store(3, std::memory_order_relaxed);
+    // issue #783: runtime-wide metadata segment (pid.3). Backs the CTE
+    // shared-memory metadata cache. Deliberately NON-FATAL: if it cannot be
+    // created the runtime still starts and every client simply falls back to
+    // the RPC path. That matters because the reservation is huge (8 GB by
+    // default) and a host with a small /dev/shm can legitimately refuse it --
+    // losing an optimization is acceptable, failing to boot is not.
+    metadata_allocator_id_ = ctp::ipc::AllocatorId::Get(pid, 3);
+    std::string metadata_segment_name =
+        config->GetSharedMemorySegmentName(kMetadataSegment);
+    size_t metadata_segment_size = config->CalculateMetadataSegmentSize();
+
+    // Sanity-clamp the reservation against physical RAM.
+    //
+    // NOTE ON WHAT BACKS THIS: on Linux these segments are memfd_create()
+    // objects (SystemInfo::CreateNewSharedMemory), NOT files under /dev/shm.
+    // memfd lives in the kernel's internal shmem pool, bounded by RAM+swap and
+    // the memory cgroup -- the /dev/shm mount size is irrelevant here, which is
+    // why a 1 GB main segment works fine on a host whose /dev/shm is 64 MB.
+    // Do not "fix" this by measuring std::filesystem::space("/dev/shm"); that
+    // reads an unrelated filesystem and needlessly shrinks the cache.
+    //
+    // The reservation itself is nearly free because the segment is sparse and
+    // never pre-faulted. The hazard is only the LIVE SET: pages actually
+    // written come out of RAM, and exhausting shmem surfaces as SIGBUS or the
+    // OOM killer rather than a clean allocation failure. Clamping to half of
+    // RAM keeps the default a no-op on real nodes while protecting small
+    // dev boxes and constrained containers.
+    {
+      size_t ram = ctp::SystemInfo::GetRamCapacity();
+      if (ram > 0 && metadata_segment_size > ram / 2) {
+        size_t clamped = ram / 2;
+        HLOG(kWarning,
+             "Metadata segment: requested {} bytes exceeds half of RAM ({} "
+             "bytes total); clamping to {} bytes",
+             metadata_segment_size, ram, clamped);
+        metadata_segment_size = clamped;
+      }
+    }
+
+    HLOG(kInfo,
+         "Initializing metadata shared memory segment: {} bytes ({} MB), "
+         "sparse/not pre-faulted",
+         metadata_segment_size, metadata_segment_size / (1024 * 1024));
+    if (metadata_backend_.shm_init(
+            metadata_allocator_id_,
+            ctp::Unit<size_t>::Bytes(metadata_segment_size),
+            metadata_segment_name)) {
+      metadata_allocator_ = metadata_backend_.MakeAlloc<CLIO_TASK_ALLOC_T>();
+    }
+    if (!metadata_allocator_) {
+      HLOG(kWarning,
+           "ServerInitShm: metadata segment '{}' unavailable ({} bytes) -- "
+           "SHM metadata caching disabled, clients will use the RPC path",
+           metadata_segment_name, metadata_segment_size);
+    }
+
+    // Reserve segment indices 0-3 of this pid's allocator-id space: index 1 is
+    // the main segment, index 2 the queue segment, index 3 the metadata
+    // segment (see above). Runtime data segments created on demand by
+    // IncreaseClientShm (for AllocateBuffer / FutureShm) start at index 4 so
+    // their AllocatorId never collides. Clients use a different pid, so they
+    // keep starting at 0.
+    shm_count_.store(4, std::memory_order_relaxed);
 
 #if CTP_IS_HOST
     // Single inbound MPSC ring shared by every SHM client (replaces the old
@@ -957,6 +1016,35 @@ bool IpcManager::ClientInitShm() {
       return false;
     }
     queue_allocator_id_ = queue_allocator_->GetId();
+
+    // issue #783: attach the runtime-wide metadata segment for SHM metadata
+    // caching. BEST-EFFORT -- unlike main/queue, a failure here is not fatal.
+    // The segment is an optimization; a client that cannot attach it just uses
+    // the RPC path. It is also legitimately absent when the runtime chose not
+    // to create it (small /dev/shm), so this must not log at error level.
+    //
+    // Mapped read-write, not PROT_READ: acquiring a lease is a store. Clients
+    // are trusted by convention to write ONLY lock words, never metadata --
+    // the runtime never treats this segment as authoritative, so a
+    // misbehaving client can degrade other clients but cannot corrupt the
+    // runtime's own state.
+    {
+      std::string metadata_segment_name =
+          config->GetSharedMemorySegmentName(kMetadataSegment);
+      if (metadata_backend_.shm_attach(metadata_segment_name)) {
+        metadata_allocator_ = metadata_backend_.AttachAlloc<CLIO_TASK_ALLOC_T>();
+      }
+      if (metadata_allocator_) {
+        metadata_allocator_id_ = metadata_allocator_->GetId();
+        HLOG(kInfo, "ClientInitShm: attached metadata segment '{}'",
+             metadata_segment_name);
+      } else {
+        HLOG(kInfo,
+             "ClientInitShm: metadata segment '{}' unavailable -- SHM metadata "
+             "caching disabled for this client (RPC path still works)",
+             metadata_segment_name);
+      }
+    }
 
 #if CTP_IS_HOST
     // Single per-process response ring (replaces the old per-thread
@@ -2625,6 +2713,11 @@ bool IpcManager::ReconnectToOriginalHost() {
     main_allocator_ = nullptr;
     worker_queues_ = ctp::ipc::FullPtr<TaskQueue>();
     main_backend_ = ctp::ipc::PosixShmMmap();
+    // issue #783: the metadata mapping points into the OLD server's segment;
+    // drop it so ClientInitShm re-attaches the restarted server's one instead
+    // of leaving a dangling pointer into an unmapped region.
+    metadata_allocator_ = nullptr;
+    metadata_backend_ = ctp::ipc::PosixShmMmap();
 
     // Re-attach to new shared memory
     if (!ClientInitShm()) return false;
@@ -2732,6 +2825,9 @@ bool IpcManager::ReconnectToNewHost(const std::string &new_addr) {
   shm_send_transport_.reset();
   shm_recv_transport_.reset();
   main_allocator_ = nullptr;
+  // issue #783: remote host -> no shared memory at all, so the metadata cache
+  // is unavailable and every read must take the RPC path.
+  metadata_allocator_ = nullptr;
   runtime_pid_ = 0;
 
   // Create new ZMQ DEALER transport

--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -934,6 +934,28 @@ bool IpcManager::ServerInitShm() {
            "ServerInitShm: metadata segment '{}' unavailable ({} bytes) -- "
            "SHM metadata caching disabled, clients will use the RPC path",
            metadata_segment_name, metadata_segment_size);
+    } else {
+      // Publish the directory of well-known roots as the FIRST object in the
+      // segment. Clients learn its offset from ClientConnect, which is what
+      // makes discovery independent of who created a pool first.
+      try {
+        auto dir_fp =
+            metadata_allocator_->template Allocate<MetadataDirectory>(
+                sizeof(MetadataDirectory));
+        if (!dir_fp.IsNull()) {
+          auto *dir = dir_fp.ptr_;
+          std::memset(dir, 0, sizeof(MetadataDirectory));
+          dir->version_ = MetadataDirectory::kVersion;
+          metadata_dir_off_ = static_cast<u64>(
+              reinterpret_cast<char *>(dir) -
+              reinterpret_cast<char *>(metadata_allocator_));
+          HLOG(kInfo, "ServerInitShm: metadata directory at offset {}",
+               metadata_dir_off_);
+        }
+      } catch (const std::exception &e) {
+        HLOG(kWarning, "ServerInitShm: metadata directory alloc failed: {}",
+             e.what());
+      }
     }
 
     // Reserve segment indices 0-3 of this pid's allocator-id space: index 1 is
@@ -1316,6 +1338,10 @@ retry_attempt:
     // assuming (1,0)/(2,0).
     main_allocator_id_ = task->main_alloc_id_;
     queue_allocator_id_ = task->queue_alloc_id_;
+    // issue #783: learn where the metadata-segment directory lives so this
+    // client can find module cache roots without depending on having been the
+    // process that created the pool.
+    metadata_dir_off_ = task->metadata_dir_off_;
     if (task->server_pid_ > 0) {
       runtime_pid_ = static_cast<int>(task->server_pid_);
     }

--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -46,6 +46,9 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#ifdef __linux__
+#include <sys/mman.h>
+#endif
 #include <functional>
 #include <iostream>
 #include <memory>
@@ -867,6 +870,38 @@ static size_t ReadCgroupMemoryLimit() {
   return 0;
 }
 
+/**
+ * Keep a large shared mapping out of core dumps (Linux MADV_DONTDUMP).
+ *
+ * The runtime shuts down via std::abort() (admin_runtime.cc), so every clean
+ * `clio_run stop` raises SIGABRT and the kernel dumps core wherever cores are
+ * enabled. With a multi-gigabyte metadata segment mapped that dump takes long
+ * enough to blow the 60s shutdown budget in the CLI lifecycle tests
+ * (cr_cli_runtime_command_tests, cr_cli_cte_wal_restart, cr_cli_compose_restart
+ * all failed this way on docker AND ubuntu-arm). It never reproduced locally
+ * because this dev box has `ulimit -c 0`, so no core is written at all.
+ *
+ * The segment is a cache; its contents have no diagnostic value in a core, so
+ * excluding it costs nothing and removes gigabytes of dump work.
+ */
+static void ExcludeFromCoreDump(void *addr, size_t size, const char *what) {
+#if defined(__linux__) && defined(MADV_DONTDUMP)
+  if (addr == nullptr || size == 0) {
+    return;
+  }
+  if (madvise(addr, size, MADV_DONTDUMP) != 0) {
+    HLOG(kWarning, "MADV_DONTDUMP failed for {} ({} bytes): {}", what, size,
+         strerror(errno));
+  } else {
+    HLOG(kInfo, "{}: excluded {} bytes from core dumps", what, size);
+  }
+#else
+  (void)addr;
+  (void)size;
+  (void)what;
+#endif
+}
+
 bool IpcManager::ServerInitShm() {
   ConfigManager *config = CLIO_CONFIG_MANAGER;
 
@@ -987,6 +1022,9 @@ bool IpcManager::ServerInitShm() {
            "SHM metadata caching disabled, clients will use the RPC path",
            metadata_segment_name, metadata_segment_size);
     } else {
+      ExcludeFromCoreDump(metadata_backend_.region_,
+                          metadata_backend_.backend_size_,
+                          "metadata segment");
       // Publish the directory of well-known roots as the FIRST object in the
       // segment. Clients learn its offset from ClientConnect, which is what
       // makes discovery independent of who created a pool first.

--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -45,6 +45,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
+#include <fstream>
 #include <functional>
 #include <iostream>
 #include <memory>
@@ -829,6 +830,43 @@ ctp::lbm::ShmMpscTransport *IpcManager::GetOrCreateShmConn(
   return raw;
 }
 
+/**
+ * Memory limit imposed on this process by its cgroup, or 0 when unlimited or
+ * unreadable (cgroup v2 first, then v1).
+ *
+ * Needed because SystemInfo::GetRamCapacity() reports the HOST's physical
+ * memory even inside a container -- sizing a shared-memory reservation off
+ * that number over-commits badly in CI images and constrained deployments.
+ */
+static size_t ReadCgroupMemoryLimit() {
+#ifdef __linux__
+  const char *paths[] = {"/sys/fs/cgroup/memory.max",
+                         "/sys/fs/cgroup/memory/memory.limit_in_bytes"};
+  for (const char *path : paths) {
+    std::ifstream f(path);
+    if (!f.is_open()) {
+      continue;
+    }
+    std::string v;
+    if (!(f >> v)) {
+      continue;
+    }
+    if (v == "max") {
+      return 0;  // explicitly unlimited
+    }
+    try {
+      unsigned long long n = std::stoull(v);
+      // cgroup v1 reports a sentinel near SIZE_MAX when unlimited.
+      if (n > 0 && n < (1ULL << 62)) {
+        return static_cast<size_t>(n);
+      }
+    } catch (...) {
+    }
+  }
+#endif
+  return 0;
+}
+
 bool IpcManager::ServerInitShm() {
   ConfigManager *config = CLIO_CONFIG_MANAGER;
 
@@ -891,6 +929,16 @@ bool IpcManager::ServerInitShm() {
         config->GetSharedMemorySegmentName(kMetadataSegment);
     size_t metadata_segment_size = config->CalculateMetadataSegmentSize();
 
+    // Sanity-clamp the reservation against the memory this process may
+    // actually use -- which is NOT the same as physical RAM in a container.
+    //
+    // SystemInfo::GetRamCapacity() reads sysinfo().totalram, i.e. the HOST's
+    // memory, and knows nothing about cgroup limits. Inside the docker CI
+    // image that made this reserve half the RUNNER's RAM, several times the
+    // container's own limit, which showed up as daemon lifecycle timeouts
+    // (cr_cli_runtime_command_tests, cr_cli_cte_wal_restart,
+    // cr_cli_compose_restart) in a job that is green on dev. Read the cgroup
+    // limit first and fall back to physical RAM only when there is none.
     // Sanity-clamp the reservation against physical RAM.
     //
     // NOTE ON WHAT BACKS THIS: on Linux these segments are memfd_create()
@@ -908,13 +956,17 @@ bool IpcManager::ServerInitShm() {
     // RAM keeps the default a no-op on real nodes while protecting small
     // dev boxes and constrained containers.
     {
-      size_t ram = ctp::SystemInfo::GetRamCapacity();
-      if (ram > 0 && metadata_segment_size > ram / 2) {
-        size_t clamped = ram / 2;
+      size_t budget = ctp::SystemInfo::GetRamCapacity();
+      size_t cgroup_limit = ReadCgroupMemoryLimit();
+      if (cgroup_limit > 0 && (budget == 0 || cgroup_limit < budget)) {
+        budget = cgroup_limit;
+      }
+      if (budget > 0 && metadata_segment_size > budget / 2) {
+        size_t clamped = budget / 2;
         HLOG(kWarning,
-             "Metadata segment: requested {} bytes exceeds half of RAM ({} "
-             "bytes total); clamping to {} bytes",
-             metadata_segment_size, ram, clamped);
+             "Metadata segment: requested {} bytes exceeds half the memory "
+             "budget ({} bytes; cgroup_limit={}); clamping to {} bytes",
+             metadata_segment_size, budget, cgroup_limit, clamped);
         metadata_segment_size = clamped;
       }
     }

--- a/context-transfer-engine/core/include/clio_cte/core/core_client.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_client.h
@@ -39,6 +39,9 @@
 #include <clio_cte/api.h>
 #include <clio_cte/core/core_tasks.h>
 #include <clio_cte/core/shm_metadata_cache.h>
+#include <clio_runtime/bdev/transports/mem_bdev_transport.h>
+#include <cstring>
+#include <unordered_map>
 
 namespace clio::cte::core {
 
@@ -150,6 +153,74 @@ class Client : public clio::run::ContainerClient {
       return false;  // name too long for the fast path
     }
     return shm_root_->blob_key_to_info_.TryGetBytes(key, n, out);
+  }
+
+  /**
+   * Zero-IPC PAYLOAD read (issue #783 phase 6).
+   *
+   * Copies blob bytes straight out of the RAM bdev's shared-memory segment,
+   * with no round-trip at all.
+   *
+   * COHERENCE (design §5.3): the metadata seqlock protects the record copy,
+   * but the hazard is the DataOrganizer relocating blocks WHILE we memcpy.
+   * So `placement_gen_` is validated before and AFTER the copy, and a change
+   * discards the bytes and reports failure. Without the post-check this
+   * function would silently return another blob's data.
+   *
+   * @return true only if `size` bytes were copied AND placement did not move.
+   *         Any false -- not cached, not direct-readable, segment missing,
+   *         placement changed -- means "fall back to RPC", never "no data".
+   */
+  bool TryReadBlobShm(const TagId &tag_id, const std::string &blob_name,
+                      char *out, size_t size, size_t offset = 0) {
+    if (shm_root_ == nullptr || out == nullptr || size == 0) {
+      return false;
+    }
+    ShmBlobRecord rec;
+    if (!TryGetBlobRecordShm(tag_id, blob_name, &rec)) {
+      return false;
+    }
+    if (!rec.IsDirectReadable()) {
+      return false;  // file/remote/GPU-tier blob, or truncated block list
+    }
+    if (offset + size > rec.total_size_) {
+      return false;
+    }
+    const clio::run::u64 gen_before = rec.placement_gen_;
+
+    size_t copied = 0;
+    clio::run::u64 want_from = offset;
+    for (clio::run::u32 i = 0; i < rec.num_blocks_ && copied < size; ++i) {
+      const ShmBlockDesc &b = rec.blocks_[i];
+      if (b.size_ <= want_from) {
+        want_from -= b.size_;  // this block is entirely before `offset`
+        continue;
+      }
+      char *base = MapRamBdev(b.target_pool_);
+      if (base == nullptr) {
+        return false;  // cannot reach this device -> RPC
+      }
+      clio::run::u64 intra = want_from;
+      size_t avail = static_cast<size_t>(b.size_ - intra);
+      size_t chunk = std::min(avail, size - copied);
+      std::memcpy(out + copied, base + b.target_offset_ + intra, chunk);
+      copied += chunk;
+      want_from = 0;
+    }
+    if (copied != size) {
+      return false;
+    }
+
+    // Re-validate placement. If the blob moved while we were copying, the
+    // bytes may be a mix of two blobs -- discard and let the caller use RPC.
+    ShmBlobRecord after;
+    if (!TryGetBlobRecordShm(tag_id, blob_name, &after)) {
+      return false;
+    }
+    if (after.placement_gen_ != gen_before) {
+      return false;
+    }
+    return true;
   }
 
   /** Zero-IPC tag-name lookup. */
@@ -968,6 +1039,61 @@ class Client : public clio::run::ContainerClient {
   // owns the segment and may drop the cache at any time, which is why every
   // read is validated rather than trusted.
   ShmMetadataCacheRoot *shm_root_ = nullptr;
+
+  /** One attached RAM-bdev segment, cached so a hot read does not re-attach. */
+  struct RamBdevMap {
+    ctp::ipc::PosixShmMmap backend;
+    char *base = nullptr;  /**< byte 0 of device space */
+  };
+  // Keyed by target pool. Attaching is not free, and the fast path is meant to
+  // be a few hundred nanoseconds, so a miss here would dominate the cost.
+  std::unordered_map<clio::run::u64, RamBdevMap> ram_bdevs_;
+
+  /**
+   * Resolve (attaching on first use) the base address of a RAM bdev's shared
+   * memory in THIS process, or nullptr when unavailable.
+   *
+   * The segment name is reconstructed from the runtime pid plus the target
+   * pool id, both of which the client already holds -- no name is published
+   * anywhere. A negative result is cached as a null base so a device that
+   * cannot be mapped is not retried on every single read.
+   */
+  char *MapRamBdev(const clio::run::PoolId &pool_id) {
+    clio::run::u64 key = pool_id.ToU64();
+    auto it = ram_bdevs_.find(key);
+    if (it != ram_bdevs_.end()) {
+      return it->second.base;
+    }
+    auto *ipc = CLIO_CPU_IPC;
+    RamBdevMap &slot = ram_bdevs_[key];  // caches the negative result too
+    if (ipc == nullptr) {
+      return nullptr;
+    }
+    clio::run::u32 server_pid = static_cast<clio::run::u32>(ipc->GetRuntimePid());
+    if (server_pid == 0) {
+      return nullptr;
+    }
+    std::string name =
+        clio::run::bdev::MemBdevTransport::ShmSegmentName(server_pid, pool_id);
+    if (!slot.backend.shm_attach(name)) {
+      return nullptr;
+    }
+    char *raw = reinterpret_cast<char *>(slot.backend.data_);
+    if (raw == nullptr) {
+      return nullptr;
+    }
+    auto *hdr =
+        reinterpret_cast<clio::run::bdev::MemBdevTransport::ShmRamHeader *>(raw);
+    // Refuse a segment we do not recognize or that is being torn down --
+    // Destroy() clears ready_ before unmapping precisely so this check works.
+    if (hdr->version_ !=
+            clio::run::bdev::MemBdevTransport::ShmRamHeader::kVersion ||
+        hdr->ready_ != 1) {
+      return nullptr;
+    }
+    slot.base = raw + hdr->data_off_;
+    return slot.base;
+  }
 #endif
 };
 

--- a/context-transfer-engine/core/include/clio_cte/core/core_client.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_client.h
@@ -116,7 +116,9 @@ class Client : public clio::run::ContainerClient {
     if (dir == nullptr) {
       return false;
     }
-    return AttachShmCache(dir->cte_cache_root_off_);
+    // Look up THIS client's pool. Using a shared slot would attach whichever
+    // CTE pool cached last, silently reading another pool's metadata.
+    return AttachShmCache(dir->FindRoot(pool_id_.ToU64()));
   }
 
   /** Convenience: attach from a completed CreateTask, falling back to the

--- a/context-transfer-engine/core/include/clio_cte/core/core_client.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_client.h
@@ -38,6 +38,7 @@
 #include <clio_ctp/util/singleton.h>
 #include <clio_cte/api.h>
 #include <clio_cte/core/core_tasks.h>
+#include <clio_cte/core/shm_metadata_cache.h>
 
 namespace clio::cte::core {
 
@@ -45,6 +46,121 @@ class Client : public clio::run::ContainerClient {
  public:
   CTP_CROSS_FUN Client() = default;
   CTP_CROSS_FUN explicit Client(const clio::run::PoolId &pool_id) { Init(pool_id); }
+
+#if CTP_IS_HOST
+  // =========================================================================
+  // issue #783: shared-memory metadata cache (client side).
+  //
+  // Strictly an OPTIMIZATION. Every accessor reports failure rather than
+  // guessing, and a caller that gets `false` must fall back to the normal RPC
+  // path. The cache can be absent (no metadata segment), stale (writes are
+  // asynchronous), or full -- none of which are errors.
+  // =========================================================================
+
+  /**
+   * Attach the cache using the root offset returned by Create.
+   *
+   * @param root_off offset from CreateParams::shm_cache_root_off_. 0 means the
+   *        runtime is not caching, and this simply leaves the cache disabled.
+   * @return true if the cache is now usable.
+   */
+  bool AttachShmCache(clio::run::u64 root_off) {
+    shm_root_ = nullptr;
+    if (root_off == 0) {
+      HLOG(kDebug, "[#783] AttachShmCache: root_off=0 (runtime not caching)");
+      return false;  // runtime is not caching -- not an error
+    }
+    auto *ipc = CLIO_CPU_IPC;
+    if (ipc == nullptr) {
+      return false;
+    }
+    auto *alloc = ipc->GetMetadataAllocator();
+    if (alloc == nullptr) {
+      HLOG(kDebug, "[#783] AttachShmCache: no metadata allocator attached");
+      return false;  // segment not attached (e.g. TCP client, or remote node)
+    }
+    auto *root = reinterpret_cast<ShmMetadataCacheRoot *>(
+        reinterpret_cast<char *>(alloc) + root_off);
+    // Refuse anything we do not recognize. The cache is derived state, so
+    // declining to use it is always safe; guessing at a layout is not.
+    if (root->ready_ != 1 ||
+        root->version_ != ShmMetadataCacheRoot::kLayoutVersion) {
+      HLOG(kDebug,
+           "[#783] AttachShmCache: rejected root (ready={}, version={}, "
+           "expected version={})",
+           root->ready_, root->version_,
+           ShmMetadataCacheRoot::kLayoutVersion);
+      return false;
+    }
+    shm_root_ = root;
+    return true;
+  }
+
+  /**
+   * Attach by discovering the cache through the metadata-segment directory.
+   *
+   * This is the RELIABLE path. The CreateTask overload below only carries a
+   * non-zero offset for the process that actually caused the pool to be
+   * created; in practice compose creates the CTE pool at startup, so every
+   * later client sees zero there. Discovery must not depend on being first.
+   */
+  bool AttachShmCache() {
+    auto *ipc = CLIO_CPU_IPC;
+    if (ipc == nullptr) {
+      return false;
+    }
+    auto *dir = ipc->GetMetadataDirectory();
+    if (dir == nullptr) {
+      return false;
+    }
+    return AttachShmCache(dir->cte_cache_root_off_);
+  }
+
+  /** Convenience: attach from a completed CreateTask, falling back to the
+   *  directory when the task carries no offset (i.e. the pool already
+   *  existed, which is the common case). */
+  bool AttachShmCache(CreateTask &task) {
+    clio::run::u64 off = task.GetParams().shm_cache_root_off_;
+    if (off != 0 && AttachShmCache(off)) {
+      return true;
+    }
+    return AttachShmCache();
+  }
+
+  bool HasShmCache() const { return shm_root_ != nullptr; }
+
+  /**
+   * Zero-IPC metadata read.
+   *
+   * @return true if a consistent record was found in shared memory. false
+   *         means "not cached / could not read consistently" -- ALWAYS fall
+   *         back to the RPC path, never treat it as "blob does not exist".
+   */
+  bool TryGetBlobRecordShm(const TagId &tag_id, const std::string &blob_name,
+                           ShmBlobRecord *out) const {
+    if (shm_root_ == nullptr || out == nullptr) {
+      return false;
+    }
+    // Key is built into a stack buffer: a client must never allocate inside
+    // the runtime-owned segment, and this is the hot path.
+    char key[512];
+    size_t n = MakeShmBlobKey(tag_id, blob_name.data(), blob_name.size(), key,
+                              sizeof(key));
+    if (n == 0) {
+      return false;  // name too long for the fast path
+    }
+    return shm_root_->blob_key_to_info_.TryGetBytes(key, n, out);
+  }
+
+  /** Zero-IPC tag-name lookup. */
+  bool TryGetTagIdShm(const std::string &tag_name, TagId *out) const {
+    if (shm_root_ == nullptr || out == nullptr) {
+      return false;
+    }
+    return shm_root_->tag_name_to_id_.TryGetBytes(tag_name.data(),
+                                                  tag_name.size(), out);
+  }
+#endif
 
 #if CTP_IS_HOST
   /**
@@ -844,6 +960,15 @@ class Client : public clio::run::ContainerClient {
     return ipc_manager->Send(task);
   }
 #endif  // CTP_IS_HOST
+
+#if CTP_IS_HOST
+ private:
+  // issue #783: resolved address of the SHM metadata cache root in THIS
+  // process, or nullptr when caching is unavailable. Not owned -- the runtime
+  // owns the segment and may drop the cache at any time, which is why every
+  // read is validated rather than trusted.
+  ShmMetadataCacheRoot *shm_root_ = nullptr;
+#endif
 };
 
 // Global pointer-based singleton for CTE client with lazy initialization

--- a/context-transfer-engine/core/include/clio_cte/core/core_runtime.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_runtime.h
@@ -47,6 +47,7 @@
 #include <clio_cte/core/dpe/dpe.h>
 #include <clio_cte/core/core_tasks.h>
 #include <clio_cte/core/data_organizer/data_organizer.h>
+#include <clio_cte/core/shm_metadata_cache.h>
 #include <clio_cte/core/gpu_metadata_cache.h>
 #include <clio_cte/core/transaction_log.h>
 #include <clio_ctp/search/regex_search_engine.h>
@@ -343,6 +344,21 @@ private:
   // tag_map_lock_ (created in GetOrAssignTagId, removed in DelTag, moved in
   // RenameTag, rebuilt after WAL/metadata restore).
   ctp::search::RegexSearchEngine<TagId> tag_search_;
+
+  // issue #783: shared-memory mirror of the tag/blob metadata, for zero-IPC
+  // client reads. DERIVED STATE ONLY -- the maps above stay authoritative.
+  // Every mirror call is best-effort and silently no-ops when the metadata
+  // segment is unavailable, so a metadata write is never rejected because the
+  // cache could not be updated.
+  ShmMetadataCache shm_cache_;
+
+  /** Project a BlobInfo into its cacheable form. Returns false when the blob
+   *  cannot be represented (too many blocks), in which case it is not
+   *  cached and clients keep using the RPC path for it. */
+  static bool BuildShmBlobRecord(const BlobInfo &info, ShmBlobRecord *out);
+
+  /** Mirror one blob into the SHM cache. No-op when caching is off. */
+  void MirrorBlobToShm(const std::string &composite_key, const BlobInfo &info);
 
   // Atomic counters for thread-safe ID generation
   std::atomic<clio::run::u32>

--- a/context-transfer-engine/core/include/clio_cte/core/core_runtime.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_runtime.h
@@ -355,7 +355,7 @@ private:
   /** Project a BlobInfo into its cacheable form. Returns false when the blob
    *  cannot be represented (too many blocks), in which case it is not
    *  cached and clients keep using the RPC path for it. */
-  static bool BuildShmBlobRecord(const BlobInfo &info, ShmBlobRecord *out);
+  bool BuildShmBlobRecord(const BlobInfo &info, ShmBlobRecord *out);
 
   /** Mirror one blob into the SHM cache. No-op when caching is off. */
   void MirrorBlobToShm(const std::string &composite_key, const BlobInfo &info);

--- a/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
@@ -120,6 +120,17 @@ struct CreateParams {
   // gpu_metadata_cache.h header for the eventual extension).
   clio::run::u64 gpu_cache_ptr_ = 0;
 
+  // OUT: byte offset of the CTE shared-memory metadata cache root within the
+  // runtime's metadata allocator (issue #783). 0 means caching is disabled --
+  // no metadata segment, or the cache could not be built -- and the client
+  // must simply use the RPC path.
+  //
+  // UNLIKE gpu_cache_ptr_ above, this is genuinely cross-process valid: it is
+  // an OFFSET into a segment both processes map, not a raw address. That is
+  // the whole reason the cache can be read by another process at all; a
+  // pointer here would resolve to garbage in the client.
+  clio::run::u64 shm_cache_root_off_ = 0;
+
   // Required: chimod library name for module manager
   static constexpr const char *chimod_lib_name = "clio_cte_core";
 
@@ -129,13 +140,15 @@ struct CreateParams {
   // Copy constructor (required for task creation)
   CreateParams(const CreateParams &other)
       : config_(other.config_),
-        gpu_cache_ptr_(other.gpu_cache_ptr_) {}
+        gpu_cache_ptr_(other.gpu_cache_ptr_),
+        shm_cache_root_off_(other.shm_cache_root_off_) {}
 
   // Constructor with pool_id and CreateParams (required for admin
   // task creation)
   CreateParams(const clio::run::PoolId &pool_id, const CreateParams &other)
       : config_(other.config_),
-        gpu_cache_ptr_(other.gpu_cache_ptr_) {
+        gpu_cache_ptr_(other.gpu_cache_ptr_),
+        shm_cache_root_off_(other.shm_cache_root_off_) {
     // pool_id is used by the admin task framework, but we don't need to store
     // it
     (void)pool_id;  // Suppress unused parameter warning
@@ -162,7 +175,8 @@ struct CreateParams {
        config_.organizer_.name_,
        config_.organizer_.organizer_tasks_,
        config_.organizer_.period_ms_,
-       gpu_cache_ptr_);
+       gpu_cache_ptr_,
+       shm_cache_root_off_);
   }
 
   /**

--- a/context-transfer-engine/core/include/clio_cte/core/shm_metadata_cache.h
+++ b/context-transfer-engine/core/include/clio_cte/core/shm_metadata_cache.h
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CLIO_CTE_CORE_SHM_METADATA_CACHE_H_
+#define CLIO_CTE_CORE_SHM_METADATA_CACHE_H_
+
+#include <clio_ctp/data_structures/ipc/string.h>
+#include <clio_ctp/data_structures/ipc/unordered_map.h>
+
+#include "clio_runtime/clio_runtime.h"
+#include "clio_runtime/types.h"
+
+namespace clio::cte::core {
+
+/** Allocator backing the metadata segment (same type as the main segment). */
+using ShmCacheAlloc = CLIO_TASK_ALLOC_T;
+using ShmCacheString = ctp::ipc::string<ShmCacheAlloc>;
+
+/**
+ * Maximum blocks stored inline in a cached blob record.
+ *
+ * Deliberately small and FIXED. The fast path exists for SMALL blobs (design
+ * §5.3: for a 1 GB blob a 72 us round-trip is already noise), and a small blob
+ * has few blocks. Capping the block list keeps the record a plain POD with no
+ * nested allocation and no second pointer chase for a lock-free reader; a blob
+ * with more blocks than this simply is not cacheable and takes the RPC path.
+ */
+static constexpr clio::run::u32 kMaxInlineBlocks = 8;
+
+/**
+ * One block of a cached blob.
+ *
+ * POD ONLY. Note what is absent: the runtime's BlobBlock embeds a
+ * clio::run::bdev::Client, which derives from ContainerClient and therefore
+ * carries a VTABLE POINTER -- a process-local address that is meaningless in a
+ * segment mapped by another process. The client is reconstructed runtime-side
+ * from target_pool_ when needed. General rule: no virtual functions in any
+ * SHM-resident type.
+ */
+struct ShmBlockDesc {
+  clio::run::PoolId target_pool_;  /**< bdev pool holding this block */
+  clio::run::u64 target_offset_;   /**< offset within the target */
+  clio::run::u64 size_;            /**< logical bytes used */
+  clio::run::u32 bdev_type_;       /**< clio::run::bdev::BdevType */
+  clio::run::u32 node_id_;         /**< owning node; only local is cacheable */
+};
+
+/** Flags on a cached blob record. */
+enum ShmBlobFlags : clio::run::u32 {
+  /** Every block is node-local AND RAM-backed, so the payload is directly
+   *  readable from shared memory. Without this the client must use RPC. */
+  kShmBlobDirectReadable = 1u << 0,
+  /** The blob had more blocks than kMaxInlineBlocks, so blocks_ is truncated
+   *  and MUST NOT be used for a payload read. */
+  kShmBlobTruncated = 1u << 1,
+};
+
+/**
+ * Cached blob metadata.
+ *
+ * Trivially copyable by construction: the map's reader copies the whole record
+ * out between two reads of the slot generation, so it must contain no
+ * allocator-owned members (an ipc::string here would make the record
+ * non-copyable and defeat the seqlock). The blob NAME is the map key, so it is
+ * not duplicated here.
+ */
+struct ShmBlobRecord {
+  clio::run::u64 total_size_;
+  clio::run::u64 last_modified_;
+  clio::run::u64 last_read_;
+  /**
+   * Bumped by the runtime on every change to this blob's PLACEMENT. A client
+   * must re-read this after copying the payload and discard the result if it
+   * moved: the seqlock only protects the metadata copy, while the hazard
+   * (design §5.3) is the DataOrganizer relocating blocks during the payload
+   * read itself.
+   */
+  clio::run::u64 placement_gen_;
+  float score_;
+  clio::run::u32 flags_;
+  clio::run::u32 num_blocks_;
+  clio::run::u32 reserved_;
+  ShmBlockDesc blocks_[kMaxInlineBlocks];
+
+  ShmBlobRecord()
+      : total_size_(0),
+        last_modified_(0),
+        last_read_(0),
+        placement_gen_(0),
+        score_(0.0f),
+        flags_(0),
+        num_blocks_(0),
+        reserved_(0) {}
+
+  /** True if the payload may be read directly out of shared memory. */
+  bool IsDirectReadable() const {
+    return (flags_ & kShmBlobDirectReadable) != 0 &&
+           (flags_ & kShmBlobTruncated) == 0 && num_blocks_ > 0;
+  }
+};
+
+/** Cached tag metadata. POD, for the same reason as ShmBlobRecord. */
+struct ShmTagRecord {
+  clio::run::u64 total_size_;
+  clio::run::u64 last_modified_;
+  clio::run::u64 last_read_;
+  clio::run::u64 last_changed_;
+
+  ShmTagRecord()
+      : total_size_(0), last_modified_(0), last_read_(0), last_changed_(0) {}
+};
+
+using ShmTagIdMap = ctp::ipc::unordered_map<ShmCacheString, clio::run::UniqueId,
+                                            ShmCacheAlloc>;
+using ShmTagInfoMap =
+    ctp::ipc::unordered_map<clio::run::UniqueId, ShmTagRecord, ShmCacheAlloc>;
+using ShmBlobInfoMap =
+    ctp::ipc::unordered_map<ShmCacheString, ShmBlobRecord, ShmCacheAlloc>;
+
+/**
+ * Root of the CTE shared-memory metadata cache (issue #783).
+ *
+ * OWNERSHIP: created and written ONLY by the runtime. Clients attach it
+ * read-mostly -- they map the segment read-write because taking a lease is a
+ * store, but by convention they write nothing except lock words.
+ *
+ * AUTHORITY: this is a CACHE, never the source of truth. The runtime keeps its
+ * own structures and may refuse to populate, defer updating, or drop this
+ * wholesale at any moment. Two consequences the design leans on: a client that
+ * corrupts it can only degrade other clients, and a wedged cache is recovered
+ * by dropping it rather than being a data-loss event.
+ *
+ * SIZING IS PERMANENT. The maps never rehash (see ipc::unordered_map), because
+ * a rehash would free a table out from under untracked cross-process readers.
+ * Capacity is therefore chosen once, here, and a full table degrades to the RPC
+ * path rather than growing.
+ */
+struct ShmMetadataCacheRoot {
+  /** Layout version. A client that does not recognize it must not attach --
+   *  the cache is derived state, so refusing is always safe. */
+  static constexpr clio::run::u32 kLayoutVersion = 1;
+
+  clio::run::u32 version_;
+  clio::run::u32 ready_;  /**< 0 until fully constructed; clients must check */
+  ShmTagIdMap tag_name_to_id_;
+  ShmTagInfoMap tag_id_to_info_;
+  ShmBlobInfoMap blob_key_to_info_;
+
+  ShmMetadataCacheRoot() : version_(0), ready_(0) {}
+};
+
+/**
+ * Build the "<tag_major>.<tag_minor>/<blob_name>" key used by the blob map.
+ *
+ * Written into a caller-provided buffer so the CLIENT never allocates: clients
+ * are readers, and allocating inside the runtime-owned segment is exactly what
+ * they must not do. Returns the length, or 0 if the buffer is too small.
+ */
+inline size_t MakeShmBlobKey(const clio::run::UniqueId &tag_id,
+                             const char *blob_name, size_t blob_name_len,
+                             char *out, size_t out_cap) {
+  auto write_u32 = [&](clio::run::u32 v, size_t &pos) -> bool {
+    char tmp[12];
+    int n = 0;
+    if (v == 0) {
+      tmp[n++] = '0';
+    }
+    while (v > 0) {
+      tmp[n++] = static_cast<char>('0' + (v % 10));
+      v /= 10;
+    }
+    if (pos + static_cast<size_t>(n) >= out_cap) {
+      return false;
+    }
+    for (int i = n - 1; i >= 0; --i) {
+      out[pos++] = tmp[i];
+    }
+    return true;
+  };
+
+  size_t pos = 0;
+  if (!write_u32(tag_id.major_, pos)) {
+    return 0;
+  }
+  if (pos + 1 >= out_cap) {
+    return 0;
+  }
+  out[pos++] = '.';
+  if (!write_u32(tag_id.minor_, pos)) {
+    return 0;
+  }
+  if (pos + 1 >= out_cap) {
+    return 0;
+  }
+  out[pos++] = '/';
+  if (pos + blob_name_len >= out_cap) {
+    return 0;
+  }
+  for (size_t i = 0; i < blob_name_len; ++i) {
+    out[pos++] = blob_name[i];
+  }
+  out[pos] = '\0';
+  return pos;
+}
+
+}  // namespace clio::cte::core
+
+#endif  // CLIO_CTE_CORE_SHM_METADATA_CACHE_H_

--- a/context-transfer-engine/core/include/clio_cte/core/shm_metadata_cache.h
+++ b/context-transfer-engine/core/include/clio_cte/core/shm_metadata_cache.h
@@ -262,7 +262,8 @@ class ShmMetadataCache {
    *         no metadata segment (small host, attach failure), or the
    *         allocation did not fit. Callers must not treat this as an error.
    */
-  bool Create(size_t tag_capacity, size_t blob_capacity) {
+  bool Create(size_t tag_capacity, size_t blob_capacity,
+              const clio::run::PoolId &owner_pool) {
     auto *ipc = CLIO_IPC;
     if (ipc == nullptr) {
       return false;
@@ -296,8 +297,11 @@ class ShmMetadataCache {
       // Publish in the segment directory so ANY client can find the cache,
       // not just one that happened to trigger pool creation. Registered after
       // ready_ for the same ordering reason.
+      // Register under THIS pool's id. CTE is multi-pool, so a single shared
+      // slot would let the most recently created pool hijack every client.
       if (auto *dir = ipc->GetMetadataDirectory()) {
-        dir->cte_cache_root_off_ = static_cast<clio::run::u64>(RootOffset());
+        dir->RegisterRoot(owner_pool.ToU64(),
+                          static_cast<clio::run::u64>(RootOffset()));
       }
       return true;
     } catch (...) {

--- a/context-transfer-engine/core/include/clio_cte/core/shm_metadata_cache.h
+++ b/context-transfer-engine/core/include/clio_cte/core/shm_metadata_cache.h
@@ -180,7 +180,13 @@ struct ShmMetadataCacheRoot {
 };
 
 /**
- * Build the "<tag_major>.<tag_minor>/<blob_name>" key used by the blob map.
+ * Build the blob-map key.
+ *
+ * Format is "<tag_major>.<tag_minor>.<blob_name>", matching the composite key
+ * the CTE runtime already builds for tag_blob_name_to_info_ EXACTLY. Using one
+ * convention rather than two is what makes the dual-write trivially
+ * consistent -- a second format would let the cache and the authoritative map
+ * disagree about which blob a key names.
  *
  * Written into a caller-provided buffer so the CLIENT never allocates: clients
  * are readers, and allocating inside the runtime-owned segment is exactly what
@@ -222,7 +228,7 @@ inline size_t MakeShmBlobKey(const clio::run::UniqueId &tag_id,
   if (pos + 1 >= out_cap) {
     return 0;
   }
-  out[pos++] = '/';
+  out[pos++] = '.';
   if (pos + blob_name_len >= out_cap) {
     return 0;
   }
@@ -232,6 +238,163 @@ inline size_t MakeShmBlobKey(const clio::run::UniqueId &tag_id,
   out[pos] = '\0';
   return pos;
 }
+
+/**
+ * Runtime-side owner of the shared-memory metadata cache (issue #783).
+ *
+ * ENTIRELY BEST-EFFORT. Every method is a no-op when the cache is disabled, and
+ * every failure is swallowed. That is deliberate: the cache is derived state,
+ * so the correct response to any problem is to stop caching, not to fail the
+ * operation the caller was actually performing. A metadata write must never be
+ * rejected because a cache mirror could not be updated.
+ *
+ * Not thread-safe on its own -- callers mirror under whatever synchronization
+ * already guards the authoritative structure.
+ */
+class ShmMetadataCache {
+ public:
+  ShmMetadataCache() = default;
+
+  /**
+   * Construct the cache in the runtime's metadata segment.
+   *
+   * @return true if the cache is live. false simply means caching is off:
+   *         no metadata segment (small host, attach failure), or the
+   *         allocation did not fit. Callers must not treat this as an error.
+   */
+  bool Create(size_t tag_capacity, size_t blob_capacity) {
+    auto *ipc = CLIO_IPC;
+    if (ipc == nullptr) {
+      return false;
+    }
+    alloc_ = ipc->GetMetadataAllocator();
+    if (alloc_ == nullptr) {
+      return false;  // segment unavailable -> caching disabled, not an error
+    }
+    try {
+      auto fp = alloc_->template Allocate<ShmMetadataCacheRoot>(
+          sizeof(ShmMetadataCacheRoot));
+      if (fp.IsNull()) {
+        alloc_ = nullptr;
+        return false;
+      }
+      root_ = fp.ptr_;
+      new (root_) ShmMetadataCacheRoot();
+      new (&root_->tag_name_to_id_) ShmTagIdMap(alloc_, tag_capacity);
+      new (&root_->tag_id_to_info_) ShmTagInfoMap(alloc_, tag_capacity);
+      new (&root_->blob_key_to_info_) ShmBlobInfoMap(alloc_, blob_capacity);
+      if (!root_->tag_name_to_id_.valid() || !root_->tag_id_to_info_.valid() ||
+          !root_->blob_key_to_info_.valid()) {
+        root_ = nullptr;
+        alloc_ = nullptr;
+        return false;
+      }
+      root_->version_ = ShmMetadataCacheRoot::kLayoutVersion;
+      // ready_ LAST: a client that observes ready_ == 1 must be guaranteed the
+      // maps behind it are fully constructed.
+      root_->ready_ = 1;
+      return true;
+    } catch (...) {
+      root_ = nullptr;
+      alloc_ = nullptr;
+      return false;
+    }
+  }
+
+  bool IsEnabled() const { return root_ != nullptr && alloc_ != nullptr; }
+
+  /** Byte offset of the root within the metadata allocator, which is what a
+   *  client needs in order to find the cache. Propagated via CreateTask in
+   *  Phase 4. */
+  size_t RootOffset() const {
+    if (!IsEnabled()) {
+      return 0;
+    }
+    return static_cast<size_t>(reinterpret_cast<const char *>(root_) -
+                               reinterpret_cast<const char *>(alloc_));
+  }
+
+  /** Mirror one blob. `composite_key` MUST be the same key the authoritative
+   *  map uses, so the two cannot disagree about identity. */
+  void PutBlob(const std::string &composite_key, const ShmBlobRecord &rec) {
+    if (!IsEnabled()) {
+      return;
+    }
+    try {
+      ShmBlobInfoMap::BytesProbe p{composite_key.data(), composite_key.size()};
+      root_->blob_key_to_info_.InsertOrAssign(
+          p,
+          ShmCacheString::HashBytes(composite_key.data(), composite_key.size()),
+          rec);
+      // A false return means the table is full. Nothing to do: the blob is
+      // simply not cached and clients take the RPC path for it.
+    } catch (...) {
+    }
+  }
+
+  void EraseBlob(const std::string &composite_key) {
+    if (!IsEnabled()) {
+      return;
+    }
+    try {
+      ShmBlobInfoMap::BytesProbe p{composite_key.data(), composite_key.size()};
+      root_->blob_key_to_info_.Erase(
+          p, ShmCacheString::HashBytes(composite_key.data(),
+                                       composite_key.size()));
+    } catch (...) {
+    }
+  }
+
+  void PutTagId(const std::string &tag_name, const clio::run::UniqueId &id) {
+    if (!IsEnabled()) {
+      return;
+    }
+    try {
+      ShmTagIdMap::BytesProbe p{tag_name.data(), tag_name.size()};
+      root_->tag_name_to_id_.InsertOrAssign(
+          p, ShmCacheString::HashBytes(tag_name.data(), tag_name.size()), id);
+    } catch (...) {
+    }
+  }
+
+  void EraseTagId(const std::string &tag_name) {
+    if (!IsEnabled()) {
+      return;
+    }
+    try {
+      ShmTagIdMap::BytesProbe p{tag_name.data(), tag_name.size()};
+      root_->tag_name_to_id_.Erase(
+          p, ShmCacheString::HashBytes(tag_name.data(), tag_name.size()));
+    } catch (...) {
+    }
+  }
+
+  void PutTagInfo(const clio::run::UniqueId &id, const ShmTagRecord &rec) {
+    if (!IsEnabled()) {
+      return;
+    }
+    try {
+      root_->tag_id_to_info_.InsertOrAssign(id, ShmTagInfoMap::Hash(id), rec);
+    } catch (...) {
+    }
+  }
+
+  void EraseTagInfo(const clio::run::UniqueId &id) {
+    if (!IsEnabled()) {
+      return;
+    }
+    try {
+      root_->tag_id_to_info_.Erase(id, ShmTagInfoMap::Hash(id));
+    } catch (...) {
+    }
+  }
+
+  ShmMetadataCacheRoot *root() { return root_; }
+
+ private:
+  ShmCacheAlloc *alloc_ = nullptr;
+  ShmMetadataCacheRoot *root_ = nullptr;
+};
 
 }  // namespace clio::cte::core
 

--- a/context-transfer-engine/core/include/clio_cte/core/shm_metadata_cache.h
+++ b/context-transfer-engine/core/include/clio_cte/core/shm_metadata_cache.h
@@ -293,6 +293,12 @@ class ShmMetadataCache {
       // ready_ LAST: a client that observes ready_ == 1 must be guaranteed the
       // maps behind it are fully constructed.
       root_->ready_ = 1;
+      // Publish in the segment directory so ANY client can find the cache,
+      // not just one that happened to trigger pool creation. Registered after
+      // ready_ for the same ordering reason.
+      if (auto *dir = ipc->GetMetadataDirectory()) {
+        dir->cte_cache_root_off_ = static_cast<clio::run::u64>(RootOffset());
+      }
       return true;
     } catch (...) {
       root_ = nullptr;

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -440,7 +440,7 @@ clio::run::TaskResume Runtime::Create(clio::run::shared_ptr<CreateTask> &task) {
   {
     static const size_t kShmTagCapacity = 64 * 1024;
     static const size_t kShmBlobCapacity = 256 * 1024;
-    if (shm_cache_.Create(kShmTagCapacity, kShmBlobCapacity)) {
+    if (shm_cache_.Create(kShmTagCapacity, kShmBlobCapacity, pool_id_)) {
       HLOG(kInfo,
            "CTE: shared-memory metadata cache enabled (tags={}, blobs={}, "
            "root_off={})",

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -438,8 +438,34 @@ clio::run::TaskResume Runtime::Create(clio::run::shared_ptr<CreateTask> &task) {
   // the RPC path rather than growing. Failure here is NOT an error: it just
   // means clients keep using RPC.
   {
-    static const size_t kShmTagCapacity = 64 * 1024;
-    static const size_t kShmBlobCapacity = 256 * 1024;
+    // Capacity is PERMANENT: the SHM maps never rehash (a rehash would free a
+    // table out from under untracked cross-process readers), so this is the
+    // one chance to size them. Entries beyond capacity are simply not cached
+    // and those blobs keep using the RPC path.
+    //
+    // COST IS RESIDENT, NOT SPARSE. Every slot is constructed at creation, so
+    // capacity is paid in RAM immediately: ~376 B per blob slot and ~80 B per
+    // tag slot. The defaults below are ~100 MB of blob table. Raise them for
+    // large deployments -- 1M blobs wants ~2M slots (~0.79 GB) since the load
+    // factor caps useful occupancy at 7/8.
+    size_t tag_capacity = 64 * 1024;
+    size_t blob_capacity = 256 * 1024;
+    if (const char *env = clio::run::env::GetCompat("CTE_SHM_TAG_CAPACITY")) {
+      char *end = nullptr;
+      unsigned long long v = std::strtoull(env, &end, 10);
+      if (end != env && v > 0) {
+        tag_capacity = static_cast<size_t>(v);
+      }
+    }
+    if (const char *env = clio::run::env::GetCompat("CTE_SHM_BLOB_CAPACITY")) {
+      char *end = nullptr;
+      unsigned long long v = std::strtoull(env, &end, 10);
+      if (end != env && v > 0) {
+        blob_capacity = static_cast<size_t>(v);
+      }
+    }
+    const size_t kShmTagCapacity = tag_capacity;
+    const size_t kShmBlobCapacity = blob_capacity;
     if (shm_cache_.Create(kShmTagCapacity, kShmBlobCapacity, pool_id_)) {
       HLOG(kInfo,
            "CTE: shared-memory metadata cache enabled (tags={}, blobs={}, "

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -633,6 +633,14 @@ clio::run::TaskResume Runtime::Create(clio::run::shared_ptr<CreateTask> &task) {
   out_params.gpu_cache_ptr_ =
       GpuCacheCreate() ? reinterpret_cast<clio::run::u64>(gpu_cache_)
                        : static_cast<clio::run::u64>(0);
+  // issue #783: hand the client the offset of the SHM metadata cache root.
+  // An OFFSET, not a pointer -- the client maps the same segment at a
+  // different base address, so only a segment-relative value survives the
+  // trip. 0 means caching is off and the client stays on the RPC path.
+  out_params.shm_cache_root_off_ =
+      shm_cache_.IsEnabled()
+          ? static_cast<clio::run::u64>(shm_cache_.RootOffset())
+          : static_cast<clio::run::u64>(0);
   clio::run::Task::Serialize(CLIO_PRIV_ALLOC, task->chimod_params_, out_params);
 
   CLIO_CO_RETURN;
@@ -1620,6 +1628,17 @@ clio::run::TaskResume Runtime::PutBlobImpl(clio::run::shared_ptr<TaskT> &task) {
     LogTelemetry(CteOp::kPutBlob, offset, size, tag_id, now,
                  blob_info_ptr->last_read_);
     GpuCacheOnPutBlob(tag_id, blob_name, *blob_info_ptr);
+    // issue #783: mirror into the SHM cache HERE, at the successful end of the
+    // put -- not when the BlobInfo is first inserted into the map. At insert
+    // time the blob is still empty (blocks and total_size_cache_ are filled in
+    // later by ExtendBlob), so mirroring there published size 0 and a client
+    // reading its own write got the wrong answer. Caught by the
+    // write-then-read test.
+    {
+      std::string shm_key = std::to_string(tag_id.major_) + "." +
+                            std::to_string(tag_id.minor_) + "." + blob_name;
+      MirrorBlobToShm(shm_key, *blob_info_ptr);
+    }
     task->return_code_ = 0;
   } catch (const std::exception &e) {
     HLOG(kError, "PutBlob failed with exception: {}", e.what());
@@ -3962,7 +3981,10 @@ std::shared_ptr<BlobInfo> Runtime::CreateNewBlob(const std::string &blob_name,
   }  // Release lock immediately after insertion
   // issue #783: mirror into the SHM cache. Best-effort and AFTER the
   // authoritative insert, so the cache can only ever lag, never lead.
-  MirrorBlobToShm(composite_key, *new_blob_info);
+  // NOTE: deliberately NOT mirrored here. The blob has no blocks and no size
+  // yet; publishing it now would let a client read a zero-sized record for a
+  // blob that is mid-write. The mirror happens at the end of PutBlobImpl,
+  // once the content is actually there.
 
   // WAL: log blob creation
   if (!blob_txn_logs_.empty()) {

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -319,6 +319,13 @@ bool Runtime::BuildShmBlobRecord(const BlobInfo &info, ShmBlobRecord *out) {
     n = kMaxInlineBlocks;
   }
   out->num_blocks_ = static_cast<clio::run::u32>(n);
+
+  // A payload may only be read directly out of shared memory when EVERY block
+  // is node-local and RAM-backed. This starts true and is cleared by the first
+  // block that fails to qualify -- the default must be "refuse", so an
+  // unknown target can never be mistaken for a readable one.
+  bool all_direct = (n > 0) && ((out->flags_ & kShmBlobTruncated) == 0);
+
   for (size_t i = 0; i < n; ++i) {
     const BlobBlock &b = info.blocks_[i];
     ShmBlockDesc &d = out->blocks_[i];
@@ -329,13 +336,28 @@ bool Runtime::BuildShmBlobRecord(const BlobInfo &info, ShmBlobRecord *out) {
     d.size_ = b.size_;
     d.bdev_type_ = 0;
     d.node_id_ = 0;
+
+    TargetInfo *tinfo = registered_targets_.find(d.target_pool_);
+    if (tinfo == nullptr) {
+      // Unknown target: record nothing and refuse direct reads.
+      all_direct = false;
+      continue;
+    }
+    d.bdev_type_ = static_cast<clio::run::u32>(tinfo->bdev_type_);
+    const bool is_ram = (tinfo->bdev_type_ == clio::run::bdev::BdevType::kRam);
+    const bool is_local = tinfo->target_query_.IsLocalMode();
+    if (!is_ram || !is_local) {
+      // kPinned/kHbm are excluded deliberately: their pages come from GPU
+      // allocators and are not SHM-backed, so their offsets are meaningless
+      // to a client. Remote targets are excluded because the bytes are not on
+      // this node at all.
+      all_direct = false;
+    }
   }
 
-  // NOTE: kShmBlobDirectReadable is intentionally NOT set yet. Proving a block
-  // is node-local AND RAM-backed requires the target registry, and the RAM
-  // bdev is not SHM-backed until Phase 6. Until then the cache serves METADATA
-  // only and every payload read still goes through RPC -- which is the safe
-  // direction to be wrong in.
+  if (all_direct) {
+    out->flags_ |= kShmBlobDirectReadable;
+  }
   return true;
 }
 

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -296,6 +296,61 @@ void Runtime::FixupAfterCopy(clio::run::u32 method,
   }
 }
 
+// ===========================================================================
+// issue #783: projection of the authoritative BlobInfo into its shared-memory
+// cache record. Deliberately lossy -- the cache stores only what a client
+// needs to answer a read, in a form that is POD and bounded.
+// ===========================================================================
+bool Runtime::BuildShmBlobRecord(const BlobInfo &info, ShmBlobRecord *out) {
+  if (out == nullptr) {
+    return false;
+  }
+  *out = ShmBlobRecord();
+  out->total_size_ = info.total_size_cache_;
+  out->last_modified_ = info.last_modified_;
+  out->last_read_ = info.last_read_;
+  out->score_ = info.score_;
+
+  size_t n = info.blocks_.size();
+  if (n > kMaxInlineBlocks) {
+    // Too many blocks to represent. Cache the metadata but mark it truncated
+    // so no client ever tries a payload read from a partial block list.
+    out->flags_ |= kShmBlobTruncated;
+    n = kMaxInlineBlocks;
+  }
+  out->num_blocks_ = static_cast<clio::run::u32>(n);
+  for (size_t i = 0; i < n; ++i) {
+    const BlobBlock &b = info.blocks_[i];
+    ShmBlockDesc &d = out->blocks_[i];
+    // Only the POD identity of the target is copied. The bdev::Client in
+    // BlobBlock carries a vtable pointer and must never enter shared memory.
+    d.target_pool_ = b.bdev_client_.pool_id_;
+    d.target_offset_ = b.target_offset_;
+    d.size_ = b.size_;
+    d.bdev_type_ = 0;
+    d.node_id_ = 0;
+  }
+
+  // NOTE: kShmBlobDirectReadable is intentionally NOT set yet. Proving a block
+  // is node-local AND RAM-backed requires the target registry, and the RAM
+  // bdev is not SHM-backed until Phase 6. Until then the cache serves METADATA
+  // only and every payload read still goes through RPC -- which is the safe
+  // direction to be wrong in.
+  return true;
+}
+
+void Runtime::MirrorBlobToShm(const std::string &composite_key,
+                              const BlobInfo &info) {
+  if (!shm_cache_.IsEnabled()) {
+    return;
+  }
+  ShmBlobRecord rec;
+  if (!BuildShmBlobRecord(info, &rec)) {
+    return;
+  }
+  shm_cache_.PutBlob(composite_key, rec);
+}
+
 clio::run::TaskResume Runtime::Create(clio::run::shared_ptr<CreateTask> &task) {
   CLIO_TASK_BODY_BEGIN
   // Initialize unordered_map_ll instances with appropriately sized bucket
@@ -355,6 +410,26 @@ clio::run::TaskResume Runtime::Create(clio::run::shared_ptr<CreateTask> &task) {
 
   // Build the DPE once from config so ExtendBlob does not pay a heap alloc
   // (and the per-call vtable construction) on every PutBlob.
+  // issue #783: bring up the shared-memory metadata mirror. Sized once and
+  // permanently -- the SHM maps never rehash (a rehash would free a table out
+  // from under untracked cross-process readers), so a full table degrades to
+  // the RPC path rather than growing. Failure here is NOT an error: it just
+  // means clients keep using RPC.
+  {
+    static const size_t kShmTagCapacity = 64 * 1024;
+    static const size_t kShmBlobCapacity = 256 * 1024;
+    if (shm_cache_.Create(kShmTagCapacity, kShmBlobCapacity)) {
+      HLOG(kInfo,
+           "CTE: shared-memory metadata cache enabled (tags={}, blobs={}, "
+           "root_off={})",
+           kShmTagCapacity, kShmBlobCapacity, shm_cache_.RootOffset());
+    } else {
+      HLOG(kInfo,
+           "CTE: shared-memory metadata cache disabled (no metadata segment) "
+           "-- clients will use the RPC path");
+    }
+  }
+
   dpe_ = DpeFactory::CreateDpe(config_.dpe_.dpe_type_);
 
   // Store storage configuration in runtime
@@ -2087,6 +2162,9 @@ clio::run::TaskResume Runtime::DelBlob(clio::run::shared_ptr<DelBlobTask> &task)
                                  std::to_string(tag_id.minor_) + "." +
                                  blob_name;
       tag_blob_name_to_info_.erase(compound_key);
+      // Mirror the erase too. A stale cache entry for a deleted blob is worse
+      // than a miss: a client would read metadata for something gone.
+      shm_cache_.EraseBlob(compound_key);
     }
 
     // Step 6: Log telemetry for DelBlob operation
@@ -2697,6 +2775,7 @@ clio::run::TaskResume Runtime::DelTag(clio::run::shared_ptr<DelTagTask> &task) {
           }, ctp::priv::ForEachLock::kShared);
       for (const auto &key : keys_to_erase) {
         tag_blob_name_to_info_.erase(key);
+        shm_cache_.EraseBlob(key);  // issue #783: keep the mirror from going stale
       }
     }
 
@@ -3035,6 +3114,18 @@ TagId Runtime::GetOrAssignTagId(const std::string &tag_name,
   // Store mappings
   tag_name_to_id_.insert_or_assign(tag_name, tag_id);
   tag_id_to_info_.insert_or_assign(tag_id, std::make_shared<TagInfo>(tag_info));
+
+  // issue #783: mirror into the SHM cache, after the authoritative insert so
+  // the cache can only lag, never lead.
+  if (shm_cache_.IsEnabled()) {
+    shm_cache_.PutTagId(tag_name, tag_id);
+    ShmTagRecord trec;
+    trec.total_size_ = tag_info.total_size_;
+    trec.last_modified_ = tag_info.last_modified_;
+    trec.last_read_ = tag_info.last_read_;
+    trec.last_changed_ = tag_info.last_changed_;
+    shm_cache_.PutTagInfo(tag_id, trec);
+  }
 
   // Index the new tag's ABSOLUTE name for regex TagQuery (#598). The parent
   // chain is already created (GetOrCreateTagChain builds parents first), so
@@ -3575,6 +3666,7 @@ void Runtime::RestoreMetadataFromLog() {
       }
 
       tag_blob_name_to_info_.insert_or_assign(composite_key, std::make_shared<BlobInfo>(blob_info));
+      MirrorBlobToShm(composite_key, blob_info);
       blobs_restored++;
 
     } else {
@@ -3641,6 +3733,7 @@ void Runtime::ReplayTransactionLogs() {
             });
         for (const auto &key : keys_to_erase) {
           tag_blob_name_to_info_.erase(key);
+          shm_cache_.EraseBlob(key);  // issue #783: keep the mirror from going stale
         }
         tag_id_to_info_.erase(tag_id);
         tags_replayed++;
@@ -3669,6 +3762,7 @@ void Runtime::ReplayTransactionLogs() {
         blob_info.blob_name_ = txn.blob_name_;
         blob_info.score_ = txn.score_;
         tag_blob_name_to_info_.insert_or_assign(composite_key, std::make_shared<BlobInfo>(blob_info));
+        MirrorBlobToShm(composite_key, blob_info);
         blobs_replayed++;
 
       } else if (type == TxnType::kExtendBlob) {
@@ -3866,6 +3960,9 @@ std::shared_ptr<BlobInfo> Runtime::CreateNewBlob(const std::string &blob_name,
   {
     tag_blob_name_to_info_.insert_or_assign(composite_key, new_blob_info);
   }  // Release lock immediately after insertion
+  // issue #783: mirror into the SHM cache. Best-effort and AFTER the
+  // authoritative insert, so the cache can only ever lag, never lead.
+  MirrorBlobToShm(composite_key, *new_blob_info);
 
   // WAL: log blob creation
   if (!blob_txn_logs_.empty()) {

--- a/context-transfer-engine/core/src/tag.cc
+++ b/context-transfer-engine/core/src/tag.cc
@@ -239,6 +239,18 @@ float Tag::GetBlobScore(const std::string &blob_name) {
 
 clio::run::u64 Tag::GetBlobSize(const std::string &blob_name) {
   auto *cte_client = CLIO_CTE_CLIENT;
+
+  // issue #783 fast path: answer from the shared-memory metadata cache with
+  // ZERO IPC when the blob is cached. A miss (or an inconsistent read) simply
+  // falls through to the RPC below -- the cache is never treated as
+  // authoritative, and "not cached" must never be reported as "size 0".
+  if (cte_client->HasShmCache()) {
+    ShmBlobRecord rec;
+    if (cte_client->TryGetBlobRecordShm(tag_id_, blob_name, &rec)) {
+      return rec.total_size_;
+    }
+  }
+
   auto task = cte_client->AsyncGetBlobSize(tag_id_, blob_name);
   task.Wait();
 

--- a/context-transfer-engine/core/src/tag.cc
+++ b/context-transfer-engine/core/src/tag.cc
@@ -185,6 +185,19 @@ void Tag::GetBlob(const std::string &blob_name, char *data, size_t data_size, si
     throw std::invalid_argument("data buffer must be pre-allocated by caller");
   }
 
+  // issue #783 fast path: for a node-local RAM-resident blob, copy the bytes
+  // straight out of shared memory -- no IPC, no staging buffer, no allocation.
+  // Any failure (not cached, not direct-readable, placement moved mid-copy)
+  // falls through to the RPC path below, so this can only ever be faster or
+  // equivalent, never wrong.
+  {
+    auto *cte_client = CLIO_CTE_CLIENT;
+    if (cte_client->HasShmCache() &&
+        cte_client->TryReadBlobShm(tag_id_, blob_name, data, data_size, off)) {
+      return;
+    }
+  }
+
   // Allocate shared memory for the data
   auto *ipc_manager = CLIO_IPC;
   ctp::ipc::FullPtr<char> shm_fullptr = ipc_manager->AllocateBuffer(data_size);

--- a/context-transfer-engine/test/integration/grayscott_congestion/docker-compose.override.yml
+++ b/context-transfer-engine/test/integration/grayscott_congestion/docker-compose.override.yml
@@ -1,0 +1,34 @@
+# LOCAL-ONLY override (untracked). DooD/Docker-Desktop; repo at /host_mnt/c/...;
+# CPU binaries in build-boost overlaid onto /workspace/build.
+#
+# This box's Docker VM has only ~12GB RAM. The base compose puts a 6GB *file*
+# bdev on /mnt which is TMPFS (RAM) -> 2 nodes x 6GB = 100% of host RAM -> the
+# OOM-killer SIGKILLs a runtime, and the surviving node hangs on the dead peer.
+# That's a host-undersizing artifact, not a Clio bug. To isolate any GENUINE
+# hang/crash, move the bdev onto a disk-backed named volume (like real Delta),
+# so bdev bytes don't consume RAM. `!reset` clears the base tmpfs mount.
+#
+# Still: CTP_LOG_LEVEL=fatal (fast, so races still trip) + LD_PRELOAD crash shim.
+services:
+  gs-node1:
+    cap_add: [SYS_PTRACE]
+    tmpfs: !reset null
+    environment:
+      - CTP_LOG_LEVEL=fatal
+      - LD_PRELOAD=/workspace/gs_hang_capture/segv_backtrace.so
+    volumes:
+      - /host_mnt/c/Users/llogan/Documents/Projects/core/build-boost:/workspace/build
+      - gs_mnt1:/mnt
+  gs-node2:
+    cap_add: [SYS_PTRACE]
+    tmpfs: !reset null
+    environment:
+      - CTP_LOG_LEVEL=fatal
+      - LD_PRELOAD=/workspace/gs_hang_capture/segv_backtrace.so
+    volumes:
+      - /host_mnt/c/Users/llogan/Documents/Projects/core/build-boost:/workspace/build
+      - gs_mnt2:/mnt
+
+volumes:
+  gs_mnt1:
+  gs_mnt2:

--- a/context-transfer-engine/test/unit/CMakeLists.txt
+++ b/context-transfer-engine/test/unit/CMakeLists.txt
@@ -1101,6 +1101,29 @@ set_tests_properties(
 # ------------------------------------------------------------------------------
 # GPU metadata cache unit tests — pure POD header, CPU-testable
 # ------------------------------------------------------------------------------
+add_executable(test_cte_shm_metadata_cache
+    test_cte_shm_metadata_cache.cc
+)
+
+target_link_libraries(test_cte_shm_metadata_cache
+    clio_cte_core_runtime
+    clio_cte_core_client
+    clio::run::admin_runtime
+    clio::run::admin_client
+    clio::run::bdev_runtime
+    clio::run::bdev_client
+    ctp::cxx
+    ${CMAKE_THREAD_LIBS_INIT}
+)
+
+add_test(NAME cte_shm_metadata_cache_all
+    COMMAND test_cte_shm_metadata_cache)
+
+set_tests_properties(
+    cte_shm_metadata_cache_all
+    PROPERTIES TIMEOUT 120
+)
+
 add_executable(test_cte_gpu_metadata_cache
     test_cte_gpu_metadata_cache.cc
 )

--- a/context-transfer-engine/test/unit/test_core_functionality.cc
+++ b/context-transfer-engine/test/unit/test_core_functionality.cc
@@ -2885,5 +2885,170 @@ TEST_CASE("CTE SHM cache direct payload read",
   }
 }
 
+/**
+ * issue #783: WRITE-THEN-READ cycle latency.
+ *
+ * The earlier benchmarks timed reads in steady state, with no interleaved
+ * writes. That flatters the cache: it measures the read in isolation, not the
+ * pattern a real caller actually performs.
+ *
+ * This measures the full cycle -- PutBlob (waited), then read the value back --
+ * with the read served three ways. Writes are NOT accelerated by #783 (they
+ * still go through the runtime), so the cycle is expected to be dominated by
+ * the write, and the read saving is only the fraction Amdahl allows.
+ */
+TEST_CASE("CTE SHM cache write-then-read cycle benchmark",
+          "[cte][core][shm_cache][bench][wtr]") {
+  auto *fixture = ctp::Singleton<CTECoreFunctionalTestFixture>::GetInstance();
+  clio::run::PoolQuery pool_query = clio::run::PoolQuery::Dynamic();
+  clio::cte::core::CreateParams params;
+
+  // Own pool with a RAM target only, so payload reads are direct-readable.
+  clio::run::PoolId wtr_pool(7802, 0);
+  clio::cte::core::Client client(wtr_pool);
+  {
+    auto t = client.AsyncCreate(pool_query, "cte_shm_wtr_pool", wtr_pool, params);
+    t.Wait();
+    client.AttachShmCache(*t);
+  }
+  {
+    auto t = client.AsyncRegisterTarget(
+        "ram_wtr_target", clio::run::bdev::BdevType::kRam,
+        64ULL * 1024 * 1024, clio::run::PoolQuery::Local(),
+        clio::run::PoolId(672, 0));
+    t.Wait();
+    REQUIRE(t->GetReturnCode() == 0);
+  }
+  if (!client.HasShmCache()) {
+    HLOG(kWarning, "[#783] SHM cache unavailable -- W-T-R benchmark SKIPPED");
+    return;
+  }
+
+  clio::cte::core::TagId tag_id;
+  {
+    auto t = client.AsyncGetOrCreateTag("shm_wtr_tag");
+    t.Wait();
+    tag_id = t->tag_id_;
+  }
+  REQUIRE(!tag_id.IsNull());
+
+  const std::string blob_name = "wtr_blob";
+  const clio::run::u64 kSize = 4096;
+  const int kIters = 300;
+  auto data = fixture->CreateTestData(kSize, 'W');
+
+  // Reusable SHM buffer for the write side.
+  auto wbuf = CLIO_IPC->AllocateBuffer(kSize);
+  REQUIRE(!wbuf.IsNull());
+  REQUIRE(fixture->CopyToSharedMemory(wbuf, data));
+
+  auto do_write = [&]() {
+    auto t = client.AsyncPutBlob(tag_id, blob_name, 0, kSize,
+                                 wbuf.shm_.template Cast<void>(), 0.9f,
+                                 clio::cte::core::Context(), 0);
+    t.Wait();
+    return t->return_code_;
+  };
+
+  // Warm up so first-touch page faults, block-allocator growth and lazy
+  // attach do not land in a measured window. A single warmup write was NOT
+  // enough: the first timed loop absorbed one-time cost and reported a
+  // "write-alone" floor HIGHER than the full write+read cycle measured later,
+  // which is impossible and gave the ordering away.
+  for (int i = 0; i < 50; ++i) {
+    REQUIRE(do_write() == 0);
+  }
+  {
+    clio::cte::core::ShmBlobRecord r;
+    (void)client.TryGetBlobRecordShm(tag_id, blob_name, &r);
+    std::vector<char> tmp(kSize);
+    (void)client.TryReadBlobShm(tag_id, blob_name, tmp.data(), kSize);
+  }
+
+  // ---- (1) write alone: the floor the cycle cannot go below ----
+  auto w0 = std::chrono::steady_clock::now();
+  for (int i = 0; i < kIters; ++i) {
+    REQUIRE(do_write() == 0);
+  }
+  double write_us = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                        std::chrono::steady_clock::now() - w0).count() /
+                    1000.0 / kIters;
+
+  // ---- (2) cycle: write + SHM metadata read ----
+  clio::run::u64 sink = 0;
+  auto a0 = std::chrono::steady_clock::now();
+  for (int i = 0; i < kIters; ++i) {
+    REQUIRE(do_write() == 0);
+    clio::cte::core::ShmBlobRecord rec;
+    REQUIRE(client.TryGetBlobRecordShm(tag_id, blob_name, &rec));
+    sink += rec.total_size_;
+  }
+  double cycle_shm_meta_us =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(
+          std::chrono::steady_clock::now() - a0).count() / 1000.0 / kIters;
+
+  // ---- (3) cycle: write + RPC metadata read ----
+  auto b0 = std::chrono::steady_clock::now();
+  for (int i = 0; i < kIters; ++i) {
+    REQUIRE(do_write() == 0);
+    auto g = client.AsyncGetBlobSize(tag_id, blob_name);
+    g.Wait();
+    sink += g->size_;
+  }
+  double cycle_rpc_meta_us =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(
+          std::chrono::steady_clock::now() - b0).count() / 1000.0 / kIters;
+
+  // ---- (4) cycle: write + SHM payload read ----
+  std::vector<char> rbuf(kSize);
+  auto c0 = std::chrono::steady_clock::now();
+  for (int i = 0; i < kIters; ++i) {
+    REQUIRE(do_write() == 0);
+    REQUIRE(client.TryReadBlobShm(tag_id, blob_name, rbuf.data(), kSize));
+  }
+  double cycle_shm_data_us =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(
+          std::chrono::steady_clock::now() - c0).count() / 1000.0 / kIters;
+
+  // ---- (5) cycle: write + RPC payload read ----
+  auto rd = CLIO_IPC->AllocateBuffer(kSize);
+  REQUIRE(!rd.IsNull());
+  auto d0 = std::chrono::steady_clock::now();
+  for (int i = 0; i < kIters; ++i) {
+    REQUIRE(do_write() == 0);
+    auto g = client.AsyncGetBlob(tag_id, blob_name.c_str(), 0, kSize, 0,
+                                 rd.shm_.template Cast<void>());
+    g.Wait();
+  }
+  double cycle_rpc_data_us =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(
+          std::chrono::steady_clock::now() - d0).count() / 1000.0 / kIters;
+  CLIO_IPC->FreeBuffer(rd);
+
+  // ---- (6) write alone AGAIN, last. If this disagrees with (1) the numbers
+  // carry an ordering artifact and must not be quoted as a clean floor.
+  auto e0 = std::chrono::steady_clock::now();
+  for (int i = 0; i < kIters; ++i) {
+    REQUIRE(do_write() == 0);
+  }
+  double write_us_last = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                             std::chrono::steady_clock::now() - e0).count() /
+                         1000.0 / kIters;
+  CLIO_IPC->FreeBuffer(wbuf);
+
+  HLOG(kWarning,
+       "[#783 WTR] write-alone first={} us last={} us | metadata cycle: SHM {} "
+       "vs RPC {} us | payload cycle: SHM {} vs RPC {} us | iters={} size={} "
+       "(sink={})",
+       write_us, write_us_last, cycle_shm_meta_us, cycle_rpc_meta_us,
+       cycle_shm_data_us, cycle_rpc_data_us, kIters, kSize, sink);
+
+  // The cycle can never beat the write floor, and the SHM variants must not be
+  // slower than the RPC ones. Loose bounds: this is a measurement, not a gate.
+  REQUIRE(cycle_shm_meta_us >= std::min(write_us, write_us_last) * 0.5);
+  REQUIRE(cycle_shm_meta_us < cycle_rpc_meta_us);
+  REQUIRE(cycle_shm_data_us < cycle_rpc_data_us);
+}
+
 // Main function using simple_test.h framework
 SIMPLE_TEST_MAIN()

--- a/context-transfer-engine/test/unit/test_core_functionality.cc
+++ b/context-transfer-engine/test/unit/test_core_functionality.cc
@@ -2626,7 +2626,7 @@ TEST_CASE("CTE SHM cache write-then-read",
  * the RPC answer would make the benchmark meaningless.
  */
 TEST_CASE("CTE SHM cache metadata read benchmark",
-          "[cte][core][shm_cache][bench]") {
+          "[cte][core][shm_cache][bench][noleak]") {
   auto *fixture = ctp::Singleton<CTECoreFunctionalTestFixture>::GetInstance();
   clio::run::PoolQuery pool_query = clio::run::PoolQuery::Dynamic();
   clio::cte::core::CreateParams params;
@@ -2736,7 +2736,7 @@ TEST_CASE("CTE SHM cache metadata read benchmark",
  * worse than no fast path, so correctness is asserted before speed.
  */
 TEST_CASE("CTE SHM cache direct payload read",
-          "[cte][core][shm_cache][payload]") {
+          "[cte][core][shm_cache][payload][noleak]") {
   auto *fixture = ctp::Singleton<CTECoreFunctionalTestFixture>::GetInstance();
   clio::run::PoolQuery pool_query = clio::run::PoolQuery::Dynamic();
   clio::cte::core::CreateParams params;
@@ -2898,7 +2898,7 @@ TEST_CASE("CTE SHM cache direct payload read",
  * the write, and the read saving is only the fraction Amdahl allows.
  */
 TEST_CASE("CTE SHM cache write-then-read cycle benchmark",
-          "[cte][core][shm_cache][bench][wtr]") {
+          "[cte][core][shm_cache][bench][wtr][noleak]") {
   auto *fixture = ctp::Singleton<CTECoreFunctionalTestFixture>::GetInstance();
   clio::run::PoolQuery pool_query = clio::run::PoolQuery::Dynamic();
   clio::cte::core::CreateParams params;

--- a/context-transfer-engine/test/unit/test_core_functionality.cc
+++ b/context-transfer-engine/test/unit/test_core_functionality.cc
@@ -2727,5 +2727,163 @@ TEST_CASE("CTE SHM cache metadata read benchmark",
   REQUIRE(shm_us < rpc_us / 5.0);
 }
 
+/**
+ * issue #783 phase 6: ZERO-IPC PAYLOAD read from a RAM bdev.
+ *
+ * Registers a kRam target so blobs land in shared memory, then reads the bytes
+ * back directly and checks them against both the known pattern and the
+ * authoritative RPC read. A fast path that returns the wrong bytes is far
+ * worse than no fast path, so correctness is asserted before speed.
+ */
+TEST_CASE("CTE SHM cache direct payload read",
+          "[cte][core][shm_cache][payload]") {
+  auto *fixture = ctp::Singleton<CTECoreFunctionalTestFixture>::GetInstance();
+  clio::run::PoolQuery pool_query = clio::run::PoolQuery::Dynamic();
+  clio::cte::core::CreateParams params;
+
+  // ISOLATED CTE pool with a RAM target as its ONLY target. The shared fixture
+  // pool accumulates file targets from earlier tests, and the DPE then places
+  // blobs there -- which correctly yields a non-direct-readable blob and makes
+  // this test unable to exercise the payload path at all.
+  clio::run::PoolId payload_pool(7801, 0);
+  clio::cte::core::Client client(payload_pool);
+  {
+    auto t = client.AsyncCreate(pool_query, "cte_shm_payload_pool",
+                                payload_pool, params);
+    t.Wait();
+    client.AttachShmCache(*t);
+  }
+
+  // A RAM target -- this is what makes the payload SHM-resident.
+  {
+    auto t = client.AsyncRegisterTarget(
+        "ram_direct_target", clio::run::bdev::BdevType::kRam,
+        64ULL * 1024 * 1024, clio::run::PoolQuery::Local(),
+        clio::run::PoolId(671, 0));
+    t.Wait();
+    REQUIRE(t->GetReturnCode() == 0);
+  }
+
+  if (!client.HasShmCache()) {
+    HLOG(kWarning,
+         "[#783] SHM cache unavailable -- payload test SKIPPED (proves "
+         "nothing on this host)");
+    return;
+  }
+
+  clio::cte::core::TagId tag_id;
+  {
+    auto t = client.AsyncGetOrCreateTag("shm_payload_tag");
+    t.Wait();
+    tag_id = t->tag_id_;
+  }
+  REQUIRE(!tag_id.IsNull());
+
+  const std::string blob_name = "direct_read_blob";
+  const clio::run::u64 blob_size = 4096;
+  auto test_data = fixture->CreateTestData(blob_size, 'D');
+
+  auto fp = CLIO_IPC->AllocateBuffer(blob_size);
+  REQUIRE(!fp.IsNull());
+  REQUIRE(fixture->CopyToSharedMemory(fp, test_data));
+  auto put = client.AsyncPutBlob(
+      tag_id, blob_name, 0, blob_size, fp.shm_.template Cast<void>(), 0.9f,
+      clio::cte::core::Context(), 0);
+  REQUIRE(!put.IsNull());
+  REQUIRE(fixture->WaitForTaskCompletion(put, 10000));
+  REQUIRE(put->return_code_ == 0);
+  CLIO_IPC->FreeBuffer(fp);
+
+  clio::cte::core::ShmBlobRecord rec;
+  REQUIRE(client.TryGetBlobRecordShm(tag_id, blob_name, &rec));
+
+  if (!rec.IsDirectReadable()) {
+    // The DPE may have placed this blob on a non-RAM target. Not a failure of
+    // the mechanism, but say so -- silently passing would hide a regression
+    // that turned direct-readability off for everything.
+    HLOG(kWarning,
+         "[#783] blob not direct-readable (flags={}, blocks={}) -- payload "
+         "assertions SKIPPED",
+         rec.flags_, rec.num_blocks_);
+    return;
+  }
+
+  SECTION("Direct read returns the correct bytes") {
+    std::vector<char> got(blob_size, 0);
+    REQUIRE(client.TryReadBlobShm(tag_id, blob_name, got.data(),
+                                                  blob_size));
+    REQUIRE(std::memcmp(got.data(), test_data.data(), blob_size) == 0);
+  }
+
+  SECTION("Direct read agrees with the authoritative RPC read") {
+    std::vector<char> direct(blob_size, 0);
+    REQUIRE(client.TryReadBlobShm(
+        tag_id, blob_name, direct.data(), blob_size));
+
+    auto rd = CLIO_IPC->AllocateBuffer(blob_size);
+    REQUIRE(!rd.IsNull());
+    auto get = client.AsyncGetBlob(
+        tag_id, blob_name.c_str(), 0, blob_size, 0,
+        rd.shm_.template Cast<void>());
+    REQUIRE(!get.IsNull());
+    REQUIRE(fixture->WaitForTaskCompletion(get, 10000));
+    REQUIRE(get->return_code_ == 0);
+    REQUIRE(std::memcmp(direct.data(), rd.ptr_, blob_size) == 0);
+    CLIO_IPC->FreeBuffer(rd);
+  }
+
+  SECTION("Partial read at an offset") {
+    const size_t off = 1024, len = 512;
+    std::vector<char> got(len, 0);
+    REQUIRE(client.TryReadBlobShm(tag_id, blob_name, got.data(),
+                                                  len, off));
+    REQUIRE(std::memcmp(got.data(), test_data.data() + off, len) == 0);
+  }
+
+  SECTION("Out-of-range read is refused, not truncated") {
+    std::vector<char> got(blob_size, 0);
+    REQUIRE_FALSE(client.TryReadBlobShm(
+        tag_id, blob_name, got.data(), blob_size, blob_size / 2));
+  }
+
+  SECTION("Payload benchmark: direct vs RPC") {
+    const int kIters = 2000;
+    std::vector<char> buf(blob_size, 0);
+    auto t0 = std::chrono::steady_clock::now();
+    int hits = 0;
+    for (int i = 0; i < kIters; ++i) {
+      if (client.TryReadBlobShm(tag_id, blob_name, buf.data(),
+                                                blob_size)) {
+        ++hits;
+      }
+    }
+    auto shm_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                      std::chrono::steady_clock::now() - t0).count();
+    REQUIRE(hits == kIters);
+
+    const int kRpcIters = 200;
+    auto rd = CLIO_IPC->AllocateBuffer(blob_size);
+    REQUIRE(!rd.IsNull());
+    auto t1 = std::chrono::steady_clock::now();
+    for (int i = 0; i < kRpcIters; ++i) {
+      auto g = client.AsyncGetBlob(
+          tag_id, blob_name.c_str(), 0, blob_size, 0,
+          rd.shm_.template Cast<void>());
+      g.Wait();
+    }
+    auto rpc_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                      std::chrono::steady_clock::now() - t1).count();
+    CLIO_IPC->FreeBuffer(rd);
+
+    double shm_us = static_cast<double>(shm_ns) / 1000.0 / kIters;
+    double rpc_us = static_cast<double>(rpc_ns) / 1000.0 / kRpcIters;
+    HLOG(kWarning,
+         "[#783 BENCH] PAYLOAD read {} bytes: SHM {} us/op vs RPC {} us/op -- "
+         "speedup {}x",
+         blob_size, shm_us, rpc_us, (rpc_us > 0 ? rpc_us / shm_us : 0.0));
+    REQUIRE(shm_us < rpc_us / 5.0);
+  }
+}
+
 // Main function using simple_test.h framework
 SIMPLE_TEST_MAIN()

--- a/context-transfer-engine/test/unit/test_core_functionality.cc
+++ b/context-transfer-engine/test/unit/test_core_functionality.cc
@@ -356,6 +356,10 @@ class CTECoreFunctionalTestFixture {
                    clio::run::PoolId pool_id, clio::cte::core::CreateParams& params) {
     auto task = core_client_->AsyncCreate(pool_query, pool_name, pool_id, params);
     task.Wait();
+    // issue #783: pick up the SHM metadata cache location returned by Create.
+    // Failure is fine and expected on hosts without a metadata segment -- the
+    // client simply keeps using RPC.
+    core_client_->AttachShmCache(*task);
   }
 
   /**
@@ -2486,5 +2490,129 @@ TEST_CASE("FUNCTIONAL - Distributed Execution Validation",
 
   INFO("Distributed execution validation test completed successfully");
 }
+/**
+ * issue #783: WRITE-THEN-READ against the shared-memory metadata cache.
+ *
+ * This is the read-your-own-writes property the design has to hold: a client
+ * that writes a blob and then reads it back must never observe the pre-write
+ * state through the cache. Because the cache is populated by the runtime while
+ * it handles PutBlob, a WAITED put is ordered before the client's next read.
+ *
+ * The test also pins the two failure modes that would make the cache unsafe:
+ *   - a miss must be reported as "not cached", never as "blob does not exist";
+ *   - cached metadata must AGREE with the authoritative RPC answer.
+ */
+TEST_CASE("CTE SHM cache write-then-read",
+          "[cte][core][shm_cache][functional]") {
+  auto *fixture = ctp::Singleton<CTECoreFunctionalTestFixture>::GetInstance();
+  clio::run::PoolQuery pool_query = clio::run::PoolQuery::Dynamic();
+  clio::cte::core::CreateParams params;
+
+  REQUIRE_NOTHROW(fixture->CreateAsync(
+      pool_query, CTECoreFunctionalTestFixture::kCTECorePoolName,
+      CTECoreFunctionalTestFixture::kCTECorePoolId, params));
+
+  const std::string target_name = fixture->test_storage_path_;
+  clio::run::u32 reg_result = fixture->RegisterTargetAsync(
+      target_name, clio::run::bdev::BdevType::kFile,
+      CTECoreFunctionalTestFixture::kTestTargetSize,
+      clio::run::PoolQuery::Local(), clio::run::PoolId(651, 0));
+  REQUIRE(reg_result == 0);
+
+  if (!fixture->core_client_->HasShmCache()) {
+    // Not a failure: the host may have no metadata segment. But say so loudly
+    // rather than passing silently, because a quietly-disabled cache would
+    // make every assertion below vacuous.
+    HLOG(kWarning,
+         "[#783] SHM metadata cache unavailable -- write-then-read assertions "
+         "SKIPPED (this test proves nothing on this host)");
+    return;
+  }
+
+  const std::string tag_name = "shm_rw_tag";
+  clio::cte::core::TagId tag_id = fixture->GetOrCreateTagAsync(tag_name);
+  REQUIRE(!tag_id.IsNull());
+
+  SECTION("A miss is reported as not-cached, never as absent") {
+    clio::cte::core::ShmBlobRecord rec;
+    // Never written -> must be a clean miss.
+    REQUIRE_FALSE(fixture->core_client_->TryGetBlobRecordShm(
+        tag_id, "definitely_never_written", &rec));
+  }
+
+  SECTION("Tag id is readable with zero IPC") {
+    clio::cte::core::TagId cached;
+    REQUIRE(fixture->core_client_->TryGetTagIdShm(tag_name, &cached));
+    REQUIRE(cached.major_ == tag_id.major_);
+    REQUIRE(cached.minor_ == tag_id.minor_);
+  }
+
+  SECTION("Write then read: the cache reflects the write") {
+    const std::string blob_name = "shm_rw_blob";
+    const clio::run::u64 blob_size = 2048;
+    auto test_data = fixture->CreateTestData(blob_size, 'S');
+
+    auto blob_data_fullptr = CLIO_IPC->AllocateBuffer(blob_size);
+    REQUIRE(!blob_data_fullptr.IsNull());
+    auto blob_data_ptr = blob_data_fullptr.shm_.template Cast<void>();
+    REQUIRE(fixture->CopyToSharedMemory(blob_data_fullptr, test_data));
+
+    auto put_task = fixture->core_client_->AsyncPutBlob(
+        tag_id, blob_name, 0, blob_size, blob_data_ptr, 0.5f,
+        clio::cte::core::Context(), 0);
+    REQUIRE(!put_task.IsNull());
+    REQUIRE(fixture->WaitForTaskCompletion(put_task, 10000));
+    REQUIRE(put_task->return_code_ == 0);
+
+    // READ-YOUR-OWN-WRITE: immediately after the waited put, the cache must
+    // already carry this blob.
+    clio::cte::core::ShmBlobRecord rec;
+    REQUIRE(fixture->core_client_->TryGetBlobRecordShm(tag_id, blob_name,
+                                                       &rec));
+    REQUIRE(rec.total_size_ == blob_size);
+
+    // The cached answer must AGREE with the authoritative RPC answer. A cache
+    // that is fast but disagrees is worse than no cache at all.
+    auto size_task = fixture->core_client_->AsyncGetBlobSize(tag_id, blob_name);
+    REQUIRE(fixture->WaitForTaskCompletion(size_task, 10000));
+    REQUIRE(rec.total_size_ == size_task->size_);
+
+    // Payload reads must still be refused until the RAM bdev is SHM-backed
+    // (phase 6): this blob lives on a FILE target, so direct read is invalid.
+    REQUIRE_FALSE(rec.IsDirectReadable());
+
+    CLIO_IPC->FreeBuffer(blob_data_fullptr);
+  }
+
+  SECTION("Overwrite then read: the cache reflects the NEW size") {
+    const std::string blob_name = "shm_rw_overwrite";
+    const clio::run::u64 first_size = 1024;
+    const clio::run::u64 second_size = 4096;
+
+    for (clio::run::u64 sz : {first_size, second_size}) {
+      auto data = fixture->CreateTestData(sz, 'O');
+      auto fp = CLIO_IPC->AllocateBuffer(sz);
+      REQUIRE(!fp.IsNull());
+      REQUIRE(fixture->CopyToSharedMemory(fp, data));
+      auto t = fixture->core_client_->AsyncPutBlob(
+          tag_id, blob_name, 0, sz, fp.shm_.template Cast<void>(), 0.5f,
+          clio::cte::core::Context(), 0);
+      REQUIRE(!t.IsNull());
+      REQUIRE(fixture->WaitForTaskCompletion(t, 10000));
+      REQUIRE(t->return_code_ == 0);
+      CLIO_IPC->FreeBuffer(fp);
+    }
+
+    // A stale cache would still report first_size here -- the exact bug this
+    // whole mechanism has to avoid.
+    clio::cte::core::ShmBlobRecord rec;
+    REQUIRE(fixture->core_client_->TryGetBlobRecordShm(tag_id, blob_name,
+                                                       &rec));
+    auto size_task = fixture->core_client_->AsyncGetBlobSize(tag_id, blob_name);
+    REQUIRE(fixture->WaitForTaskCompletion(size_task, 10000));
+    REQUIRE(rec.total_size_ == size_task->size_);
+  }
+}
+
 // Main function using simple_test.h framework
 SIMPLE_TEST_MAIN()

--- a/context-transfer-engine/test/unit/test_core_functionality.cc
+++ b/context-transfer-engine/test/unit/test_core_functionality.cc
@@ -2614,5 +2614,118 @@ TEST_CASE("CTE SHM cache write-then-read",
   }
 }
 
+/**
+ * issue #783: BEFORE/AFTER benchmark for metadata reads.
+ *
+ * Compares the shared-memory fast path against the authoritative RPC path for
+ * the same query, on the same blobs, in the same process. This is the number
+ * the whole design exists to move: the RPC floor measured on this host is
+ * ~72 us single-threaded, and the target is < 5 us.
+ *
+ * Correctness is asserted alongside speed -- a fast answer that disagrees with
+ * the RPC answer would make the benchmark meaningless.
+ */
+TEST_CASE("CTE SHM cache metadata read benchmark",
+          "[cte][core][shm_cache][bench]") {
+  auto *fixture = ctp::Singleton<CTECoreFunctionalTestFixture>::GetInstance();
+  clio::run::PoolQuery pool_query = clio::run::PoolQuery::Dynamic();
+  clio::cte::core::CreateParams params;
+
+  REQUIRE_NOTHROW(fixture->CreateAsync(
+      pool_query, CTECoreFunctionalTestFixture::kCTECorePoolName,
+      CTECoreFunctionalTestFixture::kCTECorePoolId, params));
+
+  const std::string target_name = fixture->test_storage_path_;
+  clio::run::u32 reg_result = fixture->RegisterTargetAsync(
+      target_name, clio::run::bdev::BdevType::kFile,
+      CTECoreFunctionalTestFixture::kTestTargetSize,
+      clio::run::PoolQuery::Local(), clio::run::PoolId(661, 0));
+  REQUIRE(reg_result == 0);
+
+  if (!fixture->core_client_->HasShmCache()) {
+    HLOG(kWarning,
+         "[#783] SHM metadata cache unavailable -- benchmark SKIPPED (this "
+         "measures nothing on this host)");
+    return;
+  }
+
+  clio::cte::core::TagId tag_id = fixture->GetOrCreateTagAsync("shm_bench_tag");
+  REQUIRE(!tag_id.IsNull());
+
+  // Populate a working set.
+  const int kBlobs = 32;
+  const clio::run::u64 kBlobSize = 1024;
+  std::vector<std::string> names;
+  for (int i = 0; i < kBlobs; ++i) {
+    std::string bn = "bench_blob_" + std::to_string(i);
+    names.push_back(bn);
+    auto data = fixture->CreateTestData(kBlobSize, 'K');
+    auto fp = CLIO_IPC->AllocateBuffer(kBlobSize);
+    REQUIRE(!fp.IsNull());
+    REQUIRE(fixture->CopyToSharedMemory(fp, data));
+    auto t = fixture->core_client_->AsyncPutBlob(
+        tag_id, bn, 0, kBlobSize, fp.shm_.template Cast<void>(), 0.5f,
+        clio::cte::core::Context(), 0);
+    REQUIRE(!t.IsNull());
+    REQUIRE(fixture->WaitForTaskCompletion(t, 10000));
+    REQUIRE(t->return_code_ == 0);
+    CLIO_IPC->FreeBuffer(fp);
+  }
+
+  const int kIters = 2000;
+
+  // ---- AFTER: shared-memory fast path (zero IPC) ----
+  clio::run::u64 shm_checksum = 0;
+  int shm_hits = 0;
+  auto shm_t0 = std::chrono::steady_clock::now();
+  for (int i = 0; i < kIters; ++i) {
+    clio::cte::core::ShmBlobRecord rec;
+    if (fixture->core_client_->TryGetBlobRecordShm(
+            tag_id, names[i % kBlobs], &rec)) {
+      shm_checksum += rec.total_size_;
+      ++shm_hits;
+    }
+  }
+  auto shm_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    std::chrono::steady_clock::now() - shm_t0)
+                    .count();
+
+  // Every lookup must hit; a benchmark dominated by misses would be measuring
+  // the wrong thing entirely.
+  REQUIRE(shm_hits == kIters);
+
+  // ---- BEFORE: authoritative RPC path ----
+  // Fewer iterations because each is ~70us; scaled per-op below.
+  const int kRpcIters = 200;
+  clio::run::u64 rpc_checksum = 0;
+  auto rpc_t0 = std::chrono::steady_clock::now();
+  for (int i = 0; i < kRpcIters; ++i) {
+    auto t = fixture->core_client_->AsyncGetBlobSize(tag_id,
+                                                     names[i % kBlobs]);
+    t.Wait();
+    rpc_checksum += t->size_;
+  }
+  auto rpc_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    std::chrono::steady_clock::now() - rpc_t0)
+                    .count();
+
+  double shm_us = static_cast<double>(shm_ns) / 1000.0 / kIters;
+  double rpc_us = static_cast<double>(rpc_ns) / 1000.0 / kRpcIters;
+
+  // The two paths must agree, normalized for iteration count.
+  REQUIRE(shm_checksum / kIters == rpc_checksum / kRpcIters);
+
+  HLOG(kWarning,
+       "[#783 BENCH] metadata read: SHM {} us/op vs RPC {} us/op -- speedup {}x "
+       "({} shm iters, {} rpc iters, {} byte blobs)",
+       shm_us, rpc_us, (rpc_us > 0 ? rpc_us / shm_us : 0.0), kIters, kRpcIters,
+       kBlobSize);
+
+  // The design target is < 5 us. Assert something far looser so the test is a
+  // regression guard rather than a flaky performance gate: if the fast path is
+  // not at least 5x faster than RPC, it is not doing its job.
+  REQUIRE(shm_us < rpc_us / 5.0);
+}
+
 // Main function using simple_test.h framework
 SIMPLE_TEST_MAIN()

--- a/context-transfer-engine/test/unit/test_cte_shm_metadata_cache.cc
+++ b/context-transfer-engine/test/unit/test_cte_shm_metadata_cache.cc
@@ -44,9 +44,16 @@
 #include <clio_ctp/memory/backend/posix_shm_mmap.h>
 #include <clio_runtime/bdev/bdev_tasks.h>
 
+// fork()/waitpid() are POSIX-only; the cross-process case is compiled out on
+// Windows rather than replaced with a same-process imitation, which would not
+// exercise the property it exists to prove (offsets resolving at a different
+// base address).
+#ifndef _WIN32
 #include <sys/wait.h>
 #include <unistd.h>
+#endif
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <string>
 
@@ -58,7 +65,7 @@ namespace {
 
 /** Unique-ish segment name so parallel test runs do not collide. */
 std::string SegName() {
-  return "cte_shm_cache_test_" + std::to_string(getpid());
+  return "cte_shm_cache_test_" + std::to_string(ctp::SystemInfo::GetPid());
 }
 
 struct Fixture {
@@ -69,7 +76,8 @@ struct Fixture {
 
   bool Create() {
     name = SegName();
-    ctp::ipc::AllocatorId id = ctp::ipc::AllocatorId::Get(getpid(), 77);
+    ctp::ipc::AllocatorId id =
+        ctp::ipc::AllocatorId::Get(ctp::SystemInfo::GetPid(), 77);
     if (!backend.shm_init(id, ctp::Unit<size_t>::Megabytes(64), name)) {
       return false;
     }
@@ -204,6 +212,7 @@ TEST_CASE("ShmCache: tag maps round-trip", "[shm_cache]") {
   f.Destroy();
 }
 
+#ifndef _WIN32
 TEST_CASE("ShmCache: readable from another process at a different address", "[shm_cache]") {
   // THE test that matters: every internal reference is a segment-relative
   // offset, so a child that maps the same segment at a different base address
@@ -291,5 +300,6 @@ TEST_CASE("ShmCache: readable from another process at a different address", "[sh
 
   f.Destroy();
 }
+#endif  // !_WIN32
 
 SIMPLE_TEST_MAIN()

--- a/context-transfer-engine/test/unit/test_cte_shm_metadata_cache.cc
+++ b/context-transfer-engine/test/unit/test_cte_shm_metadata_cache.cc
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Phase 3 data-model tests for the CTE shared-memory metadata cache (#783).
+ *
+ * Pure data-structure level: builds the cache in a real shared-memory segment
+ * and exercises it from a FORKED CHILD, which is the property that matters --
+ * every offset must resolve at a different base address in another process.
+ */
+
+#include "clio_cte/core/shm_metadata_cache.h"
+
+#include <clio_ctp/memory/backend/posix_shm_mmap.h>
+#include <clio_runtime/bdev/bdev_tasks.h>
+
+#include <sys/wait.h>
+#include <unistd.h>
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+#include "simple_test.h"
+
+using namespace clio::cte::core;
+
+namespace {
+
+/** Unique-ish segment name so parallel test runs do not collide. */
+std::string SegName() {
+  return "cte_shm_cache_test_" + std::to_string(getpid());
+}
+
+struct Fixture {
+  ctp::ipc::PosixShmMmap backend;
+  ShmCacheAlloc *alloc = nullptr;
+  ShmMetadataCacheRoot *root = nullptr;
+  std::string name;
+
+  bool Create() {
+    name = SegName();
+    ctp::ipc::AllocatorId id = ctp::ipc::AllocatorId::Get(getpid(), 77);
+    if (!backend.shm_init(id, ctp::Unit<size_t>::Megabytes(64), name)) {
+      return false;
+    }
+    alloc = backend.MakeAlloc<ShmCacheAlloc>();
+    if (alloc == nullptr) {
+      return false;
+    }
+    auto fp = alloc->template Allocate<ShmMetadataCacheRoot>(
+        sizeof(ShmMetadataCacheRoot));
+    if (fp.IsNull()) {
+      return false;
+    }
+    root = fp.ptr_;
+    new (root) ShmMetadataCacheRoot();
+    new (&root->tag_name_to_id_) ShmTagIdMap(alloc, 256);
+    new (&root->tag_id_to_info_) ShmTagInfoMap(alloc, 256);
+    new (&root->blob_key_to_info_) ShmBlobInfoMap(alloc, 1024);
+    root->version_ = ShmMetadataCacheRoot::kLayoutVersion;
+    root->ready_ = 1;
+    return true;
+  }
+
+  /** Offset of the root within the segment, which is what a client receives. */
+  size_t RootOffset() const {
+    return reinterpret_cast<const char *>(root) -
+           reinterpret_cast<const char *>(alloc);
+  }
+
+  void Destroy() { backend.shm_destroy(); }
+};
+
+bool PutBlob(Fixture &f, const std::string &key, const ShmBlobRecord &rec) {
+  ShmBlobInfoMap::BytesProbe p{key.data(), key.size()};
+  return f.root->blob_key_to_info_.InsertOrAssign(
+      p, ShmCacheString::HashBytes(key.data(), key.size()), rec);
+}
+
+}  // namespace
+
+TEST_CASE("ShmCache: records are trivially copyable", "[shm_cache]") {
+  // The map copies values out between two generation reads, so a non-trivially
+  // copyable record would silently defeat the seqlock.
+  REQUIRE(std::is_trivially_copyable<ShmBlockDesc>::value);
+  REQUIRE(std::is_trivially_copyable<ShmBlobRecord>::value);
+  REQUIRE(std::is_trivially_copyable<ShmTagRecord>::value);
+}
+
+TEST_CASE("ShmCache: no vtables in SHM-resident types", "[shm_cache]") {
+  // A vtable pointer is a process-local address; storing one in a segment
+  // another process maps is undefined behaviour. This is why the block
+  // descriptor is POD instead of embedding a bdev::Client.
+  REQUIRE_FALSE(std::is_polymorphic<ShmBlockDesc>::value);
+  REQUIRE_FALSE(std::is_polymorphic<ShmBlobRecord>::value);
+  REQUIRE_FALSE(std::is_polymorphic<ShmTagRecord>::value);
+}
+
+TEST_CASE("ShmCache: blob key construction", "[shm_cache]") {
+  char buf[128];
+  clio::run::UniqueId tag(12, 34);
+  size_t n = MakeShmBlobKey(tag, "myblob", 6, buf, sizeof(buf));
+  REQUIRE(n > 0);
+  REQUIRE(std::string(buf, n) == "12.34/myblob");
+
+  // Too-small buffer must refuse rather than truncate: a truncated key would
+  // alias a different blob.
+  char small[4];
+  REQUIRE(MakeShmBlobKey(tag, "myblob", 6, small, sizeof(small)) == 0);
+}
+
+TEST_CASE("ShmCache: insert and read back in-process", "[shm_cache]") {
+  Fixture f;
+  REQUIRE(f.Create());
+
+  ShmBlobRecord rec;
+  rec.total_size_ = 4096;
+  rec.num_blocks_ = 1;
+  rec.flags_ = kShmBlobDirectReadable;
+  rec.placement_gen_ = 7;
+  rec.blocks_[0].target_offset_ = 512;
+  rec.blocks_[0].size_ = 4096;
+  rec.blocks_[0].bdev_type_ =
+      static_cast<clio::run::u32>(clio::run::bdev::BdevType::kRam);
+  REQUIRE(PutBlob(f, "1.0/blob_a", rec));
+
+  ShmBlobRecord out;
+  REQUIRE(f.root->blob_key_to_info_.TryGetBytes("1.0/blob_a", 10, &out));
+  REQUIRE(out.total_size_ == 4096);
+  REQUIRE(out.num_blocks_ == 1);
+  REQUIRE(out.blocks_[0].target_offset_ == 512);
+  REQUIRE(out.IsDirectReadable());
+
+  f.Destroy();
+}
+
+TEST_CASE("ShmCache: truncated blob is not direct-readable", "[shm_cache]") {
+  ShmBlobRecord rec;
+  rec.num_blocks_ = kMaxInlineBlocks;
+  rec.flags_ = kShmBlobDirectReadable | kShmBlobTruncated;
+  // A blob with more blocks than fit must never be payload-read from the
+  // cache -- the block list it carries is incomplete.
+  REQUIRE_FALSE(rec.IsDirectReadable());
+}
+
+TEST_CASE("ShmCache: tag maps round-trip", "[shm_cache]") {
+  Fixture f;
+  REQUIRE(f.Create());
+
+  clio::run::UniqueId tag(3, 9);
+  std::string name = "my_tag";
+  ShmTagIdMap::BytesProbe p{name.data(), name.size()};
+  REQUIRE(f.root->tag_name_to_id_.InsertOrAssign(
+      p, ShmCacheString::HashBytes(name.data(), name.size()), tag));
+
+  ShmTagRecord trec;
+  trec.total_size_ = 123;
+  trec.last_modified_ = 456;
+  REQUIRE(f.root->tag_id_to_info_.InsertOrAssign(
+      tag, ShmTagInfoMap::Hash(tag), trec));
+
+  clio::run::UniqueId got_id;
+  REQUIRE(f.root->tag_name_to_id_.TryGetBytes(name.data(), name.size(),
+                                              &got_id));
+  REQUIRE(got_id.major_ == 3);
+  REQUIRE(got_id.minor_ == 9);
+
+  ShmTagRecord got_rec;
+  REQUIRE(f.root->tag_id_to_info_.TryGet(tag, ShmTagInfoMap::Hash(tag),
+                                         &got_rec));
+  REQUIRE(got_rec.total_size_ == 123);
+  REQUIRE(got_rec.last_modified_ == 456);
+
+  f.Destroy();
+}
+
+TEST_CASE("ShmCache: readable from another process at a different address", "[shm_cache]") {
+  // THE test that matters: every internal reference is a segment-relative
+  // offset, so a child that maps the same segment at a different base address
+  // must resolve identical data. A raw pointer anywhere would fail here.
+  Fixture f;
+  REQUIRE(f.Create());
+
+  const int kEntries = 200;
+  for (int i = 0; i < kEntries; ++i) {
+    ShmBlobRecord rec;
+    rec.total_size_ = static_cast<clio::run::u64>(i) * 100;
+    rec.num_blocks_ = 1;
+    rec.placement_gen_ = static_cast<clio::run::u64>(i);
+    rec.flags_ = kShmBlobDirectReadable;
+    rec.blocks_[0].target_offset_ = static_cast<clio::run::u64>(i) * 4096;
+    rec.blocks_[0].size_ = 100;
+    REQUIRE(PutBlob(f, "1.0/blob_" + std::to_string(i), rec));
+  }
+  // Long key crossing the SSO boundary, to prove spilled keys resolve too.
+  std::string longkey = "1.0/" + std::string(120, 'L');
+  ShmBlobRecord big;
+  big.total_size_ = 999999;
+  REQUIRE(PutBlob(f, longkey, big));
+
+  size_t root_off = f.RootOffset();
+  std::string seg = f.name;
+
+  pid_t pid = fork();
+  if (pid == 0) {
+    // Child: attach the segment fresh. mmap will very likely place it at a
+    // different base address than the parent's.
+    ctp::ipc::PosixShmMmap child_backend;
+    int rc = 0;
+    if (!child_backend.shm_attach(seg)) {
+      _exit(21);
+    }
+    auto *child_alloc = child_backend.AttachAlloc<ShmCacheAlloc>();
+    if (child_alloc == nullptr) {
+      _exit(22);
+    }
+    auto *child_root = reinterpret_cast<ShmMetadataCacheRoot *>(
+        reinterpret_cast<char *>(child_alloc) + root_off);
+    if (child_root->ready_ != 1 ||
+        child_root->version_ != ShmMetadataCacheRoot::kLayoutVersion) {
+      _exit(23);
+    }
+    for (int i = 0; i < kEntries; ++i) {
+      std::string k = "1.0/blob_" + std::to_string(i);
+      ShmBlobRecord out;
+      if (!child_root->blob_key_to_info_.TryGetBytes(k.data(), k.size(),
+                                                     &out)) {
+        rc = 24;
+        break;
+      }
+      if (out.total_size_ != static_cast<clio::run::u64>(i) * 100 ||
+          out.blocks_[0].target_offset_ !=
+              static_cast<clio::run::u64>(i) * 4096) {
+        rc = 25;
+        break;
+      }
+    }
+    if (rc == 0) {
+      ShmBlobRecord out;
+      if (!child_root->blob_key_to_info_.TryGetBytes(longkey.data(),
+                                                     longkey.size(), &out)) {
+        rc = 26;
+      } else if (out.total_size_ != 999999) {
+        rc = 27;
+      }
+    }
+    // A key that was never inserted must miss, not alias something else.
+    if (rc == 0) {
+      ShmBlobRecord out;
+      if (child_root->blob_key_to_info_.TryGetBytes("1.0/nope", 8, &out)) {
+        rc = 28;
+      }
+    }
+    _exit(rc);
+  }
+
+  int status = 0;
+  waitpid(pid, &status, 0);
+  REQUIRE(WIFEXITED(status));
+  REQUIRE(WEXITSTATUS(status) == 0);
+
+  f.Destroy();
+}
+
+SIMPLE_TEST_MAIN()

--- a/context-transfer-engine/test/unit/test_cte_shm_metadata_cache.cc
+++ b/context-transfer-engine/test/unit/test_cte_shm_metadata_cache.cc
@@ -131,7 +131,7 @@ TEST_CASE("ShmCache: blob key construction", "[shm_cache]") {
   clio::run::UniqueId tag(12, 34);
   size_t n = MakeShmBlobKey(tag, "myblob", 6, buf, sizeof(buf));
   REQUIRE(n > 0);
-  REQUIRE(std::string(buf, n) == "12.34/myblob");
+  REQUIRE(std::string(buf, n) == "12.34.myblob");
 
   // Too-small buffer must refuse rather than truncate: a truncated key would
   // alias a different blob.
@@ -152,10 +152,10 @@ TEST_CASE("ShmCache: insert and read back in-process", "[shm_cache]") {
   rec.blocks_[0].size_ = 4096;
   rec.blocks_[0].bdev_type_ =
       static_cast<clio::run::u32>(clio::run::bdev::BdevType::kRam);
-  REQUIRE(PutBlob(f, "1.0/blob_a", rec));
+  REQUIRE(PutBlob(f, "1.0.blob_a", rec));
 
   ShmBlobRecord out;
-  REQUIRE(f.root->blob_key_to_info_.TryGetBytes("1.0/blob_a", 10, &out));
+  REQUIRE(f.root->blob_key_to_info_.TryGetBytes("1.0.blob_a", 10, &out));
   REQUIRE(out.total_size_ == 4096);
   REQUIRE(out.num_blocks_ == 1);
   REQUIRE(out.blocks_[0].target_offset_ == 512);
@@ -220,10 +220,10 @@ TEST_CASE("ShmCache: readable from another process at a different address", "[sh
     rec.flags_ = kShmBlobDirectReadable;
     rec.blocks_[0].target_offset_ = static_cast<clio::run::u64>(i) * 4096;
     rec.blocks_[0].size_ = 100;
-    REQUIRE(PutBlob(f, "1.0/blob_" + std::to_string(i), rec));
+    REQUIRE(PutBlob(f, "1.0.blob_" + std::to_string(i), rec));
   }
   // Long key crossing the SSO boundary, to prove spilled keys resolve too.
-  std::string longkey = "1.0/" + std::string(120, 'L');
+  std::string longkey = "1.0." + std::string(120, 'L');
   ShmBlobRecord big;
   big.total_size_ = 999999;
   REQUIRE(PutBlob(f, longkey, big));
@@ -251,7 +251,7 @@ TEST_CASE("ShmCache: readable from another process at a different address", "[sh
       _exit(23);
     }
     for (int i = 0; i < kEntries; ++i) {
-      std::string k = "1.0/blob_" + std::to_string(i);
+      std::string k = "1.0.blob_" + std::to_string(i);
       ShmBlobRecord out;
       if (!child_root->blob_key_to_info_.TryGetBytes(k.data(), k.size(),
                                                      &out)) {
@@ -277,7 +277,7 @@ TEST_CASE("ShmCache: readable from another process at a different address", "[sh
     // A key that was never inserted must miss, not alias something else.
     if (rc == 0) {
       ShmBlobRecord out;
-      if (child_root->blob_key_to_info_.TryGetBytes("1.0/nope", 8, &out)) {
+      if (child_root->blob_key_to_info_.TryGetBytes("1.0.nope", 8, &out)) {
         rc = 28;
       }
     }

--- a/context-transport-primitives/include/clio_ctp/data_structures/ipc/string.h
+++ b/context-transport-primitives/include/clio_ctp/data_structures/ipc/string.h
@@ -1,0 +1,384 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CTP_DATA_STRUCTURES_IPC_STRING_H_
+#define CTP_DATA_STRUCTURES_IPC_STRING_H_
+
+#include "clio_ctp/data_structures/ipc/shm_container.h"
+#include "clio_ctp/constants/macros.h"
+
+#if CTP_IS_HOST
+#include <string>
+#endif
+
+namespace ctp::ipc {
+
+/**
+ * Shared-memory string (issue #783).
+ *
+ * Counterpart to ctp::priv::string, but every internal reference is a
+ * SEGMENT-RELATIVE OFFSET rather than a raw pointer, so the same bytes are
+ * readable from any process that maps the segment at any base address.
+ *
+ * SMALL-STRING OPTIMIZATION. Strings up to kSsoCapacity bytes live inline in
+ * the object; longer ones spill to an allocation in the same segment. This is
+ * not just an allocation-count win:
+ *   - The metadata cache is dominated by short keys (tag and blob names), so
+ *     most strings never touch the allocator at all -- meaningful when the
+ *     whole point is a sub-5us read.
+ *   - A lock-free reader that must follow an offset pointer into the arena is
+ *     at its most exposed while doing so. Inline data removes the pointer
+ *     chase entirely for the common case.
+ *
+ * NOT NULL-SAFE ACROSS ALLOCATORS. Like every ShmContainer, the allocator is
+ * recorded as an offset from `this`, so a string MUST live in the same segment
+ * as its allocator, and copying one requires naming the destination allocator
+ * (see the (alloc, other) constructor). The implicit copy constructor is
+ * therefore deleted -- a bitwise copy would carry an offset that is meaningless
+ * at the destination address.
+ *
+ * SHM-SAFE: no virtual functions, no raw pointers, trivially relocatable.
+ */
+template <typename AllocT>
+class string : public ShmContainer<AllocT> {
+ public:
+  using allocator_type = AllocT;
+
+  /** Bytes storable inline (excluding the NUL terminator). */
+  static constexpr size_t kSsoCapacity = 23;
+
+ private:
+  size_t size_;           /**< Length in bytes, excluding NUL */
+  size_t capacity_;       /**< Usable capacity, excluding NUL */
+  OffsetPtr<char> data_;  /**< Offset to heap buffer; null when inline */
+  char sso_[kSsoCapacity + 1];  /**< Inline buffer, always NUL-terminated */
+
+ public:
+  /** Default constructor -- empty, no allocator, no allocation. */
+  CTP_CROSS_FUN
+  string()
+      : ShmContainer<AllocT>(),
+        size_(0),
+        capacity_(kSsoCapacity),
+        data_(OffsetPtr<char>::GetNull()) {
+    sso_[0] = '\0';
+  }
+
+  /** Construct empty with an allocator. */
+  CTP_INLINE_CROSS_FUN
+  explicit string(AllocT *alloc)
+      : ShmContainer<AllocT>(alloc),
+        size_(0),
+        capacity_(kSsoCapacity),
+        data_(OffsetPtr<char>::GetNull()) {
+    sso_[0] = '\0';
+  }
+
+  /** Construct from a C string. */
+  CTP_INLINE_CROSS_FUN
+  string(AllocT *alloc, const char *str)
+      : ShmContainer<AllocT>(alloc),
+        size_(0),
+        capacity_(kSsoCapacity),
+        data_(OffsetPtr<char>::GetNull()) {
+    sso_[0] = '\0';
+    assign(str, StrLen(str));
+  }
+
+  /** Construct from a buffer + length (may contain embedded NULs). */
+  CTP_INLINE_CROSS_FUN
+  string(AllocT *alloc, const char *str, size_t len)
+      : ShmContainer<AllocT>(alloc),
+        size_(0),
+        capacity_(kSsoCapacity),
+        data_(OffsetPtr<char>::GetNull()) {
+    sso_[0] = '\0';
+    assign(str, len);
+  }
+
+#if CTP_IS_HOST
+  /** Construct from a std::string. */
+  string(AllocT *alloc, const std::string &str)
+      : ShmContainer<AllocT>(alloc),
+        size_(0),
+        capacity_(kSsoCapacity),
+        data_(OffsetPtr<char>::GetNull()) {
+    sso_[0] = '\0';
+    assign(str.data(), str.size());
+  }
+#endif
+
+  /**
+   * Copy into a (possibly different) allocator. Required instead of a plain
+   * copy constructor because ShmContainer stores the allocator as an offset
+   * from `this`; a bitwise copy would inherit an offset that does not resolve
+   * at the destination's address.
+   */
+  CTP_INLINE_CROSS_FUN
+  string(AllocT *alloc, const string &other)
+      : ShmContainer<AllocT>(alloc),
+        size_(0),
+        capacity_(kSsoCapacity),
+        data_(OffsetPtr<char>::GetNull()) {
+    sso_[0] = '\0';
+    assign(other.c_str(), other.size());
+  }
+
+  /** Deleted: see the (alloc, other) constructor above. */
+  string(const string &other) = delete;
+  string &operator=(const string &other) = delete;
+
+  CTP_INLINE_CROSS_FUN
+  ~string() { FreeHeap(); }
+
+  /** Replace contents. Returns false if a needed allocation failed, in which
+   *  case the string is left EMPTY rather than partially written. */
+  CTP_INLINE_CROSS_FUN
+  bool assign(const char *str, size_t len) {
+    if (!reserve(len)) {
+      clear();
+      return false;
+    }
+    char *dst = mutable_data();
+    if (dst == nullptr) {
+      clear();
+      return false;
+    }
+    for (size_t i = 0; i < len; ++i) {
+      dst[i] = str[i];
+    }
+    dst[len] = '\0';
+    size_ = len;
+    return true;
+  }
+
+  CTP_INLINE_CROSS_FUN
+  bool assign(const char *str) { return assign(str, StrLen(str)); }
+
+  /**
+   * Ensure capacity for `n` bytes (excluding NUL).
+   *
+   * Growth is one-way: once spilled to the heap a string never shrinks back
+   * inline, so a reader that has resolved the heap offset cannot have it
+   * yanked back under it by a later shrink.
+   */
+  CTP_INLINE_CROSS_FUN
+  bool reserve(size_t n) {
+    if (n <= capacity_) {
+      return true;
+    }
+    AllocT *alloc = this->GetAllocator();
+    if (alloc == nullptr) {
+      return false;
+    }
+    // Grow geometrically to avoid O(n^2) on repeated appends.
+    size_t new_cap = capacity_ * 2;
+    if (new_cap < n) {
+      new_cap = n;
+    }
+    // Allocator exhaustion must be a RECOVERABLE condition here, not an
+    // exception escaping into a caller. AllocateOffset throws OUT_OF_MEMORY
+    // (arena_allocator.h) rather than returning null, and the whole
+    // metadata-cache design rests on "cache full -> fall back to RPC": a
+    // throw propagating out of a client read path, or out of a runtime task
+    // that merely wanted to populate a cache entry, would turn a benign
+    // capacity limit into a failure. So catch it and report false.
+    OffsetPtr<> off = OffsetPtr<>::GetNull();
+#if !CTP_IS_DEVICE_PASS
+    try {
+      off = alloc->AllocateOffset(new_cap + 1);
+    } catch (...) {
+      return false;
+    }
+#else
+    // Device passes compile CTP_THROW to a no-op, so the null check below is
+    // the only signal available there.
+    off = alloc->AllocateOffset(new_cap + 1);
+#endif
+    if (off.IsNull()) {
+      return false;
+    }
+    char *new_buf = FullPtr<char>(alloc, OffsetPtr<char>(off.load())).ptr_;
+    const char *old = c_str();
+    for (size_t i = 0; i < size_; ++i) {
+      new_buf[i] = old[i];
+    }
+    new_buf[size_] = '\0';
+    FreeHeap();
+    data_ = OffsetPtr<char>(off.load());
+    capacity_ = new_cap;
+    return true;
+  }
+
+  CTP_INLINE_CROSS_FUN
+  void clear() {
+    size_ = 0;
+    char *d = mutable_data();
+    if (d != nullptr) {
+      d[0] = '\0';
+    }
+  }
+
+  /** Read-only pointer to the bytes. Always NUL-terminated. */
+  CTP_INLINE_CROSS_FUN
+  const char *c_str() const {
+    if (data_.IsNull()) {
+      return sso_;
+    }
+    AllocT *alloc = this->GetAllocator();
+    if (alloc == nullptr) {
+      return sso_;
+    }
+    return FullPtr<char>(alloc, data_).ptr_;
+  }
+
+  CTP_INLINE_CROSS_FUN
+  const char *data() const { return c_str(); }
+
+  CTP_INLINE_CROSS_FUN
+  size_t size() const { return size_; }
+
+  CTP_INLINE_CROSS_FUN
+  size_t length() const { return size_; }
+
+  CTP_INLINE_CROSS_FUN
+  size_t capacity() const { return capacity_; }
+
+  CTP_INLINE_CROSS_FUN
+  bool empty() const { return size_ == 0; }
+
+  /** True if the bytes live inline (no pointer chase for readers). */
+  CTP_INLINE_CROSS_FUN
+  bool is_inline() const { return data_.IsNull(); }
+
+  CTP_INLINE_CROSS_FUN
+  char operator[](size_t i) const { return c_str()[i]; }
+
+  CTP_INLINE_CROSS_FUN
+  bool operator==(const string &other) const {
+    return Equals(other.c_str(), other.size());
+  }
+
+  CTP_INLINE_CROSS_FUN
+  bool operator!=(const string &other) const { return !(*this == other); }
+
+  CTP_INLINE_CROSS_FUN
+  bool operator==(const char *str) const { return Equals(str, StrLen(str)); }
+
+  CTP_INLINE_CROSS_FUN
+  bool operator!=(const char *str) const { return !(*this == str); }
+
+#if CTP_IS_HOST
+  bool operator==(const std::string &str) const {
+    return Equals(str.data(), str.size());
+  }
+  bool operator!=(const std::string &str) const { return !(*this == str); }
+
+  /** Materialize as a std::string (copies out of shared memory). */
+  std::string str() const { return std::string(c_str(), size_); }
+#endif
+
+  /** FNV-1a over the bytes. Defined here so the hash is identical in every
+   *  process regardless of std::hash's implementation -- a std::hash-based
+   *  bucket index would not be stable across processes or libstdc++ versions,
+   *  which would corrupt a shared hash table. */
+  CTP_INLINE_CROSS_FUN
+  size_t hash() const { return HashBytes(c_str(), size_); }
+
+  /** FNV-1a, exposed so callers can hash a raw key without building a
+   *  string (e.g. probing the map with a const char*). */
+  CTP_INLINE_CROSS_FUN
+  static size_t HashBytes(const char *p, size_t n) {
+    size_t h = 1469598103934665603ULL;  // FNV offset basis
+    for (size_t i = 0; i < n; ++i) {
+      h ^= static_cast<size_t>(static_cast<unsigned char>(p[i]));
+      h *= 1099511628211ULL;  // FNV prime
+    }
+    return h;
+  }
+
+  CTP_INLINE_CROSS_FUN
+  static size_t StrLen(const char *s) {
+    size_t n = 0;
+    if (s == nullptr) {
+      return 0;
+    }
+    while (s[n] != '\0') {
+      ++n;
+    }
+    return n;
+  }
+
+ private:
+  CTP_INLINE_CROSS_FUN
+  bool Equals(const char *p, size_t n) const {
+    if (n != size_) {
+      return false;
+    }
+    const char *self = c_str();
+    for (size_t i = 0; i < n; ++i) {
+      if (self[i] != p[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  CTP_INLINE_CROSS_FUN
+  char *mutable_data() {
+    if (data_.IsNull()) {
+      return sso_;
+    }
+    AllocT *alloc = this->GetAllocator();
+    if (alloc == nullptr) {
+      return nullptr;
+    }
+    return FullPtr<char>(alloc, data_).ptr_;
+  }
+
+  CTP_INLINE_CROSS_FUN
+  void FreeHeap() {
+    if (data_.IsNull()) {
+      return;
+    }
+    AllocT *alloc = this->GetAllocator();
+    if (alloc != nullptr) {
+      alloc->FreeOffsetNoNullCheck(OffsetPtr<>(data_.load()));
+    }
+    data_ = OffsetPtr<char>::GetNull();
+  }
+};
+
+}  // namespace ctp::ipc
+
+#endif  // CTP_DATA_STRUCTURES_IPC_STRING_H_

--- a/context-transport-primitives/include/clio_ctp/data_structures/ipc/string.h
+++ b/context-transport-primitives/include/clio_ctp/data_structures/ipc/string.h
@@ -327,6 +327,17 @@ class string : public ShmContainer<AllocT> {
     return h;
   }
 
+  /**
+   * Compare against raw bytes without constructing a string.
+   *
+   * Required by the SHM hash map's client-side lookup: clients must never
+   * allocate inside the metadata segment (they are readers, and allocating
+   * would mutate runtime-owned structures), so probing the table with a
+   * temporary ipc::string key is not an option.
+   */
+  CTP_INLINE_CROSS_FUN
+  bool EqualsBytes(const char *p, size_t n) const { return Equals(p, n); }
+
   CTP_INLINE_CROSS_FUN
   static size_t StrLen(const char *s) {
     size_t n = 0;

--- a/context-transport-primitives/include/clio_ctp/data_structures/ipc/unordered_map.h
+++ b/context-transport-primitives/include/clio_ctp/data_structures/ipc/unordered_map.h
@@ -102,6 +102,42 @@ class unordered_map : public ShmContainer<AllocT> {
 
   enum SlotState : min_u32 { kEmpty = 0, kOccupied = 1, kTombstone = 2 };
 
+  /**
+   * Maximum load factor (7/8). NEW keys are refused past this point even
+   * though slots remain.
+   *
+   * This is not tidiness, it is the difference between a plateau and a cliff.
+   * A probe run only terminates at an EMPTY slot, so a table with none makes
+   * every MISS scan the whole table. Measured on a 65536-slot table:
+   *
+   *     load  50%  ->  miss   0.06 us
+   *     load  90%  ->  miss   0.18 us
+   *     load  99%  ->  miss  11.8  us
+   *     load 100%  ->  miss 108.9  us
+   *
+   * At 100% a miss costs MORE than the ~90 us RPC it exists to avoid -- and
+   * the caller then pays that RPC anyway, so the cache turns net-negative.
+   * Reserving 1/8 of the slots keeps the expected miss probe length ~8 and
+   * bounds it in practice.
+   */
+  static constexpr size_t kMaxLoadNum = 7;
+  static constexpr size_t kMaxLoadDen = 8;
+
+  /**
+   * Hard cap on probe length for a single lookup.
+   *
+   * Purely a pathological-case backstop: it must NOT be the binding
+   * constraint, the load factor must be. Linear probing forms clusters far
+   * longer than the average probe length, so a tight cap silently rejects
+   * legitimate inserts long before the table is full -- measured at 64, a
+   * 65536-slot table stopped accepting new keys at ~51% occupancy instead of
+   * 87.5%, cutting cache coverage for 1M blobs from 26% to 18%.
+   *
+   * 1024 leaves the load factor in charge while still bounding a worst-case
+   * miss to ~1 us, versus the ~109 us unbounded scan it replaces.
+   */
+  static constexpr size_t kMaxProbe = 1024;
+
   struct Slot {
     ipc::atomic<min_u32> state_;
     /** Seqlock counter. Odd => a write is in progress on this slot. */
@@ -113,6 +149,7 @@ class unordered_map : public ShmContainer<AllocT> {
  private:
   size_t capacity_;  /**< Power of two; never changes after construction */
   size_t size_;      /**< Occupied slots. Writer-only; advisory for readers */
+  size_t max_fill_;  /**< Refuse NEW keys past this; see kMaxLoadNum */
   OffsetPtr<Slot> slots_;
 
  public:
@@ -121,6 +158,7 @@ class unordered_map : public ShmContainer<AllocT> {
       : ShmContainer<AllocT>(),
         capacity_(0),
         size_(0),
+        max_fill_(0),
         slots_(OffsetPtr<Slot>::GetNull()) {}
 
   /**
@@ -133,6 +171,7 @@ class unordered_map : public ShmContainer<AllocT> {
       : ShmContainer<AllocT>(alloc),
         capacity_(0),
         size_(0),
+        max_fill_(0),
         slots_(OffsetPtr<Slot>::GetNull()) {
     Allocate(capacity);
   }
@@ -182,8 +221,14 @@ class unordered_map : public ShmContainer<AllocT> {
     size_t mask = capacity_ - 1;
     size_t idx = key_hash & mask;
     size_t first_tombstone = capacity_;  // sentinel: none seen
+    // Overwrites of an existing key are always allowed; only NEW keys are
+    // subject to the load cap, so a saturated cache keeps serving (and
+    // updating) what it already holds instead of going stale.
+    const bool accept_new = (size_ < max_fill_);
+    const size_t probe_limit =
+        capacity_ < kMaxProbe ? capacity_ : kMaxProbe;
 
-    for (size_t probe = 0; probe < capacity_; ++probe) {
+    for (size_t probe = 0; probe < probe_limit; ++probe) {
       Slot &s = slots[idx];
       min_u32 st = s.state_.load();
       if (st == kOccupied) {
@@ -197,6 +242,9 @@ class unordered_map : public ShmContainer<AllocT> {
         if (st == kTombstone && first_tombstone == capacity_) {
           first_tombstone = idx;
         } else if (st == kEmpty) {
+          if (!accept_new) {
+            return false;  // at load cap: not cached, caller uses RPC
+          }
           // Prefer an earlier tombstone to keep probe sequences short.
           size_t target = (first_tombstone != capacity_) ? first_tombstone : idx;
           Slot &t = slots[target];
@@ -219,7 +267,7 @@ class unordered_map : public ShmContainer<AllocT> {
       }
       idx = (idx + 1) & mask;
     }
-    return false;  // table full
+    return false;  // at load cap, or probe limit hit
   }
 
   /**
@@ -237,7 +285,8 @@ class unordered_map : public ShmContainer<AllocT> {
     Slot *slots = Slots();
     size_t mask = capacity_ - 1;
     size_t idx = key_hash & mask;
-    for (size_t probe = 0; probe < capacity_; ++probe) {
+    const size_t probe_limit = capacity_ < kMaxProbe ? capacity_ : kMaxProbe;
+    for (size_t probe = 0; probe < probe_limit; ++probe) {
       Slot &s = slots[idx];
       min_u32 st = s.state_.load();
       if (st == kEmpty) {
@@ -293,7 +342,9 @@ class unordered_map : public ShmContainer<AllocT> {
     for (min_u32 attempt = 0; attempt < max_retries; ++attempt) {
       size_t idx = key_hash & mask;
       bool saw_torn = false;
-      for (size_t probe = 0; probe < capacity_; ++probe) {
+      const size_t probe_limit =
+          capacity_ < kMaxProbe ? capacity_ : kMaxProbe;
+      for (size_t probe = 0; probe < probe_limit; ++probe) {
         const Slot &s = slots[idx];
         min_u64 g0 = s.gen_.load();
         if ((g0 & 1) != 0) {
@@ -445,6 +496,10 @@ class unordered_map : public ShmContainer<AllocT> {
     }
     slots_ = OffsetPtr<Slot>(off.load());
     capacity_ = cap;
+    max_fill_ = (cap * kMaxLoadNum) / kMaxLoadDen;
+    if (max_fill_ == 0) {
+      max_fill_ = cap > 1 ? cap - 1 : 1;  // always leave one empty slot
+    }
     Slot *slots = Slots();
     for (size_t i = 0; i < cap; ++i) {
       // The allocation is raw memory, so every slot member must be constructed

--- a/context-transport-primitives/include/clio_ctp/data_structures/ipc/unordered_map.h
+++ b/context-transport-primitives/include/clio_ctp/data_structures/ipc/unordered_map.h
@@ -1,0 +1,468 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CTP_DATA_STRUCTURES_IPC_UNORDERED_MAP_H_
+#define CTP_DATA_STRUCTURES_IPC_UNORDERED_MAP_H_
+
+#include "clio_ctp/data_structures/ipc/shm_container.h"
+#include "clio_ctp/data_structures/ipc/string.h"
+#include "clio_ctp/types/atomic.h"
+
+#include <new>
+#include <type_traits>
+
+namespace ctp::ipc {
+
+/** Detects a key type that provides its own stable hash()/EqualsBytes(). */
+namespace detail {
+template <typename T, typename = void>
+struct HasShmHash : std::false_type {};
+
+template <typename T>
+struct HasShmHash<T, std::void_t<decltype(std::declval<const T &>().hash())>>
+    : std::true_type {};
+}  // namespace detail
+
+/**
+ * Shared-memory hash map (issue #783).
+ *
+ * SINGLE WRITER, MANY CROSS-PROCESS READERS. The runtime owns the table and is
+ * the only mutator; clients read it concurrently and may be SIGKILLed at any
+ * instant, including mid-read.
+ *
+ * DESIGN CHOICES, and why:
+ *
+ * 1. OPEN ADDRESSING, not chaining. A lock-free reader can probe a flat array
+ *    safely; chasing chain pointers while the writer recycles nodes would need
+ *    epoch protection on every node.
+ *
+ * 2. FIXED CAPACITY -- the table NEVER rehashes. Growth is the one operation
+ *    that cannot be made safe for untracked cross-process readers: a rehash
+ *    must free the old table, and there is no way to know when the last reader
+ *    has left it without exactly the epoch machinery this design rejected.
+ *    Instead the map is sized up front and a full table is reported as an
+ *    insert failure, which the cache already has to handle -- "cache full ->
+ *    fall back to RPC" is a required path regardless. Capacity is rounded up
+ *    to a power of two so the modulo is a mask.
+ *
+ * 3. PER-SLOT SEQLOCK. Readers store NOTHING: read the slot generation, copy
+ *    key+value out, re-read the generation, and retry if it moved or was odd.
+ *    A reader that dies leaves no state to reclaim -- which is precisely why
+ *    the default read path is a seqlock rather than a Lease.
+ *
+ * 4. TOMBSTONES on erase, because a probe sequence must not be broken by a
+ *    hole. Tombstones are reusable by a later insert of the same key.
+ *
+ * 5. READERS NEVER ALLOCATE. Lookup by raw bytes (TryGetBytes) exists so a
+ *    client can probe a string-keyed table without constructing a key inside
+ *    the runtime-owned segment.
+ *
+ * SHM-SAFE: no virtuals, offsets only.
+ *
+ * @tparam KeyT   key type; either provides hash()/EqualsBytes() (e.g.
+ *                ipc::string) or is a trivially comparable POD.
+ * @tparam ValueT value type; must be trivially copyable (it is memcpy'd out
+ *                under the seqlock).
+ * @tparam AllocT allocator type.
+ */
+template <typename KeyT, typename ValueT, typename AllocT>
+class unordered_map : public ShmContainer<AllocT> {
+ public:
+  using allocator_type = AllocT;
+
+  enum SlotState : min_u32 { kEmpty = 0, kOccupied = 1, kTombstone = 2 };
+
+  struct Slot {
+    ipc::atomic<min_u32> state_;
+    /** Seqlock counter. Odd => a write is in progress on this slot. */
+    ipc::atomic<min_u64> gen_;
+    KeyT key_;
+    ValueT value_;
+  };
+
+ private:
+  size_t capacity_;  /**< Power of two; never changes after construction */
+  size_t size_;      /**< Occupied slots. Writer-only; advisory for readers */
+  OffsetPtr<Slot> slots_;
+
+ public:
+  CTP_CROSS_FUN
+  unordered_map()
+      : ShmContainer<AllocT>(),
+        capacity_(0),
+        size_(0),
+        slots_(OffsetPtr<Slot>::GetNull()) {}
+
+  /**
+   * @param alloc    allocator (must own the same segment as this object)
+   * @param capacity desired entry count; rounded up to a power of two. Size
+   *                 generously: the table cannot grow later.
+   */
+  CTP_INLINE_CROSS_FUN
+  unordered_map(AllocT *alloc, size_t capacity)
+      : ShmContainer<AllocT>(alloc),
+        capacity_(0),
+        size_(0),
+        slots_(OffsetPtr<Slot>::GetNull()) {
+    Allocate(capacity);
+  }
+
+  unordered_map(const unordered_map &) = delete;
+  unordered_map &operator=(const unordered_map &) = delete;
+
+  CTP_INLINE_CROSS_FUN
+  ~unordered_map() {
+    AllocT *alloc = this->GetAllocator();
+    if (alloc != nullptr && !slots_.IsNull()) {
+      alloc->FreeOffsetNoNullCheck(OffsetPtr<>(slots_.load()));
+    }
+    slots_ = OffsetPtr<Slot>::GetNull();
+    capacity_ = 0;
+    size_ = 0;
+  }
+
+  CTP_INLINE_CROSS_FUN
+  size_t size() const { return size_; }
+
+  CTP_INLINE_CROSS_FUN
+  size_t capacity() const { return capacity_; }
+
+  CTP_INLINE_CROSS_FUN
+  bool valid() const { return !slots_.IsNull() && capacity_ > 0; }
+
+  // -------------------------------------------------------------------------
+  // Writer side (runtime only)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Insert or overwrite. Returns false if the table is full (never grows).
+   *
+   * The value is published under the slot's seqlock: bump generation to odd,
+   * write, bump back to even. A concurrent reader observing the odd value
+   * retries rather than reading a half-written entry.
+   */
+  template <typename KeyInit>
+  CTP_INLINE_CROSS_FUN bool InsertOrAssign(const KeyInit &key_probe,
+                                           size_t key_hash,
+                                           const ValueT &value) {
+    if (!valid()) {
+      return false;
+    }
+    Slot *slots = Slots();
+    size_t mask = capacity_ - 1;
+    size_t idx = key_hash & mask;
+    size_t first_tombstone = capacity_;  // sentinel: none seen
+
+    for (size_t probe = 0; probe < capacity_; ++probe) {
+      Slot &s = slots[idx];
+      min_u32 st = s.state_.load();
+      if (st == kOccupied) {
+        if (KeyMatches(s.key_, key_probe)) {
+          BeginWrite(s);
+          s.value_ = value;
+          EndWrite(s);
+          return true;  // key already correct; only the value changed
+        }
+      } else {
+        if (st == kTombstone && first_tombstone == capacity_) {
+          first_tombstone = idx;
+        } else if (st == kEmpty) {
+          // Prefer an earlier tombstone to keep probe sequences short.
+          size_t target = (first_tombstone != capacity_) ? first_tombstone : idx;
+          Slot &t = slots[target];
+          BeginWrite(t);
+          if (!AssignKey(t.key_, key_probe)) {
+            // Key storage could not be allocated. Abort the insert cleanly and
+            // leave the slot unusable-but-consistent rather than publishing an
+            // entry whose key is empty -- that would alias every other lookup
+            // that happens to probe here.
+            t.state_.store(kEmpty);
+            EndWrite(t);
+            return false;
+          }
+          t.value_ = value;
+          t.state_.store(kOccupied);
+          EndWrite(t);
+          ++size_;
+          return true;
+        }
+      }
+      idx = (idx + 1) & mask;
+    }
+    return false;  // table full
+  }
+
+  /**
+   * Writer-side lookup. Returns a pointer INTO the table, valid only while the
+   * writer holds whatever external synchronization it uses. Readers in other
+   * processes must use TryGet/TryGetBytes instead -- a raw pointer gives them
+   * no way to detect a concurrent overwrite.
+   */
+  template <typename KeyInit>
+  CTP_INLINE_CROSS_FUN Slot *FindSlot(const KeyInit &key_probe,
+                                      size_t key_hash) {
+    if (!valid()) {
+      return nullptr;
+    }
+    Slot *slots = Slots();
+    size_t mask = capacity_ - 1;
+    size_t idx = key_hash & mask;
+    for (size_t probe = 0; probe < capacity_; ++probe) {
+      Slot &s = slots[idx];
+      min_u32 st = s.state_.load();
+      if (st == kEmpty) {
+        return nullptr;  // probe sequence ends
+      }
+      if (st == kOccupied && KeyMatches(s.key_, key_probe)) {
+        return &s;
+      }
+      idx = (idx + 1) & mask;
+    }
+    return nullptr;
+  }
+
+  /** Erase by key. Leaves a tombstone so probe sequences stay intact. */
+  template <typename KeyInit>
+  CTP_INLINE_CROSS_FUN bool Erase(const KeyInit &key_probe, size_t key_hash) {
+    Slot *s = FindSlot(key_probe, key_hash);
+    if (s == nullptr) {
+      return false;
+    }
+    BeginWrite(*s);
+    s->state_.store(kTombstone);
+    EndWrite(*s);
+    if (size_ > 0) {
+      --size_;
+    }
+    return true;
+  }
+
+  // -------------------------------------------------------------------------
+  // Reader side (safe cross-process; performs NO stores)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Copy a value out under the slot's seqlock.
+   *
+   * @param max_retries bounds the retry loop so a reader cannot spin forever
+   *        against a pathologically hot slot (or a writer that died mid-update
+   *        leaving the generation odd -- see the TimedMutex reclamation path).
+   *        Exhausting retries returns false, and the caller falls back to RPC.
+   * @return true if a consistent value was copied out.
+   */
+  template <typename KeyInit>
+  CTP_INLINE_CROSS_FUN bool TryGet(const KeyInit &key_probe, size_t key_hash,
+                                   ValueT *out,
+                                   min_u32 max_retries = 16) const {
+    if (!valid() || out == nullptr) {
+      return false;
+    }
+    const Slot *slots = Slots();
+    size_t mask = capacity_ - 1;
+
+    for (min_u32 attempt = 0; attempt < max_retries; ++attempt) {
+      size_t idx = key_hash & mask;
+      bool saw_torn = false;
+      for (size_t probe = 0; probe < capacity_; ++probe) {
+        const Slot &s = slots[idx];
+        min_u64 g0 = s.gen_.load();
+        if ((g0 & 1) != 0) {
+          saw_torn = true;  // write in progress; restart the whole probe
+          break;
+        }
+        min_u32 st = s.state_.load();
+        if (st == kEmpty) {
+          // End of probe sequence. Only trust it if nothing changed under us.
+          if (s.gen_.load() == g0) {
+            return false;
+          }
+          saw_torn = true;
+          break;
+        }
+        if (st == kOccupied && KeyMatches(s.key_, key_probe)) {
+          ValueT tmp = s.value_;
+          // Re-validate: if the generation moved, the bytes we just copied may
+          // be a mix of the old and new value.
+          if (s.gen_.load() == g0) {
+            *out = tmp;
+            return true;
+          }
+          saw_torn = true;
+          break;
+        }
+        idx = (idx + 1) & mask;
+      }
+      if (!saw_torn) {
+        return false;
+      }
+    }
+    return false;  // gave up; caller falls back
+  }
+
+  /**
+   * Lookup by raw bytes for string-keyed tables -- no key object is
+   * constructed, so a client never allocates inside the segment it is only
+   * supposed to read.
+   */
+  CTP_INLINE_CROSS_FUN
+  bool TryGetBytes(const char *key, size_t len, ValueT *out,
+                   min_u32 max_retries = 16) const {
+    return TryGet(BytesProbe{key, len}, KeyT::HashBytes(key, len), out,
+                  max_retries);
+  }
+
+  /** Hash a key the same way the table does. */
+  template <typename KeyInit>
+  CTP_INLINE_CROSS_FUN static size_t Hash(const KeyInit &k) {
+    if constexpr (detail::HasShmHash<KeyInit>::value) {
+      return k.hash();
+    } else {
+      return HashPod(&k, sizeof(KeyInit));
+    }
+  }
+
+  CTP_INLINE_CROSS_FUN
+  static size_t HashPod(const void *p, size_t n) {
+    const unsigned char *b = static_cast<const unsigned char *>(p);
+    size_t h = 1469598103934665603ULL;
+    for (size_t i = 0; i < n; ++i) {
+      h ^= static_cast<size_t>(b[i]);
+      h *= 1099511628211ULL;
+    }
+    return h;
+  }
+
+  /** Raw-bytes probe wrapper (see TryGetBytes). */
+  struct BytesProbe {
+    const char *p;
+    size_t n;
+  };
+
+ private:
+  CTP_INLINE_CROSS_FUN
+  Slot *Slots() {
+    return FullPtr<Slot>(this->GetAllocator(), slots_).ptr_;
+  }
+
+  CTP_INLINE_CROSS_FUN
+  const Slot *Slots() const {
+    return FullPtr<Slot>(this->GetAllocator(), slots_).ptr_;
+  }
+
+  /** Publish-begin: make the generation odd so readers retry. */
+  CTP_INLINE_CROSS_FUN
+  static void BeginWrite(Slot &s) { s.gen_.fetch_add(1); }
+
+  /** Publish-end: back to even. */
+  CTP_INLINE_CROSS_FUN
+  static void EndWrite(Slot &s) { s.gen_.fetch_add(1); }
+
+  template <typename KeyInit>
+  CTP_INLINE_CROSS_FUN static bool KeyMatches(const KeyT &stored,
+                                              const KeyInit &probe) {
+    if constexpr (std::is_same_v<KeyInit, BytesProbe>) {
+      return stored.EqualsBytes(probe.p, probe.n);
+    } else {
+      return stored == probe;
+    }
+  }
+
+  /**
+   * Copy key material into a slot.
+   *
+   * Slot keys are constructed once (with the allocator) when the table is
+   * allocated and then reused, so an insert ASSIGNS rather than constructs --
+   * a construct here would leak the previous key's buffer and, for
+   * ipc::string, would need an allocator the probe does not carry.
+   */
+  template <typename KeyInit>
+  CTP_INLINE_CROSS_FUN static bool AssignKey(KeyT &stored,
+                                             const KeyInit &probe) {
+    if constexpr (std::is_same_v<KeyInit, BytesProbe>) {
+      return stored.assign(probe.p, probe.n);
+    } else if constexpr (detail::HasShmHash<KeyT>::value) {
+      return stored.assign(probe.data(), probe.size());
+    } else {
+      stored = probe;
+      return true;
+    }
+  }
+
+  CTP_INLINE_CROSS_FUN
+  void Allocate(size_t capacity) {
+    AllocT *alloc = this->GetAllocator();
+    if (alloc == nullptr || capacity == 0) {
+      return;
+    }
+    size_t cap = 1;
+    while (cap < capacity) {
+      cap <<= 1;
+    }
+    OffsetPtr<> off = OffsetPtr<>::GetNull();
+#if !CTP_IS_DEVICE_PASS
+    // Exhaustion must be recoverable, not an escaping exception -- see
+    // ipc::string::reserve for the same reasoning.
+    try {
+      off = alloc->AllocateOffset(cap * sizeof(Slot));
+    } catch (...) {
+      return;
+    }
+#else
+    off = alloc->AllocateOffset(cap * sizeof(Slot));
+#endif
+    if (off.IsNull()) {
+      return;
+    }
+    slots_ = OffsetPtr<Slot>(off.load());
+    capacity_ = cap;
+    Slot *slots = Slots();
+    for (size_t i = 0; i < cap; ++i) {
+      // The allocation is raw memory, so every slot member must be constructed
+      // explicitly. Keys are constructed WITH the allocator here (once) and
+      // assigned on each insert -- an ipc::string key cannot allocate its
+      // buffer without one, and a probe does not carry an allocator.
+      new (&slots[i].state_) ipc::atomic<min_u32>(kEmpty);
+      new (&slots[i].gen_) ipc::atomic<min_u64>(0);
+      if constexpr (detail::HasShmHash<KeyT>::value) {
+        new (&slots[i].key_) KeyT(alloc);
+      } else {
+        new (&slots[i].key_) KeyT();
+      }
+      new (&slots[i].value_) ValueT();
+    }
+  }
+};
+
+}  // namespace ctp::ipc
+
+#endif  // CTP_DATA_STRUCTURES_IPC_UNORDERED_MAP_H_

--- a/context-transport-primitives/include/clio_ctp/memory/smart_ptr/lease.h
+++ b/context-transport-primitives/include/clio_ctp/memory/smart_ptr/lease.h
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CTP_MEMORY_SMART_PTR_LEASE_H_
+#define CTP_MEMORY_SMART_PTR_LEASE_H_
+
+#include "clio_ctp/thread/lock/timed_mutex.h"
+#include "clio_ctp/types/atomic.h"
+
+namespace ctp::ipc {
+
+/**
+ * Mix-in for a shared-memory object that cross-process readers may access
+ * (issue #783).
+ *
+ * Carries the TWO mechanisms the design keeps deliberately separate:
+ *
+ *   gen_          -- CORRECTNESS. A seqlock counter, odd while a writer is
+ *                    mid-update. Readers validate it before and after copying
+ *                    and retry on mismatch. Readers store NOTHING, so a reader
+ *                    that dies mid-read leaves no state to reclaim. This is
+ *                    the default read path.
+ *
+ *   lease_mutex_  -- PROGRESS and LIFETIME. Taken only when a reader needs a
+ *                    stable view for longer than a retry loop tolerates, or
+ *                    when the runtime must not free the object underneath a
+ *                    reader. Reclaimable, so a client that dies holding one is
+ *                    eventually serviced.
+ *
+ * The asymmetry is the whole point: a lease is the only client-side construct
+ * whose abandonment needs servicing, so the design minimizes how often one is
+ * held. Prefer SeqRead; reach for Lease only when you must.
+ *
+ * SHM-SAFE: no virtuals, no pointers.
+ */
+struct Leaseable {
+  ipc::atomic<min_u64> gen_;
+  TimedMutex lease_mutex_;
+
+  CTP_INLINE_CROSS_FUN
+  Leaseable() : gen_(0) { lease_mutex_.Init(); }
+
+  CTP_INLINE_CROSS_FUN
+  void InitLeaseable() {
+    gen_ = 0;
+    lease_mutex_.Init();
+  }
+
+  /** Writer: open an update window (generation becomes odd). */
+  CTP_INLINE_CROSS_FUN
+  void BeginUpdate() { gen_.fetch_add(1); }
+
+  /** Writer: close the update window (generation becomes even). */
+  CTP_INLINE_CROSS_FUN
+  void EndUpdate() { gen_.fetch_add(1); }
+
+  /** True if a writer currently has this object open. */
+  CTP_INLINE_CROSS_FUN
+  bool IsUpdating() const { return (gen_.load() & 1) != 0; }
+};
+
+/**
+ * Optimistic read of a Leaseable object.
+ *
+ * Runs `copy_out` between two reads of the generation counter and accepts the
+ * result only if the counter did not move and was not odd. `copy_out` MUST be
+ * side-effect-free and must tolerate reading torn bytes -- it may run against
+ * a half-written object and have its result discarded. In particular it must
+ * not dereference a pointer read out of the object without re-validating.
+ *
+ * @return true if a consistent snapshot was taken.
+ */
+template <typename T, typename Fn>
+CTP_INLINE_CROSS_FUN bool SeqRead(const T &obj, Fn &&copy_out,
+                                  min_u32 max_retries = 16) {
+  for (min_u32 attempt = 0; attempt < max_retries; ++attempt) {
+    min_u64 g0 = obj.gen_.load();
+    if ((g0 & 1) != 0) {
+      continue;  // writer mid-update
+    }
+    copy_out();
+    if (obj.gen_.load() == g0) {
+      return true;
+    }
+  }
+  // Bounded rather than infinite: a writer that died mid-update leaves the
+  // generation odd forever, and a reader must degrade to the RPC path instead
+  // of spinning. (Runtime death is already fatal, but a bounded loop keeps a
+  // client from hanging on the way down.)
+  return false;
+}
+
+/**
+ * RAII lease over a Leaseable object.
+ *
+ * Acquiring is a STORE, which is why clients map the metadata segment
+ * read-write even though metadata itself is runtime-owned (see design §5.3b).
+ *
+ * Holds the TimedMutex acquisition id so release is the ABA-safe CAS form: if
+ * this lease was broken because the holder was presumed dead, releasing it must
+ * not unlock whoever legitimately acquired it afterwards.
+ *
+ * HOLD IT BRIEFLY. Copy what you need and let it go. A lease held across a
+ * syscall, an I/O, or any unbounded operation can delay runtime progress --
+ * the reclamation timeout is a backstop, not a budget.
+ */
+template <typename T>
+class Lease {
+ public:
+  /** Blocking acquire. */
+  CTP_INLINE_CROSS_FUN
+  explicit Lease(T *obj, min_u64 timeout_ms = TimedMutex::kDefaultTimeoutMs)
+      : obj_(obj), id_(0) {
+    if (obj_ != nullptr) {
+      id_ = obj_->lease_mutex_.Lock(timeout_ms);
+    }
+  }
+
+  /** Non-blocking acquire. Check Owns() before touching the object. */
+  CTP_INLINE_CROSS_FUN
+  static Lease TryAcquire(T *obj) {
+    Lease l;
+    l.obj_ = obj;
+    if (obj != nullptr) {
+      l.id_ = obj->lease_mutex_.TryLock();
+    }
+    return l;
+  }
+
+  CTP_INLINE_CROSS_FUN
+  Lease() : obj_(nullptr), id_(0) {}
+
+  CTP_INLINE_CROSS_FUN
+  ~Lease() { Release(); }
+
+  Lease(const Lease &) = delete;
+  Lease &operator=(const Lease &) = delete;
+
+  CTP_INLINE_CROSS_FUN
+  Lease(Lease &&other) noexcept : obj_(other.obj_), id_(other.id_) {
+    other.obj_ = nullptr;
+    other.id_ = 0;
+  }
+
+  CTP_INLINE_CROSS_FUN
+  Lease &operator=(Lease &&other) noexcept {
+    if (this != &other) {
+      Release();
+      obj_ = other.obj_;
+      id_ = other.id_;
+      other.obj_ = nullptr;
+      other.id_ = 0;
+    }
+    return *this;
+  }
+
+  /** True if this lease actually holds the object. */
+  CTP_INLINE_CROSS_FUN
+  bool Owns() const { return id_ != 0; }
+
+  /** Guarded object, or nullptr if the lease was not acquired. Returning
+   *  nullptr rather than the raw pointer makes a missing Owns() check fail
+   *  loudly instead of silently reading unprotected memory. */
+  CTP_INLINE_CROSS_FUN
+  T *get() const { return (id_ != 0) ? obj_ : nullptr; }
+
+  CTP_INLINE_CROSS_FUN
+  T *operator->() const { return get(); }
+
+  CTP_INLINE_CROSS_FUN
+  T &operator*() const { return *obj_; }
+
+  CTP_INLINE_CROSS_FUN
+  explicit operator bool() const { return Owns(); }
+
+  /** Release early. Idempotent. */
+  CTP_INLINE_CROSS_FUN
+  void Release() {
+    if (obj_ != nullptr && id_ != 0) {
+      obj_->lease_mutex_.Unlock(id_);
+    }
+    obj_ = nullptr;
+    id_ = 0;
+  }
+
+ private:
+  T *obj_;
+  min_u64 id_;
+};
+
+}  // namespace ctp::ipc
+
+#endif  // CTP_MEMORY_SMART_PTR_LEASE_H_

--- a/context-transport-primitives/include/clio_ctp/thread/lock/timed_mutex.h
+++ b/context-transport-primitives/include/clio_ctp/thread/lock/timed_mutex.h
@@ -45,7 +45,11 @@
 #include <thread>
 #endif
 
-#ifdef __linux__
+// POSIX liveness (kill(pid,0)) is available on Linux and macOS/BSD alike.
+// Only the /proc start-time refinement is Linux-specific.
+#if !defined(_WIN32) && !CTP_IS_DEVICE_PASS
+#define CTP_TIMED_MUTEX_POSIX_LIVENESS 1
+#include <cerrno>
 #include <csignal>
 #include <cstdio>
 #endif
@@ -368,13 +372,24 @@ struct TimedMutex {
    */
   CTP_INLINE_CROSS_FUN
   static bool IsProcessAlive(min_u32 pid, min_u64 start_time) {
-#if defined(__linux__) && !CTP_IS_DEVICE_PASS
+#if defined(CTP_TIMED_MUTEX_POSIX_LIVENESS)
+    // kill(pid, 0) is POSIX and works on macOS/BSD too, not just Linux. An
+    // earlier version gated this on __linux__ and returned "always alive"
+    // everywhere else, which meant a lease abandoned by a killed process was
+    // NEVER reclaimed off-Linux -- the reclamation torture test hung until the
+    // ctest timeout on macOS.
     if (kill(static_cast<pid_t>(pid), 0) != 0) {
-      return false;  // no such process (or not ours -- see below)
+      // ESRCH => gone. EPERM => it exists but belongs to another user, which
+      // still means it is alive, so only treat "no such process" as dead.
+      if (errno == ESRCH) {
+        return false;
+      }
+      return true;
     }
     // The pid exists, but it may be a REUSED pid belonging to a different
-    // process. If we recorded a start time, a mismatch proves the original
-    // holder is gone.
+    // process. Where a start time is available (Linux /proc), a mismatch
+    // proves the original holder is gone. Platforms without it accept a small
+    // pid-reuse window rather than never reclaiming at all.
     if (start_time != 0) {
       min_u64 cur = GetProcessStartTime(pid);
       if (cur != 0 && cur != start_time) {
@@ -383,8 +398,8 @@ struct TimedMutex {
     }
     return true;
 #else
-    // No portable liveness check: never steal. The lock still works, it just
-    // cannot be reclaimed from a dead holder on this platform.
+    // No liveness check available (Windows, device passes): never steal. The
+    // lock still works, it just cannot be reclaimed from a dead holder here.
     (void)pid;
     (void)start_time;
     return true;

--- a/context-transport-primitives/include/clio_ctp/thread/lock/timed_mutex.h
+++ b/context-transport-primitives/include/clio_ctp/thread/lock/timed_mutex.h
@@ -1,0 +1,435 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CTP_THREAD_LOCK_TIMED_MUTEX_H_
+#define CTP_THREAD_LOCK_TIMED_MUTEX_H_
+
+#include "clio_ctp/thread/thread_model_manager.h"
+#include "clio_ctp/types/atomic.h"
+#include "clio_ctp/types/numbers.h"
+#include "clio_ctp/introspect/system_info.h"
+
+#if !CTP_IS_DEVICE_PASS
+#include <chrono>
+#include <cstdlib>
+#include <thread>
+#endif
+
+#ifdef __linux__
+#include <csignal>
+#include <cstdio>
+#endif
+
+namespace ctp {
+
+/**
+ * TimedMutex -- a cross-process mutex whose holder can be RECLAIMED if it dies
+ * (issue #783).
+ *
+ * WHY NOT `ctp::Mutex`: `Mutex` is a fair TICKET lock -- `Lock()` takes
+ * `lock_.fetch_add(1)` and spins until `head_` reaches its ticket. If the
+ * holder dies, `head_` is never advanced and every subsequent waiter blocks
+ * forever; and force-advancing `head_` releases several waiters at once,
+ * destroying mutual exclusion. A ticket lock fundamentally cannot be reclaimed.
+ * `TimedMutex` is therefore an unfair CAS lock, which trades FIFO fairness for
+ * the ability to break a lock left behind by a dead process.
+ *
+ * INTENDED USE: guarding shared-memory objects that are read by client
+ * processes the owner cannot trust to stay alive. A client may be SIGKILLed at
+ * any instant, including while holding this lock.
+ *
+ * NOT A GENERAL-PURPOSE MUTEX. Prefer `ctp::Mutex` for anything that lives
+ * inside one process: it is fair, cheaper, and has no reclamation machinery.
+ *
+ * SHM-SAFE: no virtual functions, no pointers, no heap. Every field is a
+ * fixed-width atomic, so the object is valid at any base address in any
+ * process. (Any type stored in shared memory must satisfy this -- a vtable
+ * pointer would be a process-local address.)
+ *
+ * RECLAMATION ALGORITHM. Each acquisition stamps `state_` with a unique,
+ * never-reused id drawn from `ticket_`. A waiter:
+ *   1. samples `state_` (call it `observed`, non-zero => held),
+ *   2. waits, re-checking; if `state_` ever changes the holder made progress,
+ *      so the wait restarts,
+ *   3. once `observed` has been continuously unchanged for `timeout_ms`, checks
+ *      whether the owner process is still alive,
+ *   4. steals ONLY if the owner is gone, via `CAS(observed -> 0)`.
+ *
+ * Two properties fall out of this:
+ *   - Elapsed time is measured on the WAITER's own clock against an unchanged
+ *     acquisition id, so no shared timestamp and no cross-process clock
+ *     agreement is required.
+ *   - The CAS makes the steal ABA-safe: if the holder released and someone else
+ *     acquired in the meantime, `state_` no longer equals `observed` and the
+ *     steal fails harmlessly.
+ *
+ * A live-but-slow holder is NEVER stolen from, only a provably dead one. That
+ * matters: stealing from a live reader would let a writer mutate data out from
+ * under it, which is precisely the silent corruption this exists to prevent.
+ * A timeout alone cannot distinguish "dead" from "descheduled / page-faulting",
+ * so the liveness check is mandatory, not advisory.
+ */
+struct TimedMutex {
+  /** 0 = unlocked; otherwise the unique id of the current acquisition. */
+  ipc::atomic<min_u64> state_;
+  /** Source of unique acquisition ids. Bumped per ATTEMPT; only uniqueness
+   *  matters, not density. */
+  ipc::atomic<min_u64> ticket_;
+  /** OS pid of the current holder (0 if none). Written after winning the CAS. */
+  ipc::atomic<min_u32> owner_pid_;
+  /** Holder's process start time, to defeat PID REUSE: a recycled pid would
+   *  otherwise look alive and make a dead holder unreclaimable forever.
+   *  Linux: field 22 of /proc/<pid>/stat. 0 = unknown. */
+  ipc::atomic<min_u64> owner_start_;
+  /** Count of locks broken from dead owners. Diagnostics only -- a non-zero
+   *  value means clients are dying while holding leases. */
+  ipc::atomic<min_u64> steal_count_;
+
+  /** Default reclamation threshold. A lock continuously held this long by a
+   *  process that has since died is eligible to be broken. */
+  static constexpr min_u64 kDefaultTimeoutMs = 500;
+
+  CTP_INLINE_CROSS_FUN
+  TimedMutex()
+      : state_(0), ticket_(0), owner_pid_(0), owner_start_(0), steal_count_(0) {}
+
+  /** Copy ctor leaves the copy UNLOCKED. Copying a locked mutex would
+   *  otherwise duplicate ownership. Mirrors ctp::Mutex. */
+  CTP_INLINE_CROSS_FUN
+  TimedMutex(const TimedMutex &other) { Init(); }
+
+  CTP_INLINE_CROSS_FUN
+  TimedMutex &operator=(const TimedMutex &other) {
+    if (this != &other) {
+      Init();
+    }
+    return *this;
+  }
+
+  /** Explicit initialization (placement-new into shared memory). */
+  CTP_INLINE_CROSS_FUN
+  void Init() {
+    state_ = 0;
+    ticket_ = 0;
+    owner_pid_ = 0;
+    owner_start_ = 0;
+    steal_count_ = 0;
+  }
+
+  /** True if currently held by anyone. Advisory: the answer may be stale the
+   *  instant it is returned. */
+  CTP_INLINE_CROSS_FUN
+  bool IsLocked() const { return state_.load() != 0; }
+
+  /**
+   * Try to acquire without waiting.
+   * @return the acquisition id on success (pass it to Unlock), or 0 on failure.
+   */
+  CTP_INLINE_CROSS_FUN
+  min_u64 TryLock() {
+    min_u64 my = ticket_.fetch_add(1) + 1;  // never 0
+    min_u64 expected = 0;
+    if (!state_.compare_exchange_strong(expected, my)) {
+      return 0;
+    }
+    // We own it: publish identity for liveness checks by future waiters.
+    StampOwner();
+    return my;
+  }
+
+  /**
+   * Acquire, blocking the calling THREAD until success.
+   *
+   * Callers on a runtime worker should be aware this occupies the worker for
+   * the duration; the issue #781 work-orchestrator stall detection is what
+   * makes that survivable. Prefer TryLock() plus a caller-level retry where
+   * skipping the work is acceptable (e.g. background reorganization).
+   *
+   * @param timeout_ms how long an UNCHANGED acquisition must persist before a
+   *        dead owner's lock is broken.
+   * @return the acquisition id (pass it to Unlock).
+   */
+  CTP_INLINE_CROSS_FUN
+  min_u64 Lock(min_u64 timeout_ms = kDefaultTimeoutMs) {
+    for (;;) {
+      min_u64 my = TryLock();
+      if (my != 0) {
+        return my;
+      }
+      WaitAndMaybeReclaim(timeout_ms);
+    }
+  }
+
+  /**
+   * Release.
+   *
+   * @param id the value returned by TryLock/Lock. The release is a CAS, so if
+   *        the lock was already broken (owner presumed dead) and re-acquired by
+   *        someone else, this is a NO-OP rather than a silent unlock of the new
+   *        owner's acquisition. Passing 0 force-unlocks and is for teardown only.
+   * @return true if this call actually released the lock.
+   */
+  CTP_INLINE_CROSS_FUN
+  bool Unlock(min_u64 id) {
+    if (id == 0) {
+      owner_pid_ = 0;
+      owner_start_ = 0;
+      state_ = 0;
+      return true;
+    }
+    min_u64 expected = id;
+    // Clear identity BEFORE releasing: after state_ hits 0 another process may
+    // acquire immediately, and it must not observe our pid as the owner.
+    owner_pid_ = 0;
+    owner_start_ = 0;
+    if (state_.compare_exchange_strong(expected, 0)) {
+      return true;
+    }
+    return false;  // already stolen; the new owner has re-stamped identity
+  }
+
+  /** Number of locks broken from dead owners (diagnostics). */
+  CTP_INLINE_CROSS_FUN
+  min_u64 GetStealCount() const { return steal_count_.load(); }
+
+ private:
+  /** Publish this process's identity as the holder. */
+  CTP_INLINE_CROSS_FUN
+  void StampOwner() {
+#if !CTP_IS_DEVICE_PASS
+    owner_pid_ = static_cast<min_u32>(ctp::SystemInfo::GetPid());
+    owner_start_ = GetProcessStartTime(static_cast<min_u32>(
+        ctp::SystemInfo::GetPid()));
+#endif
+  }
+
+  /**
+   * Wait for the lock to change hands; if it does not within `timeout_ms` AND
+   * the owner is dead, break it.
+   */
+  CTP_INLINE_CROSS_FUN
+  void WaitAndMaybeReclaim(min_u64 timeout_ms) {
+#if !CTP_IS_DEVICE_PASS
+    min_u64 observed = state_.load();
+    if (observed == 0) {
+      return;  // became free; caller retries immediately
+    }
+    auto start = std::chrono::steady_clock::now();
+    u32 spin = 0;
+    for (;;) {
+      CTP_THREAD_MODEL->Yield();
+      min_u64 now_state = state_.load();
+      if (now_state != observed) {
+        return;  // holder made progress -- restart the wait from scratch
+      }
+      auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                         std::chrono::steady_clock::now() - start)
+                         .count();
+      if (static_cast<min_u64>(elapsed) >= timeout_ms) {
+        TryReclaim(observed);
+        return;  // caller retries; if the steal worked the lock is now free
+      }
+      // Back off so a descheduled holder can get the core. Purely cooperative
+      // for user-level-thread models, where sleeping would block sibling ULTs
+      // (possibly the holder itself).
+      if (++spin > 64) {
+        ThreadType ty = CTP_THREAD_MODEL->GetType();
+        if (ty == ThreadType::kPthread || ty == ThreadType::kStdThread) {
+          std::this_thread::sleep_for(std::chrono::microseconds(100));
+        }
+      }
+    }
+#else
+    (void)timeout_ms;
+#endif
+  }
+
+  /** Break `observed` if and only if its owner process is gone. */
+  CTP_INLINE_CROSS_FUN
+  void TryReclaim(min_u64 observed) {
+#if !CTP_IS_DEVICE_PASS
+    min_u32 pid = owner_pid_.load();
+    min_u64 start = owner_start_.load();
+    if (pid == 0) {
+      return;  // identity not yet published; too early to judge
+    }
+    if (IsProcessAlive(pid, start)) {
+      return;  // live but slow -- stealing here would corrupt its read
+    }
+    min_u64 expected = observed;
+    if (state_.compare_exchange_strong(expected, 0)) {
+      owner_pid_ = 0;
+      owner_start_ = 0;
+      steal_count_.fetch_add(1);
+    }
+    // CAS failure is fine: the lock changed hands on its own.
+#else
+    (void)observed;
+#endif
+  }
+
+  /**
+   * Read a process's start time (Linux: /proc/<pid>/stat field 22, in clock
+   * ticks since boot). Returns 0 when unavailable, which callers treat as
+   * "unknown" rather than "mismatch".
+   */
+  CTP_INLINE_CROSS_FUN
+  static min_u64 GetProcessStartTime(min_u32 pid) {
+#if defined(__linux__) && !CTP_IS_DEVICE_PASS
+    char path[64];
+    snprintf(path, sizeof(path), "/proc/%u/stat", static_cast<unsigned>(pid));
+    FILE *f = fopen(path, "r");
+    if (f == nullptr) {
+      return 0;
+    }
+    // Field 2 (comm) may contain spaces and parentheses, so scan from the
+    // LAST ')' rather than tokenizing from the start.
+    char buf[4096];
+    size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+    fclose(f);
+    if (n == 0) {
+      return 0;
+    }
+    buf[n] = '\0';
+    char *rparen = nullptr;
+    for (char *p = buf; *p != '\0'; ++p) {
+      if (*p == ')') {
+        rparen = p;
+      }
+    }
+    if (rparen == nullptr) {
+      return 0;
+    }
+    // After ") " comes field 3; starttime is field 22, i.e. the 20th token.
+    char *p = rparen + 1;
+    int field = 2;
+    unsigned long long starttime = 0;
+    while (*p != '\0') {
+      while (*p == ' ') {
+        ++p;
+      }
+      if (*p == '\0') {
+        break;
+      }
+      ++field;
+      if (field == 22) {
+        starttime = strtoull(p, nullptr, 10);
+        break;
+      }
+      while (*p != ' ' && *p != '\0') {
+        ++p;
+      }
+    }
+    return static_cast<min_u64>(starttime);
+#else
+    (void)pid;
+    return 0;
+#endif
+  }
+
+  /**
+   * Is `pid` alive AND the same process instance that took the lock?
+   *
+   * Deliberately CONSERVATIVE: anything uncertain returns true (= do not
+   * steal). A false "dead" frees a lock a live process is still using, which
+   * corrupts data; a false "alive" only delays reclamation until the next
+   * timeout. The asymmetry is not close, so ambiguity always resolves to
+   * "alive".
+   */
+  CTP_INLINE_CROSS_FUN
+  static bool IsProcessAlive(min_u32 pid, min_u64 start_time) {
+#if defined(__linux__) && !CTP_IS_DEVICE_PASS
+    if (kill(static_cast<pid_t>(pid), 0) != 0) {
+      return false;  // no such process (or not ours -- see below)
+    }
+    // The pid exists, but it may be a REUSED pid belonging to a different
+    // process. If we recorded a start time, a mismatch proves the original
+    // holder is gone.
+    if (start_time != 0) {
+      min_u64 cur = GetProcessStartTime(pid);
+      if (cur != 0 && cur != start_time) {
+        return false;
+      }
+    }
+    return true;
+#else
+    // No portable liveness check: never steal. The lock still works, it just
+    // cannot be reclaimed from a dead holder on this platform.
+    (void)pid;
+    (void)start_time;
+    return true;
+#endif
+  }
+};
+
+/**
+ * RAII guard for TimedMutex. Holds the acquisition id so the release is the
+ * ABA-safe CAS form rather than a blind unlock.
+ */
+struct ScopedTimedLock {
+  TimedMutex *mutex_;
+  min_u64 id_;
+
+  CTP_INLINE_CROSS_FUN
+  explicit ScopedTimedLock(TimedMutex &m,
+                           min_u64 timeout_ms = TimedMutex::kDefaultTimeoutMs)
+      : mutex_(&m), id_(m.Lock(timeout_ms)) {}
+
+  /** Non-blocking form: check `Owns()` before touching the guarded data. */
+  CTP_INLINE_CROSS_FUN
+  ScopedTimedLock(TimedMutex &m, bool try_only) : mutex_(&m), id_(0) {
+    if (try_only) {
+      id_ = m.TryLock();
+    } else {
+      id_ = m.Lock();
+    }
+  }
+
+  CTP_INLINE_CROSS_FUN
+  ~ScopedTimedLock() {
+    if (mutex_ != nullptr && id_ != 0) {
+      mutex_->Unlock(id_);
+    }
+  }
+
+  ScopedTimedLock(const ScopedTimedLock &) = delete;
+  ScopedTimedLock &operator=(const ScopedTimedLock &) = delete;
+
+  /** True if this guard actually holds the lock. */
+  CTP_INLINE_CROSS_FUN
+  bool Owns() const { return id_ != 0; }
+};
+
+}  // namespace ctp
+
+#endif  // CTP_THREAD_LOCK_TIMED_MUTEX_H_

--- a/context-transport-primitives/test/unit/data_structures/ipc/CMakeLists.txt
+++ b/context-transport-primitives/test/unit/data_structures/ipc/CMakeLists.txt
@@ -40,6 +40,12 @@ add_dependencies(test_unordered_map_exec clio_ctp_host)
 target_link_libraries(test_unordered_map_exec
         clio_ctp_host Catch2::Catch2WithMain)
 
+add_executable(test_lease_exec
+        test_lease.cc)
+add_dependencies(test_lease_exec clio_ctp_host)
+target_link_libraries(test_lease_exec
+        clio_ctp_host Catch2::Catch2WithMain)
+
 add_executable(test_ring_buffer_exec
         test_ring_buffer.cc)
 add_dependencies(test_ring_buffer_exec clio_ctp_host)
@@ -109,6 +115,10 @@ add_test(NAME ctp_ipc_string COMMAND
 add_test(NAME ctp_ipc_unordered_map COMMAND
         ${CMAKE_BINARY_DIR}/bin/test_unordered_map_exec)
 
+add_test(NAME ctp_ipc_lease COMMAND
+        ${CMAKE_BINARY_DIR}/bin/test_lease_exec)
+set_tests_properties(ctp_ipc_lease PROPERTIES TIMEOUT 120)
+
 add_test(NAME ctp_ring_buffer COMMAND
         ${CMAKE_BINARY_DIR}/bin/test_ring_buffer_exec)
 add_test(NAME ctp_ring_buffer_spsc COMMAND
@@ -176,6 +186,7 @@ install(TARGETS
         test_vector_exec
         test_string_exec
         test_unordered_map_exec
+        test_lease_exec
         test_ring_buffer_exec
         test_ring_buffer_spsc_exec
         test_ring_buffer_ext_exec

--- a/context-transport-primitives/test/unit/data_structures/ipc/CMakeLists.txt
+++ b/context-transport-primitives/test/unit/data_structures/ipc/CMakeLists.txt
@@ -34,6 +34,12 @@ add_dependencies(test_string_exec clio_ctp_host)
 target_link_libraries(test_string_exec
         clio_ctp_host Catch2::Catch2WithMain)
 
+add_executable(test_unordered_map_exec
+        test_unordered_map.cc)
+add_dependencies(test_unordered_map_exec clio_ctp_host)
+target_link_libraries(test_unordered_map_exec
+        clio_ctp_host Catch2::Catch2WithMain)
+
 add_executable(test_ring_buffer_exec
         test_ring_buffer.cc)
 add_dependencies(test_ring_buffer_exec clio_ctp_host)
@@ -99,6 +105,9 @@ add_test(NAME ctp_vector_stress COMMAND
 
 add_test(NAME ctp_ipc_string COMMAND
         ${CMAKE_BINARY_DIR}/bin/test_string_exec)
+
+add_test(NAME ctp_ipc_unordered_map COMMAND
+        ${CMAKE_BINARY_DIR}/bin/test_unordered_map_exec)
 
 add_test(NAME ctp_ring_buffer COMMAND
         ${CMAKE_BINARY_DIR}/bin/test_ring_buffer_exec)
@@ -166,6 +175,7 @@ install(TARGETS
         test_rb_tree_pre_ext_exec
         test_vector_exec
         test_string_exec
+        test_unordered_map_exec
         test_ring_buffer_exec
         test_ring_buffer_spsc_exec
         test_ring_buffer_ext_exec

--- a/context-transport-primitives/test/unit/data_structures/ipc/CMakeLists.txt
+++ b/context-transport-primitives/test/unit/data_structures/ipc/CMakeLists.txt
@@ -28,6 +28,12 @@ add_dependencies(test_vector_exec clio_ctp_host)
 target_link_libraries(test_vector_exec
         clio_ctp_host)
 
+add_executable(test_string_exec
+        test_string.cc)
+add_dependencies(test_string_exec clio_ctp_host)
+target_link_libraries(test_string_exec
+        clio_ctp_host Catch2::Catch2WithMain)
+
 add_executable(test_ring_buffer_exec
         test_ring_buffer.cc)
 add_dependencies(test_ring_buffer_exec clio_ctp_host)
@@ -90,6 +96,9 @@ add_test(NAME ctp_vector_edge COMMAND
         ${CMAKE_BINARY_DIR}/bin/test_vector_exec)
 add_test(NAME ctp_vector_stress COMMAND
         ${CMAKE_BINARY_DIR}/bin/test_vector_exec)
+
+add_test(NAME ctp_ipc_string COMMAND
+        ${CMAKE_BINARY_DIR}/bin/test_string_exec)
 
 add_test(NAME ctp_ring_buffer COMMAND
         ${CMAKE_BINARY_DIR}/bin/test_ring_buffer_exec)
@@ -156,6 +165,7 @@ install(TARGETS
         test_rb_tree_pre_exec
         test_rb_tree_pre_ext_exec
         test_vector_exec
+        test_string_exec
         test_ring_buffer_exec
         test_ring_buffer_spsc_exec
         test_ring_buffer_ext_exec

--- a/context-transport-primitives/test/unit/data_structures/ipc/test_lease.cc
+++ b/context-transport-primitives/test/unit/data_structures/ipc/test_lease.cc
@@ -35,11 +35,18 @@
 
 #include "clio_ctp/memory/smart_ptr/lease.h"
 
+// The cross-process half of this suite needs fork()/mmap()/waitpid(), which
+// are POSIX-only. On Windows the single-process Lease/SeqRead cases still run;
+// the kill-readers torture test is compiled out rather than faked, because a
+// weaker stand-in would give false confidence in the one property that matters.
+#ifndef _WIN32
 #include <sys/mman.h>
 #include <sys/wait.h>
 #include <unistd.h>
 #include <csignal>
+#endif
 #include <chrono>
+#include <cstdlib>
 #include <thread>
 #include <vector>
 
@@ -68,11 +75,20 @@ struct Shared {
 };
 
 Shared *MapShared() {
+#ifndef _WIN32
   void *m = mmap(nullptr, sizeof(Shared), PROT_READ | PROT_WRITE,
                  MAP_SHARED | MAP_ANONYMOUS, -1, 0);
   if (m == MAP_FAILED) {
     return nullptr;
   }
+#else
+  // Single-process cases only need shared-nothing memory; the cross-process
+  // cases are compiled out on Windows.
+  void *m = std::malloc(sizeof(Shared));
+  if (m == nullptr) {
+    return nullptr;
+  }
+#endif
   auto *s = new (m) Shared();
   s->rec.InitLeaseable();
   s->rec.value = 0;
@@ -87,6 +103,7 @@ Shared *MapShared() {
   return s;
 }
 
+#ifndef _WIN32
 /** Reader loop: seqlock-read the record and check the invariant. */
 void ReaderLoop(Shared *s) {
   ctp::min_u64 snap[kFields];
@@ -109,8 +126,15 @@ void ReaderLoop(Shared *s) {
     s->read_ok.fetch_add(1);
   }
 }
+#endif  // !_WIN32
 
 }  // namespace
+
+#ifdef _WIN32
+static void UnmapShared(Shared *s) { std::free(s); }
+#else
+static void UnmapShared(Shared *s) { munmap(s, sizeof(Shared)); }
+#endif
 
 TEST_CASE("Lease: basic acquire and release", "[lease]") {
   auto *s = MapShared();
@@ -131,7 +155,7 @@ TEST_CASE("Lease: basic acquire and release", "[lease]") {
   // outliving its segment unlocks through a dangling pointer -- which is
   // exactly what a client must avoid when the runtime tears the metadata
   // segment down underneath it.
-  munmap(s, sizeof(Shared));
+  UnmapShared(s);
 }
 
 TEST_CASE("Lease: TryAcquire fails while held", "[lease]") {
@@ -153,7 +177,7 @@ TEST_CASE("Lease: TryAcquire fails while held", "[lease]") {
     REQUIRE(c.Owns());
   }
 
-  munmap(s, sizeof(Shared));
+  UnmapShared(s);
 }
 
 TEST_CASE("Lease: move transfers ownership exactly once", "[lease]") {
@@ -174,7 +198,7 @@ TEST_CASE("Lease: move transfers ownership exactly once", "[lease]") {
     REQUIRE(c.Owns());
   }
 
-  munmap(s, sizeof(Shared));
+  UnmapShared(s);
 }
 
 TEST_CASE("SeqRead: rejects a write in progress", "[lease]") {
@@ -193,7 +217,7 @@ TEST_CASE("SeqRead: rejects a write in progress", "[lease]") {
   REQUIRE(ok);
   REQUIRE(ran);
 
-  munmap(s, sizeof(Shared));
+  UnmapShared(s);
 }
 
 // ===========================================================================
@@ -204,6 +228,7 @@ TEST_CASE("SeqRead: rejects a write in progress", "[lease]") {
 //   2. Killing readers -- including ones holding leases -- never wedges the
 //      writer, and abandoned leases are reclaimed.
 // ===========================================================================
+#ifndef _WIN32
 TEST_CASE("Lease torture: readers killed at random never tear or wedge",
           "[lease][torture]") {
   auto *s = MapShared();
@@ -307,5 +332,6 @@ TEST_CASE("Lease torture: readers killed at random never tear or wedge",
   REQUIRE(s->read_ok.load() > 10);
   REQUIRE(s->rec.lease_mutex_.GetStealCount() >= 1);
 
-  munmap(s, sizeof(Shared));
+  UnmapShared(s);
 }
+#endif  // !_WIN32

--- a/context-transport-primitives/test/unit/data_structures/ipc/test_lease.cc
+++ b/context-transport-primitives/test/unit/data_structures/ipc/test_lease.cc
@@ -1,0 +1,311 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "clio_ctp/memory/smart_ptr/lease.h"
+
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <csignal>
+#include <chrono>
+#include <thread>
+#include <vector>
+
+using namespace ctp::ipc;
+
+namespace {
+
+constexpr size_t kFields = 16;
+
+/**
+ * A record with a checkable invariant: every field must equal `value`. A torn
+ * read shows up as fields from two different generations.
+ */
+struct Record : public Leaseable {
+  ctp::min_u64 value;
+  ctp::min_u64 fields[kFields];
+};
+
+struct Shared {
+  Record rec;
+  ctp::ipc::atomic<ctp::min_u64> torn_count;   /**< MUST stay 0 */
+  ctp::ipc::atomic<ctp::min_u64> read_ok;
+  ctp::ipc::atomic<ctp::min_u64> read_retry;
+  ctp::ipc::atomic<ctp::min_u64> writes;
+  ctp::ipc::atomic<ctp::min_u32> stop;
+};
+
+Shared *MapShared() {
+  void *m = mmap(nullptr, sizeof(Shared), PROT_READ | PROT_WRITE,
+                 MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+  if (m == MAP_FAILED) {
+    return nullptr;
+  }
+  auto *s = new (m) Shared();
+  s->rec.InitLeaseable();
+  s->rec.value = 0;
+  for (size_t i = 0; i < kFields; ++i) {
+    s->rec.fields[i] = 0;
+  }
+  s->torn_count = 0;
+  s->read_ok = 0;
+  s->read_retry = 0;
+  s->writes = 0;
+  s->stop = 0;
+  return s;
+}
+
+/** Reader loop: seqlock-read the record and check the invariant. */
+void ReaderLoop(Shared *s) {
+  ctp::min_u64 snap[kFields];
+  while (s->stop.load() == 0) {
+    bool ok = SeqRead(s->rec, [&]() {
+      for (size_t i = 0; i < kFields; ++i) {
+        snap[i] = s->rec.fields[i];
+      }
+    });
+    if (!ok) {
+      s->read_retry.fetch_add(1);
+      continue;
+    }
+    for (size_t i = 1; i < kFields; ++i) {
+      if (snap[i] != snap[0]) {
+        s->torn_count.fetch_add(1);
+        break;
+      }
+    }
+    s->read_ok.fetch_add(1);
+  }
+}
+
+}  // namespace
+
+TEST_CASE("Lease: basic acquire and release", "[lease]") {
+  auto *s = MapShared();
+  REQUIRE(s != nullptr);
+
+  {
+    Lease<Record> l(&s->rec);
+    REQUIRE(l.Owns());
+    REQUIRE(l.get() == &s->rec);
+    REQUIRE(static_cast<bool>(l));
+  }
+  // Released on scope exit -- a fresh lease must succeed.
+  {
+    Lease<Record> l2 = Lease<Record>::TryAcquire(&s->rec);
+    REQUIRE(l2.Owns());
+  }
+  // NOTE: every lease must be destroyed BEFORE the mapping goes away. A lease
+  // outliving its segment unlocks through a dangling pointer -- which is
+  // exactly what a client must avoid when the runtime tears the metadata
+  // segment down underneath it.
+  munmap(s, sizeof(Shared));
+}
+
+TEST_CASE("Lease: TryAcquire fails while held", "[lease]") {
+  auto *s = MapShared();
+  REQUIRE(s != nullptr);
+
+  Lease<Record> a(&s->rec);
+  REQUIRE(a.Owns());
+
+  Lease<Record> b = Lease<Record>::TryAcquire(&s->rec);
+  REQUIRE_FALSE(b.Owns());
+  // A non-owning lease must not hand out the object -- a missed Owns() check
+  // should fail loudly, not silently read unprotected memory.
+  REQUIRE(b.get() == nullptr);
+
+  a.Release();
+  {
+    Lease<Record> c = Lease<Record>::TryAcquire(&s->rec);
+    REQUIRE(c.Owns());
+  }
+
+  munmap(s, sizeof(Shared));
+}
+
+TEST_CASE("Lease: move transfers ownership exactly once", "[lease]") {
+  auto *s = MapShared();
+  REQUIRE(s != nullptr);
+
+  {
+    Lease<Record> a(&s->rec);
+    REQUIRE(a.Owns());
+    Lease<Record> b(std::move(a));
+    REQUIRE(b.Owns());
+    REQUIRE_FALSE(a.Owns());  // NOLINT(bugprone-use-after-move)
+  }
+  // If the moved-from lease had also released, this would still pass; the real
+  // check is that the lock is free exactly once and is acquirable now.
+  {
+    Lease<Record> c = Lease<Record>::TryAcquire(&s->rec);
+    REQUIRE(c.Owns());
+  }
+
+  munmap(s, sizeof(Shared));
+}
+
+TEST_CASE("SeqRead: rejects a write in progress", "[lease]") {
+  auto *s = MapShared();
+  REQUIRE(s != nullptr);
+
+  s->rec.BeginUpdate();  // leave it odd
+  REQUIRE(s->rec.IsUpdating());
+  bool ran = false;
+  bool ok = SeqRead(s->rec, [&]() { ran = true; }, 4);
+  REQUIRE_FALSE(ok);
+  REQUIRE_FALSE(ran);  // never even attempted while odd
+
+  s->rec.EndUpdate();
+  ok = SeqRead(s->rec, [&]() { ran = true; }, 4);
+  REQUIRE(ok);
+  REQUIRE(ran);
+
+  munmap(s, sizeof(Shared));
+}
+
+// ===========================================================================
+// The Phase 2 exit criterion (design §6): concurrent cross-process readers
+// that are SIGKILLed at random mid-read, against a continuously mutating
+// writer. Asserts the two properties the whole design rests on:
+//   1. No reader EVER observes a torn record.
+//   2. Killing readers -- including ones holding leases -- never wedges the
+//      writer, and abandoned leases are reclaimed.
+// ===========================================================================
+TEST_CASE("Lease torture: readers killed at random never tear or wedge",
+          "[lease][torture]") {
+  auto *s = MapShared();
+  REQUIRE(s != nullptr);
+
+  constexpr int kReaders = 6;
+  std::vector<pid_t> kids;
+
+  // Plain seqlock readers.
+  for (int i = 0; i < kReaders; ++i) {
+    pid_t p = fork();
+    if (p == 0) {
+      ReaderLoop(s);
+      _exit(0);
+    }
+    kids.push_back(p);
+  }
+
+  // Two lease-holding readers that will be killed WHILE HOLDING the lease.
+  // These are the ones that would deadlock a non-reclaimable lock.
+  std::vector<pid_t> lease_kids;
+  for (int i = 0; i < 2; ++i) {
+    pid_t p = fork();
+    if (p == 0) {
+      Lease<Record> l(&s->rec);
+      while (true) {
+        pause();  // hold forever; parent kills us
+      }
+      _exit(0);
+    }
+    lease_kids.push_back(p);
+  }
+
+  // Writer: mutate all fields inside an update window, with a deliberate gap
+  // between field writes so an unsynchronized reader WOULD see a tear.
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+  unsigned rng = 12345;
+  size_t kill_idx = 0;
+  while (std::chrono::steady_clock::now() < deadline) {
+    s->rec.BeginUpdate();
+    ctp::min_u64 v = s->writes.load() + 1;
+    s->rec.value = v;
+    for (size_t i = 0; i < kFields; ++i) {
+      s->rec.fields[i] = v;
+      if ((i & 3) == 0) {
+        std::this_thread::yield();  // widen the tear window
+      }
+    }
+    s->rec.EndUpdate();
+    s->writes.fetch_add(1);
+
+    // Periodically kill a reader and replace it.
+    rng = rng * 1103515245u + 12345u;
+    if ((rng >> 16) % 64 == 0 && kill_idx < kids.size()) {
+      kill(kids[kill_idx], SIGKILL);
+      int st = 0;
+      waitpid(kids[kill_idx], &st, 0);
+      pid_t p = fork();
+      if (p == 0) {
+        ReaderLoop(s);
+        _exit(0);
+      }
+      kids[kill_idx] = p;
+      ++kill_idx;
+    }
+  }
+
+  // Kill the lease holders while they still hold the lease.
+  for (pid_t p : lease_kids) {
+    kill(p, SIGKILL);
+    int st = 0;
+    waitpid(p, &st, 0);
+  }
+
+  // The writer must still be able to take the lease: the abandoned one has to
+  // be reclaimed rather than blocking forever. Short threshold to keep the
+  // test quick.
+  auto t0 = std::chrono::steady_clock::now();
+  Lease<Record> recovered(&s->rec, 200);
+  auto wait_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                     std::chrono::steady_clock::now() - t0)
+                     .count();
+  REQUIRE(recovered.Owns());
+  REQUIRE(wait_ms < 3000);  // reclaimed, not wedged
+  recovered.Release();
+
+  s->stop.store(1);
+  for (pid_t p : kids) {
+    kill(p, SIGKILL);
+    int st = 0;
+    waitpid(p, &st, 0);
+  }
+
+  // The invariant that matters.
+  INFO("writes=" << s->writes.load() << " read_ok=" << s->read_ok.load()
+                 << " retries=" << s->read_retry.load()
+                 << " steals=" << s->rec.lease_mutex_.GetStealCount());
+  REQUIRE(s->torn_count.load() == 0);
+  // Sanity: the test actually exercised the paths it claims to.
+  REQUIRE(s->writes.load() > 10);
+  REQUIRE(s->read_ok.load() > 10);
+  REQUIRE(s->rec.lease_mutex_.GetStealCount() >= 1);
+
+  munmap(s, sizeof(Shared));
+}

--- a/context-transport-primitives/test/unit/data_structures/ipc/test_lease.cc
+++ b/context-transport-primitives/test/unit/data_structures/ipc/test_lease.cc
@@ -327,9 +327,17 @@ TEST_CASE("Lease torture: readers killed at random never tear or wedge",
                  << " retries=" << s->read_retry.load()
                  << " steals=" << s->rec.lease_mutex_.GetStealCount());
   REQUIRE(s->torn_count.load() == 0);
-  // Sanity: the test actually exercised the paths it claims to.
-  REQUIRE(s->writes.load() > 10);
-  REQUIRE(s->read_ok.load() > 10);
+  // Sanity bounds only -- "did this actually exercise anything", NOT
+  // correctness. Keep them loose: the writer is heavily starved by the reader
+  // fleet, so on a slow or contended runner it lands far lower than on a quiet
+  // one. A macos-26-intel run recorded writes=10 against 8.2M reads and failed
+  // a "> 10" bound by exactly one, which says nothing about the code.
+  //
+  // The starvation itself is worth noting: 57M retries for 8.2M successful
+  // reads, with the WRITER getting only a handful of update windows. That is
+  // the contention question tracked in #787, surfacing here as a side effect.
+  REQUIRE(s->writes.load() >= 1);
+  REQUIRE(s->read_ok.load() > 1000);
   REQUIRE(s->rec.lease_mutex_.GetStealCount() >= 1);
 
   UnmapShared(s);

--- a/context-transport-primitives/test/unit/data_structures/ipc/test_string.cc
+++ b/context-transport-primitives/test/unit/data_structures/ipc/test_string.cc
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "clio_ctp/data_structures/ipc/string.h"
+#include "clio_ctp/memory/allocator/arena_allocator.h"
+#include "clio_ctp/memory/backend/malloc_backend.h"
+
+#include <string>
+
+using namespace ctp::ipc;
+
+using Alloc = ArenaAllocator<false>;
+using shm_string = string<Alloc>;
+
+static Alloc *CreateTestAllocator(MallocBackend &backend, size_t arena_size) {
+  backend.shm_init(MemoryBackendId(0, 0), arena_size);
+  return backend.MakeAlloc<Alloc>();
+}
+
+TEST_CASE("IpcString: default and empty", "[ipc_string]") {
+  MallocBackend backend;
+  auto *alloc = CreateTestAllocator(backend, 1024 * 1024);
+
+  shm_string s(alloc);
+  REQUIRE(s.size() == 0);
+  REQUIRE(s.empty());
+  REQUIRE(s.is_inline());
+  REQUIRE(std::string(s.c_str()) == "");
+}
+
+TEST_CASE("IpcString: short string stays inline", "[ipc_string]") {
+  MallocBackend backend;
+  auto *alloc = CreateTestAllocator(backend, 1024 * 1024);
+
+  shm_string s(alloc, "blob_name");
+  REQUIRE(s.size() == 9);
+  REQUIRE(s.is_inline());  // the whole point of SSO for short keys
+  REQUIRE(std::string(s.c_str()) == "blob_name");
+  REQUIRE(s == "blob_name");
+  REQUIRE(s != "blob_nam");
+}
+
+TEST_CASE("IpcString: exactly at the SSO boundary", "[ipc_string]") {
+  MallocBackend backend;
+  auto *alloc = CreateTestAllocator(backend, 1024 * 1024);
+
+  // kSsoCapacity bytes must still be inline; one more must spill.
+  std::string at(shm_string::kSsoCapacity, 'x');
+  std::string over(shm_string::kSsoCapacity + 1, 'y');
+
+  shm_string s_at(alloc, at);
+  REQUIRE(s_at.size() == shm_string::kSsoCapacity);
+  REQUIRE(s_at.is_inline());
+  REQUIRE(s_at.str() == at);
+
+  shm_string s_over(alloc, over);
+  REQUIRE(s_over.size() == shm_string::kSsoCapacity + 1);
+  REQUIRE_FALSE(s_over.is_inline());
+  REQUIRE(s_over.str() == over);
+}
+
+TEST_CASE("IpcString: long string round-trips", "[ipc_string]") {
+  MallocBackend backend;
+  auto *alloc = CreateTestAllocator(backend, 1024 * 1024);
+
+  std::string big(5000, 'z');
+  big[0] = 'a';
+  big[4999] = 'b';
+
+  shm_string s(alloc, big);
+  REQUIRE(s.size() == 5000);
+  REQUIRE_FALSE(s.is_inline());
+  REQUIRE(s.str() == big);
+  REQUIRE(s[0] == 'a');
+  REQUIRE(s[4999] == 'b');
+}
+
+TEST_CASE("IpcString: assign replaces contents and can shrink", "[ipc_string]") {
+  MallocBackend backend;
+  auto *alloc = CreateTestAllocator(backend, 1024 * 1024);
+
+  shm_string s(alloc, std::string(100, 'q'));
+  REQUIRE_FALSE(s.is_inline());
+
+  REQUIRE(s.assign("short"));
+  REQUIRE(s.size() == 5);
+  REQUIRE(s == "short");
+  // Growth is one-way: the buffer stays on the heap so a reader that already
+  // resolved the offset is never left pointing at freed memory.
+  REQUIRE_FALSE(s.is_inline());
+}
+
+TEST_CASE("IpcString: embedded NUL is preserved", "[ipc_string]") {
+  MallocBackend backend;
+  auto *alloc = CreateTestAllocator(backend, 1024 * 1024);
+
+  const char raw[] = {'a', '\0', 'b'};
+  shm_string s(alloc, raw, 3);
+  REQUIRE(s.size() == 3);
+  REQUIRE(s[0] == 'a');
+  REQUIRE(s[1] == '\0');
+  REQUIRE(s[2] == 'b');
+}
+
+TEST_CASE("IpcString: copy into allocator", "[ipc_string]") {
+  MallocBackend backend;
+  auto *alloc = CreateTestAllocator(backend, 1024 * 1024);
+
+  shm_string a(alloc, "hello world, this is a longer string");
+  shm_string b(alloc, a);
+  REQUIRE(b.str() == a.str());
+  REQUIRE(a == b);
+
+  // Mutating the copy must not disturb the original (no shared buffer).
+  REQUIRE(b.assign("changed"));
+  REQUIRE(b == "changed");
+  REQUIRE(a == "hello world, this is a longer string");
+}
+
+TEST_CASE("IpcString: clear", "[ipc_string]") {
+  MallocBackend backend;
+  auto *alloc = CreateTestAllocator(backend, 1024 * 1024);
+
+  shm_string s(alloc, "something");
+  s.clear();
+  REQUIRE(s.empty());
+  REQUIRE(s.size() == 0);
+  REQUIRE(s == "");
+}
+
+TEST_CASE("IpcString: hash is content-based and stable", "[ipc_string]") {
+  MallocBackend backend;
+  auto *alloc = CreateTestAllocator(backend, 1024 * 1024);
+
+  shm_string a(alloc, "same_key");
+  shm_string b(alloc, "same_key");
+  shm_string c(alloc, "other_key");
+
+  REQUIRE(a.hash() == b.hash());
+  REQUIRE(a.hash() != c.hash());
+
+  // Equal for inline and spilled representations of the same content, so a
+  // hash table cannot lose an entry just because it crossed the SSO boundary.
+  std::string longkey(shm_string::kSsoCapacity + 10, 'k');
+  shm_string d(alloc, longkey);
+  REQUIRE(d.hash() == shm_string::HashBytes(longkey.data(), longkey.size()));
+
+  // Hashing a raw key must match hashing the string -- the map probes with
+  // const char* to avoid constructing a string per lookup.
+  REQUIRE(a.hash() == shm_string::HashBytes("same_key", 8));
+}
+
+TEST_CASE("IpcString: allocation failure degrades to empty", "[ipc_string]") {
+  MallocBackend backend;
+  // Tiny arena: a large assign cannot be satisfied.
+  auto *alloc = CreateTestAllocator(backend, 4096);
+
+  shm_string s(alloc);
+  std::string huge(1024 * 1024, 'x');
+  bool ok = s.assign(huge.data(), huge.size());
+  // Either it fit or it failed -- but it must never be left half-written,
+  // because the cache falls back to RPC on failure and a torn string would
+  // be read by clients before that happens.
+  if (!ok) {
+    REQUIRE(s.empty());
+    REQUIRE(s.size() == 0);
+  }
+}

--- a/context-transport-primitives/test/unit/data_structures/ipc/test_unordered_map.cc
+++ b/context-transport-primitives/test/unit/data_structures/ipc/test_unordered_map.cc
@@ -178,9 +178,49 @@ TEST_CASE("IpcMap: full table reports failure and never grows", "[ipc_map]") {
   }
   // Must have refused the overflow rather than rehashing -- a rehash would
   // free the table out from under cross-process readers.
-  REQUIRE(inserted == 8);
+  //
+  // Note it stops at the LOAD CAP (7/8), not at 100%. Filling every slot
+  // leaves no empty slot to terminate a probe run, which makes every MISS scan
+  // the entire table: measured at 108.9 us on a 65536-slot table, i.e. worse
+  // than the RPC the cache exists to avoid. Reserving 1/8 keeps misses at
+  // ~0.1 us.
+  REQUIRE(inserted == 7);
   REQUIRE(m.capacity() == 8);
-  REQUIRE(m.size() == 8);
+  REQUIRE(m.size() == 7);
+
+  // The entries that WERE accepted must still be readable, and a miss on the
+  // saturated table must still return quickly rather than scanning it.
+  Rec out;
+  REQUIRE(m.TryGetBytes("k0", 2, &out));
+  REQUIRE_FALSE(m.TryGetBytes("k63", 3, &out));
+}
+
+TEST_CASE("IpcMap: load cap leaves headroom at scale", "[ipc_map]") {
+  MallocBackend backend;
+  auto *alloc = CreateTestAllocator(backend, 256 * 1024 * 1024);
+
+  StrMap m(alloc, 4096);
+  REQUIRE(m.capacity() == 4096);
+  int inserted = 0;
+  for (int i = 0; i < 8192; ++i) {
+    if (Put(m, "load_key_" + std::to_string(i), Rec(i, i))) {
+      ++inserted;
+    }
+  }
+  // 7/8 of 4096. The load factor must be the binding constraint, NOT the
+  // probe-length cap: an over-tight probe cap silently rejects inserts far
+  // below the load limit (measured: a 64-probe cap stopped a 65536-slot table
+  // at ~51% occupancy).
+  REQUIRE(inserted == 3584);
+  REQUIRE(m.size() == 3584);
+
+  // Overwrites of existing keys must still succeed at the cap, so a saturated
+  // cache keeps its entries fresh instead of going stale.
+  REQUIRE(Put(m, "load_key_0", Rec(999, 999)));
+  Rec out;
+  REQUIRE(m.TryGetBytes("load_key_0", 10, &out));
+  REQUIRE(out == Rec(999, 999));
+  REQUIRE(m.size() == 3584);
 }
 
 TEST_CASE("IpcMap: many keys round-trip", "[ipc_map]") {

--- a/context-transport-primitives/test/unit/data_structures/ipc/test_unordered_map.cc
+++ b/context-transport-primitives/test/unit/data_structures/ipc/test_unordered_map.cc
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "clio_ctp/data_structures/ipc/unordered_map.h"
+#include "clio_ctp/memory/allocator/arena_allocator.h"
+#include "clio_ctp/memory/backend/malloc_backend.h"
+
+#include <string>
+#include <vector>
+
+using namespace ctp::ipc;
+
+using Alloc = ArenaAllocator<false>;
+using shm_string = string<Alloc>;
+
+/** Stand-in for a cached BlobInfo record: trivially copyable POD. */
+struct Rec {
+  ctp::u64 a;
+  ctp::u64 b;
+  Rec() : a(0), b(0) {}
+  Rec(ctp::u64 x, ctp::u64 y) : a(x), b(y) {}
+  bool operator==(const Rec &o) const { return a == o.a && b == o.b; }
+};
+
+using StrMap = unordered_map<shm_string, Rec, Alloc>;
+
+static Alloc *CreateTestAllocator(MallocBackend &backend, size_t arena_size) {
+  backend.shm_init(MemoryBackendId(0, 0), arena_size);
+  return backend.MakeAlloc<Alloc>();
+}
+
+static bool Put(StrMap &m, const std::string &k, const Rec &v) {
+  StrMap::BytesProbe p{k.data(), k.size()};
+  return m.InsertOrAssign(p, shm_string::HashBytes(k.data(), k.size()), v);
+}
+
+TEST_CASE("IpcMap: capacity rounds up to a power of two", "[ipc_map]") {
+  MallocBackend backend;
+  auto *alloc = CreateTestAllocator(backend, 16 * 1024 * 1024);
+
+  StrMap m(alloc, 100);
+  REQUIRE(m.valid());
+  REQUIRE(m.capacity() == 128);
+  REQUIRE(m.size() == 0);
+}
+
+TEST_CASE("IpcMap: insert and read back", "[ipc_map]") {
+  MallocBackend backend;
+  auto *alloc = CreateTestAllocator(backend, 16 * 1024 * 1024);
+
+  StrMap m(alloc, 64);
+  REQUIRE(Put(m, "tag/blob_a", Rec(1, 2)));
+  REQUIRE(Put(m, "tag/blob_b", Rec(3, 4)));
+  REQUIRE(m.size() == 2);
+
+  Rec out;
+  REQUIRE(m.TryGetBytes("tag/blob_a", 10, &out));
+  REQUIRE(out == Rec(1, 2));
+  REQUIRE(m.TryGetBytes("tag/blob_b", 10, &out));
+  REQUIRE(out == Rec(3, 4));
+}
+
+TEST_CASE("IpcMap: missing key returns false", "[ipc_map]") {
+  MallocBackend backend;
+  auto *alloc = CreateTestAllocator(backend, 16 * 1024 * 1024);
+
+  StrMap m(alloc, 64);
+  REQUIRE(Put(m, "present", Rec(7, 7)));
+
+  Rec out;
+  REQUIRE_FALSE(m.TryGetBytes("absent", 6, &out));
+}
+
+TEST_CASE("IpcMap: overwrite replaces value, not size", "[ipc_map]") {
+  MallocBackend backend;
+  auto *alloc = CreateTestAllocator(backend, 16 * 1024 * 1024);
+
+  StrMap m(alloc, 64);
+  REQUIRE(Put(m, "k", Rec(1, 1)));
+  REQUIRE(Put(m, "k", Rec(9, 9)));
+  REQUIRE(m.size() == 1);
+
+  Rec out;
+  REQUIRE(m.TryGetBytes("k", 1, &out));
+  REQUIRE(out == Rec(9, 9));
+}
+
+TEST_CASE("IpcMap: erase leaves probe sequence intact", "[ipc_map]") {
+  MallocBackend backend;
+  auto *alloc = CreateTestAllocator(backend, 16 * 1024 * 1024);
+
+  StrMap m(alloc, 64);
+  // Insert enough keys that some collide and form probe chains.
+  std::vector<std::string> keys;
+  for (int i = 0; i < 20; ++i) {
+    keys.push_back("key_" + std::to_string(i));
+    REQUIRE(Put(m, keys.back(), Rec(i, i * 2)));
+  }
+
+  // Erase every third key, then confirm the survivors are all still findable.
+  // A tombstone that terminated a probe would lose them.
+  for (size_t i = 0; i < keys.size(); i += 3) {
+    StrMap::BytesProbe p{keys[i].data(), keys[i].size()};
+    REQUIRE(m.Erase(p, shm_string::HashBytes(keys[i].data(), keys[i].size())));
+  }
+  for (size_t i = 0; i < keys.size(); ++i) {
+    Rec out;
+    bool found = m.TryGetBytes(keys[i].data(), keys[i].size(), &out);
+    if (i % 3 == 0) {
+      REQUIRE_FALSE(found);
+    } else {
+      REQUIRE(found);
+      REQUIRE(out == Rec(i, i * 2));
+    }
+  }
+}
+
+TEST_CASE("IpcMap: erased slot is reusable", "[ipc_map]") {
+  MallocBackend backend;
+  auto *alloc = CreateTestAllocator(backend, 16 * 1024 * 1024);
+
+  StrMap m(alloc, 64);
+  REQUIRE(Put(m, "recycle", Rec(1, 1)));
+  StrMap::BytesProbe p{"recycle", 7};
+  REQUIRE(m.Erase(p, shm_string::HashBytes("recycle", 7)));
+  REQUIRE(m.size() == 0);
+
+  REQUIRE(Put(m, "recycle", Rec(5, 5)));
+  Rec out;
+  REQUIRE(m.TryGetBytes("recycle", 7, &out));
+  REQUIRE(out == Rec(5, 5));
+}
+
+TEST_CASE("IpcMap: full table reports failure and never grows", "[ipc_map]") {
+  MallocBackend backend;
+  auto *alloc = CreateTestAllocator(backend, 16 * 1024 * 1024);
+
+  StrMap m(alloc, 8);  // rounds to 8
+  REQUIRE(m.capacity() == 8);
+
+  int inserted = 0;
+  for (int i = 0; i < 64; ++i) {
+    if (Put(m, "k" + std::to_string(i), Rec(i, i))) {
+      ++inserted;
+    }
+  }
+  // Must have refused the overflow rather than rehashing -- a rehash would
+  // free the table out from under cross-process readers.
+  REQUIRE(inserted == 8);
+  REQUIRE(m.capacity() == 8);
+  REQUIRE(m.size() == 8);
+}
+
+TEST_CASE("IpcMap: many keys round-trip", "[ipc_map]") {
+  MallocBackend backend;
+  auto *alloc = CreateTestAllocator(backend, 64 * 1024 * 1024);
+
+  StrMap m(alloc, 4096);
+  const int kN = 2000;
+  for (int i = 0; i < kN; ++i) {
+    REQUIRE(Put(m, "blob_name_number_" + std::to_string(i), Rec(i, i + 1)));
+  }
+  REQUIRE(m.size() == kN);
+  for (int i = 0; i < kN; ++i) {
+    std::string k = "blob_name_number_" + std::to_string(i);
+    Rec out;
+    REQUIRE(m.TryGetBytes(k.data(), k.size(), &out));
+    REQUIRE(out == Rec(i, i + 1));
+  }
+}
+
+TEST_CASE("IpcMap: long keys crossing the SSO boundary", "[ipc_map]") {
+  MallocBackend backend;
+  auto *alloc = CreateTestAllocator(backend, 64 * 1024 * 1024);
+
+  StrMap m(alloc, 64);
+  std::string shortk(10, 's');
+  std::string longk(200, 'l');
+  REQUIRE(Put(m, shortk, Rec(1, 1)));
+  REQUIRE(Put(m, longk, Rec(2, 2)));
+
+  Rec out;
+  REQUIRE(m.TryGetBytes(shortk.data(), shortk.size(), &out));
+  REQUIRE(out == Rec(1, 1));
+  REQUIRE(m.TryGetBytes(longk.data(), longk.size(), &out));
+  REQUIRE(out == Rec(2, 2));
+}
+
+TEST_CASE("IpcMap: seqlock rejects a torn read", "[ipc_map]") {
+  MallocBackend backend;
+  auto *alloc = CreateTestAllocator(backend, 16 * 1024 * 1024);
+
+  StrMap m(alloc, 64);
+  REQUIRE(Put(m, "torn", Rec(1, 1)));
+
+  // Simulate a writer that died mid-update: leave the slot generation odd.
+  // A reader must refuse to return a value rather than read half of one.
+  auto *slot = m.FindSlot(StrMap::BytesProbe{"torn", 4},
+                          shm_string::HashBytes("torn", 4));
+  REQUIRE(slot != nullptr);
+  slot->gen_.fetch_add(1);  // now odd == "write in progress"
+
+  Rec out;
+  REQUIRE_FALSE(m.TryGetBytes("torn", 4, &out, 4));
+
+  // Completing the write makes it readable again.
+  slot->gen_.fetch_add(1);
+  REQUIRE(m.TryGetBytes("torn", 4, &out, 4));
+  REQUIRE(out == Rec(1, 1));
+}
+
+TEST_CASE("IpcMap: POD keys work without an allocator-aware key", "[ipc_map]") {
+  MallocBackend backend;
+  auto *alloc = CreateTestAllocator(backend, 16 * 1024 * 1024);
+
+  using PodMap = unordered_map<ctp::u64, Rec, Alloc>;
+  PodMap m(alloc, 64);
+
+  for (ctp::u64 i = 0; i < 30; ++i) {
+    REQUIRE(m.InsertOrAssign(i, PodMap::Hash(i), Rec(i, i * 3)));
+  }
+  REQUIRE(m.size() == 30);
+  for (ctp::u64 i = 0; i < 30; ++i) {
+    Rec out;
+    REQUIRE(m.TryGet(i, PodMap::Hash(i), &out));
+    REQUIRE(out == Rec(i, i * 3));
+  }
+  Rec out;
+  REQUIRE_FALSE(m.TryGet(ctp::u64(999), PodMap::Hash(ctp::u64(999)), &out));
+}

--- a/project_cte_shm_metadata_cache.md
+++ b/project_cte_shm_metadata_cache.md
@@ -276,22 +276,30 @@ A steal must bump a steal counter so a resurrected holder can detect it lost the
 thread*.** DECIDED: waiting is unavoidable, since a lease that the runtime could
 ignore would not protect anything. The constraint is not *whether* to wait but *how*.
 
-A thread-blocking wait is not available here. `ReorganizeBlobInternal` /
-`DynamicReorganize` are coroutines on workers, and `core_tasks.h:820-831` already
-documents why: a thread-blocking lock "CANNOT be used here — it would deadlock the
-single worker the instant the holder suspends at a `co_await`." With 4 workers, a few
-contended blobs would wedge the runtime — the exact failure class issue #781 exists to
-prevent.
+**Thread-blocking waits are ACCEPTED for the initial implementation**, on the strength
+of the issue #781 work-orchestrator mechanisms (elastic pool + stall detection + worker
+spawn/steal), which detect a wedged worker and spawn a replacement. This branch merges
+`origin/dev` at PR #782 specifically so those mechanisms are present — they landed in
+dev *after* this branch was cut, and without them a blocking lease wait would reproduce
+the exact deadlock class #781 exists to prevent.
 
-The codebase already has the right pattern, in that same comment: the `write_owner_`
-contender "busy-polls via `co_await yield()` ... which is lost-wakeup-proof because it
-re-checks every worker iteration." So:
+Historical constraint, retained because it still applies to any path that must not
+depend on stall detection: `core_tasks.h:820-831` documents that a thread-blocking lock
+"CANNOT be used here — it would deadlock the single worker the instant the holder
+suspends at a `co_await`," and demonstrates the alternative — the `write_owner_`
+contender "busy-polls via `co_await yield()` ... lost-wakeup-proof because it re-checks
+every worker iteration."
 
-- `Lease` acquisition on the runtime side is a **`co_await` retry loop**, not a
-  blocking acquire. The task suspends; the worker goes and runs other tasks.
-- The reorganizer, being pure background work, still prefers `try_lock`-and-skip — it
-  has no obligation to reorganize any particular blob right now.
-- Metadata writes wait via `co_await`, bounded by the `TimedMutex` threshold.
+So, in order of preference:
+
+- The reorganizer, being pure background work, still prefers **`try_lock`-and-skip** —
+  it has no obligation to reorganize any particular blob right now, so it should never
+  wait at all.
+- Metadata writes may **block the worker**, bounded by the `TimedMutex` threshold and
+  backstopped by #781 stall detection.
+- If stall detection proves insufficient under load, the `co_await` retry loop above is
+  the fallback — same semantics, no worker occupancy. Worth revisiting if Phase 5/6
+  benchmarks show worker starvation.
 
 Two consequences to keep in view:
 - The `TimedMutex` timeout now **bounds runtime write latency**, not just reclamation

--- a/project_cte_shm_metadata_cache.md
+++ b/project_cte_shm_metadata_cache.md
@@ -5,6 +5,30 @@ Branch: `783-cte-shm-metadata-cache`
 
 ## Result
 
+### Write-then-read cycle (the pattern callers actually perform)
+
+The read benchmarks below are **steady-state**: they time reads with no
+interleaved writes. That measures the read in isolation. For a caller that
+writes then reads back, the cycle is **write-dominated**, because writes are
+NOT accelerated by this work:
+
+| Measurement | SHM | RPC | Ratio |
+|---|---|---|---|
+| write alone | 79-140 µs | (same) | — |
+| **write + metadata read** | **81-114 µs** | 162-195 µs | **~2x** |
+| **write + payload read** | **83-128 µs** | 187-278 µs | **~2x** |
+
+So the honest headline for write-then-read is **~2x**, not the several-hundred-x
+figure the read-only benchmarks show. The read component goes from ~90-140 µs to
+~0.2 µs — effectively free — but Amdahl caps the cycle at the cost of the write.
+The read-only numbers are the right measure for read-mostly workloads (repeated
+`GetBlobSize`/`GetBlob` on cached blobs); the cycle numbers are the right measure
+for write-then-read.
+
+Note the run-to-run spread: the RPC baseline swings 90-280 µs on this host while
+the SHM path stays at ~0.2 µs, so quote ranges, not single figures.
+
+
 Client reads of node-local CTE data now complete with **zero IPC**. Measured
 cross-process (external daemon), same query and same blobs on both paths:
 

--- a/project_cte_shm_metadata_cache.md
+++ b/project_cte_shm_metadata_cache.md
@@ -436,8 +436,35 @@ the read path on metadata-only ops is far cheaper to debug than on payload reads
 - `data_structures/ipc/unordered_map.h`: open addressing, **fixed capacity**,
   per-slot seqlock, tombstones, `TryGetBytes` so clients never allocate.
   11 cases / 6191 assertions.
-- Still to build: `Lease` (over `TimedMutex`), and the multi-process
-  kill-readers-at-random torture test.
+- `memory/smart_ptr/lease.h`: `Leaseable` mix-in carrying BOTH mechanisms
+  (`gen_` seqlock for correctness, `lease_mutex_` for progress/lifetime),
+  `SeqRead()` optimistic-read helper, and move-only RAII `Lease<T>` whose
+  `get()` returns nullptr unless owned, so a missed `Owns()` check fails loudly
+  instead of silently reading unprotected memory. 5 cases / 28 assertions.
+
+**Phase 2 exit criterion MET.** The torture test forks 6 seqlock readers plus 2
+lease-holding readers, SIGKILLs them at random mid-read (and the lease holders
+while they still hold the lease) against a writer that deliberately widens its
+update window. Result over a 3s run:
+
+| metric | value |
+|---|---|
+| writes | 503,400 |
+| successful cross-process reads | 25,554,659 |
+| **torn reads** | **0** |
+| reader retries | 242,412,642 |
+| leases reclaimed from dead holders | 1 |
+
+Zero tears across 25.5M reads while readers were being killed, and the writer
+never wedged behind an abandoned lease.
+
+**Caveat to carry into Phase 5:** the retry rate here is ~90%, because this
+writer holds its update window open almost continuously by design. Real writes
+are rare and short, but reader retry rate under realistic write load is a
+number worth measuring rather than assuming — a hot blob under sustained
+rewrite could starve readers into the RPC fallback.
+
+- Still to build: nothing in Phase 2. Next is Phase 3.
 
 **Design refinement made during implementation: the map never rehashes.** Growth
 is the one operation that cannot be made safe for untracked cross-process

--- a/project_cte_shm_metadata_cache.md
+++ b/project_cte_shm_metadata_cache.md
@@ -490,6 +490,33 @@ purpose: the slot generation protects the METADATA copy, while §5.3's hazard is
 the DataOrganizer relocating blocks during the PAYLOAD read. A client must
 re-check `placement_gen_` after copying bytes.
 
+**Phase 6a DONE — RAM bdev is shared-memory backed.** (6b/6c pending: the
+direct-readable flag and the client payload read.)
+
+A `kRam` device's bytes now live in a dedicated SHM segment, mapped as ONE
+contiguous sparse region rather than a page table. Since these are memfd
+segments an untouched reservation costs nothing, so a flat mapping is both
+simpler and faster to index than the old 1 GiB page vector — `EnsureRamPage`
+now allocates nothing and is pure arithmetic. The paged API is retained only so
+existing call sites are unchanged.
+
+Segment name derives purely from **(runtime pid, pool id)**, so a client can
+reconstruct it from what it already has — server pid from ClientConnect, target
+pool id from each cached block descriptor. No name or page table needs
+publishing through a side channel.
+
+`kPinned` stays on the private heap (`cudaMallocHost` memory cannot be
+SHM-backed). Backing is best-effort: failure costs only the client fast path.
+`Destroy` clears `ready_` before unmapping so a client mid-attach refuses
+rather than reading a dying segment.
+
+Verified: bdev chimod suite **21/21** with three devices reporting themselves
+SHM-backed.
+
+*Unrelated pre-existing bug found while testing:* `clio_run_thrpt_bench
+--test-case bdev_allocation` segfaults against an external daemon on BOTH the
+ram and file paths, so it predates this work. Worth its own issue.
+
 **Phase 5 COMPLETE — fast path wired and MEASURED.**
 
 `Tag::GetBlobSize` now answers from the SHM cache when the blob is cached and

--- a/project_cte_shm_metadata_cache.md
+++ b/project_cte_shm_metadata_cache.md
@@ -490,8 +490,30 @@ purpose: the slot generation protects the METADATA copy, while §5.3's hazard is
 the DataOrganizer relocating blocks during the PAYLOAD read. A client must
 re-check `placement_gen_` after copying bytes.
 
-**Phase 6a DONE — RAM bdev is shared-memory backed.** (6b/6c pending: the
-direct-readable flag and the client payload read.)
+**PHASE 6 COMPLETE — zero-IPC payload reads working and measured.**
+
+| Read type | SHM fast path | RPC path | Speedup |
+|---|---|---|---|
+| **Payload (4 KB blob)** | **0.207 µs/op** | **94.3 µs/op** | **455x** |
+| Metadata (cross-process) | 0.170 µs/op | 82.7 µs/op | 488x |
+
+`BuildShmBlobRecord` sets `kShmBlobDirectReadable` only when EVERY block is
+node-local and `kRam`; the flag starts true and is cleared by the first block
+that fails, so the default is *refuse* and an unknown target can never be
+mistaken for readable. `Client::TryReadBlobShm` attaches the bdev segment
+lazily (cached per pool, negative results cached too) and validates
+`placement_gen_` **before and after** the copy — the metadata seqlock protects
+only the record, while the real hazard is the DataOrganizer relocating blocks
+mid-`memcpy`.
+
+**Test isolation was the hard part, not the code.** The first version
+registered a RAM target on the *shared* fixture pool, where file targets had
+accumulated from earlier tests and the DPE placed the blob on one. The blob was
+therefore correctly not direct-readable and the payload path was never
+exercised — the test warned loudly instead of passing vacuously. Giving it its
+own CTE pool with a RAM target as the ONLY target is what made it a real test.
+
+**Phase 6a — RAM bdev is shared-memory backed.**
 
 A `kRam` device's bytes now live in a dedicated SHM segment, mapped as ONE
 contiguous sparse region rather than a page table. Since these are memfd

--- a/project_cte_shm_metadata_cache.md
+++ b/project_cte_shm_metadata_cache.md
@@ -205,6 +205,53 @@ all. **Exact cap is TBD from measurement (open question 6).**
 
 **Lock ordering:** `TagInfo` before `BlobInfo`, enforced identically on both sides.
 
+### 5.3b `TimedMutex` and `Lease` (replaces `shared_ptr`)
+
+Decision: a reclaimable `TimedMutex` (`clio_ctp/thread/lock/timed_mutex.h`, beside
+`Mutex`) plus a SHM smart pointer `Lease` (`clio_ctp/memory/smart_ptr/lease.h`, beside
+`shared_ptr`/`unique_ptr`). A `Lease` acquires the target's `TimedMutex` on
+construction and releases on destruction; because the lock is reclaimable, a client
+that dies holding one is eventually serviced. Clients **copy metadata out and release
+immediately** rather than holding a lease across work.
+
+This replaces epochs/hazard pointers for the **lifetime** problem. It does *not*
+replace the generation counter, which remains the **coherence** mechanism (§5.3).
+They are complementary: the lease stops the object being freed under a reader; the
+generation catches the payload being moved under a reader.
+
+Four constraints on the implementation:
+
+**1. Lock words must live in a separate read-write region.** Acquiring a lease is a
+store, and clients map the data `PROT_READ` (§5.5). A `TimedMutex` therefore cannot be
+embedded inline in an `ShmBlobInfo` that lives in the read-only region. Layout: a
+lock array in a small **RW-mapped** region, indexed parallel to the objects, with
+metadata and payload staying **RO**. This yields a useful safety property — since
+correctness rests on the generation counter, a client that corrupts a lock word can
+only damage *liveness*, never silently corrupt another reader's data.
+
+**2. Default to a lock-free read; take a lease only when you need a stable view.**
+An exclusive `TimedMutex` serializes concurrent readers of the same hot blob, and the
+CAS ping-pongs that cache line across every reading core — the opposite of what a
+read-mostly cache wants. So the common path is a **seqlock read that performs zero
+stores** (read generation, copy, re-read generation, retry), and `Lease` is reserved
+for operations needing a stable view for longer than a retry loop tolerates. Keeping
+leases *rare* is also what keeps reclamation simple: an exclusive lock has a single
+owner, so a dead holder is identifiable, which a shared/reader-counted lease would
+not be (that would need per-holder tracking, i.e. epochs again by another name).
+
+**3. Reclamation needs PID + process start time, not a bare timeout.** A timeout alone
+cannot distinguish a dead holder from a live-but-slow one (§5.3, point 4). The lock
+word carries `{owner_pid, process_start_time, acquire_timestamp}`; a waiter past the
+threshold checks liveness and steals **only if the owner is genuinely gone**. Start
+time is required because PIDs are recycled — on Linux, field 22 of `/proc/<pid>/stat`.
+A steal must bump a steal counter so a resurrected holder can detect it lost the lock.
+
+**4. The runtime must never block on a lease.** Per §5.3 the reorganizer `try_lock`s
+and skips. Writes cannot "skip" as such, but they do not need to block either: the
+runtime updates its own authoritative structure and **defers the SHM mirror update**
+if the lease is contended. This is only sound because the SHM copy is a *cache*, never
+the source of truth — see the revised Phase 7.
+
 ### 5.4 Read-your-own-writes
 
 Fully-async write-through means a client that does `PutBlob` then `GetBlob` can miss
@@ -250,31 +297,58 @@ Dual-write is what keeps a 127-call-site refactor from becoming a flag-day.
 |---|---|---|
 | 0 | CTE metadata benchmark harness | Baseline recorded |
 | 1 | `kMetadataSegment` + `IpcManager` plumbing | Runtime creates it; client attaches RO |
-| 2 | `ipc::string`, `ipc::unordered_map`, reclaimable lease primitive + epoch reclamation | Standalone torture test, incl. random reader kills mid-lease |
+| 2 | `ipc::string`, `ipc::unordered_map`, `TimedMutex`, `Lease` | Standalone torture test, incl. random reader kills mid-lease |
 | 3 | `ShmTagInfo`/`ShmBlobInfo`; runtime **dual-writes** | Old path still authoritative; all CTE tests green |
 | 4 | Propagate map locations via `CreateTask` | Client holds valid handles |
 | 5 | Client fast path for **metadata-only** ops (`GetBlobSize`, `GetBlobScore`) | Correctness parity; latency win measured |
 | 6 | SHM RAM bdev + client payload fast path | `GetBlob` < 5 µs, zero IPC |
-| 7 | Retire dual-write and legacy structures | Single source of truth |
+| 7 | Retire the *scaffolding*, keep SHM as a pure cache | Steady state (see below) |
+
+**Phase 7 revised.** The original plan was to retire the legacy structures and make SHM
+the single source of truth. That is now rejected: if SHM were authoritative, a runtime
+write would have to *land* there, so the runtime would have to block on a client-held
+lease — violating §5.3b constraint 4. Instead the runtime keeps its own authoritative
+structures permanently and the SHM segment stays a **pure read cache** the runtime may
+always defer updating or invalidate wholesale. This also means a corrupted or wedged
+cache is recoverable by dropping it, never a data-loss event. Phase 7 therefore only
+removes benchmarking scaffolding and any redundant bookkeeping, not the legacy path.
 
 Phases 0-2 are self-contained and carry essentially no risk to existing behavior.
 Phase 3 is where the blast radius starts. Phase 5 before Phase 6 deliberately: proving
 the read path on metadata-only ops is far cheaper to debug than on payload reads.
 
-## 7. Open questions
+## 7. Decisions
 
-1. Trust boundary (§5.6) — accept node-wide metadata visibility, or partition?
-2. Epoch reclamation vs. hazard pointers vs. never-reclaim (bounded arena + compaction
-   at quiesce)? Never-reclaim is dramatically simpler and may be adequate at 8 GB.
-3. Do we need `TagId -> TagInfo` *and* `string -> TagId` in SHM, or can the client
-   resolve names once and cache the ID privately?
-4. `BlobBlock` embeds a `bdev::Client` — is that SHM-safe as-is, or does the SHM
-   variant need a slimmed block descriptor?
-5. Does `kPinned` (GPU page-locked) RAM bdev stay on the old private-heap path?
-   `cudaMallocHost` memory cannot trivially be SHM-backed.
-6. **Fast-path blob size cap** (§5.3) — measure where the SHM path stops beating the
-   RPC path and set the cap there. Expected to land near 256 KB - 1 MB.
-7. The reclaimable lease needs a **new lock primitive** (CAS word + owner PID +
-   timestamp); `ctp::Mutex` cannot be reclaimed. Does it belong in
-   `clio_ctp/thread/lock/` next to `Mutex`, or in the SHM-cache layer as a
-   special-purpose type?
+1. **Trust boundary — DECIDED: accept node-wide metadata visibility.** Any client may
+   read every tag/blob name and size on the node. Single-tenant assumption; revisit if
+   multi-tenancy becomes a requirement.
+2. **Reclamation — DECIDED: `Lease` + `TimedMutex` (§5.3b).** Not epochs, not hazard
+   pointers, not never-reclaim. Lifetime is handled by a reclaimable lease; coherence
+   stays with the generation counter.
+3. **Both maps in SHM — DECIDED.** `string -> TagId` *and* `TagId -> TagInfo` (and the
+   blob equivalents). No client-private ID caching scheme.
+4. **`BlobBlock` — RESOLVED BY INSPECTION: a slimmed POD descriptor is required.**
+   `BlobBlock` embeds a `bdev::Client`, which derives from `ContainerClient`
+   (`container.h:590`). Its *data* is only `PoolId pool_id_` + `u32 return_code_`, but
+   it declares `virtual void Init()` and `virtual ~ContainerClient()`, so the object
+   **carries a vtable pointer**. A vptr is a process-local address (and moves under
+   ASLR / differing .so load addresses), so it is meaningless — and dangerous — in a
+   segment mapped by another process. The SHM block descriptor must therefore be plain
+   POD: `{PoolId target_pool, PoolQuery target_query, u64 target_offset, u64 size,
+   u64 capacity}`, with the `bdev::Client` reconstructed runtime-side on demand.
+   **General rule for this work: no virtual functions in any type stored in SHM.**
+5. **`kPinned` — DECIDED: stays on the private heap.** `cudaMallocHost` memory is not
+   SHM-backed; the GPU-pinned RAM bdev keeps the existing path and simply does not
+   participate in the client fast path.
+6. **Fast-path blob size cap — measure in Phase 0/6.** Set it where the SHM path stops
+   beating RPC; expected near 256 KB - 1 MB.
+7. **Lock primitive — DECIDED: new `TimedMutex`** in `clio_ctp/thread/lock/timed_mutex.h`,
+   alongside `mutex.h` / `rwlock.h` / `spin_lock.h` / `cvrwlock.h`.
+8. **Smart pointer — DECIDED: new `Lease`** in `clio_ctp/memory/smart_ptr/lease.h`,
+   alongside `shared_ptr.h` / `unique_ptr.h`. See §5.3b for its four constraints.
+
+### Still open
+
+- The exact fast-path size cap (item 6) — needs measurement, not a decision.
+- Whether the `TimedMutex` threshold stays at 500 ms or drops once the size cap bounds
+  legitimate hold time (§5.3).

--- a/project_cte_shm_metadata_cache.md
+++ b/project_cte_shm_metadata_cache.md
@@ -147,16 +147,78 @@ blobs. Sequence that corrupts data:
 2. Runtime reorganizes the blob; blocks are freed and reused by another blob.
 3. Client `memcpy`s from those offsets → **silently returns another blob's bytes.**
 
-No error surfaces. Mitigation: a per-blob generation counter validated *before and
-after* the payload copy (extending the seqlock across the data read, not just the
-metadata read), plus epoch-deferred reuse of RAM-bdev blocks so recycling cannot
-outrun an in-flight reader.
+No error surfaces.
+
+**Scope note:** locking only the *metadata copy-out* does not fix this. The hazard is
+the **payload** read. Whatever mechanism we use must span the `memcpy` from the RAM
+bdev, not just the `BlobInfo` field read.
+
+#### Chosen design: generation for correctness, lease for progress
+
+A per-blob **timed lease** (proposed: 500 ms) that the reorganizer respects is the
+right shape, but it cannot be the *correctness* mechanism, for four reasons found in
+the existing code:
+
+1. **A lock requires the client to write.** Clients map `PROT_READ` (§5.5). Acquiring
+   any mutex is a store. This forces the lock words into a **separate small
+   read-write mapped region**, with the payload staying read-only. Consequence: a
+   buggy or hostile client can corrupt lock state, and corrupting it to *unlocked*
+   breaks safety rather than merely liveness. So the lock cannot be load-bearing.
+2. **`ctp::Mutex` is a ticket lock and cannot be reclaimed.**
+   `thread/lock/mutex.h:47` — `Lock()` does `lock_.fetch_add(1)` and spins until
+   `head_ == tkt`. If a client dies holding it, `head_` never advances and *every*
+   later waiter blocks forever. Forcibly advancing `head_` releases multiple waiters
+   at once, destroying mutual exclusion. A reclaimable lease needs a different
+   primitive: a CAS word carrying **owner PID + acquire timestamp**.
+3. **The reorganizer is a coroutine on a runtime worker.**
+   `ReorganizeBlobInternal` / `DynamicReorganize` return `TaskResume`, and
+   `core_tasks.h:820-831` already warns that a thread-blocking lock "CANNOT be used
+   here — it would deadlock the single worker the instant the holder suspends at a
+   `co_await`." A 500 ms blocking wait would stall a whole worker; with 4 workers, a
+   few stuck blobs wedge the runtime. **The reorganizer must `try_lock` and skip** —
+   it is background work and is free to reorganize a different blob.
+4. **Timeout-and-steal is probabilistic, not correct.** If the timeout fires on a
+   *live but slow* client — page fault against an undersized `/dev/shm` (§5.7),
+   descheduled, swapped — the reorganizer moves data under an active reader, which is
+   exactly the corruption being prevented. 500 ms makes that rare; rare **plus
+   silent** is the worst failure mode to ship.
+
+Therefore:
+
+- **Correctness** = a per-blob **generation counter**, validated before *and* after
+  the payload copy. Requires no client writes, costs nothing on the read path, and
+  stays correct even if the lease is stolen, corrupted, or skipped.
+- **The lease** = a *progress* optimization, so readers do not livelock retrying while
+  the organizer churns a hot blob.
+- **Neither side ever blocks on the other.** Client: `try_lock` with a tiny budget,
+  else fall back to RPC. Runtime: `try_lock`, else skip this blob this pass.
+- **500 ms becomes the stale-lease janitor threshold, not a wait.** If a lease has
+  been held longer than that, check the owner PID for liveness and reclaim only if it
+  is gone — never as a blind timeout.
+
+**Size cap.** The motivation is *small* I/O; for a 1 GB blob a 71 µs round-trip is
+already noise. Restricting the fast path to blobs under ~1 MB bounds a client's
+legitimate lease hold to well under 100 µs, which lets the janitor threshold be far
+tighter than 500 ms and shrinks the damage a dead client can do. 500 ms is ~100,000x
+the 5 µs target — it is sized for large-blob copies that should not use this path at
+all. **Exact cap is TBD from measurement (open question 6).**
+
+**Lock ordering:** `TagInfo` before `BlobInfo`, enforced identically on both sides.
 
 ### 5.4 Read-your-own-writes
 
 Fully-async write-through means a client that does `PutBlob` then `GetBlob` can miss
-its own write — which breaks the filesystem adapter's expectations. Mitigation: a
-per-client pending-write key set; those keys take the slow path until acknowledged.
+its own write — which breaks the filesystem adapter's expectations.
+
+Mitigation: a client-local `std::unordered_map` of **pending writes**, consulted
+before every fast-path read; a hit forces the slow path until the write is
+acknowledged. This is client-local plain heap — no SHM, no cross-process concern.
+
+Two requirements that are easy to miss:
+- It must track **deletes, truncates and renames**, not just puts. Otherwise a client
+  reads a blob it just deleted straight out of the stale SHM cache.
+- It must be consulted by **metadata-only** fast paths (`GetBlobSize`, `GetBlobScore`)
+  too, not only payload reads — a stale size is just as wrong as stale bytes.
 
 ### 5.5 `PROT_READ` discipline
 
@@ -188,7 +250,7 @@ Dual-write is what keeps a 127-call-site refactor from becoming a flag-day.
 |---|---|---|
 | 0 | CTE metadata benchmark harness | Baseline recorded |
 | 1 | `kMetadataSegment` + `IpcManager` plumbing | Runtime creates it; client attaches RO |
-| 2 | `ipc::string`, `ipc::unordered_map` + epoch reclamation | Standalone torture test, incl. random reader kills |
+| 2 | `ipc::string`, `ipc::unordered_map`, reclaimable lease primitive + epoch reclamation | Standalone torture test, incl. random reader kills mid-lease |
 | 3 | `ShmTagInfo`/`ShmBlobInfo`; runtime **dual-writes** | Old path still authoritative; all CTE tests green |
 | 4 | Propagate map locations via `CreateTask` | Client holds valid handles |
 | 5 | Client fast path for **metadata-only** ops (`GetBlobSize`, `GetBlobScore`) | Correctness parity; latency win measured |
@@ -210,3 +272,9 @@ the read path on metadata-only ops is far cheaper to debug than on payload reads
    variant need a slimmed block descriptor?
 5. Does `kPinned` (GPU page-locked) RAM bdev stay on the old private-heap path?
    `cudaMallocHost` memory cannot trivially be SHM-backed.
+6. **Fast-path blob size cap** (§5.3) — measure where the SHM path stops beating the
+   RPC path and set the cap there. Expected to land near 256 KB - 1 MB.
+7. The reclaimable lease needs a **new lock primitive** (CAS word + owner PID +
+   timestamp); `ctp::Mutex` cannot be reclaimed. Does it belong in
+   `clio_ctp/thread/lock/` next to `Mutex`, or in the SHM-cache layer as a
+   special-purpose type?

--- a/project_cte_shm_metadata_cache.md
+++ b/project_cte_shm_metadata_cache.md
@@ -490,6 +490,31 @@ purpose: the slot generation protects the METADATA copy, while §5.3's hazard is
 the DataOrganizer relocating blocks during the PAYLOAD read. A client must
 re-check `placement_gen_` after copying bytes.
 
+**Phase 5 COMPLETE — fast path wired and MEASURED.**
+
+`Tag::GetBlobSize` now answers from the SHM cache when the blob is cached and
+falls through to RPC on any miss or inconsistent read. Measured on this host,
+same query, same blobs, same process:
+
+| Configuration | SHM fast path | RPC path | Speedup |
+|---|---|---|---|
+| **External daemon (cross-process — the real target)** | **0.170 µs/op** | **82.7 µs/op** | **488x** |
+| In-process runtime (`CLIO_INIT` with runtime) | 0.075 µs/op | 5.57 µs/op | 74x |
+
+**Design target was < 5 µs; achieved 0.17 µs cross-process — ~29x better than
+target.** The 82.7 µs RPC figure lines up with the §1 baseline (72 µs transport
+floor plus CTE handler work), which is the sanity check that the benchmark is
+measuring the right thing.
+
+Note the two rows measure genuinely different baselines: with an in-process
+runtime there is no cross-process round-trip at all, so its 5.6 µs is not the
+number this design set out to beat. Quote the cross-process row.
+
+The benchmark asserts correctness alongside speed — both paths must return the
+same size, and every fast-path lookup must hit — so a regression that turned
+the fast path into a miss-storm would fail rather than silently look fast.
+CTE suite: **11/11** in both configurations.
+
 **Phase 4 COMPLETE — client attach + write-then-read tests passing.**
 Two bugs surfaced only by writing the test:
 

--- a/project_cte_shm_metadata_cache.md
+++ b/project_cte_shm_metadata_cache.md
@@ -424,14 +424,33 @@ the read path on metadata-only ops is far cheaper to debug than on payload reads
   runtime RSS ~35 MB with ~6 GB reserved (confirming it is not pre-faulted), and a
   client logs a successful attach.
 
-**Phase 2 (primitives) — `TimedMutex` done, rest pending.**
-- `clio_ctp/thread/lock/timed_mutex.h`: unfair CAS lock with PID +
-  process-start-time reclamation, `TryLock`/`Lock`/`Unlock`, ABA-safe release,
-  `ScopedTimedLock` RAII guard, `steal_count_` diagnostics.
-- Standalone smoke test passes (unique ids, reentrant `TryLock` correctly fails,
-  clean release, no spurious steals).
-- Still to build: `ipc::string`, `ipc::unordered_map`, `Lease`, and the
-  kill-clients-at-random torture test.
+**Phase 2 (primitives) — 3 of 4 done.**
+- `thread/lock/timed_mutex.h`: unfair CAS lock with PID + process-start-time
+  reclamation, ABA-safe release, `ScopedTimedLock`, `steal_count_`. Verified by
+  fork/SIGKILL: a killed holder is reclaimed at the threshold; a live-but-slow
+  holder is never stolen from.
+- `data_structures/ipc/string.h`: offset-based, SSO (23 bytes inline), one-way
+  growth, deleted implicit copy, FNV-1a `hash()` (NOT `std::hash`, which is not
+  stable across processes), `EqualsBytes` for allocation-free probing.
+  10 cases / 43 assertions.
+- `data_structures/ipc/unordered_map.h`: open addressing, **fixed capacity**,
+  per-slot seqlock, tombstones, `TryGetBytes` so clients never allocate.
+  11 cases / 6191 assertions.
+- Still to build: `Lease` (over `TimedMutex`), and the multi-process
+  kill-readers-at-random torture test.
+
+**Design refinement made during implementation: the map never rehashes.** Growth
+is the one operation that cannot be made safe for untracked cross-process
+readers — a rehash must free the old table, and knowing when the last reader has
+left it requires exactly the epoch machinery §5.3b rejected. So the table is
+sized up front and a full table is an insert failure, which routes into the
+"cache full -> fall back to RPC" path that already had to exist. This removes an
+entire class of use-after-free rather than trying to synchronize it.
+
+**Also found: `AllocateOffset` THROWS `OUT_OF_MEMORY`** (`arena_allocator.h:143`)
+rather than returning null. Both containers now catch it, because the whole
+fallback strategy depends on exhaustion being a recoverable condition rather
+than an exception escaping into a client read path.
 
 **Phase 0 (baseline) — done.** Measured on this branch after a consistent full
 rebuild, single thread, `--test-case latency`: **SHM 72.1 µs**, IPC 109.7 µs, TCP

--- a/project_cte_shm_metadata_cache.md
+++ b/project_cte_shm_metadata_cache.md
@@ -490,6 +490,33 @@ purpose: the slot generation protects the METADATA copy, while §5.3's hazard is
 the DataOrganizer relocating blocks during the PAYLOAD read. A client must
 re-check `placement_gen_` after copying bytes.
 
+**Phase 4 COMPLETE — client attach + write-then-read tests passing.**
+Two bugs surfaced only by writing the test:
+
+1. **CreateTask propagation alone does not work.** The OUT offset is written
+   only by the process that actually causes pool creation, and compose creates
+   the CTE pool at startup — so every real client called GetOrCreatePool, hit
+   the existing pool, never ran the ChiMod's `Create`, and got offset 0.
+   Discovery must not depend on being the first caller. Added a
+   `MetadataDirectory` as the first object in the metadata segment, published
+   to every client in the **ClientConnect handshake** beside the allocator ids.
+   The CreateTask path is kept and tried first, then falls back to the
+   directory.
+2. **The blob mirror was published too early.** `BlobInfo` is inserted into the
+   map empty and only gains blocks/`total_size_cache_` later in `ExtendBlob`,
+   so mirroring at insert time published size 0 — a client reading its own
+   write got the wrong answer. The mirror now runs at the successful end of
+   `PutBlobImpl`.
+
+The write-then-read test asserts what makes the cache *safe*, not merely fast:
+a miss is reported as not-cached and never as absent; the cached size AGREES
+with the authoritative RPC answer; an overwrite is reflected rather than served
+stale; payload reads stay refused while blobs live on file targets. It also
+fails loudly rather than passing vacuously when the cache is unavailable — the
+first version silently skipped every assertion and "passed".
+
+CTE functional suite: **10/10**.
+
 **Phase 3 COMPLETE — dual-write wired and verified end-to-end.**
 `ShmMetadataCache` (runtime-side owner) is created in `Runtime::Create` and
 mirrored at every blob insert (3 sites: PutBlob, WAL replay, metadata restore),

--- a/project_cte_shm_metadata_cache.md
+++ b/project_cte_shm_metadata_cache.md
@@ -490,8 +490,38 @@ purpose: the slot generation protects the METADATA copy, while §5.3's hazard is
 the DataOrganizer relocating blocks during the PAYLOAD read. A client must
 re-check `placement_gen_` after copying bytes.
 
-Still to build in Phase 3: runtime dual-write into the cache from
-`core_runtime.cc`, gated so the legacy path stays authoritative.
+**Phase 3 COMPLETE — dual-write wired and verified end-to-end.**
+`ShmMetadataCache` (runtime-side owner) is created in `Runtime::Create` and
+mirrored at every blob insert (3 sites: PutBlob, WAL replay, metadata restore),
+every blob erase (3 sites), and tag creation. Every mirror call is best-effort
+and swallows failure: the cache is derived state, so the right response to any
+problem is to stop caching, never to reject the metadata write the caller was
+actually performing. Mirrors run AFTER the authoritative insert, so the cache
+can only lag, never lead.
+
+Verified against a live daemon by attaching the metadata segment from an
+UNRELATED process and reading the maps:
+
+```
+ready=1 version=1
+tag_name_to_id  : size=11  cap=65536
+tag_id_to_info  : size=11  cap=65536
+blob_key_to_info: size=87  cap=262144
+```
+
+CTE functional suite stays 9/9 with the mirror active.
+
+**Method note worth keeping.** The first "green" run proved nothing: the suite
+that passed (`cte_core_functionality_simple_tests`) never creates a CTE pool, so
+`Runtime::Create` — and therefore the whole dual-write path — never executed.
+Confirming the cache was actually *enabled* (`root_off=68072` in the log) and
+then reading the populated maps from another process is what made the result
+mean something. A green suite that does not reach the new code is not evidence.
+
+`kShmBlobDirectReadable` is deliberately NOT set yet: proving a block is
+node-local AND RAM-backed needs the target registry, and the RAM bdev is not
+SHM-backed until Phase 6. Until then the cache serves METADATA only and every
+payload read still goes through RPC — the safe direction to be wrong in.
 
 **Design refinement made during implementation: the map never rehashes.** Growth
 is the one operation that cannot be made safe for untracked cross-process

--- a/project_cte_shm_metadata_cache.md
+++ b/project_cte_shm_metadata_cache.md
@@ -1,0 +1,212 @@
+# CTE Shared-Memory Metadata Cache (issue #783)
+
+Status: design / not yet implemented
+Branch: `783-cte-shm-metadata-cache`
+
+## 1. Problem
+
+Blobs are arbitrary-sized, so the fixed-size page-cache trick does not apply. Every
+metadata lookup is a runtime round-trip, and the round-trip is expensive no matter
+which transport we pick. Measured on a 6-core WSL host (`clio_run_thrpt_bench
+--test-case latency`, 4 reps, medians):
+
+| Transport | 1 thread | 4 threads | 8 threads |
+|---|---|---|---|
+| SHM | 70.6 µs | 145.3 µs | 240.5 µs |
+| IPC (unix socket) | 124.5 µs | 175.5 µs | 297.1 µs |
+| TCP (loopback) | 471.7 µs | 574.8 µs | 691.5 µs |
+
+The floor is ~71 µs and it degrades with concurrency. No hardware extension helps.
+The only way to make small reads cheap is to remove the round-trip entirely.
+
+**Target: node-local RAM-resident `GetBlob` in < 5 µs with zero IPC.**
+
+## 2. Model
+
+- The **runtime owns** all shared metadata. It is the only writer.
+- **Clients are strictly read-only**, mapping the segment `PROT_READ`.
+- **Reads are synchronous** (in-process SHM lookup). **Writes are fully asynchronous**
+  (write-through to the runtime; the SHM copy is updated by the runtime afterward).
+- Clients are **untrusted for liveness**: any client may be `SIGKILL`ed at any
+  instant, including mid-read. Nothing the runtime does may ever block on a client.
+
+That last point is the load-bearing constraint. It rules out the obvious designs.
+
+## 3. What already exists (and what does not)
+
+Useful groundwork already in the tree:
+
+- `ctp::ipc::vector<AllocT>` and `ShmContainer<AllocT>` —
+  `context-transport-primitives/include/clio_ctp/data_structures/ipc/`
+- A segment/allocator pattern: `backend.shm_init(alloc_id, size, name)` →
+  `MakeAlloc<T>()` on the runtime, `AttachAlloc<T>()` on the client
+  (`context-runtime/src/ipc_manager.cc:839-945`)
+- `MemorySegment` enum with `kMainSegment` / `kClientDataSegment` / `kQueueSegment`
+  (`context-runtime/include/clio_runtime/types.h:596`)
+- `TagInfo`/`BlobInfo` are **already allocator-parameterized** (`priv::string`,
+  `priv::vector`, `CLIO_PRIV_ALLOC`) — they are not hard-wired to `new`/`delete`.
+
+Missing, and must be built:
+
+- **`ipc::string`** — does not exist.
+- **`ipc::unordered_map`** — does not exist. Only `priv::unordered_map_ll`
+  (malloc-backed, lock-taking) and `priv::unordered_map_lhash` exist.
+- Any read-only / lock-free lookup path.
+- SHM-backed RAM bdev. Today `MemBdevTransport` uses `new char[1 GiB]` pages
+  (`mem_bdev_transport.cc:80`).
+
+Note `CLIO_PRIV_ALLOC` expands to `CTP_MALLOC` on host (`types.h:551`) — the `priv::*`
+containers are allocator-aware but currently bound to malloc. Retargeting them is
+plausible; it is *not* free, because the map values are `std::shared_ptr`.
+
+## 4. Architecture
+
+### 4.1 Metadata segment
+
+New `kMetadataSegment` in the `MemorySegment` enum. 8 GB fixed size, created at
+context-runtime startup, **runtime-wide** (not CTE-owned — other modules will want
+it). Not pre-faulted: `shm_open` + `ftruncate(8 GB)` + `mmap` is lazily populated, so
+only touched pages cost RAM. `IpcManager` creates it on the server path and attaches
+it read-only on the client path, exposing it next to `main_allocator_`.
+
+### 4.2 Containers
+
+- `ipc::string` — offset-based, SSO optional, no heap pointers.
+- `ipc::unordered_map` — open addressing with tombstones, power-of-two capacity,
+  per-slot generation counter. Chosen over chaining because a lock-free reader can
+  probe a flat array safely; chasing chain pointers while the writer recycles nodes
+  needs epoch protection on *every* node.
+- Reuse `ipc::vector` for `blocks_` and `aliases_`.
+
+All internal references are **segment-relative offsets**, never raw pointers — the
+segment maps at different base addresses in each process.
+
+### 4.3 Data structures
+
+`ShmTagInfo` / `ShmBlobInfo` mirror the existing structs with SHM-safe members.
+Notable conversions:
+
+| Current | Becomes | Note |
+|---|---|---|
+| `priv::string blob_name_` | `ipc::string` | |
+| `priv::vector<BlobBlock> blocks_` | `ipc::vector<BlobBlock>` | verify `BlobBlock` is POD-safe; it embeds a `bdev::Client` |
+| `ctp::Mutex prealloc_lock_` | runtime-side only | clients never take it; must not be on the RO read path |
+| `std::shared_ptr<T>` in maps | offset + generation | see §5.1 — this is the hard part |
+
+### 4.4 Client read path
+
+```
+GetBlob(tag, name)
+  -> seqlock-read blob slot from SHM map
+  -> all blocks node-local && kRam?
+       yes -> memcpy from SHM RAM bdev, re-validate generation, return
+       no  -> fall back to existing async RPC path
+```
+
+Fallback is always available, which is what makes incremental rollout safe.
+
+## 5. The hard problems
+
+### 5.1 Reclamation without `shared_ptr`
+
+`core_runtime.h:366` documents the current safety property explicitly: *"Values are
+`std::shared_ptr`, so a concurrent erase just drops the map's reference while any
+in-flight handle keeps the object alive — no use-after-free."* There are 61
+`shared_ptr<TagInfo>`/`shared_ptr<BlobInfo>` sites. Shared memory has no `shared_ptr`,
+and the readers are in other processes.
+
+Proposal: **epoch-based reclamation.**
+- Global epoch counter in SHM, bumped by the runtime.
+- Each attached client publishes a per-client epoch slot (entering/leaving a read).
+- The runtime defers freeing a slot until every live client has advanced past the
+  epoch in which it was retired.
+- **Liveness:** a client that dies inside a read section would pin the epoch forever.
+  Each slot carries a PID + heartbeat; the runtime reaps slots whose owner is gone.
+  Reaping must be conservative (a false reap is a use-after-free).
+
+This is the single riskiest piece of the design and deserves its own standalone
+test harness before it is wired into CTE.
+
+### 5.2 Optimistic reads only
+
+Because the runtime may never wait on a client, **no client-held lock may exist**.
+All reads are seqlock-style: read sequence, read payload, re-read sequence, retry on
+mismatch or odd value.
+
+Direct consequence: **clients cannot call `unordered_map_ll::find()`** — it acquires
+locks, i.e. it writes, which both blocks the runtime and faults a `PROT_READ` mapping.
+The runtime's writer path and the client's reader path are therefore *different code*
+over the *same* layout. That asymmetry needs to be explicit in the API, not implied.
+
+### 5.3 Coherence against the DataOrganizer
+
+The frecency organizer (`data_organizer/frecency_organizer.cc`) moves and evicts
+blobs. Sequence that corrupts data:
+
+1. Client reads `BlobInfo`, gets block offsets into the RAM bdev.
+2. Runtime reorganizes the blob; blocks are freed and reused by another blob.
+3. Client `memcpy`s from those offsets → **silently returns another blob's bytes.**
+
+No error surfaces. Mitigation: a per-blob generation counter validated *before and
+after* the payload copy (extending the seqlock across the data read, not just the
+metadata read), plus epoch-deferred reuse of RAM-bdev blocks so recycling cannot
+outrun an in-flight reader.
+
+### 5.4 Read-your-own-writes
+
+Fully-async write-through means a client that does `PutBlob` then `GetBlob` can miss
+its own write — which breaks the filesystem adapter's expectations. Mitigation: a
+per-client pending-write key set; those keys take the slow path until acknowledged.
+
+### 5.5 `PROT_READ` discipline
+
+A stray write on the client read path is a `SIGSEGV`, not a wrong answer. No lock
+acquisition, no lazy init, no refcount updates, no `operator[]` (which inserts).
+Worth enforcing in CI with a test that maps the segment read-only and exercises every
+client path.
+
+### 5.6 Trust boundary — **needs an explicit decision**
+
+A shared metadata segment lets *any* client read *every* tag and blob name/size on
+the node. Today a client sees only what the runtime returns. This is a genuine change
+to the isolation model. Options: accept it (single-tenant assumption), or partition
+segments per tenant/pool. This should be decided deliberately and recorded, not
+inherited by accident.
+
+### 5.7 `/dev/shm` sizing
+
+`/dev/shm` is **64 MB** on this dev host. An 8 GB sparse segment maps fine, but
+touching past the tmpfs limit raises **`SIGBUS`**, not `ENOMEM` — a crash, not a
+clean failure. We need (a) a graceful "cache full → fall back to RPC" path, and
+(b) documented tmpfs sizing for realistic benchmarking.
+
+## 6. Phasing
+
+Dual-write is what keeps a 127-call-site refactor from becoming a flag-day.
+
+| Phase | Work | Exit criterion |
+|---|---|---|
+| 0 | CTE metadata benchmark harness | Baseline recorded |
+| 1 | `kMetadataSegment` + `IpcManager` plumbing | Runtime creates it; client attaches RO |
+| 2 | `ipc::string`, `ipc::unordered_map` + epoch reclamation | Standalone torture test, incl. random reader kills |
+| 3 | `ShmTagInfo`/`ShmBlobInfo`; runtime **dual-writes** | Old path still authoritative; all CTE tests green |
+| 4 | Propagate map locations via `CreateTask` | Client holds valid handles |
+| 5 | Client fast path for **metadata-only** ops (`GetBlobSize`, `GetBlobScore`) | Correctness parity; latency win measured |
+| 6 | SHM RAM bdev + client payload fast path | `GetBlob` < 5 µs, zero IPC |
+| 7 | Retire dual-write and legacy structures | Single source of truth |
+
+Phases 0-2 are self-contained and carry essentially no risk to existing behavior.
+Phase 3 is where the blast radius starts. Phase 5 before Phase 6 deliberately: proving
+the read path on metadata-only ops is far cheaper to debug than on payload reads.
+
+## 7. Open questions
+
+1. Trust boundary (§5.6) — accept node-wide metadata visibility, or partition?
+2. Epoch reclamation vs. hazard pointers vs. never-reclaim (bounded arena + compaction
+   at quiesce)? Never-reclaim is dramatically simpler and may be adequate at 8 GB.
+3. Do we need `TagId -> TagInfo` *and* `string -> TagId` in SHM, or can the client
+   resolve names once and cache the ID privately?
+4. `BlobBlock` embeds a `bdev::Client` — is that SHM-safe as-is, or does the SHM
+   variant need a slimmed block descriptor?
+5. Does `kPinned` (GPU page-locked) RAM bdev stay on the old private-heap path?
+   `cudaMallocHost` memory cannot trivially be SHM-backed.

--- a/project_cte_shm_metadata_cache.md
+++ b/project_cte_shm_metadata_cache.md
@@ -379,7 +379,7 @@ Dual-write is what keeps a 127-call-site refactor from becoming a flag-day.
 
 | Phase | Work | Exit criterion |
 |---|---|---|
-| 0 | CTE metadata benchmark harness | Baseline recorded |
+| 0 | CTE metadata benchmark harness | DONE -- baseline SHM 72.1 µs (see §6b) |
 | 1 | `kMetadataSegment` + `IpcManager` plumbing | Runtime creates it; client attaches RO |
 | 2 | `ipc::string`, `ipc::unordered_map`, `TimedMutex`, `Lease` | Standalone torture test, incl. random reader kills mid-lease |
 | 3 | `ShmTagInfo`/`ShmBlobInfo`; runtime **dual-writes** | Old path still authoritative; all CTE tests green |
@@ -433,12 +433,27 @@ the read path on metadata-only ops is far cheaper to debug than on payload reads
 - Still to build: `ipc::string`, `ipc::unordered_map`, `Lease`, and the
   kill-clients-at-random torture test.
 
-**Known blocker (not caused by this work):** `clio_run_thrpt_bench` aborts shortly
-after client init with `Fatal glibc error: tpp.c:83 (__pthread_tpp_change_priority)`,
-in every transport mode including TCP (which maps no SHM at all). Needs isolating
-before Phase 0 baselines can be taken — note that a partial rebuild after an
-`IpcManager` layout change produces ABI skew between the core library and the module
-`.so`s, which can present as spurious crashes, so always rebuild modules together.
+**Phase 0 (baseline) — done.** Measured on this branch after a consistent full
+rebuild, single thread, `--test-case latency`: **SHM 72.1 µs**, IPC 109.7 µs, TCP
+517.5 µs. Matches the pre-merge numbers (70.6 / 124.5 / 471.7), so merging `dev`
+introduced no latency regression. **SHM 72 µs is the number the cache must beat**;
+the target is < 5 µs.
+
+**Resolved false alarm — ABI skew, not a `dev` bug.** During Phase 1,
+`clio_run_thrpt_bench` aborted just after client init with `Fatal glibc error:
+tpp.c:83 (__pthread_tpp_change_priority)`, in every transport mode including TCP. It
+looked like a pre-existing `dev` regression. It was not: adding members to
+`IpcManager` changes its layout, and rebuilding only `clio_run` left the module
+`.so`s (`clio_*_runtime`) compiled against the old layout. The resulting ABI skew
+presented as unrelated crashes — including a startup segfault when the skew ran the
+other way. A consistent rebuild of runtime + all modules + bench made it vanish.
+
+**Rule for this work:** after touching the layout of any widely-included type, rebuild
+the modules in the same command, e.g.
+`cmake --build build-cpu --target clio_run clio_admin_runtime clio_bdev_runtime
+clio_MOD_NAME_runtime clio_cte_core_runtime clio_cae_core_runtime
+clio_run_thrpt_bench -j 6`. A partial rebuild will produce crashes that look like
+someone else's bug.
 
 ## 7. Decisions
 

--- a/project_cte_shm_metadata_cache.md
+++ b/project_cte_shm_metadata_cache.md
@@ -178,7 +178,7 @@ the existing code:
    few stuck blobs wedge the runtime. **The reorganizer must `try_lock` and skip** —
    it is background work and is free to reorganize a different blob.
 4. **Timeout-and-steal is probabilistic, not correct.** If the timeout fires on a
-   *live but slow* client — page fault against an undersized `/dev/shm` (§5.7),
+   *live but slow* client — page fault under memory pressure (§5.7),
    descheduled, swapped — the reorganizer moves data under an active reader, which is
    exactly the corruption being prevented. 500 ms makes that rare; rare **plus
    silent** is the worst failure mode to ship.
@@ -341,12 +341,37 @@ to the isolation model. Options: accept it (single-tenant assumption), or partit
 segments per tenant/pool. This should be decided deliberately and recorded, not
 inherited by accident.
 
-### 5.7 `/dev/shm` sizing
+### 5.7 Segment sizing — it is RAM, not `/dev/shm`
 
-`/dev/shm` is **64 MB** on this dev host. An 8 GB sparse segment maps fine, but
-touching past the tmpfs limit raises **`SIGBUS`**, not `ENOMEM` — a crash, not a
-clean failure. We need (a) a graceful "cache full → fall back to RPC" path, and
-(b) documented tmpfs sizing for realistic benchmarking.
+**Corrected during Phase 1 implementation.** The original text here assumed these
+segments are `/dev/shm` files and that this host's 64 MB `/dev/shm` was the binding
+constraint. That is wrong.
+
+On Linux the runtime creates segments with **`memfd_create()`**
+(`SystemInfo::CreateNewSharedMemory`, `system_info.cc:519`), then publishes a symlink
+under a per-user directory (`/tmp/clio_<user>/`) pointing at `/proc/<pid>/fd/<n>` so
+other processes can find and open them. memfd objects live in the kernel's internal
+shmem pool — bounded by **RAM + swap and the memory cgroup** — and are *not* subject
+to the `/dev/shm` mount size at all. Verified: `/proc/<pid>/maps` shows
+`/memfd:chi_metadata_segment_...`, and `/dev/shm` stays 0% used with a 1 GB main
+segment live.
+
+This also explains an older observation that a 1 GB main segment and a 128 MB ring
+"work anyway" on a host with a 64 MB `/dev/shm` — not sparseness, just the wrong
+filesystem.
+
+Consequences:
+- **Do not clamp against `std::filesystem::space("/dev/shm")`.** It measures an
+  unrelated filesystem and needlessly shrinks the cache (an early Phase 1 draft cut
+  8 GB to 57 MB this way).
+- The reservation is close to free — sparse and never pre-faulted, so cost is only
+  pages actually written. Verified: with a ~6 GB metadata segment mapped, runtime RSS
+  is ~35 MB.
+- The real limit is the **live set** against RAM/cgroup. Exhausting shmem surfaces as
+  `SIGBUS` or the OOM killer rather than a clean allocation failure, so Phase 1 clamps
+  the reservation to **half of physical RAM** as a sanity bound.
+- A "cache full → fall back to RPC" path is still required, since allocator exhaustion
+  inside the segment must degrade rather than fail.
 
 ## 6. Phasing
 
@@ -382,6 +407,38 @@ the legacy path.
 Phases 0-2 are self-contained and carry essentially no risk to existing behavior.
 Phase 3 is where the blast radius starts. Phase 5 before Phase 6 deliberately: proving
 the read path on metadata-only ops is far cheaper to debug than on payload reads.
+
+## 6b. Implementation status
+
+**Phase 1 (metadata segment) — done.**
+- `kMetadataSegment` added to `MemorySegment` (`types.h`).
+- `ConfigManager`: `metadata_segment_name_`, `metadata_segment_size_`,
+  `CalculateMetadataSegmentSize()`, plus the name switch case.
+- `IpcManager`: `metadata_backend_` / `metadata_allocator_id_` /
+  `metadata_allocator_`, `GetMetadataAllocator()`, `HasMetadataSegment()`.
+- Server creates it at `pid.3` (allocator index reservation bumped 3 -> 4);
+  client attaches best-effort. **Both paths are non-fatal**: if the segment is
+  missing the runtime still boots and clients silently use the RPC path.
+- Reservation sanity-clamped to half of RAM (see §5.7).
+- Verified live: segment mapped as `/memfd:chi_metadata_segment_<user>_<port>`,
+  runtime RSS ~35 MB with ~6 GB reserved (confirming it is not pre-faulted), and a
+  client logs a successful attach.
+
+**Phase 2 (primitives) — `TimedMutex` done, rest pending.**
+- `clio_ctp/thread/lock/timed_mutex.h`: unfair CAS lock with PID +
+  process-start-time reclamation, `TryLock`/`Lock`/`Unlock`, ABA-safe release,
+  `ScopedTimedLock` RAII guard, `steal_count_` diagnostics.
+- Standalone smoke test passes (unique ids, reentrant `TryLock` correctly fails,
+  clean release, no spurious steals).
+- Still to build: `ipc::string`, `ipc::unordered_map`, `Lease`, and the
+  kill-clients-at-random torture test.
+
+**Known blocker (not caused by this work):** `clio_run_thrpt_bench` aborts shortly
+after client init with `Fatal glibc error: tpp.c:83 (__pthread_tpp_change_priority)`,
+in every transport mode including TCP (which maps no SHM at all). Needs isolating
+before Phase 0 baselines can be taken — note that a partial rebuild after an
+`IpcManager` layout change produces ABI skew between the core library and the module
+`.so`s, which can present as spurious crashes, so always rebuild modules together.
 
 ## 7. Decisions
 

--- a/project_cte_shm_metadata_cache.md
+++ b/project_cte_shm_metadata_cache.md
@@ -1,7 +1,28 @@
 # CTE Shared-Memory Metadata Cache (issue #783)
 
-Status: design / not yet implemented
+Status: **IMPLEMENTED** (phases 0-7 complete)
 Branch: `783-cte-shm-metadata-cache`
+
+## Result
+
+Client reads of node-local CTE data now complete with **zero IPC**. Measured
+cross-process (external daemon), same query and same blobs on both paths:
+
+| Read type | SHM fast path | RPC path | Speedup |
+|---|---|---|---|
+| **Payload (4 KB blob)** | **0.26 µs/op** | **120.2 µs/op** | **461x** |
+| **Metadata** | **0.15 µs/op** | **90.0 µs/op** | **590x** |
+
+Design target was < 5 µs; both paths land at 0.15-0.26 µs. The starting point
+recorded in §1 was a 72 µs transport floor that got worse under concurrency.
+
+Wired into the real APIs: `Tag::GetBlobSize` and `Tag::GetBlob` both take the
+fast path when the blob qualifies and fall through to RPC otherwise, so callers
+get the speedup without changing a line.
+
+Test coverage: ctp primitives 43 + 6191 + 28 assertions; CTE SHM data model
+7/7; CTE functional 12/12 (incl. write-then-read and payload correctness);
+bdev chimod 21/21.
 
 ## 1. Problem
 

--- a/project_cte_shm_metadata_cache.md
+++ b/project_cte_shm_metadata_cache.md
@@ -221,13 +221,21 @@ generation catches the payload being moved under a reader.
 
 Four constraints on the implementation:
 
-**1. Lock words must live in a separate read-write region.** Acquiring a lease is a
-store, and clients map the data `PROT_READ` (§5.5). A `TimedMutex` therefore cannot be
-embedded inline in an `ShmBlobInfo` that lives in the read-only region. Layout: a
-lock array in a small **RW-mapped** region, indexed parallel to the objects, with
-metadata and payload staying **RO**. This yields a useful safety property — since
-correctness rests on the generation counter, a client that corrupts a lock word can
-only damage *liveness*, never silently corrupt another reader's data.
+**1. Mapping is `PROT_READ|PROT_WRITE`; read-only is enforced by discipline.**
+DECIDED: clients map the segment read-write, because acquiring a lease is a store and
+splitting lock words into a separate region is not worth the layout complexity. **The
+only bytes a client may write are lock words. Metadata is never client-writable.**
+
+This trades a hardware guarantee for a convention, so two invariants become
+load-bearing:
+- The runtime **must never read the SHM cache as authoritative**. It keeps its own
+  structures; the cache is derived state, and a client that scribbles on it can only
+  harm other clients, never the runtime. (This is why Phase 7 keeps it a pure cache.)
+- A corrupted cache must be **droppable and rebuildable** wholesale, since we can no
+  longer rely on `PROT_READ` to prevent corruption from happening at all.
+
+Acceptable because §7.1 already accepts a single-tenant trust model. Under
+multi-tenancy this decision would have to be revisited along with §5.6.
 
 **2. Default to a lock-free read; take a lease only when you need a stable view.**
 An exclusive `TimedMutex` serializes concurrent readers of the same hot blob, and the
@@ -239,6 +247,24 @@ leases *rare* is also what keeps reclamation simple: an exclusive lock has a sin
 owner, so a dead holder is identifiable, which a shared/reader-counted lease would
 not be (that would need per-holder tracking, i.e. epochs again by another name).
 
+**What if a client dies mid-seqlock-read?** Nothing happens, and this is the whole
+reason to prefer a seqlock for the default path. A seqlock *reader* acquires nothing
+and stores nothing — it reads the sequence, copies, and re-reads the sequence. A dead
+reader therefore leaves **no state to release, reclaim, or unwind**; there is no
+counter to decrement and no lock to steal. It has copied garbage into its own address
+space, but it is dead, so nobody consumes it. No cross-process effect whatsoever.
+
+The seqlock's one death hazard is on the **writer** side: a writer that dies between
+its two sequence bumps leaves the sequence odd forever, and readers retry forever. But
+the writer is always the **runtime** — the single trusted owner — and if the runtime
+dies the whole session is being torn down anyway. The asymmetry is exactly the one we
+want: the untrusted-liveness side (clients) is stateless, and the stateful side is the
+one process whose death is already fatal.
+
+This is precisely why the seqlock is the *default* and `Lease` is the *exception*: a
+lease is the only client-side construct whose abandonment needs servicing, so the
+design minimizes how often one is held.
+
 **3. Reclamation needs PID + process start time, not a bare timeout.** A timeout alone
 cannot distinguish a dead holder from a live-but-slow one (§5.3, point 4). The lock
 word carries `{owner_pid, process_start_time, acquire_timestamp}`; a waiter past the
@@ -246,11 +272,36 @@ threshold checks liveness and steals **only if the owner is genuinely gone**. St
 time is required because PIDs are recycled — on Linux, field 22 of `/proc/<pid>/stat`.
 A steal must bump a steal counter so a resurrected holder can detect it lost the lock.
 
-**4. The runtime must never block on a lease.** Per §5.3 the reorganizer `try_lock`s
-and skips. Writes cannot "skip" as such, but they do not need to block either: the
-runtime updates its own authoritative structure and **defers the SHM mirror update**
-if the lease is contended. This is only sound because the SHM copy is a *cache*, never
-the source of truth — see the revised Phase 7.
+**4. The runtime may wait on a lease — but the *task* waits, never the *worker
+thread*.** DECIDED: waiting is unavoidable, since a lease that the runtime could
+ignore would not protect anything. The constraint is not *whether* to wait but *how*.
+
+A thread-blocking wait is not available here. `ReorganizeBlobInternal` /
+`DynamicReorganize` are coroutines on workers, and `core_tasks.h:820-831` already
+documents why: a thread-blocking lock "CANNOT be used here — it would deadlock the
+single worker the instant the holder suspends at a `co_await`." With 4 workers, a few
+contended blobs would wedge the runtime — the exact failure class issue #781 exists to
+prevent.
+
+The codebase already has the right pattern, in that same comment: the `write_owner_`
+contender "busy-polls via `co_await yield()` ... which is lost-wakeup-proof because it
+re-checks every worker iteration." So:
+
+- `Lease` acquisition on the runtime side is a **`co_await` retry loop**, not a
+  blocking acquire. The task suspends; the worker goes and runs other tasks.
+- The reorganizer, being pure background work, still prefers `try_lock`-and-skip — it
+  has no obligation to reorganize any particular blob right now.
+- Metadata writes wait via `co_await`, bounded by the `TimedMutex` threshold.
+
+Two consequences to keep in view:
+- The `TimedMutex` timeout now **bounds runtime write latency**, not just reclamation
+  lag. A 500 ms threshold means a metadata write can stall that long behind a wedged
+  client. This is the strongest argument for the §5.3 size cap: bounding legitimate
+  lease hold time lets the threshold come down proportionally.
+- A client holding a lease can now delay runtime progress, which is a denial-of-service
+  vector even under a single-tenant model — a merely *buggy* client that leaks a lease
+  is enough. The timeout is the backstop, and clients must never hold a lease across a
+  syscall, an I/O, or anything else unbounded.
 
 ### 5.4 Read-your-own-writes
 
@@ -305,13 +356,20 @@ Dual-write is what keeps a 127-call-site refactor from becoming a flag-day.
 | 7 | Retire the *scaffolding*, keep SHM as a pure cache | Steady state (see below) |
 
 **Phase 7 revised.** The original plan was to retire the legacy structures and make SHM
-the single source of truth. That is now rejected: if SHM were authoritative, a runtime
-write would have to *land* there, so the runtime would have to block on a client-held
-lease — violating §5.3b constraint 4. Instead the runtime keeps its own authoritative
-structures permanently and the SHM segment stays a **pure read cache** the runtime may
-always defer updating or invalidate wholesale. This also means a corrupted or wedged
-cache is recoverable by dropping it, never a data-loss event. Phase 7 therefore only
-removes benchmarking scaffolding and any redundant bookkeeping, not the legacy path.
+the single source of truth. That is now rejected, primarily because of §5.3b constraint
+1: clients map the segment **read-write**, so a buggy client can corrupt it. Derived
+state that can be dropped and rebuilt is a recoverable annoyance; *authoritative* state
+that a client can corrupt is data loss. The runtime therefore keeps its own structures
+permanently, and the SHM segment stays a **pure read cache** it may defer updating or
+invalidate wholesale at any time.
+
+(A secondary argument also applies: an authoritative cache would put client-held leases
+on the critical path of every metadata write, rather than merely on cache freshness.
+The runtime is willing to wait on leases — §5.3b constraint 4 — but there is no reason
+to make correctness, rather than staleness, depend on that wait.)
+
+Phase 7 therefore only removes benchmarking scaffolding and redundant bookkeeping, not
+the legacy path.
 
 Phases 0-2 are self-contained and carry essentially no risk to existing behavior.
 Phase 3 is where the blast radius starts. Phase 5 before Phase 6 deliberately: proving
@@ -347,8 +405,17 @@ the read path on metadata-only ops is far cheaper to debug than on payload reads
 8. **Smart pointer — DECIDED: new `Lease`** in `clio_ctp/memory/smart_ptr/lease.h`,
    alongside `shared_ptr.h` / `unique_ptr.h`. See §5.3b for its four constraints.
 
+9. **Mapping — DECIDED: `PROT_READ|PROT_WRITE`.** Clients map read-write; only lock
+   words are client-writable, enforced by convention rather than by the MMU. See
+   §5.3b constraint 1 for the two invariants this makes load-bearing.
+10. **Runtime waiting — DECIDED: the runtime may wait on leases.** Unavoidable, since
+    an ignorable lease protects nothing. But it waits by `co_await` retry, never by
+    blocking a worker thread (§5.3b constraint 4).
+
 ### Still open
 
 - The exact fast-path size cap (item 6) — needs measurement, not a decision.
 - Whether the `TimedMutex` threshold stays at 500 ms or drops once the size cap bounds
-  legitimate hold time (§5.3).
+  legitimate hold time. This now matters more than it did: with the runtime waiting on
+  leases (item 10), the threshold bounds **runtime metadata-write latency**, not just
+  reclamation lag.

--- a/project_cte_shm_metadata_cache.md
+++ b/project_cte_shm_metadata_cache.md
@@ -556,9 +556,23 @@ rather than reading a dying segment.
 Verified: bdev chimod suite **21/21** with three devices reporting themselves
 SHM-backed.
 
-*Unrelated pre-existing bug found while testing:* `clio_run_thrpt_bench
---test-case bdev_allocation` segfaults against an external daemon on BOTH the
-ram and file paths, so it predates this work. Worth its own issue.
+*Retracted (was: "unrelated pre-existing bug").* `clio_run_thrpt_bench
+--test-case bdev_allocation` was segfaulting against an external daemon, and I
+recorded it here as pre-existing because the file path crashed too. **That
+conclusion was wrong.** After destroying `build-cpu` and rebuilding the whole
+repo from scratch it does not reproduce (6/6 clean runs, both bdev types).
+
+Root cause was **ABI skew from my own partial rebuilds**: this work changed the
+layout of `IpcManager` and added an OUT field to `ClientConnectTask`, but
+`clio_run_thrpt_bench` was not rebuilt, so the bench carried the old handshake
+layout while the daemon used the new one. The client faulted on the first task
+after `ClientConnect` — exactly where the crash appeared — and the daemon was
+unaffected because only the client's view was stale.
+
+Filed as #786 and closed as invalid. The lesson is the one already recorded in
+Phase 0: **a crash that appears after a layout change is a stale-build suspect
+first.** Rebuild the runtime, every module `.so`, and any test/bench binaries
+together — or do a clean build before concluding anything about the cause.
 
 **Phase 5 COMPLETE — fast path wired and MEASURED.**
 

--- a/project_cte_shm_metadata_cache.md
+++ b/project_cte_shm_metadata_cache.md
@@ -3,6 +3,62 @@
 Status: **IMPLEMENTED** (phases 0-7 complete)
 Branch: `783-cte-shm-metadata-cache`
 
+## Scaling: how many blobs and tags fit?
+
+**The maps are FIXED CAPACITY and never rehash** (see §5.3b — a rehash would
+free a table out from under untracked cross-process readers). Capacity is set
+once at pool creation and is the permanent ceiling. Defaults: 64K tags, 256K
+blobs per CTE pool, overridable via `CLIO_CTE_SHM_TAG_CAPACITY` /
+`CLIO_CTE_SHM_BLOB_CAPACITY`.
+
+Useful occupancy is **7/8 of capacity** (load cap, below), so the defaults hold
+~229K blobs. **A million blobs does NOT fit the default** — it gets ~23%
+coverage, and the other 77% silently use the RPC path.
+
+Memory is **resident, not sparse**: every slot is constructed at creation.
+
+| Slot | Size | 1M blobs needs | Table size |
+|---|---|---|---|
+| blob | 376 B | 2,097,152 slots | **0.79 GB** |
+| tag (name→id) | 80 B | — | — |
+| tag (id→info) | 56 B | — | — |
+
+So 1M blobs is reachable (0.79 GB inside a 6 GB segment) but must be configured
+deliberately; 10M would need 6.3 GB and does not fit today.
+
+### The load cap exists because a full table was slower than not caching
+
+Measured on a 65536-slot table, before the cap:
+
+| load | hit | **miss** | insert |
+|---|---|---|---|
+| 50% | 0.042 µs | 0.056 µs | 0.15 µs |
+| 90% | 0.037 µs | 0.184 µs | 0.22 µs |
+| 99% | 0.071 µs | **11.8 µs** | 0.85 µs |
+| 100% | 0.046 µs | **108.9 µs** | 1.71 µs |
+
+A probe run only stops at an EMPTY slot, so a table with none makes every miss
+scan all of it. At 100% a miss cost **more than the ~90 µs RPC the cache exists
+to avoid** — and the caller still paid that RPC afterwards. A saturated cache
+was strictly worse than no cache.
+
+Fix: refuse NEW keys past 7/8 load (overwrites still accepted, so a saturated
+cache stays fresh rather than going stale), plus a 1024-probe backstop. Miss
+cost is now **0.09–0.24 µs at every fill level**.
+
+A cautionary detail: the first probe cap I tried (64) became the *binding*
+constraint instead of the load factor — linear-probing clusters run far longer
+than the average, so a 65536-slot table stopped accepting keys at ~51%
+occupancy and 1M coverage *fell* from 26% to 18%. The backstop must be loose
+enough that the load factor is what binds.
+
+### Still open
+
+Overflow is **silent**: blobs beyond capacity simply are not cached and quietly
+take the RPC path. That is the same visibility gap as #787 — the correct
+behaviour is invisible, so a badly-sized deployment looks identical to a
+well-sized one. Exposing cached/refused counters is the follow-up.
+
 ## Result
 
 ### Write-then-read cycle (the pattern callers actually perform)

--- a/project_cte_shm_metadata_cache.md
+++ b/project_cte_shm_metadata_cache.md
@@ -464,7 +464,34 @@ are rare and short, but reader retry rate under realistic write load is a
 number worth measuring rather than assuming — a hot blob under sustained
 rewrite could starve readers into the RPC fallback.
 
-- Still to build: nothing in Phase 2. Next is Phase 3.
+- Still to build: nothing in Phase 2.
+
+**Phase 3 (SHM records) — data model done; dual-write wiring pending.**
+`clio_cte/core/shm_metadata_cache.h` defines `ShmBlockDesc`, `ShmBlobRecord`,
+`ShmTagRecord`, the three maps, and `ShmMetadataCacheRoot`. 7 tests pass,
+including a **forked child** that attaches the segment independently and reads
+back 200 entries plus a spilled long key — the property that validates the
+whole offset-based design.
+
+Two shape decisions forced by the primitives:
+
+- **Map values are strictly POD.** The map's reader copies the value out
+  between two generation reads, so a value containing an `ipc::string` (which
+  is non-copyable by design) would defeat the seqlock. The blob NAME is
+  therefore the map key, not a field of the record.
+- **Block lists are fixed-size inline (`kMaxInlineBlocks = 8`), not vectors.**
+  The fast path only serves small blobs, and a small blob has few blocks.
+  Capping keeps the record POD with no nested allocation and no second pointer
+  chase for a lock-free reader; a blob with more blocks is flagged
+  `kShmBlobTruncated` and is never payload-read from the cache.
+
+`ShmBlobRecord::placement_gen_` is separate from the map's slot seqlock on
+purpose: the slot generation protects the METADATA copy, while §5.3's hazard is
+the DataOrganizer relocating blocks during the PAYLOAD read. A client must
+re-check `placement_gen_` after copying bytes.
+
+Still to build in Phase 3: runtime dual-write into the cache from
+`core_runtime.cc`, gated so the legacy path stays authoritative.
 
 **Design refinement made during implementation: the map never rehashes.** Growth
 is the one operation that cannot be made safe for untracked cross-process


### PR DESCRIPTION
Closes #783.

Client reads of node-local CTE metadata and blob payloads now complete with **zero IPC**, by reading shared-memory structures the runtime owns instead of making a round-trip.

Draft: the implementation is complete and tested, but see **Open questions** below before merging.

## Why

Blobs are arbitrary-sized, so the fixed-size page-cache trick does not apply, and every metadata lookup was a runtime round-trip. Measured on a 6-core WSL host before any of this work:

| Transport | 1 thread | 4 threads | 8 threads |
|---|---|---|---|
| SHM | 70.6 µs | 145.3 µs | 240.5 µs |
| IPC (unix socket) | 124.5 µs | 175.5 µs | 297.1 µs |
| TCP (loopback) | 471.7 µs | 574.8 µs | 691.5 µs |

The floor was ~71 µs and it degraded under concurrency. No hardware extension fixes that; the only way to make small reads cheap is to not make the trip.

## Results

**Read-only (steady state, cached blobs — read-mostly workloads):**

| Read type | SHM | RPC | Speedup |
|---|---|---|---|
| Metadata | 0.14–0.21 µs | 89–102 µs | ~430–730x |
| Payload (4 KB) | 0.20–0.31 µs | 110–140 µs | ~350–700x |

**Write-then-read cycle (write-dominated — quote this one for read-after-write):**

| Measurement | SHM | RPC | Ratio |
|---|---|---|---|
| write alone | 79–140 µs | (same) | — |
| write + metadata read | 81–114 µs | 162–195 µs | **~2x** |
| write + payload read | 83–128 µs | 187–278 µs | **~2x** |

Writes are deliberately **not** accelerated here, so a read-after-write caller sees ~2x, not several-hundred-x. The read component becomes effectively free (~0.2 µs); Amdahl caps the rest. Both figures are recorded so the right one gets quoted for the right workload.

The RPC baseline swings run-to-run on this host (89–280 µs) while the SHM path stays ~0.2 µs, so these are ranges, not point estimates.

## Design

Full write-up in `project_cte_shm_metadata_cache.md` (in this PR). The load-bearing constraint is that **a client may be `SIGKILL`ed at any instant, including mid-read**, so nothing the runtime does may block on a client. That rules out the obvious designs and drives everything below.

- **Runtime-wide metadata segment** (`kMetadataSegment`), 8 GB sparse, created at startup, clamped to half of RAM. Non-fatal throughout: no segment means clients simply use RPC.
- **`ipc::string`** — offset-based, 23-byte SSO. Uses FNV-1a rather than `std::hash`, which is stable neither across processes nor libstdc++ versions; a shared table keyed on it would silently corrupt.
- **`ipc::unordered_map`** — open addressing, per-slot seqlock, tombstones. **Never rehashes**: growth is the one operation that cannot be made safe for untracked cross-process readers, since a rehash frees a table out from under them. Capacity is fixed and a full table degrades to RPC.
- **`TimedMutex`** — `ctp::Mutex` is a ticket lock and cannot be reclaimed (a dead holder never advances `head_`). This is an unfair CAS lock that trades FIFO fairness for reclaimability, using PID **plus process start time** since PIDs recycle.
- **`Lease` / `SeqRead`** — `gen_` is correctness, `lease_mutex_` is progress/lifetime. A seqlock reader stores nothing, so a reader that dies leaves nothing to reclaim; a lease is the only client-side construct whose abandonment needs servicing, so the design minimises how often one is held.
- **SHM-backed RAM bdev** — mapped as one contiguous sparse region rather than a page table; segment name derives from (runtime pid, pool id) so clients reconstruct it without anything being published.
- **Cache, never authority.** Clients map read-write (acquiring a lease is a store), so a corrupted cache must stay droppable. The runtime keeps its own structures permanently.

## Correctness properties under test

- **Read-your-own-writes** — a waited `PutBlob` is visible to the next read.
- **Cached answers agree with RPC** — a fast wrong answer is worse than no fast path.
- **A miss is "not cached", never "absent"** — always falls back, never reports missing data.
- **Torn reads rejected** — seqlock validated before and after.
- **`placement_gen_` validated before AND after the payload copy** — the metadata seqlock protects the record, but the real hazard is the DataOrganizer relocating blocks mid-`memcpy`.
- **Kill-readers torture test** — 6 seqlock readers + 2 lease holders SIGKILLed at random against a writer: 503k writes, 25.5M cross-process reads, **0 torn reads**, abandoned lease reclaimed.

## Testing

All on a from-scratch rebuild (`build-cpu` destroyed, 163 targets, 0 errors):

| Suite | Result |
|---|---|
| `test_string_exec` | 43 assertions / 10 cases |
| `test_unordered_map_exec` | 6191 assertions / 11 cases |
| `test_lease_exec` (incl. torture) | 28 assertions / 5 cases |
| `test_cte_shm_metadata_cache` | 7/7 |
| `test_core_functionality` | 13/13 |
| `clio_run_bdev_chimod_tests` | 21/21 |
| Transports (latency) | SHM 81.9 µs · IPC 150.0 µs · TCP 573.7 µs |

## Open questions for review

1. **Reader retry/fallback rate under concurrent write load is unmeasured** (#787). The fast path degrades to RPC rather than ever returning wrong data — correct, but the degradation is currently **invisible**. A workload could get no benefit and nothing would say so. Exposing fallback counters is the obvious follow-up.
2. **Fixed capacities** (64K tags, 256K blobs per pool) are chosen, not derived. Exceeding them degrades to RPC silently, same visibility gap.
3. **Node-wide metadata visibility** was accepted as a single-tenant assumption: any client can read every tag/blob name and size on the node. Fine today, but it is a real change to the isolation model and should be a conscious call.
4. **`MetadataDirectory` caps at 32 registered pools.** Beyond that a pool simply is not discoverable (degrades to RPC).

## Notes

- Includes a merge of `origin/dev` to pick up PR #782, which the design depends on.
- #786 was filed during this work and **closed as invalid** — it was ABI skew from my own partial rebuilds, not a repo defect. Worth knowing: changing the layout of a widely-included type and rebuilding only some targets produces crashes that look like unrelated bugs elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
