### PR TITLE
ci(conda): use conda-forge only, drop the Anaconda defaults channel

### DIFF
--- a/.github/workflows/install-conda.yml
+++ b/.github/workflows/install-conda.yml
@@ -33,7 +33,11 @@ jobs:
         with:
           auto-update-conda: true
           python-version: '3.12'
-          channels: conda-forge,defaults
+          # conda-forge only. The Anaconda `defaults` channels (pkgs/main,
+          # pkgs/r behind repo.anaconda.com) now 403 for CI use without a
+          # license and were an intermittent dependency-install flake. See
+          # CI/ci-deps.sh for the same change and the full explanation.
+          channels: conda-forge
           channel-priority: strict
 
       - name: Install conda-build

--- a/CI/ci-deps.sh
+++ b/CI/ci-deps.sh
@@ -150,18 +150,35 @@ ensure_conda() {
 # Ensure conda is available
 ensure_conda
 
-# Accept Conda Terms of Service for Anaconda channels
-echo -e "${BLUE}Accepting Conda Terms of Service...${NC}"
-conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main 2>/dev/null || true
-conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r 2>/dev/null || true
-echo -e "${GREEN}Conda ToS accepted${NC}"
-echo ""
-
-# Configure conda channels (add conda-forge if not already present)
-echo -e "${BLUE}Configuring conda channels...${NC}"
+# Configure conda to use conda-forge ONLY, and never the Anaconda `defaults`
+# channels (pkgs/main, pkgs/r).
+#
+# Those channels sit behind repo.anaconda.com, which now returns HTTP 403
+# Forbidden for CI/commercial use unless the org has an Anaconda license:
+#
+#   CondaHTTPError: HTTP 403 Forbidden for url
+#     <https://repo.anaconda.com/pkgs/main/noarch/repodata.json>
+#   - The channel requires authentication.
+#
+# Previously this script did `conda tos accept ...` for pkgs/main and pkgs/r
+# and then `conda config --add channels conda-forge`, which only PREPENDED
+# conda-forge while leaving `defaults` in the channel list. conda still
+# fetched pkgs/main repodata and intermittently 403'd — a flake that fails the
+# dependency-install step before any build begins, and the create-retry loop
+# below could not help because every retry hit the same forbidden channel.
+# Accepting a ToS also does nothing when the runner IP is refused outright.
+#
+# `--remove-key channels` clears whatever the base install seeded (which
+# includes defaults), then we add only conda-forge and pin strict priority so
+# conda never falls back to defaults for a package conda-forge lacks.
+echo -e "${BLUE}Configuring conda channels (conda-forge only, no defaults)...${NC}"
+conda config --remove-key channels 2>/dev/null || true
 conda config --add channels conda-forge 2>/dev/null || true
-conda config --set channel_priority flexible 2>/dev/null || true
-echo -e "${GREEN}Conda channels configured${NC}"
+conda config --set channel_priority strict 2>/dev/null || true
+# Belt and braces: some conda versions still consult the implicit `defaults`
+# unless it is explicitly disabled.
+conda config --set default_channels "[]" 2>/dev/null || true
+echo -e "${GREEN}Conda channels configured (conda-forge only)${NC}"
 echo ""
 
 # Create and activate environment if not already in one
@@ -176,7 +193,7 @@ if [ -z "$CONDA_PREFIX" ]; then
         # Retry up to 3 times: conda-forge CDN occasionally returns 403/502.
         _created=0
         for _attempt in 1 2 3; do
-            if conda create -n "$ENV_NAME" -y "python=$PYVER"; then
+            if conda create -n "$ENV_NAME" -y -c conda-forge --override-channels "python=$PYVER"; then
                 _created=1
                 break
             fi


### PR DESCRIPTION
An infrastructure flake that fails conda-based jobs before any build runs.

## Symptom

`build-test (macos-26)` on PR #805 failed at **Install dependencies (conda)** — nothing to do with the change under test:

```
CondaHTTPError: HTTP 403 Forbidden for url
  <https://repo.anaconda.com/pkgs/main/noarch/repodata.json>
- The channel requires authentication.
conda-build install failed (attempt 3/3)
```

## Cause

`repo.anaconda.com` now returns **403** for CI/commercial use of the Anaconda `defaults` channels (`pkgs/main`, `pkgs/r`) without a license. Any conda job that queries `defaults` can hit this intermittently.

`ci-deps.sh` already tried to work around it with `conda tos accept` for those channels — but that doesn't help. It only *prepended* conda-forge and left `defaults` in the channel list, so conda still fetched `pkgs/main` repodata and 403'd. The existing 3× create-retry loop couldn't recover either: every retry hit the same forbidden channel. And accepting a ToS is irrelevant when the IP is refused outright rather than prompted.

## Fix

Drop `defaults` entirely, pin conda-forge:

**`CI/ci-deps.sh`**
- clear seeded channels, add conda-forge, `channel_priority strict`, `default_channels []` so conda never falls back to defaults
- `conda create ... -c conda-forge --override-channels`
- removed the now-pointless `pkgs/main` + `pkgs/r` `tos accept` calls

**`.github/workflows/install-conda.yml`**
- `channels: conda-forge` (was `conda-forge,defaults`)

conda-forge is a strict superset of what this project pulls from defaults, so nothing needed is lost.

## Verification

`bash -n CI/ci-deps.sh` and YAML parse on `install-conda.yml` both pass. No functional `defaults` / `-c defaults` reference remains anywhere under `.github/workflows` or `CI/`.

I cannot run the macOS conda flow locally, so the proof is the next macOS CI run — but the mechanism is unambiguous: the 403 comes from a channel this change no longer contacts.

## Context

Found while checking why #805 (a heap-buffer-overflow fix) had a red macOS job. It was this flake, not the fix — the same shape as most of what this flake investigation has surfaced: a red job caused by something other than the PR's content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)