### PR TITLE
SHM transport scalability: parallel inbound rings + nonblocking queued per-destination SendOut (#807)

### DIFF
--- a/context-runtime/include/clio_runtime/comutex.h
+++ b/context-runtime/include/clio_runtime/comutex.h
@@ -43,37 +43,56 @@ namespace clio::run {
  * CoMutex - Reentrant cooperative mutex for coroutine-based task execution.
  * When a parent task holds the lock and spawns a subtask on the same worker,
  * the subtask can reacquire the lock without deadlocking.
+ *
+ * SOUNDNESS: the reentrancy fast path is gated on holder_tid_, an atomic
+ * OS-thread id — every legitimate reentrant acquire runs on the OS thread
+ * that already owns the lock (same-stack nesting, or a same-worker subtask
+ * of the holding parent), and only that gate makes the unsynchronized
+ * holder_/depth_ accesses sound. Comparing holder_ alone (the previous
+ * version) is a data race: a thread could observe a STALE holder_ equal to
+ * its own identity from an EARLIER hold and enter the critical section
+ * while another thread held the mutex. See CoRwLock for the full analysis
+ * (#807 stress-test corruption).
  */
 class CoMutex {
  public:
   ctp::Mutex lock_;
   LockOwnerId holder_;
+  ctp::ipc::atomic<u64> holder_tid_;
   u32 depth_;
 
-  CoMutex() : depth_(0) {}
+  CoMutex() : holder_tid_(0), depth_(0) {}
 
   /** Copy constructor reinitializes to unlocked (needed for std::vector) */
-  CoMutex(const CoMutex &other) : depth_(0) { (void)other; }
+  CoMutex(const CoMutex &other) : holder_tid_(0), depth_(0) { (void)other; }
+
+  /** True iff the calling OS thread currently owns the mutex. Only then may
+   *  holder_ / depth_ be touched without lock_. */
+  bool HeldByThisThread() const {
+    u64 self = GetCoLockThreadId();
+    return self != 0 &&
+           holder_tid_.load(std::memory_order_acquire) == self;
+  }
 
   void Lock() {
-    LockOwnerId cur = GetCurrentLockOwnerId();
-    if (cur == holder_) {
+    if (HeldByThisThread() && GetCurrentLockOwnerId() == holder_) {
       ++depth_;
       return;
     }
     lock_.Lock(0);
-    holder_ = cur;
+    holder_ = GetCurrentLockOwnerId();
+    holder_tid_.store(GetCoLockThreadId(), std::memory_order_release);
     depth_ = 1;
   }
 
   bool TryLock() {
-    LockOwnerId cur = GetCurrentLockOwnerId();
-    if (cur == holder_) {
+    if (HeldByThisThread() && GetCurrentLockOwnerId() == holder_) {
       ++depth_;
       return true;
     }
     if (!lock_.TryLock(0)) return false;
-    holder_ = cur;
+    holder_ = GetCurrentLockOwnerId();
+    holder_tid_.store(GetCoLockThreadId(), std::memory_order_release);
     depth_ = 1;
     return true;
   }
@@ -82,6 +101,7 @@ class CoMutex {
     --depth_;
     if (depth_ == 0) {
       holder_.Clear();
+      holder_tid_.store(0, std::memory_order_release);
       lock_.Unlock();
     }
   }

--- a/context-runtime/include/clio_runtime/config_manager.h
+++ b/context-runtime/include/clio_runtime/config_manager.h
@@ -396,7 +396,14 @@ class ConfigManager : public ctp::BaseConfig {
 
   // Configuration parameters
   u32 num_threads_ = 4;
-  u32 shm_in_shards_ = 4;  // issue #807: parallel inbound SHM rings
+  // issue #807: parallel inbound SHM rings. Default 1 (single ring, identical to
+  // pre-#807 behaviour). Sharding is OPT-IN: measured on a 6-core box, S>1
+  // REGRESSED throughput (S=4 gave 4413 ops/s vs S=1's 5729 at 8 client threads)
+  // because the extra drain threads contend with workers for cores. It only pays
+  // off when client concurrency exceeds what one drain thread can service AND
+  // there are spare cores — high-core-count, high-client-count deployments.
+  // Raise via CLIO_SHM_IN_SHARDS / runtime.shm_in_shards there.
+  u32 shm_in_shards_ = 1;
   u32 queue_depth_ = 1024;
 
   size_t main_segment_size_ = ctp::Unit<size_t>::Gigabytes(1);

--- a/context-runtime/include/clio_runtime/config_manager.h
+++ b/context-runtime/include/clio_runtime/config_manager.h
@@ -411,14 +411,14 @@ class ConfigManager : public ctp::BaseConfig {
 
   // Configuration parameters
   u32 num_threads_ = 4;
-  // issue #807: parallel inbound SHM rings. Default 1 (single ring, identical to
-  // pre-#807 behaviour). Sharding is OPT-IN: measured on a 6-core box, S>1
-  // REGRESSED throughput (S=4 gave 4413 ops/s vs S=1's 5729 at 8 client threads)
-  // because the extra drain threads contend with workers for cores. It only pays
-  // off when client concurrency exceeds what one drain thread can service AND
-  // there are spare cores — high-core-count, high-client-count deployments.
-  // Raise via CLIO_SHM_IN_SHARDS / runtime.shm_in_shards there.
-  u32 shm_in_shards_ = 1;
+  // issue #807: parallel inbound SHM rings, ENABLED by default. 0 = auto (=
+  // worker count, so every worker drains its own shard). Since the drain is
+  // done by the EXISTING workers in their poll loop (not dedicated threads),
+  // more shards spreads ingest across the pool with no extra threads — measured
+  // worker-driven S=1 1.48x and S=4 1.68x over dev. Capped at the worker count
+  // in ServerInitShm (worker w owns shard w). CLIO_SHM_IN_SHARDS overrides;
+  // set 1 to restore a single ingest ring.
+  u32 shm_in_shards_ = 0;
   bool shm_async_send_ = false;  // issue #807: deferred SHM response send (opt-in)
   u32 shm_client_spin_us_ = 50;  // issue #807/#784: waiter spin before park
   u32 queue_depth_ = 1024;

--- a/context-runtime/include/clio_runtime/config_manager.h
+++ b/context-runtime/include/clio_runtime/config_manager.h
@@ -157,6 +157,9 @@ class ConfigManager : public ctp::BaseConfig {
    */
   u32 GetNumThreads() const { return num_threads_; }
 
+  /** issue #807: number of parallel inbound SHM rings + drain threads. */
+  u32 GetShmInShards() const { return shm_in_shards_; }
+
   /**
    * issue #785: extra task lanes reserved for elastic replacement workers.
    * Lanes are indexed by worker id, so replacements spawned by a stall rescue
@@ -393,6 +396,7 @@ class ConfigManager : public ctp::BaseConfig {
 
   // Configuration parameters
   u32 num_threads_ = 4;
+  u32 shm_in_shards_ = 4;  // issue #807: parallel inbound SHM rings
   u32 queue_depth_ = 1024;
 
   size_t main_segment_size_ = ctp::Unit<size_t>::Gigabytes(1);

--- a/context-runtime/include/clio_runtime/config_manager.h
+++ b/context-runtime/include/clio_runtime/config_manager.h
@@ -167,6 +167,14 @@ class ConfigManager : public ctp::BaseConfig {
    *  the common case. Enable for overload/back-pressure-heavy deployments. */
   bool GetShmAsyncSend() const { return shm_async_send_; }
 
+  /** issue #807/#784: microseconds a SHM client waiter spins polling for its
+   *  response before parking on its EventManager. On SHM the round-trip is
+   *  microseconds, so a brief spin catches the completion without a park/wake +
+   *  signal syscall — the dominant cost at low latency. Larger values trade
+   *  throughput for latency (#784: 1ms spin = 2.2x latency, -45% throughput), so
+   *  keep it small. Default 50us. */
+  u32 GetShmClientSpinUs() const { return shm_client_spin_us_; }
+
   /**
    * issue #785: extra task lanes reserved for elastic replacement workers.
    * Lanes are indexed by worker id, so replacements spawned by a stall rescue
@@ -412,6 +420,7 @@ class ConfigManager : public ctp::BaseConfig {
   // Raise via CLIO_SHM_IN_SHARDS / runtime.shm_in_shards there.
   u32 shm_in_shards_ = 1;
   bool shm_async_send_ = false;  // issue #807: deferred SHM response send (opt-in)
+  u32 shm_client_spin_us_ = 50;  // issue #807/#784: waiter spin before park
   u32 queue_depth_ = 1024;
 
   size_t main_segment_size_ = ctp::Unit<size_t>::Gigabytes(1);

--- a/context-runtime/include/clio_runtime/config_manager.h
+++ b/context-runtime/include/clio_runtime/config_manager.h
@@ -160,6 +160,13 @@ class ConfigManager : public ctp::BaseConfig {
   /** issue #807: number of parallel inbound SHM rings + drain threads. */
   u32 GetShmInShards() const { return shm_in_shards_; }
 
+  /** issue #807: if true, SHM responses are handed to a background sender thread
+   *  (nonblocking, never stalls a worker on a full client ring). Default false:
+   *  measured ~3x latency regression on latency-bound workloads because the
+   *  thread handoff is pure overhead when the client ring is not full, which is
+   *  the common case. Enable for overload/back-pressure-heavy deployments. */
+  bool GetShmAsyncSend() const { return shm_async_send_; }
+
   /**
    * issue #785: extra task lanes reserved for elastic replacement workers.
    * Lanes are indexed by worker id, so replacements spawned by a stall rescue
@@ -404,6 +411,7 @@ class ConfigManager : public ctp::BaseConfig {
   // there are spare cores — high-core-count, high-client-count deployments.
   // Raise via CLIO_SHM_IN_SHARDS / runtime.shm_in_shards there.
   u32 shm_in_shards_ = 1;
+  bool shm_async_send_ = false;  // issue #807: deferred SHM response send (opt-in)
   u32 queue_depth_ = 1024;
 
   size_t main_segment_size_ = ctp::Unit<size_t>::Gigabytes(1);

--- a/context-runtime/include/clio_runtime/corwlock.h
+++ b/context-runtime/include/clio_runtime/corwlock.h
@@ -43,15 +43,33 @@ namespace clio::run {
  * CoRwLock - Reentrant cooperative read-write lock for coroutine-based
  * task execution. Allows write->write and write->read reentrancy
  * from the same logical execution context (parent/subtask chain).
+ *
+ * SOUNDNESS: holder_ and the depth counters are plain fields; they may be
+ * touched without the underlying lock ONLY by the OS thread that currently
+ * owns the write lock. Every legitimate reentrant acquire runs on that
+ * thread (same-stack nesting, or a same-worker subtask of the holding
+ * parent — LockOwnerId embeds the worker id), so the fast path is gated on
+ * holder_tid_, an atomic OS-thread id: another thread can never store OUR
+ * tid, and our own release of it is visible to us in program order, so
+ * (holder_tid_ == this thread) <=> this thread genuinely holds the write
+ * lock right now. The previous version compared holder_ alone — an
+ * unsynchronized read that could observe a STALE value equal to the
+ * caller's own identity from an EARLIER hold, granting lock-free access
+ * while another thread held the write lock. Under the #807 stress test
+ * that let ToFullPtr read alloc_map_ mid-rehash (spurious misses of
+ * registered allocators -> NULL-source memcpy in the RAM bdev), and the
+ * same false grant on the write side double-entered critical sections and
+ * corrupted the underlying RwLock — wedging every worker.
  */
 class CoRwLock {
  public:
   ctp::RwLock lock_;
   LockOwnerId holder_;
+  ctp::ipc::atomic<u64> holder_tid_;
   u32 write_depth_;
   u32 read_depth_;
 
-  CoRwLock() : write_depth_(0), read_depth_(0) {}
+  CoRwLock() : holder_tid_(0), write_depth_(0), read_depth_(0) {}
 
   /** Deleted copy constructor (matches ctp::RwLock) */
   CoRwLock(const CoRwLock &other) = delete;
@@ -59,9 +77,11 @@ class CoRwLock {
   CoRwLock(CoRwLock &&other) noexcept
       : lock_(std::move(other.lock_)),
         holder_(other.holder_),
+        holder_tid_(other.holder_tid_.load()),
         write_depth_(other.write_depth_),
         read_depth_(other.read_depth_) {
     other.holder_.Clear();
+    other.holder_tid_.store(0);
     other.write_depth_ = 0;
     other.read_depth_ = 0;
   }
@@ -70,18 +90,28 @@ class CoRwLock {
     if (this != &other) {
       lock_ = std::move(other.lock_);
       holder_ = other.holder_;
+      holder_tid_.store(other.holder_tid_.load());
       write_depth_ = other.write_depth_;
       read_depth_ = other.read_depth_;
       other.holder_.Clear();
+      other.holder_tid_.store(0);
       other.write_depth_ = 0;
       other.read_depth_ = 0;
     }
     return *this;
   }
 
+  /** True iff the calling OS thread currently owns the write lock. Only
+   *  then may holder_ / the depth counters be touched without lock_. */
+  bool HeldByThisThread() const {
+    u64 self = GetCoLockThreadId();
+    return self != 0 &&
+           holder_tid_.load(std::memory_order_acquire) == self;
+  }
+
   void ReadLock() {
-    LockOwnerId cur = GetCurrentLockOwnerId();
-    if (cur == holder_) {
+    // Write->read reentrancy for the holding thread's logical context.
+    if (HeldByThisThread() && GetCurrentLockOwnerId() == holder_) {
       ++read_depth_;
       return;
     }
@@ -89,8 +119,8 @@ class CoRwLock {
   }
 
   void ReadUnlock() {
-    LockOwnerId cur = GetCurrentLockOwnerId();
-    if (cur == holder_ && read_depth_ > 0) {
+    if (HeldByThisThread() && read_depth_ > 0 &&
+        GetCurrentLockOwnerId() == holder_) {
       --read_depth_;
       return;
     }
@@ -98,13 +128,13 @@ class CoRwLock {
   }
 
   void WriteLock() {
-    LockOwnerId cur = GetCurrentLockOwnerId();
-    if (cur == holder_) {
+    if (HeldByThisThread() && GetCurrentLockOwnerId() == holder_) {
       ++write_depth_;
       return;
     }
     lock_.WriteLock(0);
-    holder_ = cur;
+    holder_ = GetCurrentLockOwnerId();
+    holder_tid_.store(GetCoLockThreadId(), std::memory_order_release);
     write_depth_ = 1;
   }
 
@@ -112,6 +142,7 @@ class CoRwLock {
     --write_depth_;
     if (write_depth_ == 0 && read_depth_ == 0) {
       holder_.Clear();
+      holder_tid_.store(0, std::memory_order_release);
       lock_.WriteUnlock();
     }
   }

--- a/context-runtime/include/clio_runtime/ipc/ipc_cpu2cpu.h
+++ b/context-runtime/include/clio_runtime/ipc/ipc_cpu2cpu.h
@@ -37,7 +37,7 @@ struct IpcCpu2Cpu {
    * scheduler involvement is needed to establish it.
    * @return true if a task was received and enqueued.
    */
-  static bool RecvIn(IpcManager *ipc);
+  static bool RecvIn(IpcManager *ipc, u32 shard);  // #807: drains shard ring
 
   /** Deserialize task from SHM ring buffer on runtime side (inbound). */
   static clio::run::shared_ptr<clio::run::Task> RecvIn(

--- a/context-runtime/include/clio_runtime/ipc/ipc_cpu2cpu.h
+++ b/context-runtime/include/clio_runtime/ipc/ipc_cpu2cpu.h
@@ -44,8 +44,20 @@ struct IpcCpu2Cpu {
       IpcManager *ipc, Future<Task> &future,
       u32 method_id, ctp::lbm::Transport *recv_transport);
 
-  /** Serialize outputs and set FUTURE_COMPLETE (outbound). */
+  /** Outbound response (SHM). issue #807: this no longer transfers on the
+   *  caller (worker) thread — it enqueues an owning future onto the
+   *  destination's per-client send queue (IpcManager::EnqueueShmSend),
+   *  nonblocking, and returns. The background sender thread later calls
+   *  SendOutTransfer to do the serialize + ring transfer + completion. */
   static void SendOut(
+      IpcManager *ipc, const clio::run::shared_ptr<Task> &task_ptr,
+      ctp::lbm::Transport *send_transport);
+
+  /** issue #807: the actual serialize + MPSC transfer + completion, run on the
+   *  background sender thread (IpcManager::SendShmServerThread), never on a
+   *  worker. `send_transport` is a SHM transport owned by the sender thread,
+   *  used only to Expose bulk descriptors. */
+  static void SendOutTransfer(
       IpcManager *ipc, const clio::run::shared_ptr<Task> &task_ptr,
       ctp::lbm::Transport *send_transport);
 

--- a/context-runtime/include/clio_runtime/ipc/ipc_cpu2cpu.h
+++ b/context-runtime/include/clio_runtime/ipc/ipc_cpu2cpu.h
@@ -37,7 +37,10 @@ struct IpcCpu2Cpu {
    * scheduler involvement is needed to establish it.
    * @return true if a task was received and enqueued.
    */
-  static bool RecvIn(IpcManager *ipc, u32 shard);  // #807: drains shard ring
+  // #807: pop one task off shard ring `shard`, deserialize it, and return it as
+  // a resolved Future for the calling worker to route + execute INLINE. Empty
+  // Future (get()==nullptr) when the ring has nothing. No lane push, no wakeup.
+  static Future<Task> RecvIn(IpcManager *ipc, u32 shard);
 
   /** Deserialize task from SHM ring buffer on runtime side (inbound). */
   static clio::run::shared_ptr<clio::run::Task> RecvIn(

--- a/context-runtime/include/clio_runtime/ipc/ipc_cpu2cpu_impl.h
+++ b/context-runtime/include/clio_runtime/ipc/ipc_cpu2cpu_impl.h
@@ -124,6 +124,22 @@ bool IpcCpu2Cpu::RecvOut(IpcManager *ipc,
   ctp::lbm::EventManager *em = &ipc->GetTls()->event_manager_;
   ctp::Timepoint start;
   start.Now();
+
+  // issue #807/#784: spin-poll for the response before parking. On SHM the
+  // round-trip is microseconds; a brief spin catches the completion (set by
+  // RecvShmClientThread when it demuxes our archive) without the park/wake +
+  // signal syscall that otherwise dominates low-latency round-trips. Bounded by
+  // config so a slow/absent response still falls through to the parked Wait.
+  const double spin_us =
+      static_cast<double>(CLIO_CONFIG_MANAGER->GetShmClientSpinUs());
+  if (spin_us > 0.0 && !task_ptr->IsComplete()) {
+    ctp::Timepoint spin_now;
+    do {
+      if (task_ptr->IsComplete()) break;
+      spin_now.Now();
+    } while (start.GetUsecFromStart(spin_now) < spin_us);
+  }
+
   while (!task_ptr->IsComplete()) {
     em->Wait(100);
     if (max_sec > 0) {

--- a/context-runtime/include/clio_runtime/ipc/ipc_cpu2cpu_impl.h
+++ b/context-runtime/include/clio_runtime/ipc/ipc_cpu2cpu_impl.h
@@ -69,12 +69,16 @@ Future<TaskT> IpcCpu2Cpu::SendIn(IpcManager *ipc,
     ipc->pending_zmq_futures_[net_key] = {task_ptr.get()};
   }
 
-  // Send the task to the runtime's single inbound ring. Clients no longer
-  // load-balance across per-worker rings (worker_tids_); the net_recv worker
-  // drains this one ring and fans tasks out to worker lanes, mirroring the ZMQ
-  // ROUTER model. The runtime pid (learned via ClientConnect) keys the name.
+  // issue #807: shard across the runtime's S inbound rings. Key by this client
+  // thread's tid so a given thread always targets the same ring — preserves
+  // per-thread request order and keeps the ring's producer set stable (locality).
+  // Each shard ring has its own dedicated drain thread on the runtime, so this
+  // spreads both the MPSC-tail contention and the deserialize+route work.
+  u32 shards = ipc->shm_in_shards_ >= 1 ? ipc->shm_in_shards_ : 1;
+  u32 shard = static_cast<u32>(ctp::SystemInfo::GetTid()) % shards;
   ctp::lbm::ShmMpscTransport *conn = ipc->GetOrCreateShmConn(
-      "clio-" + std::to_string(ipc->runtime_pid_) + "-shm-in");
+      "clio-" + std::to_string(ipc->runtime_pid_) + "-shm-in-" +
+      std::to_string(shard));
   if (conn == nullptr) {
     HLOG(kError, "IpcCpu2Cpu::SendIn: inbound SHM ring unavailable");
     task_ptr->SetComplete();  // unblock the waiter on the error path

--- a/context-runtime/include/clio_runtime/ipc/ipc_cpu2cpu_impl.h
+++ b/context-runtime/include/clio_runtime/ipc/ipc_cpu2cpu_impl.h
@@ -135,6 +135,15 @@ bool IpcCpu2Cpu::RecvOut(IpcManager *ipc,
   if (spin_us > 0.0 && !task_ptr->IsComplete()) {
     ctp::Timepoint spin_now;
     do {
+      // issue #807: DRAIN INLINE while spinning instead of waiting for the
+      // dedicated RecvShmClientThread to demux our response and signal us. The
+      // try-lock inside makes us the sole consumer when we win it (no concurrent
+      // Recv with the fallback thread); if another drainer holds it we just poll
+      // our own completion below. Draining here also demuxes other waiters'
+      // responses, so one active waiter serves the whole process — and it cuts
+      // the entire RecvShmClientThread wake+demux hop off the response path,
+      // which the split-timing showed dominates the round-trip.
+      ipc->DrainShmResponses();
       if (task_ptr->IsComplete()) break;
       spin_now.Now();
     } while (start.GetUsecFromStart(spin_now) < spin_us);

--- a/context-runtime/include/clio_runtime/ipc_manager.h
+++ b/context-runtime/include/clio_runtime/ipc_manager.h
@@ -938,7 +938,6 @@ class IpcManager {
    * scheduler needs to know the ring exists: this thread IS the ring's single
    * consumer.
    */
-  void RecvShmServerThread(u32 shard);  // #807: drains shm_in_servers_[shard]
 
   // issue #807: WORKER-DRIVEN inbound shard draining. Instead of dedicated drain
   // threads (which oversubscribe cores on a small box — the whole reason the
@@ -950,9 +949,9 @@ class IpcManager {
   // push does.
   void RegisterShardConsumer(u32 worker_id);    // publish worker tid on its ring
   void UnregisterShardConsumer(u32 worker_id);  // withdraw at worker exit
-  u32 DrainShard(u32 worker_id);                // drain owned ring (bounded)
   bool ShardEmpty(u32 worker_id) const;         // park-recheck
   void SetShardParked(u32 worker_id, bool parked);  // park protocol
+  // Worker w drains + executes its own shard inline — see Worker::DrainMyShard.
 
   /**
    * Start RecvShmServerThread. Called once from the admin ChiMod's Create,

--- a/context-runtime/include/clio_runtime/ipc_manager.h
+++ b/context-runtime/include/clio_runtime/ipc_manager.h
@@ -940,6 +940,20 @@ class IpcManager {
    */
   void RecvShmServerThread(u32 shard);  // #807: drains shm_in_servers_[shard]
 
+  // issue #807: WORKER-DRIVEN inbound shard draining. Instead of dedicated drain
+  // threads (which oversubscribe cores on a small box — the whole reason the
+  // first cut regressed), the EXISTING workers drain the shard rings in their
+  // poll loop. Worker w owns shard w (shards are capped at the worker count), so
+  // each ring still has exactly one consumer, satisfying MPSC. The worker's own
+  // signalfd EventManager IS the ring's consumer wake target (consumer_tid_ =
+  // worker tid), so a client send SIGUSR1s the owning worker exactly as a lane
+  // push does.
+  void RegisterShardConsumer(u32 worker_id);    // publish worker tid on its ring
+  void UnregisterShardConsumer(u32 worker_id);  // withdraw at worker exit
+  u32 DrainShard(u32 worker_id);                // drain owned ring (bounded)
+  bool ShardEmpty(u32 worker_id) const;         // park-recheck
+  void SetShardParked(u32 worker_id, bool parked);  // park protocol
+
   /**
    * Start RecvShmServerThread. Called once from the admin ChiMod's Create,
    * next to IpcManagerRun2Run::StartRecvThreads — by then the pool manager,

--- a/context-runtime/include/clio_runtime/ipc_manager.h
+++ b/context-runtime/include/clio_runtime/ipc_manager.h
@@ -1513,6 +1513,10 @@ class IpcManager {
   std::atomic<bool> shm_send_running_{false};
   std::mutex shm_send_wake_mutex_;
   std::condition_variable shm_send_wake_cv_;
+  // Set by EnqueueShmSend before notify; checked in the sender's CV predicate so
+  // an enqueue that races the park is not lost (which would cost up to the park
+  // timeout in response latency).
+  std::atomic<bool> shm_send_pending_{false};
 
  public:
   /** Get (or lazily create) a cached MPSC client connection to `name`. Returns

--- a/context-runtime/include/clio_runtime/ipc_manager.h
+++ b/context-runtime/include/clio_runtime/ipc_manager.h
@@ -1523,14 +1523,7 @@ class IpcManager {
   std::unordered_map<std::string, std::unique_ptr<ShmSendQueue>>
       shm_send_queues_;
   std::mutex shm_send_queues_mutex_;   // guards the MAP (not the per-queue FIFOs)
-  std::thread shm_send_thread_;        // single sender for now; a pool in P1b
-  std::atomic<bool> shm_send_running_{false};
-  std::mutex shm_send_wake_mutex_;
-  std::condition_variable shm_send_wake_cv_;
-  // Set by EnqueueShmSend before notify; checked in the sender's CV predicate so
-  // an enqueue that races the park is not lost (which would cost up to the park
-  // timeout in response latency).
-  std::atomic<bool> shm_send_pending_{false};
+  std::atomic<bool> shm_send_running_{false};  // #807: SHM-mode gate for flush
 
  public:
   /** Get (or lazily create) a cached MPSC client connection to `name`. Returns
@@ -1542,11 +1535,12 @@ class IpcManager {
    *  serialization or a ring transfer on the caller (worker) thread. */
   void EnqueueShmSend(const std::string &dest, clio::run::Future<Task> &&future);
 
-  /** issue #807: background sender loop — drains every per-destination queue in
-   *  order (serialize + MPSC transfer into the client's out-ring). */
-  void SendShmServerThread();
-  void StartShmServerSendThread();
-  void StopShmServerSendThread();
+  /** issue #807: drain up to `budget` deferred responses across the
+   *  per-destination queues (serialize + MPSC transfer). Called from the
+   *  WORKERS' poll loop — no dedicated sender thread. Returns the count sent. */
+  u32 DrainShmSends(ctp::lbm::Transport *transport, u32 budget);
+  void StartShmServerSendThread();  // #807: no-op (workers drain)
+  void StopShmServerSendThread();   // #807: shutdown flush
 
  private:
 #endif

--- a/context-runtime/include/clio_runtime/ipc_manager.h
+++ b/context-runtime/include/clio_runtime/ipc_manager.h
@@ -37,6 +37,8 @@
 #include <atomic>
 #include <chrono>
 #include <functional>
+#include <condition_variable>
+#include <deque>
 #include <iostream>
 #include <memory>
 #include <mutex>
@@ -1480,10 +1482,43 @@ class IpcManager {
   ctp::lbm::ShmMpscTransport shm_out_server_;
   bool shm_out_server_ok_ = false;
 
+  // issue #807 D2: nonblocking, ordered, PER-DESTINATION response send.
+  //
+  // The old SHM SendOut ran INLINE on the executing worker: it serialized the
+  // result and did a blocking MPSC transfer into the client's out-ring, so a
+  // full client ring stalled task processing — the exact thing the transport
+  // was meant to avoid. Now a worker ENQUEUES an owning future here (nonblocking)
+  // and returns; a dedicated background sender thread drains each destination's
+  // queue in order and does the serialize + transfer, mirroring the ZMQ path's
+  // EnqueueSendOut. One queue per destination ring keeps per-client response
+  // ordering while letting different clients' responses proceed independently.
+  struct ShmSendQueue {
+    std::mutex mtx;
+    std::deque<clio::run::Future<Task>> pending;
+  };
+  std::unordered_map<std::string, std::unique_ptr<ShmSendQueue>>
+      shm_send_queues_;
+  std::mutex shm_send_queues_mutex_;   // guards the MAP (not the per-queue FIFOs)
+  std::thread shm_send_thread_;        // single sender for now; a pool in P1b
+  std::atomic<bool> shm_send_running_{false};
+  std::mutex shm_send_wake_mutex_;
+  std::condition_variable shm_send_wake_cv_;
+
  public:
   /** Get (or lazily create) a cached MPSC client connection to `name`. Returns
    *  nullptr if the named server cannot be attached. #642 */
   ctp::lbm::ShmMpscTransport *GetOrCreateShmConn(const std::string &name);
+
+  /** issue #807: enqueue an owning response future onto the per-destination SHM
+   *  send queue named `dest` and wake the sender thread. Nonblocking; never runs
+   *  serialization or a ring transfer on the caller (worker) thread. */
+  void EnqueueShmSend(const std::string &dest, clio::run::Future<Task> &&future);
+
+  /** issue #807: background sender loop — drains every per-destination queue in
+   *  order (serialize + MPSC transfer into the client's out-ring). */
+  void SendShmServerThread();
+  void StartShmServerSendThread();
+  void StopShmServerSendThread();
 
  private:
 #endif

--- a/context-runtime/include/clio_runtime/ipc_manager.h
+++ b/context-runtime/include/clio_runtime/ipc_manager.h
@@ -938,7 +938,7 @@ class IpcManager {
    * scheduler needs to know the ring exists: this thread IS the ring's single
    * consumer.
    */
-  void RecvShmServerThread();
+  void RecvShmServerThread(u32 shard);  // #807: drains shm_in_servers_[shard]
 
   /**
    * Start RecvShmServerThread. Called once from the admin ChiMod's Create,
@@ -1445,6 +1445,11 @@ class IpcManager {
   // PID of the runtime process (for tgkill)
   pid_t runtime_pid_ = 0;
 
+  // issue #807: number of parallel inbound SHM rings. On the runtime this is
+  // GetShmInShards(); on a client it is learned from ClientConnect and selects
+  // which shard (clio-<pid>-shm-in-<k>) a request is sent to.
+  u32 shm_in_shards_ = 1;
+
   // Monotonic counter, set from epoch nanos at init
   std::atomic<u64> server_generation_{0};
 
@@ -1477,7 +1482,12 @@ class IpcManager {
   //   (RecvShmClientThread), which demuxes by net_key and wakes waiters. This
   //   mirrors the ZMQ model (one recv path, event-woken waiters) instead of
   //   clients load-balancing across per-worker rings.
-  ctp::lbm::ShmMpscTransport shm_in_server_;
+  // issue #807: S parallel inbound rings (clio-<pid>-shm-in-<k>), each with its
+  // own drain thread, replacing the single shm_in_server_. unique_ptr because
+  // ShmMpscTransport owns SHM handles and is not movable into a vector. Index k
+  // is the shard the producing client selected. shm_in_server_ok_ is true once
+  // ALL shards initialised.
+  std::vector<std::unique_ptr<ctp::lbm::ShmMpscTransport>> shm_in_servers_;
   bool shm_in_server_ok_ = false;
   ctp::lbm::ShmMpscTransport shm_out_server_;
   bool shm_out_server_ok_ = false;
@@ -1591,7 +1601,7 @@ class IpcManager {
   // inbound ring) and pushes tasks onto worker lanes, mirroring the ZMQ path's
   // ClientRecvThread. Owning the drain here — rather than on a designated
   // worker — is what keeps the schedulers and Worker free of transport state.
-  std::thread shm_in_recv_thread_;
+  std::vector<std::thread> shm_in_recv_threads_;  // #807: one per shard
   std::atomic<bool> shm_in_recv_running_{false};
 
   // Background heartbeat thread for server liveness detection

--- a/context-runtime/include/clio_runtime/ipc_manager.h
+++ b/context-runtime/include/clio_runtime/ipc_manager.h
@@ -1033,6 +1033,23 @@ class IpcManager {
     allocator_map_lock_.ReadUnlock();
     if (result.ptr_ != nullptr) return result;
 
+    // Issue #807: a multithreaded client can hand the runtime a ShmPtr into a
+    // freshly created segment BEFORE the creating thread's RegisterMemory
+    // admin round-trip lands — segment creation exposes the allocator to the
+    // client's sibling threads immediately, and the SHM data plane is much
+    // faster than the TCP control plane the registration rides on. Attach the
+    // segment on demand and retry, instead of handing back a null resolution
+    // (which a bdev write would memcpy from).
+    if (TryLazyRegisterClientSegment(shm_ptr.alloc_id_)) {
+      allocator_map_lock_.ReadLock();
+      auto retry_it = alloc_map_.find(alloc_key);
+      if (retry_it != alloc_map_.end()) {
+        result = ctp::ipc::FullPtr<T>(retry_it->second, shm_ptr);
+      }
+      allocator_map_lock_.ReadUnlock();
+      if (result.ptr_ != nullptr) return result;
+    }
+
     // Case 4: Check GPU client backends (kPinnedHost / kManagedUvm /
     // kDeviceMem). The IpcGpu2Cpu producer convention stashes the raw
     // device-or-host-accessible address in `off_` directly, so resolution
@@ -1251,6 +1268,17 @@ class IpcManager {
    * @return true if successful (or already registered), false on error
    */
   bool RegisterMemory(const ctp::ipc::AllocatorId &alloc_id);
+
+  /**
+   * Runtime-side fallback for ToFullPtr: attach a client segment whose
+   * RegisterMemory control-plane round-trip has not landed yet (issue #807 —
+   * the SHM data plane outruns the TCP admin path, so a sibling client
+   * thread's first use of a fresh segment can reach a worker before the
+   * creating thread's registration does). No-op on clients / null ids.
+   * @return true if the segment is now registered (attached here or already
+   *         present), false otherwise
+   */
+  bool TryLazyRegisterClientSegment(const ctp::ipc::AllocatorId &alloc_id);
 
   /**
    * Get the current process's shared memory info for registration

--- a/context-runtime/include/clio_runtime/ipc_manager.h
+++ b/context-runtime/include/clio_runtime/ipc_manager.h
@@ -930,6 +930,15 @@ class IpcManager {
    */
   void RecvShmClientThread();
 
+  /** issue #807: drain + demux available SHM responses off the client out-ring,
+   *  under a try-lock so exactly one thread consumes at a time. Called BOTH by a
+   *  waiter spinning in RecvOut (inline fast path) and by RecvShmClientThread
+   *  (fallback when waiters are parked). Returns true if it drained anything;
+   *  false if another thread holds the drain lock (caller just polls its own
+   *  completion) or the ring was empty. Sets IsComplete + stashes the archive
+   *  for every response it demuxes, so one draining waiter serves all waiters. */
+  bool DrainShmResponses();
+
   /**
    * Runtime-side thread that drains the single inbound SHM ring
    * (shm_in_server_) in SHM mode, deserializing each client task and pushing it
@@ -1504,6 +1513,11 @@ class IpcManager {
   bool shm_in_server_ok_ = false;
   ctp::lbm::ShmMpscTransport shm_out_server_;
   bool shm_out_server_ok_ = false;
+  // issue #807: serialises out-ring consumption. The out-ring is single-consumer
+  // (recv_conns_ reassembly state is shared, not thread-local), so a waiter that
+  // drains inline (RecvOut spin) and the fallback RecvShmClientThread must never
+  // Recv concurrently — whoever holds this try-lock is the sole consumer.
+  std::mutex shm_out_drain_mutex_;
 
   // issue #807 D2: nonblocking, ordered, PER-DESTINATION response send.
   //

--- a/context-runtime/include/clio_runtime/types.h
+++ b/context-runtime/include/clio_runtime/types.h
@@ -391,6 +391,25 @@ inline CTP_CROSS_FUN LockOwnerId GetCurrentLockOwnerId() {
 }
 #endif
 
+/**
+ * The calling OS thread's id, cached in TLS, for the CoMutex/CoRwLock
+ * reentrancy fast paths. Every legitimate reentrant acquire happens on the
+ * OS thread that already owns the lock (same-stack nesting, or a same-worker
+ * subtask of the holding parent), so gating the fast path on this id is what
+ * makes the unsynchronized holder_/depth accesses sound — see CoRwLock.
+ * Returns 0 under a device pass (device code never takes these locks);
+ * callers treat 0 as "no fast path".
+ */
+#if !CTP_IS_DEVICE_PASS
+inline u64 GetCoLockThreadId() {
+  static thread_local const u64 kTid =
+      static_cast<u64>(ctp::SystemInfo::GetTid());
+  return kTid;
+}
+#else
+inline CTP_CROSS_FUN u64 GetCoLockThreadId() { return 0; }
+#endif
+
 using MethodId = u32;
 
 // Worker and Lane identifiers

--- a/context-runtime/include/clio_runtime/worker.h
+++ b/context-runtime/include/clio_runtime/worker.h
@@ -561,6 +561,17 @@ class Worker {
    */
   bool ProcessNewTask(TaskLane *lane);
 
+  /** issue #807: bind a resolved Future to this worker, route it, and execute it
+   *  INLINE if it maps here (else RouteTask enqueues it to the right worker).
+   *  Shared by the lane path (ProcessNewTask) and the inline SHM-ingest path
+   *  (DrainMyShard). `lane` is where the task's RunContext should point for
+   *  subtask wakeups (the popped lane, or this worker's own lane on ingest). */
+  void RouteAndExec(Future<Task> &future, TaskLane *lane);
+
+  /** issue #807: drain this worker's inbound SHM shard, executing each request
+   *  INLINE (no lane round-trip, no per-request wakeup). Returns count handled. */
+  u32 DrainMyShard();
+
   /**
    * Get the time remaining before the next periodic task should resume
    * Scans all periodic queues to find the task with the shortest remaining time

--- a/context-runtime/modules/admin/include/clio_runtime/admin/admin_tasks.h
+++ b/context-runtime/modules/admin/include/clio_runtime/admin/admin_tasks.h
@@ -806,6 +806,9 @@ struct ClientConnectTask : public clio::run::Task {
 
   // Worker task queue SHM offset (for SHM-mode client attach)
   OUT clio::run::u64 worker_queues_off_;  ///< SHM offset of worker_queues_ within queue allocator
+  // issue #807: number of parallel inbound SHM rings the runtime is draining.
+  // The client shards its requests across clio-<pid>-shm-in-<k> for k in [0,S).
+  OUT clio::run::u32 shm_in_shards_;
 
   // #642: worker OS thread ids so an SHM client can address each worker's
   // "clio-<server_pid>-<worker_tid>" MPSC receive server.
@@ -841,6 +844,7 @@ struct ClientConnectTask : public clio::run::Task {
         server_generation_(0),
         server_pid_(0),
         worker_queues_off_(0),
+        shm_in_shards_(1),
         num_worker_tids_(0),
         num_gpus_(0),
         gpu_queue_depth_(0) {
@@ -862,6 +866,7 @@ struct ClientConnectTask : public clio::run::Task {
         server_generation_(0),
         server_pid_(0),
         worker_queues_off_(0),
+        shm_in_shards_(1),
         num_worker_tids_(0),
         num_gpus_(0),
         gpu_queue_depth_(0) {
@@ -889,7 +894,7 @@ struct ClientConnectTask : public clio::run::Task {
     Task::SerializeOut(ar);
     ar(response_, server_generation_, server_pid_, worker_queues_off_,
        main_alloc_id_, queue_alloc_id_, num_gpus_, gpu_queue_depth_,
-       metadata_dir_off_);
+       metadata_dir_off_, shm_in_shards_);
     ar(num_worker_tids_);
     for (clio::run::u32 i = 0; i < kMaxWorkerTids; ++i) {
       ar(worker_tids_[i]);

--- a/context-runtime/modules/admin/src/admin_runtime.cc
+++ b/context-runtime/modules/admin/src/admin_runtime.cc
@@ -591,6 +591,8 @@ clio::run::TaskResume Runtime::ClientConnect(clio::run::shared_ptr<ClientConnect
   task->server_generation_ = CLIO_IPC->GetServerGeneration();
   task->server_pid_ = static_cast<int32_t>(getpid());
   task->worker_queues_off_ = CLIO_IPC->GetWorkerQueuesOffset();
+  // issue #807: tell the client how many inbound SHM rings to shard across.
+  task->shm_in_shards_ = CLIO_CONFIG_MANAGER->GetShmInShards();
   // Report this runtime's pid-based allocator ids so the client attaches the
   // correct allocators (segments are no longer the hardcoded (1,0)/(2,0)).
   task->main_alloc_id_ = CLIO_IPC->GetMainAllocatorId();

--- a/context-runtime/modules/admin/src/admin_runtime.cc
+++ b/context-runtime/modules/admin/src/admin_runtime.cc
@@ -128,10 +128,14 @@ clio::run::TaskResume Runtime::Create(clio::run::shared_ptr<CreateTask> &task) {
   // otherwise). Same rationale and same lifetime as the threads above: by this
   // point the pool manager, task queue and scheduler it pushes into all exist.
   CLIO_IPC->StartShmServerRecvThread();
+  // issue #807: dedicated background thread that owns SHM response send, so no
+  // worker ever serializes or blocks on a full client ring. Same lifetime.
+  CLIO_IPC->StartShmServerSendThread();
   // Stop recv threads before the main transport is freed.
   CLIO_IPC->RegisterTransportShutdownHook([]() {
     CLIO_IPC->GetRun2Run()->StopRecvThreads();
     CLIO_IPC->StopShmServerRecvThread();
+    CLIO_IPC->StopShmServerSendThread();
   });
 
   // Spawn periodic WreapDeadIpcs task with 1 second period

--- a/context-runtime/modules/bdev/src/transports/mem_bdev_transport.cc
+++ b/context-runtime/modules/bdev/src/transports/mem_bdev_transport.cc
@@ -291,6 +291,20 @@ clio::run::TaskResume MemBdevTransport::WriteBlocks(ctp::ipc::FullPtr<WriteTask>
   auto *ipc_mgr = CLIO_IPC;
   ctp::ipc::FullPtr<char> data_ptr = ipc_mgr->ToFullPtr(task->data_).Cast<char>();
 
+  // A task's data pointer comes from another process; if it does not resolve
+  // (unregistered/reaped segment), fail the write instead of memcpy'ing from
+  // NULL — this segfaulted the whole runtime under the #807 stress test.
+  if (data_ptr.ptr_ == nullptr && task->length_ > 0) {
+    HLOG(kError,
+         "MemBdevTransport::WriteBlocks: unresolvable data ShmPtr "
+         "alloc_id=({}.{}) off={} length={} — failing with EIO",
+         task->data_.alloc_id_.major_, task->data_.alloc_id_.minor_,
+         task->data_.off_.load(), task->length_);
+    task->return_code_ = EIO;
+    task->bytes_written_ = 0;
+    CLIO_CO_RETURN;
+  }
+
   // Host source: a synchronous host->host memcpy is fastest and gains nothing
   // from a GPU stream.
   if (!ctp::IsDevicePointer(data_ptr.ptr_)) {
@@ -416,6 +430,19 @@ clio::run::TaskResume MemBdevTransport::ReadBlocks(ctp::ipc::FullPtr<ReadTask> t
 
   auto *ipc_mgr = CLIO_IPC;
   ctp::ipc::FullPtr<char> data_ptr = ipc_mgr->ToFullPtr(task->data_).Cast<char>();
+
+  // Mirror of the WriteBlocks guard: never memset/memcpy into an
+  // unresolvable destination pointer.
+  if (data_ptr.ptr_ == nullptr && task->length_ > 0) {
+    HLOG(kError,
+         "MemBdevTransport::ReadBlocks: unresolvable data ShmPtr "
+         "alloc_id=({}.{}) off={} length={} — failing with EIO",
+         task->data_.alloc_id_.major_, task->data_.alloc_id_.minor_,
+         task->data_.off_.load(), task->length_);
+    task->return_code_ = EIO;
+    task->bytes_read_ = 0;
+    CLIO_CO_RETURN;
+  }
 
   // Host destination: synchronous host<->host copy.
   if (!ctp::IsDevicePointer(data_ptr.ptr_)) {

--- a/context-runtime/src/config_manager.cc
+++ b/context-runtime/src/config_manager.cc
@@ -186,6 +186,18 @@ void ConfigManager::ApplyEnvOverrides() {
       num_threads_ = static_cast<u32>(n);
     }
   }
+
+  // issue #807: number of parallel inbound SHM rings (each with its own drain
+  // thread). CLIO_SHM_IN_SHARDS overrides. Default 4 spreads the MPSC tail
+  // contention and the deserialize+route work across cores without oversubscribing
+  // a small box; 1 restores the single-ring behaviour.
+  if (const char *env = clio::run::env::GetCompat("SHM_IN_SHARDS")) {
+    char *end = nullptr;
+    unsigned long n = std::strtoul(env, &end, 10);
+    if (end != env && n >= 1) {
+      shm_in_shards_ = static_cast<u32>(n);
+    }
+  }
 }
 
 bool ConfigManager::ServerInit() {

--- a/context-runtime/src/config_manager.cc
+++ b/context-runtime/src/config_manager.cc
@@ -198,6 +198,13 @@ void ConfigManager::ApplyEnvOverrides() {
       shm_in_shards_ = static_cast<u32>(n);
     }
   }
+
+  // issue #807: CLIO_SHM_ASYNC_SEND=1 defers SHM response send to a background
+  // thread. Off by default (see GetShmAsyncSend — 3x latency regression on
+  // latency-bound workloads).
+  if (const char *env = clio::run::env::GetCompat("SHM_ASYNC_SEND")) {
+    shm_async_send_ = (env[0] == '1' || env[0] == 't' || env[0] == 'T');
+  }
 }
 
 bool ConfigManager::ServerInit() {

--- a/context-runtime/src/config_manager.cc
+++ b/context-runtime/src/config_manager.cc
@@ -205,6 +205,15 @@ void ConfigManager::ApplyEnvOverrides() {
   if (const char *env = clio::run::env::GetCompat("SHM_ASYNC_SEND")) {
     shm_async_send_ = (env[0] == '1' || env[0] == 't' || env[0] == 'T');
   }
+
+  // issue #807/#784: CLIO_SHM_CLIENT_SPIN_US — waiter spin-before-park budget.
+  if (const char *env = clio::run::env::GetCompat("SHM_CLIENT_SPIN_US")) {
+    char *end = nullptr;
+    unsigned long n = std::strtoul(env, &end, 10);
+    if (end != env) {
+      shm_client_spin_us_ = static_cast<u32>(n);
+    }
+  }
 }
 
 bool ConfigManager::ServerInit() {

--- a/context-runtime/src/ipc/ipc_cpu2cpu.cc
+++ b/context-runtime/src/ipc/ipc_cpu2cpu.cc
@@ -11,18 +11,19 @@
 
 namespace clio::run {
 
-bool IpcCpu2Cpu::RecvIn(IpcManager *ipc) {
-  // Drain the runtime's SINGLE inbound ring (shm_in_server_, DONTWAIT) and
-  // enqueue any received external-client task onto the normal dispatch path.
-  // The only caller is IpcManager::RecvShmServerThread, a dedicated non-worker
-  // thread — that satisfies the ring's single-consumer contract on its own and
-  // keeps every byte of task/future deserialization off the workers.
-  if (!ipc->shm_in_server_ok_) {
+bool IpcCpu2Cpu::RecvIn(IpcManager *ipc, u32 shard) {
+  // Drain ONE inbound shard ring (shm_in_servers_[shard], DONTWAIT) and enqueue
+  // any received external-client task onto the normal dispatch path. issue #807:
+  // there are now S shard rings, each with its own dedicated drain thread, so
+  // each ring still has exactly one consumer — the MPSC single-consumer contract
+  // holds per shard — and S clients-worth of deserialize+route runs on S cores.
+  if (!ipc->shm_in_server_ok_ || shard >= ipc->shm_in_servers_.size() ||
+      ipc->shm_in_servers_[shard] == nullptr) {
     return false;
   }
   LoadTaskArchive archive;
   ctp::lbm::ClientInfo info =
-      ipc->shm_in_server_.Recv(archive, ctp::lbm::SHM_MPSC_DONTWAIT);
+      ipc->shm_in_servers_[shard]->Recv(archive, ctp::lbm::SHM_MPSC_DONTWAIT);
   if (info.rc != 0) {
     return false;
   }

--- a/context-runtime/src/ipc/ipc_cpu2cpu.cc
+++ b/context-runtime/src/ipc/ipc_cpu2cpu.cc
@@ -11,35 +11,38 @@
 
 namespace clio::run {
 
-bool IpcCpu2Cpu::RecvIn(IpcManager *ipc, u32 shard) {
-  // Drain ONE inbound shard ring (shm_in_servers_[shard], DONTWAIT) and enqueue
-  // any received external-client task onto the normal dispatch path. issue #807:
-  // there are now S shard rings, each with its own dedicated drain thread, so
-  // each ring still has exactly one consumer — the MPSC single-consumer contract
-  // holds per shard — and S clients-worth of deserialize+route runs on S cores.
+Future<Task> IpcCpu2Cpu::RecvIn(IpcManager *ipc, u32 shard) {
+  // Drain ONE task off inbound shard ring `shard` (DONTWAIT) and return it as a
+  // resolved Future for the CALLING WORKER to route + execute INLINE. issue #807:
+  // the ingesting worker executes the request itself (when it maps here) instead
+  // of pushing to a lane and SIGUSR1-waking a worker — that lane round-trip and
+  // per-request signal syscall were the bulk of the added latency vs the
+  // original inline design. Returns an empty Future (get()==nullptr) when the
+  // ring is empty. Each shard has exactly one consumer (worker `shard`), so the
+  // MPSC contract holds.
   if (!ipc->shm_in_server_ok_ || shard >= ipc->shm_in_servers_.size() ||
       ipc->shm_in_servers_[shard] == nullptr) {
-    return false;
+    return Future<Task>();
   }
   LoadTaskArchive archive;
   ctp::lbm::ClientInfo info =
       ipc->shm_in_servers_[shard]->Recv(archive, ctp::lbm::SHM_MPSC_DONTWAIT);
   if (info.rc != 0) {
-    return false;
+    return Future<Task>();
   }
   const auto &tis = archive.GetTaskInfos();
   if (tis.empty()) {
-    return false;
+    return Future<Task>();
   }
   const auto &ti = tis[0];
   auto container = CLIO_POOL_MANAGER->GetStaticContainer(ti.pool_id_).get();
   if (container == nullptr) {
-    return false;
+    return Future<Task>();
   }
   clio::run::shared_ptr<clio::run::Task> tp =
       container->AllocLoadTask(ti.method_id_, archive);
   if (tp.IsNull()) {
-    return false;
+    return Future<Task>();
   }
   tp->SetFlags(TASK_EXTERNAL_CLIENT);
   // The Future owns the FutureShm via shared_ptr; pushing it onto the lane
@@ -66,19 +69,8 @@ bool IpcCpu2Cpu::RecvIn(IpcManager *ipc, u32 shard) {
   // Allocate the task's RunContext (and resolve its container) now that it is
   // deserialized, so RouteTask / the worker have an active RunContext.
   f.GetTaskPtr()->BeginRunContext();
-  // issue #807: deposit on the DRAINING worker's own lane (shard k is drained by
-  // worker k), not a shared ingress lane 0. The worker that deserialized the
-  // task also routes it, so both halves parallelise across the pool instead of
-  // funnelling every shard's traffic through lane 0. RuntimeMapTask still
-  // re-routes from here if a different worker is a better fit. Bounded to the
-  // lane count defensively. Always signal: see ipc_cpu2cpu_impl.h for the
-  // enqueue/sleep race this closes.
-  u32 num_lanes = ipc->GetTaskQueue()->GetNumLanes();
-  LaneId lane_id = (num_lanes > 0) ? (shard % num_lanes) : 0;
-  auto &lane_ref = ipc->GetTaskQueue()->GetLane(lane_id, 0);
-  lane_ref.Push(f);
-  ipc->AwakenWorker(&lane_ref);
-  return true;
+  // Return the resolved future; the calling worker routes + executes it inline.
+  return f;
 }
 
 clio::run::shared_ptr<clio::run::Task> IpcCpu2Cpu::RecvIn(

--- a/context-runtime/src/ipc/ipc_cpu2cpu.cc
+++ b/context-runtime/src/ipc/ipc_cpu2cpu.cc
@@ -92,6 +92,28 @@ clio::run::shared_ptr<clio::run::Task> IpcCpu2Cpu::RecvIn(
 void IpcCpu2Cpu::SendOut(
     IpcManager *ipc, const clio::run::shared_ptr<Task> &task_ptr,
     ctp::lbm::Transport *send_transport) {
+  // issue #807: do NOT serialize or transfer on the worker. Enqueue an OWNING
+  // future onto the destination client's per-client send queue and return; the
+  // background sender thread does the work via SendOutTransfer.
+  //
+  // The owning copy is mandatory, exactly as in IpcCpu2CpuZmq::EnqueueSendOut:
+  // task_ptr->RunFuture()'s task_ptr_ may be a NON-OWNING self-handle (RouteGlobal
+  // / RouteManyToOne rebind it non-owning to break the leak cycle), so enqueuing
+  // that handle could let the task free before the sender drains it — its
+  // GetFutureShm() would then resolve through freed memory and the client's
+  // Wait() would hang. An owning copy keeps the task alive until the response is
+  // on the wire; run_ctx_->future_ stays non-owning, so no leak is added.
+  (void)send_transport;  // the sender thread owns the transport it serializes on
+  clio::run::Future<Task> owning = task_ptr->RunFuture();
+  owning.GetTaskPtr() = task_ptr;
+  std::string dest =
+      "clio-" + std::to_string(task_ptr->WaiterPid()) + "-shm-out";
+  ipc->EnqueueShmSend(dest, std::move(owning));
+}
+
+void IpcCpu2Cpu::SendOutTransfer(
+    IpcManager *ipc, const clio::run::shared_ptr<Task> &task_ptr,
+    ctp::lbm::Transport *send_transport) {
   clio::run::ContainerHold container =
       CLIO_POOL_MANAGER->GetStaticContainer(task_ptr->pool_id_).get();
   auto future_shm = task_ptr->RunFuture().GetFutureShm();

--- a/context-runtime/src/ipc/ipc_cpu2cpu.cc
+++ b/context-runtime/src/ipc/ipc_cpu2cpu.cc
@@ -66,11 +66,15 @@ bool IpcCpu2Cpu::RecvIn(IpcManager *ipc, u32 shard) {
   // Allocate the task's RunContext (and resolve its container) now that it is
   // deserialized, so RouteTask / the worker have an active RunContext.
   f.GetTaskPtr()->BeginRunContext();
-  // issue #781: ClientMapTask removed. Like the ZMQ client recv thread
-  // (IpcCpu2CpuZmq::RecvIn), this SHM recv path deposits on the shared ingress
-  // lane (0); the runtime maps the task to a worker via RuntimeMapTask. Always
-  // signal: see ipc_cpu2cpu_impl.h for the enqueue/sleep race this closes.
-  LaneId lane_id = 0;
+  // issue #807: deposit on the DRAINING worker's own lane (shard k is drained by
+  // worker k), not a shared ingress lane 0. The worker that deserialized the
+  // task also routes it, so both halves parallelise across the pool instead of
+  // funnelling every shard's traffic through lane 0. RuntimeMapTask still
+  // re-routes from here if a different worker is a better fit. Bounded to the
+  // lane count defensively. Always signal: see ipc_cpu2cpu_impl.h for the
+  // enqueue/sleep race this closes.
+  u32 num_lanes = ipc->GetTaskQueue()->GetNumLanes();
+  LaneId lane_id = (num_lanes > 0) ? (shard % num_lanes) : 0;
   auto &lane_ref = ipc->GetTaskQueue()->GetLane(lane_id, 0);
   lane_ref.Push(f);
   ipc->AwakenWorker(&lane_ref);

--- a/context-runtime/src/ipc/ipc_cpu2cpu.cc
+++ b/context-runtime/src/ipc/ipc_cpu2cpu.cc
@@ -93,18 +93,27 @@ clio::run::shared_ptr<clio::run::Task> IpcCpu2Cpu::RecvIn(
 void IpcCpu2Cpu::SendOut(
     IpcManager *ipc, const clio::run::shared_ptr<Task> &task_ptr,
     ctp::lbm::Transport *send_transport) {
-  // issue #807: do NOT serialize or transfer on the worker. Enqueue an OWNING
-  // future onto the destination client's per-client send queue and return; the
-  // background sender thread does the work via SendOutTransfer.
+  // issue #807: two paths.
   //
-  // The owning copy is mandatory, exactly as in IpcCpu2CpuZmq::EnqueueSendOut:
-  // task_ptr->RunFuture()'s task_ptr_ may be a NON-OWNING self-handle (RouteGlobal
-  // / RouteManyToOne rebind it non-owning to break the leak cycle), so enqueuing
-  // that handle could let the task free before the sender drains it — its
-  // GetFutureShm() would then resolve through freed memory and the client's
-  // Wait() would hang. An owning copy keeps the task alive until the response is
-  // on the wire; run_ctx_->future_ stays non-owning, so no leak is added.
-  (void)send_transport;  // the sender thread owns the transport it serializes on
+  // Default (fast): serialize + transfer INLINE on the worker, right here. The
+  // client's dedicated recv thread always drains its out-ring, so this Send only
+  // ever blocks transiently under back-pressure, never deadlocks (that is what
+  // the #768 refactor's client recv thread guarantees). Measured ~3x faster than
+  // the deferred path on latency-bound workloads, because there is no thread
+  // handoff on the critical path.
+  //
+  // Opt-in (CLIO_SHM_ASYNC_SEND): enqueue an OWNING future onto the destination's
+  // per-client send queue and return nonblocking; the background sender thread
+  // does the transfer. This never stalls a worker on a full client ring, which
+  // matters under sustained overload — at a latency cost that is pure overhead
+  // when the ring is not full. The owning copy is mandatory (same non-owning
+  // self-handle hazard as IpcCpu2CpuZmq::EnqueueSendOut): RunFuture's task_ptr
+  // may be a non-owning self-handle, so we take an owning copy to keep the task
+  // alive until the sender drains it.
+  if (!CLIO_CONFIG_MANAGER->GetShmAsyncSend()) {
+    SendOutTransfer(ipc, task_ptr, send_transport);
+    return;
+  }
   clio::run::Future<Task> owning = task_ptr->RunFuture();
   owning.GetTaskPtr() = task_ptr;
   std::string dest =

--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -1075,6 +1075,10 @@ bool IpcManager::ServerInitShm() {
       // down proportionally so total inbound SHM stays ~128MB regardless of S.
       u32 shards = CLIO_CONFIG_MANAGER->GetShmInShards();
       if (shards < 1) shards = 1;
+      // issue #807: cap at the worker count. Worker w owns shard w, so a shard
+      // beyond the last worker would have no consumer (its clients would hang).
+      u32 nworkers = CLIO_CONFIG_MANAGER->GetNumThreads();
+      if (shards > nworkers) shards = nworkers;
       shm_in_shards_ = shards;
       size_t per_ring_mb = std::max<size_t>(8, 128 / shards);
       shm_in_servers_.clear();
@@ -3371,34 +3375,94 @@ void IpcManager::RecvShmServerThread(u32 shard) {
 
 void IpcManager::StartShmServerRecvThread() {
 #if CTP_IS_HOST
-  // Only a SHM-mode runtime has an inbound ring; every other configuration
-  // (client processes, ZMQ/TCP/IPC runtimes) makes this a no-op.
-  if (!shm_in_server_ok_ || shm_in_recv_running_.load()) {
-    return;
-  }
+  // issue #807: NO dedicated inbound drain threads. The workers drain the shard
+  // rings themselves (RegisterShardConsumer / DrainShard from Worker::Run), so
+  // parallel ingress comes from oversubscribing the existing pool rather than
+  // from spawning threads that contend for cores — which is what made the first
+  // cut regress. Intentionally a no-op; rings are created in ServerInitShm and
+  // consumed by workers.
   shm_in_recv_running_.store(true, std::memory_order_release);
-  // issue #807: one drain thread per shard ring.
-  for (u32 k = 0; k < shm_in_servers_.size(); ++k) {
-    shm_in_recv_threads_.emplace_back(
-        [this, k]() { RecvShmServerThread(k); });
-  }
-  HLOG(kInfo, "[ShmServerRecvThread] started {} shard drainer(s)",
-       shm_in_servers_.size());
 #endif
 }
 
 void IpcManager::StopShmServerRecvThread() {
 #if CTP_IS_HOST
   shm_in_recv_running_.store(false, std::memory_order_release);
-  // Kick each drainer in case it is parked, so joins don't wait out the park
-  // timeout. Harmless if awake.
-  for (auto &ring : shm_in_servers_) {
-    if (ring) ring->SignalConsumerIfParked();
+#endif
+}
+
+// --- issue #807: worker-driven shard draining --------------------------------
+
+void IpcManager::RegisterShardConsumer(u32 worker_id) {
+#if CTP_IS_HOST
+  if (!shm_in_server_ok_ || worker_id >= shm_in_servers_.size() ||
+      shm_in_servers_[worker_id] == nullptr) {
+    return;
   }
-  for (auto &t : shm_in_recv_threads_) {
-    if (t.joinable()) t.join();
+  // Publishes THIS worker thread's tid as the ring's consumer, so a producing
+  // client's SignalConsumerIfParked SIGUSR1s this worker — the same signalfd
+  // path Worker::SuspendMe already parks on.
+  shm_in_servers_[worker_id]->RegisterConsumer();
+#else
+  (void)worker_id;
+#endif
+}
+
+void IpcManager::UnregisterShardConsumer(u32 worker_id) {
+#if CTP_IS_HOST
+  if (!shm_in_server_ok_ || worker_id >= shm_in_servers_.size() ||
+      shm_in_servers_[worker_id] == nullptr) {
+    return;
   }
-  shm_in_recv_threads_.clear();
+  shm_in_servers_[worker_id]->UnregisterConsumer();
+#else
+  (void)worker_id;
+#endif
+}
+
+u32 IpcManager::DrainShard(u32 worker_id) {
+#if CTP_IS_HOST
+  if (!shm_in_server_ok_ || worker_id >= shm_in_servers_.size() ||
+      shm_in_servers_[worker_id] == nullptr) {
+    return 0;
+  }
+  // Bounded batch so a burst on one shard can't starve the worker's own lane /
+  // blocked-queue processing in the same poll iteration.
+  constexpr u32 kShardDrainBudget = 16;
+  u32 n = 0;
+  while (n < kShardDrainBudget && IpcCpu2Cpu::RecvIn(this, worker_id)) {
+    ++n;
+  }
+  return n;
+#else
+  (void)worker_id;
+  return 0;
+#endif
+}
+
+bool IpcManager::ShardEmpty(u32 worker_id) const {
+#if CTP_IS_HOST
+  if (!shm_in_server_ok_ || worker_id >= shm_in_servers_.size() ||
+      shm_in_servers_[worker_id] == nullptr) {
+    return true;
+  }
+  return shm_in_servers_[worker_id]->IsEmpty();
+#else
+  (void)worker_id;
+  return true;
+#endif
+}
+
+void IpcManager::SetShardParked(u32 worker_id, bool parked) {
+#if CTP_IS_HOST
+  if (!shm_in_server_ok_ || worker_id >= shm_in_servers_.size() ||
+      shm_in_servers_[worker_id] == nullptr) {
+    return;
+  }
+  shm_in_servers_[worker_id]->SetConsumerParked(parked);
+#else
+  (void)worker_id;
+  (void)parked;
 #endif
 }
 

--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -3424,12 +3424,11 @@ void IpcManager::EnqueueShmSend(const std::string &dest,
     std::lock_guard<std::mutex> lk(q->mtx);
     q->pending.push_back(std::move(future));
   }
-  // Wake the sender. notify under the wake mutex so a concurrent park cannot
-  // miss it (the classic lost-wakeup: enqueue between the sender's empty-check
-  // and its wait).
-  {
-    std::lock_guard<std::mutex> lk(shm_send_wake_mutex_);
-  }
+  // Wake the sender. Publish the pending flag BEFORE notify and check it in the
+  // sender's CV predicate, so an enqueue that lands between the sender's
+  // drain-came-up-empty and its park is not lost (which would cost up to the
+  // park timeout in response latency).
+  shm_send_pending_.store(true, std::memory_order_release);
   shm_send_wake_cv_.notify_one();
 #else
   (void)dest;
@@ -3501,7 +3500,11 @@ void IpcManager::SendShmServerThread() {
     }
     idle_spins = 0;
     std::unique_lock<std::mutex> lk(shm_send_wake_mutex_);
-    shm_send_wake_cv_.wait_for(lk, std::chrono::milliseconds(2));
+    shm_send_wake_cv_.wait_for(lk, std::chrono::milliseconds(2), [this]() {
+      return shm_send_pending_.load(std::memory_order_acquire) ||
+             !shm_send_running_.load(std::memory_order_acquire);
+    });
+    shm_send_pending_.store(false, std::memory_order_release);
   }
   // Shutdown flush: recv threads are already stopped, so drain whatever
   // responses are still queued instead of dropping them (which would hang the
@@ -3519,6 +3522,11 @@ void IpcManager::SendShmServerThread() {
 
 void IpcManager::StartShmServerSendThread() {
 #if CTP_IS_HOST
+  // issue #807: the background sender only exists for the opt-in async path.
+  // The default (inline) path transfers on the worker, so no thread is needed.
+  if (!CLIO_CONFIG_MANAGER->GetShmAsyncSend()) {
+    return;
+  }
   // Only a SHM-mode runtime services SHM responses. Idempotent.
   if (shm_send_running_.load()) {
     return;

--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -3336,42 +3336,9 @@ void IpcManager::RecvShmClientThread() {
 #endif
 }
 
-void IpcManager::RecvShmServerThread(u32 shard) {
-#if CTP_IS_HOST
-  ctp::SystemInfo::SetCurrentThreadName("chi-shm-in-recv");
-  if (shard >= shm_in_servers_.size() || shm_in_servers_[shard] == nullptr) {
-    return;
-  }
-  ctp::lbm::ShmMpscTransport &ring = *shm_in_servers_[shard];
-  // Runtime-side analogue of the ZMQ ClientRecvThread. This thread is the
-  // inbound ring's single consumer, which is the whole reason the schedulers
-  // and Worker need no knowledge of it: there is no "which worker drains it"
-  // question to answer. IpcCpu2Cpu::RecvIn deserializes one task per call and
-  // pushes it onto a scheduler-chosen lane.
-  // Same rendezvous as the client drainer: our signalfd EventManager (which
-  // blocks SIGUSR1 on this thread) plus publishing our tid in the ring header
-  // so producing clients know whom to wake.
-  ctp::lbm::EventManager *em = &GetTls()->event_manager_;
-  ring.RegisterConsumer();
-  size_t idle_spins = 0;
-  while (shm_in_recv_running_.load(std::memory_order_acquire)) {
-    bool drained_any = false;
-    // Drain everything currently queued before parking, so a burst is ingested
-    // in one pass rather than one task per wakeup.
-    while (shm_in_recv_running_.load(std::memory_order_acquire) &&
-           IpcCpu2Cpu::RecvIn(this, shard)) {
-      drained_any = true;
-    }
-    if (drained_any) {
-      idle_spins = 0;
-    } else {
-      ShmDrainIdle(ring, em, idle_spins);
-    }
-  }
-  ring.UnregisterConsumer();
-  HLOG(kInfo, "[ShmServerRecvThread] shard {} shutting down", shard);
-#endif
-}
+// issue #807: RecvShmServerThread removed — workers drain shards inline
+// (Worker::DrainMyShard). No dedicated inbound drain thread exists.
+
 
 void IpcManager::StartShmServerRecvThread() {
 #if CTP_IS_HOST
@@ -3417,26 +3384,6 @@ void IpcManager::UnregisterShardConsumer(u32 worker_id) {
   shm_in_servers_[worker_id]->UnregisterConsumer();
 #else
   (void)worker_id;
-#endif
-}
-
-u32 IpcManager::DrainShard(u32 worker_id) {
-#if CTP_IS_HOST
-  if (!shm_in_server_ok_ || worker_id >= shm_in_servers_.size() ||
-      shm_in_servers_[worker_id] == nullptr) {
-    return 0;
-  }
-  // Bounded batch so a burst on one shard can't starve the worker's own lane /
-  // blocked-queue processing in the same poll iteration.
-  constexpr u32 kShardDrainBudget = 16;
-  u32 n = 0;
-  while (n < kShardDrainBudget && IpcCpu2Cpu::RecvIn(this, worker_id)) {
-    ++n;
-  }
-  return n;
-#else
-  (void)worker_id;
-  return 0;
 #endif
 }
 

--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -3287,45 +3287,11 @@ void IpcManager::RecvShmClientThread() {
   shm_out_server_.RegisterConsumer();
   size_t idle_spins = 0;
   while (shm_recv_running_.load()) {
-    bool drained_any = false;
-    // Drain everything currently available before parking.
-    while (shm_recv_running_.load()) {
-      auto archive = std::make_unique<LoadTaskArchive>();
-      ctp::lbm::ClientInfo info =
-          shm_out_server_.Recv(*archive, ctp::lbm::SHM_MPSC_DONTWAIT);
-      if (info.rc != 0) break;  // EAGAIN: nothing more in flight right now
-      drained_any = true;
-
-      if (archive->GetTaskInfos().empty()) {
-        HLOG(kError, "RecvShmClientThread: response with no task_infos");
-        continue;
-      }
-      size_t net_key = archive->GetTaskInfos()[0].task_id_.net_key_;
-
-      std::lock_guard<std::mutex> lock(pending_futures_mutex_);
-      auto it = pending_zmq_futures_.find(net_key);
-      if (it == pending_zmq_futures_.end()) {
-        ++miss_count;
-        HLOG(kError,
-             "RecvShmClientThread: no pending future for net_key {} "
-             "(received={}, misses={})",
-             net_key, recv_count, miss_count);
-        continue;
-      }
-      Task *task = it->second.task;
-      // Park the archive; RecvOut moves it out and deserializes into the task.
-      pending_response_archives_[net_key] = std::move(archive);
-      // Publish the parked archive before the waiter observes completion.
-      std::atomic_thread_fence(std::memory_order_release);
-      task->SetNewData();
-      task->SetComplete();
-      if (task->WaiterPid() != 0) {
-        ctp::lbm::EventManager::Signal(static_cast<int>(task->WaiterPid()),
-                                       static_cast<int>(task->WaiterTid()));
-      }
-      pending_zmq_futures_.erase(it);
-      ++recv_count;
-    }
+    // issue #807: the shared drainer. When app threads are actively waiting they
+    // drain inline (RecvOut) and win the try-lock, so this thread mostly falls
+    // through to park; when they are parked, it wins the lock and drains for
+    // them. Either way exactly one consumer runs at a time.
+    bool drained_any = DrainShmResponses();
     if (drained_any) {
       idle_spins = 0;
     } else {
@@ -3333,6 +3299,69 @@ void IpcManager::RecvShmClientThread() {
     }
   }
   shm_out_server_.UnregisterConsumer();
+  (void)recv_count;
+  (void)miss_count;
+#endif
+}
+
+bool IpcManager::DrainShmResponses() {
+#if CTP_IS_HOST
+  if (!shm_out_server_ok_) {
+    return false;
+  }
+  // Sole-consumer gate: if another thread (a spinning waiter or this fallback
+  // thread) is already draining, back off — the caller polls its own IsComplete.
+  std::unique_lock<std::mutex> drain_lk(shm_out_drain_mutex_, std::try_to_lock);
+  if (!drain_lk.owns_lock()) {
+    return false;
+  }
+  bool any = false;
+  while (true) {
+    // Cheap check before allocating: a spinning waiter calls this every
+    // iteration, so allocating a LoadTaskArchive only to hit EAGAIN on an empty
+    // ring dominated the spin (measured +7us). IsEmpty is two atomic loads and
+    // is safe here — we hold the sole-consumer lock.
+    if (shm_out_server_.IsEmpty()) {
+      break;
+    }
+    auto archive = std::make_unique<LoadTaskArchive>();
+    ctp::lbm::ClientInfo info =
+        shm_out_server_.Recv(*archive, ctp::lbm::SHM_MPSC_DONTWAIT);
+    if (info.rc != 0) {
+      break;  // EAGAIN: nothing more in flight right now
+    }
+    any = true;
+    if (archive->GetTaskInfos().empty()) {
+      HLOG(kError, "DrainShmResponses: response with no task_infos");
+      continue;
+    }
+    size_t net_key = archive->GetTaskInfos()[0].task_id_.net_key_;
+
+    std::lock_guard<std::mutex> lock(pending_futures_mutex_);
+    auto it = pending_zmq_futures_.find(net_key);
+    if (it == pending_zmq_futures_.end()) {
+      HLOG(kError, "DrainShmResponses: no pending future for net_key {}",
+           net_key);
+      continue;
+    }
+    Task *task = it->second.task;
+    // Park the archive; RecvOut moves it out and deserializes into the task.
+    // Demuxing here (not just for our own net_key) is what lets one draining
+    // waiter serve every waiter's response.
+    pending_response_archives_[net_key] = std::move(archive);
+    // Publish the parked archive before the waiter observes completion.
+    std::atomic_thread_fence(std::memory_order_release);
+    task->SetNewData();
+    task->SetComplete();
+    if (task->WaiterPid() != 0) {
+      ctp::lbm::EventManager::Signal(static_cast<int>(task->WaiterPid()),
+                                     static_cast<int>(task->WaiterTid()));
+    }
+    pending_zmq_futures_.erase(it);
+  }
+  return any;
+#else
+  return false;
 #endif
 }
 

--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -3450,12 +3450,14 @@ void IpcManager::SendShmServerThread() {
   // sender thread => one transport => no cross-thread sharing.
   ctp::lbm::TransportPtr send_transport = ctp::lbm::TransportFactory::Get(
       "", ctp::lbm::TransportType::kShm, ctp::lbm::TransportMode::kClient);
-  size_t idle_spins = 0;
-  while (shm_send_running_.load(std::memory_order_acquire)) {
+
+  // One full pass over every destination queue; returns whether it sent
+  // anything. Factored out so the shutdown path can flush remaining responses.
+  auto drain_all = [&]() -> bool {
     bool did_work = false;
-    // Snapshot the destination list so we don't hold the map lock across a
-    // send (a send may lazily create a new dest conn, and we must not block
-    // enqueues on the map lock meanwhile).
+    // Snapshot the destination list so we don't hold the map lock across a send
+    // (a send may lazily create a new dest conn, and we must not block enqueues
+    // on the map lock meanwhile).
     std::vector<ShmSendQueue *> queues;
     {
       std::lock_guard<std::mutex> lk(shm_send_queues_mutex_);
@@ -3477,12 +3479,17 @@ void IpcManager::SendShmServerThread() {
           IpcCpu2Cpu::SendOutTransfer(this, task, send_transport.get());
         }
         did_work = true;
-        // `fut` drops here: the owning reference that kept the task alive
-        // across the async send releases, freeing the task by RAII on THIS
-        // (non-worker) thread once the worker's own ref is already gone.
+        // `fut` drops here: the owning reference that kept the task alive across
+        // the async send releases, freeing the task by RAII on THIS (non-worker)
+        // thread once the worker's own ref is already gone.
       }
     }
-    if (did_work) {
+    return did_work;
+  };
+
+  size_t idle_spins = 0;
+  while (shm_send_running_.load(std::memory_order_acquire)) {
+    if (drain_all()) {
       idle_spins = 0;
       continue;
     }
@@ -3495,6 +3502,16 @@ void IpcManager::SendShmServerThread() {
     idle_spins = 0;
     std::unique_lock<std::mutex> lk(shm_send_wake_mutex_);
     shm_send_wake_cv_.wait_for(lk, std::chrono::milliseconds(2));
+  }
+  // Shutdown flush: recv threads are already stopped, so drain whatever
+  // responses are still queued instead of dropping them (which would hang the
+  // waiting clients). Loop until two consecutive empty passes so a response a
+  // worker enqueued during teardown is not missed.
+  int empty_passes = 0;
+  int total_passes = 0;
+  while (empty_passes < 2 && total_passes < 10000) {
+    empty_passes = drain_all() ? 0 : empty_passes + 1;
+    ++total_passes;
   }
   HLOG(kInfo, "[ShmServerSendThread] shutting down");
 #endif

--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -3488,125 +3488,86 @@ void IpcManager::EnqueueShmSend(const std::string &dest,
     std::lock_guard<std::mutex> lk(q->mtx);
     q->pending.push_back(std::move(future));
   }
-  // Wake the sender. Publish the pending flag BEFORE notify and check it in the
-  // sender's CV predicate, so an enqueue that lands between the sender's
-  // drain-came-up-empty and its park is not lost (which would cost up to the
-  // park timeout in response latency).
-  shm_send_pending_.store(true, std::memory_order_release);
-  shm_send_wake_cv_.notify_one();
+  // No wake needed: the workers drain these queues in their poll loop
+  // (DrainShmSends), and the enqueuing worker itself will drain on its next
+  // iteration; the 50ms max_sleep cap bounds the worst case if all workers park.
 #else
   (void)dest;
   (void)future;
 #endif
 }
 
-void IpcManager::SendShmServerThread() {
+u32 IpcManager::DrainShmSends(ctp::lbm::Transport *transport, u32 budget) {
 #if CTP_IS_HOST
-  ctp::SystemInfo::SetCurrentThreadName("chi-shm-out-send");
-  // Dedicated non-worker thread that owns response serialization + transfer, so
-  // no task-processing worker ever serializes or blocks on a full client ring.
-  // Drains every destination queue in FIFO order (per-client ordering) each
-  // pass; parks on a CV when everything is empty.
+  // issue #807: called from the WORKERS' poll loop (and the shutdown flush), so
+  // deferred response send is oversubscribed onto the existing pool rather than
+  // owned by a dedicated thread. Bounded per call so one worker cannot spend a
+  // whole iteration here and starve its own lane. A no-op when the queues are
+  // empty, which is always the case on the inline-default path.
   //
-  // Its own SHM transport, created ON this thread, used only to Expose bulk
-  // descriptors while building each response archive (task_archive.cc). One
-  // sender thread => one transport => no cross-thread sharing.
-  ctp::lbm::TransportPtr send_transport = ctp::lbm::TransportFactory::Get(
-      "", ctp::lbm::TransportType::kShm, ctp::lbm::TransportMode::kClient);
-
-  // One full pass over every destination queue; returns whether it sent
-  // anything. Factored out so the shutdown path can flush remaining responses.
-  auto drain_all = [&]() -> bool {
-    bool did_work = false;
-    // Snapshot the destination list so we don't hold the map lock across a send
-    // (a send may lazily create a new dest conn, and we must not block enqueues
-    // on the map lock meanwhile).
-    std::vector<ShmSendQueue *> queues;
-    {
-      std::lock_guard<std::mutex> lk(shm_send_queues_mutex_);
-      queues.reserve(shm_send_queues_.size());
-      for (auto &kv : shm_send_queues_) queues.push_back(kv.second.get());
-    }
-    for (ShmSendQueue *q : queues) {
-      for (;;) {
-        clio::run::Future<Task> fut;
-        {
-          std::lock_guard<std::mutex> lk(q->mtx);
-          if (q->pending.empty()) break;
-          fut = std::move(q->pending.front());
-          q->pending.pop_front();
-        }
-        clio::run::shared_ptr<Task> task = fut.GetTaskPtr();
-        if (!task.IsNull()) {
-          // The actual serialize + MPSC transfer + completion, off the worker.
-          IpcCpu2Cpu::SendOutTransfer(this, task, send_transport.get());
-        }
-        did_work = true;
-        // `fut` drops here: the owning reference that kept the task alive across
-        // the async send releases, freeing the task by RAII on THIS (non-worker)
-        // thread once the worker's own ref is already gone.
+  // Multiple workers may drain concurrently: pops are atomic under each queue's
+  // mutex, and conn->Send serialises per client ring via its own send_mu_, so
+  // two workers transferring to the same client are safe. The client demuxes
+  // responses by net_key, so cross-worker delivery order does not matter.
+  u32 sent = 0;
+  std::vector<ShmSendQueue *> queues;
+  {
+    std::lock_guard<std::mutex> lk(shm_send_queues_mutex_);
+    queues.reserve(shm_send_queues_.size());
+    for (auto &kv : shm_send_queues_) queues.push_back(kv.second.get());
+  }
+  for (ShmSendQueue *q : queues) {
+    while (sent < budget) {
+      clio::run::Future<Task> fut;
+      {
+        std::lock_guard<std::mutex> lk(q->mtx);
+        if (q->pending.empty()) break;
+        fut = std::move(q->pending.front());
+        q->pending.pop_front();
       }
+      clio::run::shared_ptr<Task> task = fut.GetTaskPtr();
+      if (!task.IsNull()) {
+        IpcCpu2Cpu::SendOutTransfer(this, task, transport);
+      }
+      ++sent;
+      // `fut` drops here, freeing the task by RAII on this worker thread.
     }
-    return did_work;
-  };
-
-  size_t idle_spins = 0;
-  while (shm_send_running_.load(std::memory_order_acquire)) {
-    if (drain_all()) {
-      idle_spins = 0;
-      continue;
-    }
-    // Nothing to send. Spin briefly (low latency for a busy runtime), then park
-    // on the CV until an enqueue notifies or shutdown flips the flag.
-    if (++idle_spins < kShmSpinBudget) {
-      CTP_THREAD_MODEL->Yield();
-      continue;
-    }
-    idle_spins = 0;
-    std::unique_lock<std::mutex> lk(shm_send_wake_mutex_);
-    shm_send_wake_cv_.wait_for(lk, std::chrono::milliseconds(2), [this]() {
-      return shm_send_pending_.load(std::memory_order_acquire) ||
-             !shm_send_running_.load(std::memory_order_acquire);
-    });
-    shm_send_pending_.store(false, std::memory_order_release);
+    if (sent >= budget) break;
   }
-  // Shutdown flush: recv threads are already stopped, so drain whatever
-  // responses are still queued instead of dropping them (which would hang the
-  // waiting clients). Loop until two consecutive empty passes so a response a
-  // worker enqueued during teardown is not missed.
-  int empty_passes = 0;
-  int total_passes = 0;
-  while (empty_passes < 2 && total_passes < 10000) {
-    empty_passes = drain_all() ? 0 : empty_passes + 1;
-    ++total_passes;
-  }
-  HLOG(kInfo, "[ShmServerSendThread] shutting down");
+  return sent;
+#else
+  (void)transport;
+  (void)budget;
+  return 0;
 #endif
 }
 
 void IpcManager::StartShmServerSendThread() {
 #if CTP_IS_HOST
-  // issue #807: the background sender only exists for the opt-in async path.
-  // The default (inline) path transfers on the worker, so no thread is needed.
-  if (!CLIO_CONFIG_MANAGER->GetShmAsyncSend()) {
-    return;
-  }
-  // Only a SHM-mode runtime services SHM responses. Idempotent.
-  if (shm_send_running_.load()) {
-    return;
-  }
+  // issue #807: no dedicated sender thread. The default (inline) send transfers
+  // on the executing worker; the opt-in async send is drained by the workers via
+  // DrainShmSends in their poll loop. Kept as a no-op so the admin bring-up call
+  // site is unchanged.
   shm_send_running_.store(true, std::memory_order_release);
-  shm_send_thread_ = std::thread([this]() { SendShmServerThread(); });
-  HLOG(kInfo, "[ShmServerSendThread] started");
 #endif
 }
 
 void IpcManager::StopShmServerSendThread() {
 #if CTP_IS_HOST
   shm_send_running_.store(false, std::memory_order_release);
-  shm_send_wake_cv_.notify_all();
-  if (shm_send_thread_.joinable()) {
-    shm_send_thread_.join();
+  // Shutdown flush: workers have stopped draining, so transfer whatever
+  // responses are still queued instead of dropping them (which would hang the
+  // waiting clients). A temp transport on this thread; bounded so a pathological
+  // producer cannot hang shutdown.
+  ctp::lbm::TransportPtr flush_transport = ctp::lbm::TransportFactory::Get(
+      "", ctp::lbm::TransportType::kShm, ctp::lbm::TransportMode::kClient);
+  int empty_passes = 0;
+  int total_passes = 0;
+  while (empty_passes < 2 && total_passes < 10000) {
+    empty_passes = (DrainShmSends(flush_transport.get(), 4096) > 0)
+                       ? 0
+                       : empty_passes + 1;
+    ++total_passes;
   }
 #endif
 }

--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -1073,12 +1073,13 @@ bool IpcManager::ServerInitShm() {
       // by its own thread, replacing the single ring. Spreads MPSC-tail
       // contention and deserialize+route work across cores. Each ring is sized
       // down proportionally so total inbound SHM stays ~128MB regardless of S.
-      u32 shards = CLIO_CONFIG_MANAGER->GetShmInShards();
-      if (shards < 1) shards = 1;
-      // issue #807: cap at the worker count. Worker w owns shard w, so a shard
-      // beyond the last worker would have no consumer (its clients would hang).
+      // issue #807: 0 = auto = one shard per worker (default). Worker w owns
+      // shard w, so cap at the worker count — a shard beyond the last worker
+      // would have no consumer and its clients would hang.
       u32 nworkers = CLIO_CONFIG_MANAGER->GetNumThreads();
-      if (shards > nworkers) shards = nworkers;
+      u32 shards = CLIO_CONFIG_MANAGER->GetShmInShards();
+      if (shards == 0 || shards > nworkers) shards = nworkers;
+      if (shards < 1) shards = 1;
       shm_in_shards_ = shards;
       size_t per_ring_mb = std::max<size_t>(8, 128 / shards);
       shm_in_servers_.clear();

--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -2558,6 +2558,29 @@ bool IpcManager::RegisterMemory(const ctp::ipc::AllocatorId &alloc_id) {
   }
 }
 
+bool IpcManager::TryLazyRegisterClientSegment(
+    const ctp::ipc::AllocatorId &alloc_id) {
+#if CTP_IS_HOST
+  // Runtime only: clients never resolve other processes' segments, and the
+  // attach below is the server-side registration RegisterMemory performs.
+  if (CLIO_RUNTIME_MANAGER == nullptr || !CLIO_RUNTIME_MANAGER->IsRuntime()) {
+    return false;
+  }
+  if (alloc_id == ctp::ipc::AllocatorId::GetNull()) {
+    return false;
+  }
+  HLOG(kWarning,
+       "IpcManager::TryLazyRegisterClientSegment: resolving ({}.{}) before "
+       "its RegisterMemory round-trip landed — attaching on demand (#807)",
+       alloc_id.major_, alloc_id.minor_);
+  // Idempotent: returns true if the segment is already registered.
+  return RegisterMemory(alloc_id);
+#else
+  (void)alloc_id;
+  return false;
+#endif
+}
+
 ClientShmInfo IpcManager::GetClientShmInfo(u32 index) const {
   std::lock_guard<std::mutex> lock(shm_mutex_);
 

--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -712,7 +712,10 @@ void IpcManager::ServerFinalize() {
 #if CTP_IS_HOST
   StopShmServerRecvThread();
   if (shm_in_server_ok_) {
-    shm_in_server_.Shutdown();  // unmap + unlink "clio-<pid>-shm-in"
+    for (auto &ring : shm_in_servers_) {
+      if (ring) ring->Shutdown();  // unmap + unlink clio-<pid>-shm-in-<k>
+    }
+    shm_in_servers_.clear();
     shm_in_server_ok_ = false;
   }
 #endif
@@ -1066,15 +1069,31 @@ bool IpcManager::ServerInitShm() {
     // producer in SendBytes. The name is derived from the runtime pid so a
     // client can form it from the server_pid_ it learns via ClientConnect.
     {
-      std::string in_name = "clio-" + std::to_string(pid) + "-shm-in";
-      shm_in_server_ok_ =
-          shm_in_server_.ServerInit(in_name, ctp::Unit<size_t>::Megabytes(128));
-      if (!shm_in_server_ok_) {
-        HLOG(kError, "ServerInitShm: failed to create inbound SHM ring '{}'",
-             in_name);
-        return false;
+      // issue #807: S parallel inbound rings clio-<pid>-shm-in-<k>, each drained
+      // by its own thread, replacing the single ring. Spreads MPSC-tail
+      // contention and deserialize+route work across cores. Each ring is sized
+      // down proportionally so total inbound SHM stays ~128MB regardless of S.
+      u32 shards = CLIO_CONFIG_MANAGER->GetShmInShards();
+      if (shards < 1) shards = 1;
+      shm_in_shards_ = shards;
+      size_t per_ring_mb = std::max<size_t>(8, 128 / shards);
+      shm_in_servers_.clear();
+      shm_in_server_ok_ = true;
+      for (u32 k = 0; k < shards; ++k) {
+        std::string in_name =
+            "clio-" + std::to_string(pid) + "-shm-in-" + std::to_string(k);
+        auto ring = std::make_unique<ctp::lbm::ShmMpscTransport>();
+        if (!ring->ServerInit(in_name,
+                              ctp::Unit<size_t>::Megabytes(per_ring_mb))) {
+          HLOG(kError, "ServerInitShm: failed to create inbound SHM ring '{}'",
+               in_name);
+          shm_in_server_ok_ = false;
+          return false;
+        }
+        shm_in_servers_.push_back(std::move(ring));
       }
-      HLOG(kInfo, "ServerInitShm: inbound SHM ring '{}' (128MB)", in_name);
+      HLOG(kInfo, "ServerInitShm: {} inbound SHM ring(s) '{}-shm-in-0..{}' ({}MB each)",
+           shards, "clio-" + std::to_string(pid), shards - 1, per_ring_mb);
     }
 #endif
 
@@ -1438,8 +1457,14 @@ retry_attempt:
     if (task->server_pid_ > 0) {
       runtime_pid_ = static_cast<int>(task->server_pid_);
     }
-    HLOG(kInfo, "Successfully connected to runtime (generation={}, server_pid={})",
-         client_generation_, runtime_pid_);
+    // issue #807: learn how many inbound SHM rings to shard requests across.
+    if (task->shm_in_shards_ >= 1) {
+      shm_in_shards_ = task->shm_in_shards_;
+    }
+    HLOG(kInfo,
+         "Successfully connected to runtime (generation={}, server_pid={}, "
+         "shm_in_shards={})",
+         client_generation_, runtime_pid_, shm_in_shards_);
 
     // Client-side GPU queue init was for the cpu2gpu / gpu2gpu queues
     // of the GPU runtime. With the runtime gone, kernels submit
@@ -3307,9 +3332,13 @@ void IpcManager::RecvShmClientThread() {
 #endif
 }
 
-void IpcManager::RecvShmServerThread() {
+void IpcManager::RecvShmServerThread(u32 shard) {
 #if CTP_IS_HOST
   ctp::SystemInfo::SetCurrentThreadName("chi-shm-in-recv");
+  if (shard >= shm_in_servers_.size() || shm_in_servers_[shard] == nullptr) {
+    return;
+  }
+  ctp::lbm::ShmMpscTransport &ring = *shm_in_servers_[shard];
   // Runtime-side analogue of the ZMQ ClientRecvThread. This thread is the
   // inbound ring's single consumer, which is the whole reason the schedulers
   // and Worker need no knowledge of it: there is no "which worker drains it"
@@ -3319,24 +3348,24 @@ void IpcManager::RecvShmServerThread() {
   // blocks SIGUSR1 on this thread) plus publishing our tid in the ring header
   // so producing clients know whom to wake.
   ctp::lbm::EventManager *em = &GetTls()->event_manager_;
-  shm_in_server_.RegisterConsumer();
+  ring.RegisterConsumer();
   size_t idle_spins = 0;
   while (shm_in_recv_running_.load(std::memory_order_acquire)) {
     bool drained_any = false;
     // Drain everything currently queued before parking, so a burst is ingested
     // in one pass rather than one task per wakeup.
     while (shm_in_recv_running_.load(std::memory_order_acquire) &&
-           IpcCpu2Cpu::RecvIn(this)) {
+           IpcCpu2Cpu::RecvIn(this, shard)) {
       drained_any = true;
     }
     if (drained_any) {
       idle_spins = 0;
     } else {
-      ShmDrainIdle(shm_in_server_, em, idle_spins);
+      ShmDrainIdle(ring, em, idle_spins);
     }
   }
-  shm_in_server_.UnregisterConsumer();
-  HLOG(kInfo, "[ShmServerRecvThread] shutting down");
+  ring.UnregisterConsumer();
+  HLOG(kInfo, "[ShmServerRecvThread] shard {} shutting down", shard);
 #endif
 }
 
@@ -3348,21 +3377,28 @@ void IpcManager::StartShmServerRecvThread() {
     return;
   }
   shm_in_recv_running_.store(true, std::memory_order_release);
-  shm_in_recv_thread_ = std::thread([this]() { RecvShmServerThread(); });
-  HLOG(kInfo, "[ShmServerRecvThread] started");
+  // issue #807: one drain thread per shard ring.
+  for (u32 k = 0; k < shm_in_servers_.size(); ++k) {
+    shm_in_recv_threads_.emplace_back(
+        [this, k]() { RecvShmServerThread(k); });
+  }
+  HLOG(kInfo, "[ShmServerRecvThread] started {} shard drainer(s)",
+       shm_in_servers_.size());
 #endif
 }
 
 void IpcManager::StopShmServerRecvThread() {
 #if CTP_IS_HOST
   shm_in_recv_running_.store(false, std::memory_order_release);
-  // Kick the drainer in case it is parked, so the join doesn't wait out the
-  // park timeout. Harmless if it is awake, and the bounded wait bounds the
-  // worst case anyway if this signal races the park.
-  shm_in_server_.SignalConsumerIfParked();
-  if (shm_in_recv_thread_.joinable()) {
-    shm_in_recv_thread_.join();
+  // Kick each drainer in case it is parked, so joins don't wait out the park
+  // timeout. Harmless if awake.
+  for (auto &ring : shm_in_servers_) {
+    if (ring) ring->SignalConsumerIfParked();
   }
+  for (auto &t : shm_in_recv_threads_) {
+    if (t.joinable()) t.join();
+  }
+  shm_in_recv_threads_.clear();
 #endif
 }
 

--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -3366,6 +3366,126 @@ void IpcManager::StopShmServerRecvThread() {
 #endif
 }
 
+// ===========================================================================
+// issue #807 D2: nonblocking, per-destination, background response sender.
+// ===========================================================================
+
+void IpcManager::EnqueueShmSend(const std::string &dest,
+                                clio::run::Future<Task> &&future) {
+#if CTP_IS_HOST
+  ShmSendQueue *q = nullptr;
+  {
+    std::lock_guard<std::mutex> lk(shm_send_queues_mutex_);
+    auto it = shm_send_queues_.find(dest);
+    if (it == shm_send_queues_.end()) {
+      it = shm_send_queues_
+               .emplace(dest, std::make_unique<ShmSendQueue>())
+               .first;
+    }
+    q = it->second.get();
+  }
+  {
+    std::lock_guard<std::mutex> lk(q->mtx);
+    q->pending.push_back(std::move(future));
+  }
+  // Wake the sender. notify under the wake mutex so a concurrent park cannot
+  // miss it (the classic lost-wakeup: enqueue between the sender's empty-check
+  // and its wait).
+  {
+    std::lock_guard<std::mutex> lk(shm_send_wake_mutex_);
+  }
+  shm_send_wake_cv_.notify_one();
+#else
+  (void)dest;
+  (void)future;
+#endif
+}
+
+void IpcManager::SendShmServerThread() {
+#if CTP_IS_HOST
+  ctp::SystemInfo::SetCurrentThreadName("chi-shm-out-send");
+  // Dedicated non-worker thread that owns response serialization + transfer, so
+  // no task-processing worker ever serializes or blocks on a full client ring.
+  // Drains every destination queue in FIFO order (per-client ordering) each
+  // pass; parks on a CV when everything is empty.
+  //
+  // Its own SHM transport, created ON this thread, used only to Expose bulk
+  // descriptors while building each response archive (task_archive.cc). One
+  // sender thread => one transport => no cross-thread sharing.
+  ctp::lbm::TransportPtr send_transport = ctp::lbm::TransportFactory::Get(
+      "", ctp::lbm::TransportType::kShm, ctp::lbm::TransportMode::kClient);
+  size_t idle_spins = 0;
+  while (shm_send_running_.load(std::memory_order_acquire)) {
+    bool did_work = false;
+    // Snapshot the destination list so we don't hold the map lock across a
+    // send (a send may lazily create a new dest conn, and we must not block
+    // enqueues on the map lock meanwhile).
+    std::vector<ShmSendQueue *> queues;
+    {
+      std::lock_guard<std::mutex> lk(shm_send_queues_mutex_);
+      queues.reserve(shm_send_queues_.size());
+      for (auto &kv : shm_send_queues_) queues.push_back(kv.second.get());
+    }
+    for (ShmSendQueue *q : queues) {
+      for (;;) {
+        clio::run::Future<Task> fut;
+        {
+          std::lock_guard<std::mutex> lk(q->mtx);
+          if (q->pending.empty()) break;
+          fut = std::move(q->pending.front());
+          q->pending.pop_front();
+        }
+        clio::run::shared_ptr<Task> task = fut.GetTaskPtr();
+        if (!task.IsNull()) {
+          // The actual serialize + MPSC transfer + completion, off the worker.
+          IpcCpu2Cpu::SendOutTransfer(this, task, send_transport.get());
+        }
+        did_work = true;
+        // `fut` drops here: the owning reference that kept the task alive
+        // across the async send releases, freeing the task by RAII on THIS
+        // (non-worker) thread once the worker's own ref is already gone.
+      }
+    }
+    if (did_work) {
+      idle_spins = 0;
+      continue;
+    }
+    // Nothing to send. Spin briefly (low latency for a busy runtime), then park
+    // on the CV until an enqueue notifies or shutdown flips the flag.
+    if (++idle_spins < kShmSpinBudget) {
+      CTP_THREAD_MODEL->Yield();
+      continue;
+    }
+    idle_spins = 0;
+    std::unique_lock<std::mutex> lk(shm_send_wake_mutex_);
+    shm_send_wake_cv_.wait_for(lk, std::chrono::milliseconds(2));
+  }
+  HLOG(kInfo, "[ShmServerSendThread] shutting down");
+#endif
+}
+
+void IpcManager::StartShmServerSendThread() {
+#if CTP_IS_HOST
+  // Only a SHM-mode runtime services SHM responses. Idempotent.
+  if (shm_send_running_.load()) {
+    return;
+  }
+  shm_send_running_.store(true, std::memory_order_release);
+  shm_send_thread_ = std::thread([this]() { SendShmServerThread(); });
+  HLOG(kInfo, "[ShmServerSendThread] started");
+#endif
+}
+
+void IpcManager::StopShmServerSendThread() {
+#if CTP_IS_HOST
+  shm_send_running_.store(false, std::memory_order_release);
+  shm_send_wake_cv_.notify_all();
+  if (shm_send_thread_.joinable()) {
+    shm_send_thread_.join();
+  }
+#endif
+}
+
 void IpcManager::HeartbeatThread() {
   while (heartbeat_running_.load()) {
     bool alive = IsServerAlive();

--- a/context-runtime/src/scheduler/default_sched.cc
+++ b/context-runtime/src/scheduler/default_sched.cc
@@ -228,6 +228,35 @@ u32 DefaultScheduler::RuntimeMapTask(Worker *worker, const Future<Task> &task,
     selected = scheduler_worker_;
   }
 
+  // issue #807: PREFER INLINE EXECUTION on the calling worker for a quick task.
+  // When a worker ingests a request off its SHM shard (or routes any cheap
+  // task) and is not itself backlogged, run it right here instead of handing it
+  // to another worker via a lane + AwakenWorker SIGUSR1. That cross-worker hop
+  // is the bulk of the per-request latency vs the original inline design; for a
+  // sub-100us task it dominates the actual work. Heavy tasks (high predicted
+  // cost) and a backlogged caller fall through to least-loaded routing, so the
+  // ingesting worker is never blocked from draining its shard by a big task.
+  // The client sharding provides the cross-worker load balancing.
+  if (selected == nullptr && worker != nullptr && task_ptr != nullptr &&
+      container != nullptr && !kFunnel) {
+    constexpr double kInlineCostThresholdUs = 100.0;   // "quick"
+    constexpr double kInlineCallerLoadUs = 250.0;      // caller not backlogged
+    double now_us = NowUs();
+    clio::run::TaskStat stat = container->GetTaskStats(task_ptr);
+    double predicted = container->InferCpuTime(task_ptr->method_, stat);
+    if (predicted <= kInlineCostThresholdUs &&
+        worker->RealtimeLoad(now_us) <= kInlineCallerLoadUs) {
+      // Account the predicted cost on the caller so a burst of quick ingests
+      // doesn't all decide "I'm idle" simultaneously and pile onto one worker.
+      if (predicted > 0.0) {
+        task_ptr->SetPredictedLoad(static_cast<float>(predicted));
+        task_ptr->SetSchedReservedUs(static_cast<float>(predicted));
+        worker->ReserveLoad(predicted);
+      }
+      return worker->GetId();  // ExecHere -> RouteAndExec runs it inline
+    }
+  }
+
   if (selected == nullptr) {
     // Build the compute candidate pool. Prefer the dedicated I/O workers so the
     // scheduler worker (lane 0) stays a pure INGRESS DISPATCHER — a heavy task

--- a/context-runtime/src/worker.cc
+++ b/context-runtime/src/worker.cc
@@ -284,6 +284,13 @@ void Worker::Run() {
     if (CLIO_IPC->DrainShard(worker_id_) > 0) {
       did_work_ = true;
     }
+    // issue #807: also drain any DEFERRED SHM responses (opt-in async send path)
+    // onto the client rings, using this worker's own send transport. A cheap
+    // no-op on the inline-default path (queues stay empty). Bounded so it can't
+    // starve this worker's own task processing.
+    if (CLIO_IPC->DrainShmSends(shm_send_transport_.get(), 16) > 0) {
+      did_work_ = true;
+    }
 
     // Process tasks from assigned lane
     // issue #785: re-read every iteration. The monitor thread may have moved

--- a/context-runtime/src/worker.cc
+++ b/context-runtime/src/worker.cc
@@ -278,10 +278,9 @@ void Worker::Run() {
     task_did_work_ = false;  // Reset task-level work tracker
 
     // issue #807: drain THIS worker's inbound SHM shard ring (worker w owns
-    // shard w). Deserialize+route runs on the existing workers — oversubscribed
-    // — instead of on dedicated drain threads that would contend for cores. A
-    // no-op for workers that own no shard and for non-SHM runtimes.
-    if (CLIO_IPC->DrainShard(worker_id_) > 0) {
+    // shard w) and execute each request INLINE — no lane round-trip, no
+    // per-request wakeup. A no-op for workers that own no shard / non-SHM.
+    if (DrainMyShard() > 0) {
       did_work_ = true;
     }
     // issue #807: also drain any DEFERRED SHM responses (opt-in async send path)
@@ -530,6 +529,16 @@ bool Worker::ProcessNewTask(TaskLane *lane) {
     return true;
   }
 
+  // Bind + route + execute (shared with the inline SHM-ingest path).
+  RouteAndExec(future, lane);
+  return true;
+}
+
+void Worker::RouteAndExec(Future<Task> &future, TaskLane *lane) {
+  clio::run::shared_ptr<Task> task_full_ptr = future.GetTaskPtr();
+  if (task_full_ptr.IsNull()) {
+    return;
+  }
   // The RunContext (with its container resolved) was allocated by the ipc
   // receive/send site that introduced this task (Task::BeginRunContext). Bind it
   // to THIS worker/lane and record the future so subtask-completion events and
@@ -550,8 +559,35 @@ bool Worker::ProcessNewTask(TaskLane *lane) {
     ExecTask(task_full_ptr, is_started);
 #endif
   }
+}
 
-  return true;
+u32 Worker::DrainMyShard() {
+#if CTP_IS_HOST
+  // issue #807: pop requests off this worker's inbound SHM shard and execute
+  // each INLINE — bind, route, and (when it maps here, the common case for a
+  // quick local task) run it right here, then the response is sent inline. No
+  // lane push, no per-request AwakenWorker SIGUSR1: those were the bulk of the
+  // latency gap vs the original inline design. A task that maps elsewhere is
+  // enqueued by RouteTask as usual.
+  constexpr u32 kShardDrainBudget = 16;
+  TaskLane *my_lane = assigned_lane_.load(std::memory_order_acquire);
+  u32 n = 0;
+  while (n < kShardDrainBudget) {
+    Future<Task> f = IpcCpu2Cpu::RecvIn(CLIO_IPC, worker_id_);
+    if (f.get() == nullptr) {
+      break;  // shard empty
+    }
+    // Bind + route + execute. RuntimeMapTask decides whether this ingesting
+    // worker keeps the task (inline, the quick-local common case) or routes it
+    // to another worker (heavy tasks), so all placement policy stays in the
+    // scheduler.
+    RouteAndExec(f, my_lane);
+    ++n;
+  }
+  return n;
+#else
+  return 0;
+#endif
 }
 
 double Worker::GetSuspendPeriod() const {

--- a/context-runtime/src/worker.cc
+++ b/context-runtime/src/worker.cc
@@ -731,12 +731,24 @@ void Worker::SuspendMe() {
                          : std::min(static_cast<int>(suspend_period_us),
                                     static_cast<int>(max_sleep));
 
-    // issue #807: announce to producing clients that we are about to park, so
-    // their SignalConsumerIfParked wakes us. Publish BEFORE the wait; a request
-    // that lands after this still SIGUSR1s us out of the Wait (or the max_sleep
-    // cap re-polls). Cleared immediately on wake so a send during processing
-    // does not waste a signal.
+    // issue #807: park protocol for the inbound SHM shard. The ORDER is
+    // load-bearing and must match the transport's documented rendezvous:
+    // publish "parked" BEFORE the final empty re-check, so it interlocks with a
+    // producer that does "reserve slot (tail++) THEN check consumer_parked_".
+    // The store(parked) and the load(tail, via ShardEmpty) form a Dekker
+    // StoreLoad pair — if a request landed after our earlier fast-path check, we
+    // now either observe its slot here (and skip the park) or it observes us
+    // parked (and signals). Doing the re-check BEFORE setting parked (as an
+    // earlier cut did) loses the wakeup: the producer pushes in the gap, sees
+    // parked==0, skips the signal, and we park anyway — bounded only by the
+    // 50ms max_sleep re-poll, which under the ARM weak-memory model fires
+    // constantly and crawled cr_cli_cfs_parallel_stress into its timeout (x86
+    // TSO mostly hid it).
     CLIO_IPC->SetShardParked(worker_id_, true);
+    if (!CLIO_IPC->ShardEmpty(worker_id_)) {
+      CLIO_IPC->SetShardParked(worker_id_, false);
+      return;  // a request arrived during/before the park setup — go drain it
+    }
     // Wait for signal using EventManager
     int nfds = event_manager_.Wait(timeout_us);
     CLIO_IPC->SetShardParked(worker_id_, false);

--- a/context-runtime/src/worker.cc
+++ b/context-runtime/src/worker.cc
@@ -266,16 +266,24 @@ void Worker::Run() {
   if (TaskLane *lane = assigned_lane_.load(std::memory_order_acquire)) {
     lane->SetTid(tid);
   }
+  // issue #807: become the consumer of this worker's inbound SHM shard ring, so
+  // a producing client's SignalConsumerIfParked SIGUSR1s THIS worker (its tid is
+  // now published on the ring). Must run after AddSignalEvent, which blocks
+  // SIGUSR1 on this thread — otherwise the wake would kill the process.
+  CLIO_IPC->RegisterShardConsumer(worker_id_);
 
   // Main worker loop - process tasks from assigned lane
   while (is_running_) {
     did_work_ = false;  // Reset work tracker at start of each loop iteration
     task_did_work_ = false;  // Reset task-level work tracker
 
-    // NOTE: the inbound SHM ring is NOT drained here. A dedicated thread
-    // (IpcManager::RecvShmServerThread) owns it and pushes tasks onto worker
-    // lanes, mirroring the ZMQ path's ClientRecvThread. Workers therefore never
-    // touch serialized task bytes and need no knowledge of the transport.
+    // issue #807: drain THIS worker's inbound SHM shard ring (worker w owns
+    // shard w). Deserialize+route runs on the existing workers — oversubscribed
+    // — instead of on dedicated drain threads that would contend for cores. A
+    // no-op for workers that own no shard and for non-SHM runtimes.
+    if (CLIO_IPC->DrainShard(worker_id_) > 0) {
+      did_work_ = true;
+    }
 
     // Process tasks from assigned lane
     // issue #785: re-read every iteration. The monitor thread may have moved
@@ -319,6 +327,10 @@ void Worker::Run() {
       did_work_ = false;
     }
   }
+
+  // issue #807: stop being the shard ring's consumer before this thread's tid
+  // can be recycled by an unrelated thread that does not block SIGUSR1.
+  CLIO_IPC->UnregisterShardConsumer(worker_id_);
 
   // EventManager destructor handles signalfd and epoll cleanup
 }
@@ -650,6 +662,11 @@ void Worker::SuspendMe() {
         return;
       }
     }
+    // issue #807: last-chance check of this worker's inbound SHM shard, so a
+    // request that arrived before we park is not missed.
+    if (!CLIO_IPC->ShardEmpty(worker_id_)) {
+      return;
+    }
 
     // Calculate timeout from periodic tasks, then cap it by max_sleep so a
     // worker NEVER sleeps indefinitely. GetSuspendPeriod() returns -1 when this
@@ -668,8 +685,15 @@ void Worker::SuspendMe() {
                          : std::min(static_cast<int>(suspend_period_us),
                                     static_cast<int>(max_sleep));
 
+    // issue #807: announce to producing clients that we are about to park, so
+    // their SignalConsumerIfParked wakes us. Publish BEFORE the wait; a request
+    // that lands after this still SIGUSR1s us out of the Wait (or the max_sleep
+    // cap re-polls). Cleared immediately on wake so a send during processing
+    // does not waste a signal.
+    CLIO_IPC->SetShardParked(worker_id_, true);
     // Wait for signal using EventManager
     int nfds = event_manager_.Wait(timeout_us);
+    CLIO_IPC->SetShardParked(worker_id_, false);
 
     if (nfds == 0) {
       sleep_count_++;

--- a/context-runtime/src/worker.cc
+++ b/context-runtime/src/worker.cc
@@ -664,7 +664,10 @@ void Worker::SuspendMe() {
     // FUSE thread that must submit it), livelocking the whole pipeline. That
     // is why the embedded-FUSE xfstests (generic/006/007/011/013/089/100/113/
     // 127/286/363/438/471) pass on a 16-core box but hang in CI. Yielding lets
-    // the runnable thread get scheduled so forward progress resumes.
+    // the runnable thread get scheduled so forward progress resumes. (issue
+    // #807: measured a bare tight-spin here at only ~1us over the yield on a
+    // spare-core box — sched_yield is already ~free when a core is idle — so it
+    // is not worth risking the oversubscription livelock the yield prevents.)
     CTP_THREAD_MODEL->Yield();
     return;
   } else {

--- a/context-transport-primitives/include/clio_ctp/search/regex_search_engine.h
+++ b/context-transport-primitives/include/clio_ctp/search/regex_search_engine.h
@@ -73,10 +73,13 @@ namespace ctp::search {
  * Thread-safety: internally synchronized with a shared_mutex — mutators
  * (Insert/Delete/Rename/Clear) take it exclusively, queries (Search/Contains/
  * Find/Size/Empty) take it shared. Search returns a SNAPSHOT of the matching
- * keys (SearchResult::keys()), so callers can iterate keys() safely without
- * external locking. NOTE: the value-yielding SearchResult iterator fetches
- * values live via Find() and is NOT safe against concurrent deletes — use
- * keys() under concurrency.
+ * (key, value) pairs, so a SearchResult — keys() and the value-yielding
+ * iterator alike — is stable under concurrent mutation. A key deleted between
+ * the candidate scan and the value snapshot is simply absent from the result
+ * (the documented "live subset" semantics). The previous design fetched
+ * values lazily via Find() at iteration time; a concurrent Delete then made
+ * the iterator dereference Find()'s nullptr — a NULL TagId read that crashed
+ * the runtime under the #807 CFS stress (readdir's TagQuery racing unlink).
  */
 template <typename ValueT>
 class RegexSearchEngine {
@@ -211,8 +214,9 @@ class RegexSearchEngine {
         return *this;
       }
       reference operator*() const {
-        const std::string &k = r_->keys_[i_];
-        return reference(k, *r_->eng_->Find(k));
+        // Both halves come from the result's own snapshot — no live engine
+        // access, so iteration is safe against concurrent mutation.
+        return reference(r_->keys_[i_], r_->values_[i_]);
       }
 
      private:
@@ -229,10 +233,10 @@ class RegexSearchEngine {
 
    private:
     friend class RegexSearchEngine;
-    SearchResult(std::vector<std::string> keys, const RegexSearchEngine *eng)
-        : keys_(std::move(keys)), eng_(eng) {}
-    std::vector<std::string> keys_;
-    const RegexSearchEngine *eng_;
+    SearchResult(std::vector<std::string> keys, std::vector<ValueT> values)
+        : keys_(std::move(keys)), values_(std::move(values)) {}
+    std::vector<std::string> keys_;   // sorted; aligned with values_
+    std::vector<ValueT> values_;      // snapshot taken under the shared lock
   };
 
   /**
@@ -270,7 +274,8 @@ class RegexSearchEngine {
           auto it = index_.find(t);
           if (it == index_.end()) {
             // Some required trigram indexes no key => no match possible.
-            return SearchResult(std::vector<std::string>(), this);
+            return SearchResult(std::vector<std::string>(),
+                                std::vector<ValueT>());
           }
           if (smallest == nullptr || it->second.size() < smallest->size()) {
             smallest = &it->second;
@@ -296,7 +301,26 @@ class RegexSearchEngine {
     }
 
     std::sort(matches.begin(), matches.end());
-    return SearchResult(std::move(matches), this);
+
+    // Snapshot the values under a brief re-acquired shared lock, AFTER the
+    // (deliberately unlocked, see above) regex pass and the sort, so keys_
+    // and values_ stay aligned. A key deleted since the candidate scan is
+    // dropped from the result here — the "live subset" semantics — instead
+    // of surfacing as a null value at iteration time.
+    std::vector<std::string> keys;
+    std::vector<ValueT> values;
+    keys.reserve(matches.size());
+    values.reserve(matches.size());
+    {
+      std::shared_lock<std::shared_mutex> lk(mtx_);
+      for (auto &k : matches) {
+        auto it = entries_.find(k);
+        if (it == entries_.end()) continue;  // concurrently deleted
+        values.push_back(it->second);
+        keys.push_back(std::move(k));
+      }
+    }
+    return SearchResult(std::move(keys), std::move(values));
   }
 
  private:

--- a/project_shm_transport_scalability.md
+++ b/project_shm_transport_scalability.md
@@ -1,0 +1,222 @@
+# Project: Scalable, Low-Latency SHM Transport (issue #807)
+
+Branch `807-shm-transport-scalability`, based on `origin/dev` @ `f679f31c`.
+
+Follow-up to the SHM transport refactor (branch `debug-delta-transport-deadlock`) that reshaped the
+transport into the ZMQ model — one inbound ring + one outbound ring, each drained by one dedicated
+background thread. That fixed the #768/#774 bidirectional-deadlock class but made the transport
+deliberately single-threaded. This is the deferred second half: keep the deadlock fix, remove the
+serialization.
+
+---
+
+## 1. Where we are (verified current architecture)
+
+The SHM path today, as reshaped by the refactor:
+
+**Inbound (client → runtime):**
+* ONE ring `clio-<pid>-shm-in` (MPSC), created in `ServerInitShm` (`IpcManager::shm_in_server_`).
+* Drained by ONE dedicated `IpcManager::RecvShmServerThread` (`ipc_manager.cc:3098`), which loops
+  `IpcCpu2Cpu::RecvIn(this)` (`ipc_cpu2cpu.cc:14`) — deserialize one task, push onto **lane 0**,
+  `AwakenWorker`. `RuntimeMapTask` then redistributes off lane 0.
+
+**Outbound (runtime → client):**
+* SHM `IpcCpu2Cpu::SendOut` (`ipc_cpu2cpu.cc:92`) runs **INLINE on the executing worker**: it
+  serializes the result and does an MPSC transfer into the client's single `clio-<pid>-shm-out`
+  ring (`conn->Send`). It can block if that ring is full.
+* Contrast the ZMQ path: `IpcCpu2CpuZmq::EnqueueSendOut` (`ipc_cpu2cpu_zmq.cc:229`) enqueues an
+  OWNING future onto `net_queue_` (nonblocking) and a background drainer (`ClientSend` periodic →
+  `IpcCpu2CpuZmq::SendOut`) serializes and sends. **The ZMQ path already does what #807 asks for; the
+  SHM path does not.**
+
+**Client outbound recv:**
+* ONE ring `clio-<pid>-shm-out` per client process (`IpcManager::shm_out_server_`), drained by ONE
+  `RecvShmClientThread` (`ipc_manager.cc:401`) that demuxes by net_key and wakes the waiting thread
+  via `EventManager::Signal`. `RecvOut` blocks on the EventManager.
+
+**The pivotal primitive constraint.** `ShmMpscTransport` is **MPSC**: *"multiple producers … push
+concurrently; a single consumer RecvBytes"* (`shm_mpsc_transport.h:12,18`). One ring cannot be
+drained by two threads. **Therefore parallel draining requires N rings, not N consumers on one ring.**
+`RegisterConsumer()` is liveness tracking (is anyone draining?), not multi-consumer support.
+
+---
+
+## 2. The serialization points (the bottlenecks)
+
+| # | Point | Cost |
+|---|---|---|
+| 1 | Single inbound ring | Every client contends on one MPSC tail atomic |
+| 2 | Single inbound drainer | One core does ALL task deserialization + routing |
+| 3 | Lane-0 ingress funnel | `RecvIn` deposits every task on lane 0 before routing |
+| 4 | Inline blocking `SendOut` | Worker thread pays serialize+transfer; blocks on a full client ring — stalling task processing, the exact thing the design meant to avoid |
+| 5 | Single client out-ring + drainer | A client receiving many concurrent responses is bottlenecked on one ring + one thread |
+
+**Measured impact (mixed 1µs–1s workload, 12 client threads, SHM forced, this box):** Clio's median
+latency for sub-100µs tasks is ~1.2 ms vs ~250 µs for a self-RPC libthallium na+sm baseline — 4.8×
+on median, on a workload where our *scheduler* wins the p99 (25 ms vs 31 ms). Much of the median gap
+is transport overhead, and points 1–5 are where it lives. (Bench: `thallium_variety_bench.cc` on the
+785 branch; reproduce with the same distribution.)
+
+---
+
+## 3. Design — combine the two approaches
+
+Neither "single dedicated drain thread" (deadlock-safe but serial) nor "workers do their own I/O"
+(parallel but deadlock-prone, the pre-refactor model) is right alone. Combine them:
+
+* **Parallel sharded rings** replace each single ring, so producers spread across tails and each
+  ring has its own drainer.
+* **A background drain-thread pool** keeps every ring constantly drained regardless of whether app
+  or worker threads are blocked — this is what preserves the #768 deadlock fix.
+* **Nonblocking rings** — no producer (client submit, or worker response) ever blocks on a full
+  ring; the drainers guarantee forward progress.
+* **Nonblocking `SendOut` + an ordered pending queue** — the worker enqueues a pending response and
+  returns immediately; a background sender drains the queue in order, mirroring `EnqueueSendOut`.
+
+### D1 — Inbound: N sharded in-rings, N drain threads
+
+Replace the single `clio-<pid>-shm-in` with `clio-<pid>-shm-in-<k>` for `k in [0, S)`. Each ring has
+one dedicated drain thread (`RecvShmServerThread(k)`), satisfying MPSC single-consumer per ring.
+
+* **Client → ring assignment**: shard by client `(pid,tid)` hash so a given client thread always
+  targets the same ring (cache locality; preserves per-thread request ordering). Round-robin is the
+  alternative — better balance, no per-thread ordering. See open Q1.
+* **Removes points 1 and 2.** S clients-worth of deserialization now runs on S cores.
+* **Point 3 (lane-0 funnel)**: each drainer can deposit on a *different* ingress lane (e.g. lane
+  `k`) instead of all on lane 0, so `RuntimeMapTask` starts from a spread rather than a funnel.
+  Cheap and worth doing here.
+* **Sharding factor S**: tie to a config knob, default ~= number of I/O workers, capped. Too many
+  drain threads on a small box just steals cores from workers (the #785 lesson).
+
+### D2 — Outbound `SendOut`: nonblocking enqueue + ordered pending queue + sender pool
+
+Make SHM `SendOut` match the ZMQ model instead of running inline:
+
+1. The worker calls `SendOut`, which now **enqueues an OWNING future** (as `EnqueueSendOut` does —
+   the non-owning self-handle hazard at `ipc_cpu2cpu_zmq.cc:229` applies identically) onto a pending
+   SHM-send queue, nonblocking, and returns. The worker never serializes and never touches the
+   client ring.
+2. A **background SHM-sender pool** drains the pending queue: serialize the result, MPSC-transfer
+   into the destination client's out-ring. Processed **in order** per destination.
+3. Task lifetime: the owning future keeps the task alive until the response is transferred; then the
+   pending-queue entry drops. `SetComplete` / `ClearFlags(TASK_DATA_OWNER)` move from the worker to
+   the sender (they currently run at the end of the inline `SendOut`).
+
+**Sharding the send side**: partition the pending queue by destination client so responses to
+different clients proceed in parallel and in-order-per-client. A single global pending queue with a
+pool draining it loses per-destination ordering unless entries are keyed — see open Q2.
+
+**Do NOT reuse the `net_queue_` / `ClientSend`-periodic machinery.** That path runs on a *worker*
+(the net worker), and #785 is removing net-worker roles. The SHM sender must be its own background
+thread pool, independent of the worker pool.
+
+### D3 — Nonblocking rings + the full-ring problem
+
+Producers must never block. Today `conn->Send` into a full out-ring can spin/block on the worker.
+Options, in preference order:
+
+* **(a) Size + constant drain.** With a dedicated drainer per ring always running, a correctly sized
+  ring rarely fills; make `Send` fail-fast (`SHM_MPSC_DONTWAIT`-style) and the *sender thread* (never
+  the worker) retries/backs off. The worker is already decoupled by D2, so back-pressure lands on the
+  sender pool, not on task processing.
+* **(b) Spill list.** On a full ring, the sender parks the entry on an in-process overflow list
+  drained ahead of the ring next tick. Bounds memory to in-flight responses.
+* Never busy-spin a *worker* on a full ring (the #785 monitor-thread lesson: a `WAIT_FOR_SPACE` push
+  from the wrong thread freezes it).
+
+Symmetric on the client's inbound submit: a client submitting into a full in-ring must not block a
+latency-critical app thread indefinitely — fail-fast + brief spin + park, never an unbounded spin.
+
+### D4 — Client outbound: N sharded out-rings, N drain threads (optional, phase 3)
+
+Mirror D1 on the client: `clio-<pid>-shm-out-<k>`, each drained by its own thread, demuxed by
+net_key. Only helps a single client with high response concurrency; lower priority than D1/D2 because
+most latency wins come from the runtime side. Gate on measurement.
+
+---
+
+## 4. Correctness constraints (must not regress)
+
+* **#768/#774 deadlock fix**: every out-ring stays drained by a dedicated thread even when app
+  threads block in submit. Preserved by construction — D1–D4 only *add* drain threads.
+* **net_key demux**: the `client_net_key_` save (`RecvIn`) / restore (`SendOut`) must survive the
+  move of `SendOut` to the sender pool (`ipc_cpu2cpu.cc:55,116`). It is per-task state, so it rides
+  the pending-queue entry — verify it is restored in the sender, not the worker.
+* **`TASK_DATA_OWNER` payload adoption** on the consumed SHM path (the refactor's bug #2:
+  `CleanupResponseArchive` must not blanket-free a CHI-allocated `bulk.data.ptr_`). Untouched here,
+  but the sender now owns the archive lifetime — re-verify.
+* **Per-destination response ordering**: a client that submitted A then B on one thread and awaits
+  both must still observe correct completion; out-of-order *delivery* is fine (net_key demux) but
+  the pending queue must not drop or reorder within a destination in a way that breaks the demux.
+* **Single-consumer per ring**: never point two drain threads at one ring. The sharding is the only
+  parallelism; enforce it (assert `RegisterConsumer` returns exclusive).
+
+---
+
+## 5. Phases
+
+**P0 — Repro + baseline.** Port `thallium_variety_bench` alongside `clio_run_thrpt_bench
+--test-case sched_variety`; capture current SHM median/p99/throughput at 1/4/12/24 client threads on
+this box as the before-number. Add transport counters (per-ring drained counts, pending-queue depth,
+full-ring events). Success metric for the whole issue: **sub-100µs median latency and per-client
+throughput both improve materially with client-thread count**, closing the gap to the thallium
+baseline without regressing the p99 the scheduler already wins.
+
+**P1 — Nonblocking queued `SendOut` (D2 + D3).** Highest value, smallest blast radius, no SHM-layout
+change. Move SHM `SendOut` off the worker to a background sender pool with an ordered per-destination
+pending queue; make the ring push fail-fast on the sender. This alone should cut the median (removes
+point 4, the inline serialize+block on the worker).
+
+**P2 — Sharded inbound rings (D1).** N in-rings + N drain threads + per-ring ingress lane. This is
+the scalability half — measure throughput vs client-thread count before/after. Changes SHM segment
+layout, so it carries the ABI/segment-sizing risk.
+
+**P3 — Sharded client out-rings (D4).** Only if P1/P2 measurements show the client's single out-ring
++ drainer is still a bottleneck at high response concurrency.
+
+Each phase independently benchmarkable against the P0 baseline.
+
+---
+
+## 6. Open questions
+
+1. **Inbound shard key** (D1): hash by `(pid,tid)` (locality + per-thread order) vs round-robin
+   (balance)? Leaning hash, since per-thread request order is the property clients expect.
+2. **Send-side ordering vs sharding** (D2): per-destination pending queues (clean ordering, more
+   queues) vs one global queue with keyed entries drained by a pool (fewer structures, ordering
+   needs care)? Leaning per-destination — ordering is a correctness constraint, not a tuning knob.
+3. **Sharding factor S and thread budget**: how many drain + sender threads before they contend with
+   workers for cores? #785 showed unbounded threads hurt on small boxes. Tie to core count with a
+   cap; measure the knee.
+4. **One pool or two?** Separate inbound-drain and outbound-send thread pools, or a unified transport
+   pool that does both? Separate is simpler to reason about; unified may pack better on small boxes.
+5. **Does the client submit path (SendIn) also need sharding**, or is a client thread's own submit
+   already parallel enough (each thread pushes independently into its shard's ring)? Likely fine
+   once D1 shards the rings; confirm by measurement.
+
+---
+
+## 7. Test / benchmark plan
+
+* **Correctness**: all 4 transport modes still pass; SHM transport-mode integration (real bdev 1MB
+  write+read round-trip); `per_process_shm`; the #768/#774 deadlock repro (bidirectional submit
+  while app threads blocked) must stay green.
+* **Ordering**: a client thread submitting a dependent sequence over SHM observes correct
+  completions under the sharded/queued path.
+* **Scalability**: `sched_variety` + `thallium_variety_bench` at 1/4/12/24 client threads;
+  report median + p99 + throughput per phase; ratios only within a session (this box is ±20%
+  cross-session, per [[clio-vs-thallium-latency]]).
+* **Deadlock-safety**: full in-ring / full out-ring under sustained load must not hang — the
+  fail-fast + drainer path (D3) keeps producers live.
+* **No worker stalls**: with `SendOut` moved off the worker (P1), a full client ring must show up as
+  sender-pool back-pressure, never as a stalled task-processing worker.
+
+---
+
+## 8. Out of scope
+
+* The ZMQ/TCP/IPC transports (already queue their sends via `net_queue_`); this issue is SHM-only,
+  though it should converge the SHM path toward the ZMQ path's shape.
+* Cross-node run2run transport.
+* The #785 net-worker-role removal — related (the SHM sender must NOT depend on a net worker) but a
+  separate change.


### PR DESCRIPTION
Draft. Implements the two mechanisms from #807: **per-destination queued nonblocking SendOut** (D2) and **inbound ring sharding** (D1). Design doc: `project_shm_transport_scalability.md`. Local: per_process_shm 9/9, autogen_coverage 249, comutex 13, wait_functionality 4. Perf: not yet demonstrated on this workload (sched_variety is scheduler-bound); a transport-stress benchmark is next.

Closes #807 when complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)