### PR TITLE
fix(bdev): charge the aligned size on allocate to match the free credit (#798)

### DIFF
--- a/context-runtime/modules/bdev/src/transports/block_allocator.cc
+++ b/context-runtime/modules/bdev/src/transports/block_allocator.cc
@@ -156,9 +156,20 @@ bool StandardBlockAllocator::AllocateBlocks(size_t size, int worker_id, std::vec
     block_type = static_cast<int>(BlockSizeCategory::kMaxCategories) - 1;
   }
   if (heap_.Allocate(aligned_total_size, block_type, block)) {
+    // block.size_ stays the caller's requested size — that is what the
+    // caller reads and writes, and what it hands back to FreeBlocks.
     block.size_ = total_size;
     blocks.push_back(block);
-    allocated_bytes_.fetch_add(block.size_, std::memory_order_relaxed);
+    // Charge the ALIGNED size, not the raw request. The heap advanced by
+    // aligned_total_size, and FreeBlocks credits AlignSize(block.size_),
+    // which is the same aligned value. Charging total_size here made every
+    // first allocation of a non-4096-multiple block credit more on free
+    // than it charged, so allocated_bytes_ drifted downward by
+    // (AlignSize(size) - size) per block and GetRemainingSize() reported
+    // progressively more free space than the target actually had. The
+    // `std::min` clamp in FreeBlocks hid it by silently absorbing the
+    // difference rather than underflowing. See #798.
+    allocated_bytes_.fetch_add(aligned_total_size, std::memory_order_relaxed);
     return true;
   }
 

--- a/context-runtime/modules/bdev/test/test_bdev_chimod.cc
+++ b/context-runtime/modules/bdev/test/test_bdev_chimod.cc
@@ -431,6 +431,108 @@ TEST_CASE("bdev_block_allocation_4kb", "[bdev][allocate][4kb]") {
   }
 }
 
