### PR TITLE
fix(cte): log target name via c_str(), not data() — heap-buffer-overflow

### DIFF
--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -4504,10 +4504,17 @@ clio::run::TaskResume Runtime::AllocateFromTarget(TargetInfo &target_info,
   clio::run::shared_ptr<clio::run::Task> cur_task = clio::run::GetCurrentTask();
 #endif
   CLIO_TASK_BODY_BEGIN
+  // NOTE: .c_str(), not .data(). The logger formats a char* as a
+  // null-terminated C string (operator<< -> strlen), but priv::string::data()
+  // returns the raw buffer WITHOUT a guaranteed terminator — only c_str()
+  // writes ptr[size_] = '\0'. Passing .data() here caused strlen to run off
+  // the end of the heap buffer, an AddressSanitizer heap-buffer-overflow on
+  // the hot PutBlob path (core_runtime.cc via ExtendBlob/AllocateFromTarget).
   HLOG(kDebug,
        "AllocateFromTarget: ENTER - target_name={}, "
        "bdev_client_.pool_id_=({},{}), size={}, remaining_space={}",
-       target_info.target_name_.data(), target_info.bdev_client_.pool_id_.major_,
+       target_info.target_name_.c_str(),
+       target_info.bdev_client_.pool_id_.major_,
        target_info.bdev_client_.pool_id_.minor_, size,
        target_info.remaining_space_);
 


### PR DESCRIPTION
A real heap-buffer-overflow on the PutBlob hot path, found via the sanitizer investigation in #803 and landing on the exact tests that segfault in #794.

## The bug

`AllocateFromTarget` (`core_runtime.cc:4507`) logged:

```cpp
HLOG(kDebug, "AllocateFromTarget: ENTER - target_name={}, ...",
     target_info.target_name_.data(), ...);
```

The logger formats a `char*` as a null-terminated C string (`operator<<` → `strlen`). But `priv::string::data()` returns the raw buffer with **no guaranteed terminator** — only `c_str()` writes `ptr[size_] = '\0'`:

```cpp
const T* data() const { return GetData(); }          // no terminator
const T* c_str() const { ...; ptr[size_] = T(); return ptr; }  // terminates
```

So `strlen` runs off the end of the heap allocation. It's an out-of-bounds **read** whose length depends on whatever bytes follow the buffer — benign under one allocator, a fatal read under another. Every `PutBlob` that allocates from a target hits this path.

## How it was found

The CI sanitizer jobs flag `cte_tiered_storage_all` (2 defects) and `cte_tiered_dram_default_all` (1 defect) — the **same two tests that segfault on Windows in #794**. But those jobs can't fail (#803), so the reports were invisible. I built `--preset=asan` locally and read them.

```
==ERROR: AddressSanitizer: heap-buffer-overflow ... in strlen
  #2 ctp::Formatter::format<char*, ...>
  #6 ctp::Logger::Log<...>
  #7 AllocateFromTarget core_runtime.cc:4507
  #10 ExtendBlob      core_runtime.cc:4053
  #13 PutBlobImpl     core_runtime.cc:1393
```

## Verification

On the asan build, before → after this one-line change:

| test | ASan errors before | after | result |
|---|---|---|---|
| `test_tiered_storage_stress` | 2 | **0** | 4/4 pass |
| `test_tiered_storage_dram_default` | 1 | **0** | pass |

The single `.c_str()` fix clears all three defects.

## Scope

This is the only `.data()`-into-a-`{}`-formatter site in `core_runtime.cc`. The other `.data()` uses there are `ofs.write()` / `ifs.read()` with an explicit length, which are correct.

## Honest caveat

I have **not** confirmed this is *the* cause of the #794 Windows segfaults — the crash didn't reproduce on Linux even before this fix. But it's a real out-of-bounds read on the exact tests that crash, so it's the strongest candidate found so far. #794 stays open until a Windows run confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)