### PR TITLE
fix(organizer): treat a zero access timestamp as a sentinel, not a time (#792)

### DIFF
--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -1988,6 +1988,14 @@ void Runtime::CollectOrganizerBlobStats(clio::run::u32 replica_id,
         // organizer replica. The key hash partitions the blob space
         // disjointly across the `organizer_tasks` periodic replicas.
         if (blob_info.blocks_.empty()) return;
+        // Skip blobs whose access timestamps have not been written yet. A
+        // BlobInfo is constructed with last_modified_/last_read_ zeroed and
+        // stamped shortly after (PutBlobImpl), so a periodic organizer round
+        // can observe one in between. Scoring it would treat the zero as a
+        // real timestamp and derive an age from the steady_clock epoch — see
+        // the sentinel note in FrecencyDataOrganizer::ComputeScore (#792).
+        // Skipping costs nothing: the next round rescores it correctly.
+        if (blob_info.last_modified_ == 0 && blob_info.last_read_ == 0) return;
         if (num_replicas > 1 && (hasher(key) % num_replicas) != replica_id) {
           return;
         }

--- a/context-transfer-engine/core/src/data_organizer/frecency_organizer.cc
+++ b/context-transfer-engine/core/src/data_organizer/frecency_organizer.cc
@@ -45,7 +45,23 @@ float FrecencyDataOrganizer::ComputeScore(const OrganizerBlobStat &stat,
   // steady-clock ns; guard against a stamp taken after `now` was sampled.
   Timestamp last_access = std::max(stat.last_read_, stat.last_modified_);
   double age_sec = 0.0;
-  if (now > last_access) {
+  if (last_access == 0) {
+    // No access has been recorded yet — the blob was observed between its
+    // insertion into the metadata map and the write of its timestamps.
+    //
+    // Zero is a sentinel, NOT a point in time. Computing `now - 0` here
+    // would yield the full value of the steady_clock counter, whose epoch
+    // is machine boot, so a blob written seconds ago would score as though
+    // it were as old as the machine's uptime — demoting brand-new data to
+    // the slow tier, and making the outcome depend on how long the host had
+    // been running. That is issue #792; it flaked cte_data_organizer_all
+    // whenever CI runners had been up longer than ~17 minutes.
+    //
+    // Treat it as just-accessed: a blob with no recorded access is new, not
+    // ancient. Collection also skips these (see CollectOrganizerBlobStats),
+    // so this is a second line of defence for any other caller.
+    age_sec = 0.0;
+  } else if (now > last_access) {
     age_sec = static_cast<double>(now - last_access) / 1e9;
   }
 


### PR DESCRIPTION
Fixes #792.

## The bug

`FrecencyDataOrganizer::ComputeScore` derives a blob's age from `now - max(last_read_, last_modified_)`. Those timestamps come from `GetCurrentTimeNs()`, which is `std::chrono::steady_clock` — **whose epoch is arbitrary**, and is effectively machine boot on Linux and Windows.

`BlobInfo` is constructed with those fields zeroed and stamped shortly after in `PutBlobImpl`, so a periodic organizer round can observe one in between. When it does, `now - 0` is not an age — it is the entire steady_clock counter, i.e. **the host's uptime**.

## Why it matters beyond a flaky test

The organizer demotes brand-new data to the slow tier, inverting the purpose of frecency scoring. Any blob it happens to catch in that window is treated as ancient.

It also made `cte_data_organizer_all` flaky in a way that looked inexplicable: the test failed on runners that had been up longer than ~17 minutes and passed otherwise, appearing 6 times across 6 unrelated branches with no code in common.

## The arithmetic

With `score = 0.5·2^(-age/600) + 0.5·n/(n+10)` and `n = 1`, the CI failure value of `0.0900307` solves to an age of **~2093 s (~35 min)** for a blob written **2.5 s** earlier. Uptime is the only quantity in the system on that scale.

## The fix

- `CollectOrganizerBlobStats` skips blobs whose timestamps are both still zero, alongside the existing empty-blob skip. This costs nothing — the next round 500 ms later rescores them correctly.
- `ComputeScore` treats `last_access == 0` as just-accessed rather than deriving an age from the epoch, as a second line of defence for any other caller.

A blob with no recorded access is new, not ancient.

## Verification

`test_data_organizer` 6/6 across two runs. Cold-blob score is now **0.5454**, matching the predicted `0.5·2^(-2.5/600) + 0.5/11 = 0.544`, versus `0.0900307` in the CI failures.

## Note on scope

This fixes the *interpretation* of a zero timestamp. It does not change `GetCurrentTimeNs()` itself — using a `steady_clock` epoch as though it were an absolute timestamp is a broader pattern worth auditing separately, since any other code comparing an unset zero against it has the same latent bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)