+/**
+ * Regression for #798: alloc/free accounting must be alignment-symmetric.
+ *
+ * StandardBlockAllocator charged the caller's raw request on allocate but
+ * credited AlignSize(request) on free, so every first allocation of a
+ * non-4096-multiple block drifted allocated_bytes_ down by
+ * (AlignSize(size) - size). GetRemainingSize() — surfaced to the CTE as
+ * TargetInfo::remaining_space_ — then reported steadily more free space
+ * than the target actually had, letting DPE over-commit it. The `std::min`
+ * clamp in FreeBlocks hid the drift by absorbing it instead of underflowing.
+ *
+ * This deliberately uses an UNALIGNED size. Both existing bdev leak-stress
+ * tests use 1 MiB blobs, which are already 4096-aligned, so for them
+ * AlignSize(size) - size == 0 and they cannot observe this class of bug.
+ */
+TEST_CASE("bdev_unaligned_alloc_free_accounting", "[bdev][allocate][align]") {
+  BdevChimodFixture fixture;
+
+  SECTION("Setup") {
+    REQUIRE(g_initialized);
+    REQUIRE(fixture.createTestFile(kDefaultFileSize));
+  }
+
+  SECTION("Unaligned alloc/free cycles leave remaining_size unchanged") {
+    clio::run::PoolId custom_pool_id(110, 0);
+    clio::run::bdev::Client client(custom_pool_id);
+
+    bool success = BdevChimodFixture::CreateBdevAsync(
+        client, clio::run::PoolQuery::Dynamic(), fixture.getTestFile(),
+        custom_pool_id, clio::run::bdev::BdevType::kFile);
+    REQUIRE(success);
+
+    auto pool_query = clio::run::PoolQuery::DirectHash(0);
+
+    // 5000 is deliberately not a multiple of 4096: AlignSize(5000) == 8192,
+    // so a broken allocator drifts 3192 bytes for every fresh block.
+    const clio::run::u64 kUnalignedSize = 5000;
+    const int kBatch = 32;
+
+    // A residual batch must stay allocated across the measurement, for two
+    // reasons that both otherwise hide the bug:
+    //
+    //   1. Freed blocks return to the free list, and the reuse path in
+    //      AllocateBlocks is alignment-symmetric. A simple
+    //      alloc/free/alloc/free loop therefore takes the heap path only
+    //      once and never accumulates drift.
+    //   2. FreeBlocks clamps with `dec = std::min(cur, freed_bytes)`, so
+    //      once everything is released allocated_bytes_ floors at 0 and the
+    //      drift is absorbed rather than observable.
+    //
+    // Holding kBatch blocks keeps allocated_bytes_ positive, so the
+    // over-credit from the second batch eats into a non-zero balance and
+    // becomes visible as inflated free space.
+    std::vector<clio::run::bdev::Block> held;
+    for (int i = 0; i < kBatch; ++i) {
+      auto alloc = client.AsyncAllocateBlocks(pool_query, kUnalignedSize);
+      alloc.Wait();
+      REQUIRE(alloc->return_code_ == 0);
+      REQUIRE(alloc->blocks_.size() > 0);
+      held.insert(held.end(), alloc->blocks_.begin(), alloc->blocks_.end());
+    }
+
+    clio::run::u64 remaining_before = 0;
+    BdevChimodFixture::GetStatsAsync(client, remaining_before);
+
+    // Balanced batch: allocate kBatch fresh blocks (these take the heap
+    // path, since the free list is empty) and release them all again.
+    std::vector<clio::run::bdev::Block> churn;
+    for (int i = 0; i < kBatch; ++i) {
+      auto alloc = client.AsyncAllocateBlocks(pool_query, kUnalignedSize);
+      alloc.Wait();
+      REQUIRE(alloc->return_code_ == 0);
+      REQUIRE(alloc->blocks_.size() > 0);
+      churn.insert(churn.end(), alloc->blocks_.begin(), alloc->blocks_.end());
+    }
+    {
+      auto freed = client.AsyncFreeBlocks(pool_query, churn);
+      freed.Wait();
+      REQUIRE(freed->return_code_ == 0);
+    }
+
+    clio::run::u64 remaining_after = 0;
+    BdevChimodFixture::GetStatsAsync(client, remaining_after);
+
+    // Release the residual batch so the test leaves no allocation behind.
+    {
+      auto freed = client.AsyncFreeBlocks(pool_query, held);
+      freed.Wait();
+      REQUIRE(freed->return_code_ == 0);
+    }
+
+    HLOG(kInfo, "unaligned alloc/free accounting: before={} after={}",
+         remaining_before, remaining_after);
+
+    // Balanced alloc/free must be a no-op for the accounting in EITHER
+    // direction. Drifting upward is as wrong as leaking: it over-reports
+    // free space, so the target can be over-committed while still claiming
+    // capacity. Hence exact equality rather than a one-sided bound.
+    REQUIRE(remaining_after == remaining_before);
+  }
+}
+
 TEST_CASE("bdev_write_read_basic", "[bdev][io][basic]") {
   BdevChimodFixture fixture;
 


### PR DESCRIPTION
Fixes #798.

## The bug

`StandardBlockAllocator` charged the caller's raw request when taking a block from the heap, but credited `AlignSize(request)` when freeing it:

```cpp
block.size_ = total_size;                       // unaligned
allocated_bytes_.fetch_add(block.size_, ...);   // charge

aligned_size = AlignSize(block.size_);          // aligned
freed_bytes += aligned_size;                    // credit
```

Every first allocation of a non-4096-multiple block credited `AlignSize(size) - size` more than it charged, so `allocated_bytes_` drifted downward.

`GetRemainingSize()` returns `capacity_ - allocated_bytes_` and is surfaced to the CTE as `TargetInfo::remaining_space_` — so **targets reported progressively more free space than they actually had**, and DPE could over-commit them. The `dec = std::min(cur, freed_bytes)` clamp in `FreeBlocks` concealed it by absorbing the difference instead of underflowing.

Blobs are explicitly arbitrary-sized, so unaligned allocations are the normal case.

## The fix

The heap already advances by `aligned_total_size`, so charging the aligned size is both physically accurate and makes charge equal credit. `block.size_` still carries the caller's requested size — what the caller reads/writes and hands back to `FreeBlocks`.

Only the heap path was wrong. The reuse path is already symmetric: `FreeBlocks` writes the aligned size into the block before returning it to the free list, so blocks served from `global_block_map_` are charged and credited the same aligned value.

## Verification

Reverting the one-line fix, with the new test in place:

| | `remaining_before` | `remaining_after` | result |
|---|---|---|---|
| without fix | 10325760 | 10427904 | **FAILS** (drift +102144) |
| with fix | 10223616 | 10223616 | passes |

`+102144` is exactly `32 × (AlignSize(5000) − 5000) = 32 × 3192`, matching the predicted drift. The baselines differ for the same reason: the held batch is charged `32×5000` vs `32×8192`.

Full bdev suite: **22/22** with the fix.

## About the test

Two mechanisms mask this bug, and the test has to defeat both:

1. Freed blocks return to the free list and the reuse path is symmetric, so a plain alloc/free loop takes the heap path **exactly once** and never accumulates drift.
2. The `std::min` clamp floors `allocated_bytes_` at 0, so once everything is released the drift is absorbed rather than observable.

So the test holds a residual batch of 32 blocks across the measurement, then allocates and frees a second batch of 32. My first attempt did neither and passed against the broken code — worth knowing if this test is ever refactored.

It asserts exact equality rather than a one-sided bound: drifting **upward** is as wrong as leaking, since it over-reports free space.

## Why CI never caught this

Both `cte_bdev_leak_stress` and `cte_bdev_leak_stress_force_net` use `kBlobSize = 1 MiB`, which is already 4096-aligned — so `AlignSize(size) - size == 0` and they are structurally incapable of observing this.

## Note

This was found while investigating #791 and initially suspected as its cause. That was **ruled out** (see the retraction there): #791's test uses 1 MiB blobs on a dedicated target, so this drift cannot occur there. The two are independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)