### PR TITLE
ci(sanitizers): surface what the sanitizers actually found (#803)

### DIFF
--- a/CI/run_sanitizers.sh
+++ b/CI/run_sanitizers.sh
@@ -120,6 +120,78 @@ fi
 # Core function: build and/or run memcheck for one sanitizer mode
 ################################################################################
 
+# Write what the sanitizer actually found into the GitHub step summary.
+#
+# These jobs are non-gating by construction: the ctest invocation is followed by
+# `|| true` and this script ends with `exit 0`, so a sanitizer finding can never
+# turn a job red. That is not obviously wrong -- ubsan currently flags 151 of
+# 259 tests, and flipping the jobs to gating today would simply pin CI red --
+# but it does mean the findings are invisible unless somebody opens the raw log
+# and knows what to grep for. Nobody does, so nothing gets triaged.
+#
+# This prints the ctest pass/fail line, the per-test defect counts, and a sample
+# of the actual sanitizer messages from the MemoryChecker output files, which
+# otherwise only reach CDash. Purely additive: no job changes colour. Issue #803
+# tracks triaging the backlog and then ratcheting these to gating.
+emit_findings_summary() {
+    local MODE="$1"
+    local CTEST_LOG="$2"
+
+    # Local runs have no step summary; do nothing rather than fail.
+    [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
+    [ -f "${CTEST_LOG}" ] || return 0
+
+    {
+        echo "## Sanitizer findings: ${MODE}"
+        echo ""
+
+        local SUMMARY_LINE
+        SUMMARY_LINE=$(grep -oE "[0-9]+% tests passed, [0-9]+ tests failed out of [0-9]+" \
+                       "${CTEST_LOG}" | tail -1 || true)
+        echo "${SUMMARY_LINE:-(no ctest summary line found)}"
+        echo ""
+
+        local DEFECT_COUNT
+        DEFECT_COUNT=$(grep -c "Defects: " "${CTEST_LOG}" || true)
+        echo "Tests reporting defects: ${DEFECT_COUNT:-0}"
+        echo ""
+        echo "> These jobs are non-gating: this is a report, not a gate (issue #803)."
+        echo ""
+
+        if [ "${DEFECT_COUNT:-0}" != "0" ]; then
+            echo "<details><summary>Tests with defects</summary>"
+            echo ""
+            echo '```'
+            grep -E "Defects: [0-9]+" "${CTEST_LOG}" | sed 's/^[0-9]*: //' | head -60 || true
+            echo '```'
+            echo ""
+            echo "</details>"
+            echo ""
+        fi
+
+        # The per-defect detail lives in the MemoryChecker files, not stdout, so
+        # the console alone cannot tell you WHAT the undefined behaviour was.
+        # Surface a sample so a reader can judge real-vs-artifact without
+        # fetching anything from CDash.
+        local MEMCHECK_DIR="${BUILD_DIR}/Testing/Temporary"
+        if compgen -G "${MEMCHECK_DIR}/MemoryChecker.*.log" > /dev/null 2>&1; then
+            echo "<details><summary>Sample sanitizer messages</summary>"
+            echo ""
+            echo '```'
+            grep -hoE "(runtime error: .*|ERROR: [A-Za-z]+Sanitizer: .*|SUMMARY: [A-Za-z]+Sanitizer: .*)" \
+                 "${MEMCHECK_DIR}"/MemoryChecker.*.log 2>/dev/null \
+                 | sort | uniq -c | sort -rn | head -40 || true
+            echo '```'
+            echo ""
+            echo "</details>"
+        else
+            echo "_No MemoryChecker output files found under ${MEMCHECK_DIR}._"
+        fi
+    } >> "${GITHUB_STEP_SUMMARY}" 2>/dev/null || true
+
+    return 0
+}
+
 run_sanitizer_mode() {
     local MODE="$1"          # asan | ubsan | msan | sanitize
     local MEMCHECK_TYPE="$2" # AddressSanitizer | UndefinedBehaviorSanitizer | MemorySanitizer
@@ -227,8 +299,13 @@ EOFCMAKE
     fi
 
     cd "${BUILD_DIR}"
-    ctest -S "${DASHBOARD_SCRIPT}" -VV || true
+    local CTEST_LOG="${BUILD_DIR}/sanitizer-ctest-${MODE}.log"
+    # `|| true` keeps this non-gating -- see emit_findings_summary() for why
+    # that is deliberate for now, and issue #803 for the plan to change it.
+    ctest -S "${DASHBOARD_SCRIPT}" -VV 2>&1 | tee "${CTEST_LOG}" || true
     cd "${REPO_ROOT}"
+
+    emit_findings_summary "${MODE}" "${CTEST_LOG}"
 
     print_success "Done: ${MODE}"
     echo ""


### PR DESCRIPTION
Step 1 of #803. Purely additive — **no job changes colour**.

## The problem

The `asan`/`ubsan`/`msan` jobs **cannot fail**:

```bash
ctest -S "${DASHBOARD_SCRIPT}" -VV || true    # swallows the result
message(STATUS "Sanitizer defects detected...")  # informational only
exit 0                                         # unconditional
```

And they are finding a lot. From `dev` run 29946221722, all three green:

| job | ctest summary | tests reporting defects |
|---|---|---|
| asan | 100% passed, 0 failed of 259 | 25 |
| msan | 50% passed, 4 failed of 8 | 4 |
| ubsan | **42% passed, 151 failed of 259** | 151 |

The ubsan log literally contains `Sanitizer defects detected (exit code: -1)` — and the job is green.

## What this PR does *not* do

It does not make them gating. Flipping today would pin CI red on 151 tests, and **it is not yet known how many are genuine product defects versus sanitizer/harness artifacts**. This PR makes the findings visible so that question can be answered.

## What it does

Writes to `$GITHUB_STEP_SUMMARY`:
- the ctest pass/fail summary line
- the count and list of tests reporting defects
- a frequency-sorted sample of the **actual sanitizer messages**, read from the MemoryChecker output files

That last point is the important one: the per-defect detail never reaches stdout — only CDash — so today's console output cannot tell you *what* the undefined behaviour was. Without it there's no way to judge real-vs-artifact from a CI run.

## Why it matters beyond tidiness

Undefined behaviour is a leading cause of **nondeterministic crashes** — exactly the open symptom in #794, where two tiered tests segfault on Windows and don't reproduce on Linux. If any ubsan finding is real, it's a candidate cause that is currently invisible.

This is the third mechanism in this repo found to look like a safety net while silently doing nothing, alongside ctest's `--repeat until-pass:3` and the `-E` exclusions in `ci-linux.yml` — both of which were also hiding real problems.

## Verification

Extracted the function and ran it against a synthetic ctest log and synthetic MemoryChecker files. Both branches render correctly; the message sample is deduplicated and frequency-sorted:

```
      2 runtime error: signed integer overflow: 2147483647 + 1
      1 runtime error: member call on null pointer of type 'X'
```

Local runs are unaffected — the function returns early when `GITHUB_STEP_SUMMARY` is unset.

## Follow-up

#803 tracks the rest: triage the backlog (`EXCLUDE_LABEL` already supports `asan_skip`/`msan_skip` for genuinely incompatible tests), then ratchet to gating against a baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)