### PR TITLE
test(cte): don't gate the SHM-cache benchmark on a wall-clock race (#783)

### DIFF
--- a/context-transfer-engine/test/unit/test_core_functionality.cc
+++ b/context-transfer-engine/test/unit/test_core_functionality.cc
@@ -3043,11 +3043,34 @@ TEST_CASE("CTE SHM cache write-then-read cycle benchmark",
        write_us, write_us_last, cycle_shm_meta_us, cycle_rpc_meta_us,
        cycle_shm_data_us, cycle_rpc_data_us, kIters, kSize, sink);
 
-  // The cycle can never beat the write floor, and the SHM variants must not be
-  // slower than the RPC ones. Loose bounds: this is a measurement, not a gate.
+  // Structural sanity: a write+read cycle includes a write, so it cannot take
+  // less than half the write-alone floor. This catches a broken/near-zero
+  // measurement, and holds regardless of runner load.
   REQUIRE(cycle_shm_meta_us >= std::min(write_us, write_us_last) * 0.5);
-  REQUIRE(cycle_shm_meta_us < cycle_rpc_meta_us);
-  REQUIRE(cycle_shm_data_us < cycle_rpc_data_us);
+
+  // SHM is EXPECTED to beat RPC — that is the point of the cache — but this is
+  // a wall-clock comparison of two timing samples, so on a loaded CI runner
+  // the faster path occasionally samples slower and the strict inequality
+  // inverts. This used to be REQUIRE(shm < rpc), which flaked
+  // (cte_functional_all, retry-masked on dev boost/docker). The comment above
+  // it already declared the intent — "a measurement, not a gate" — so the hard
+  // assertion was the bug. Report the comparison and warn if the expectation
+  // is not met, but do not fail the test on sample noise. A genuine
+  // performance regression shows up as a persistent warning across runs, not a
+  // single-sample flake; gate it in a dedicated perf job with repetition and
+  // statistics if it needs gating at all.
+  if (!(cycle_shm_meta_us < cycle_rpc_meta_us)) {
+    HLOG(kWarning,
+         "[#783 WTR] metadata SHM cycle ({} us) did not beat RPC ({} us) this "
+         "run — expected SHM faster; treating as sample noise, not a failure",
+         cycle_shm_meta_us, cycle_rpc_meta_us);
+  }
+  if (!(cycle_shm_data_us < cycle_rpc_data_us)) {
+    HLOG(kWarning,
+         "[#783 WTR] payload SHM cycle ({} us) did not beat RPC ({} us) this "
+         "run — expected SHM faster; treating as sample noise, not a failure",
+         cycle_shm_data_us, cycle_rpc_data_us);
+  }
 }
 
 // Main function using simple_test.h framework


### PR DESCRIPTION
A flake I introduced in #788/#783, found by scanning green `dev` runs for retry-masked failures.

## The flake

The "CTE SHM cache write-then-read cycle benchmark" ended with:

```cpp
// Loose bounds: this is a measurement, not a gate.
REQUIRE(cycle_shm_meta_us < cycle_rpc_meta_us);
REQUIRE(cycle_shm_data_us < cycle_rpc_data_us);
```

A hard pass/fail gate on a strict `<` between two wall-clock samples. SHM is *expected* to beat RPC — that's the cache's purpose — but on a loaded runner the faster path occasionally samples slower and the inequality inverts. **The comment right above already said "a measurement, not a gate" — so the `REQUIRE` contradicted the intent and was the bug.**

## How it was found

It never appeared in a red column. It failed then passed under `--repeat until-pass:3` inside a **green** `boost (docker deps-cpu)` run on `dev` — retry-masked. Surfaced by scanning 81 successful `dev` jobs (7,669 test results) for fail-then-pass sequences; this was the only one.

```
test_core_functionality.cc:3049
Condition: cycle_shm_meta_us < cycle_rpc_meta_us   ***Failed
(retry) Passed
```

## Fix

- Keep the structural sanity floor: a write+read cycle can't take less than half the write-alone floor — load-independent, stays a `REQUIRE`.
- Turn the two relative-timing checks into a **warning-only** report. A genuine perf regression shows as a persistent warning across runs; if it needs gating, that belongs in a dedicated perf job with repetition and statistics, not a single sample in a functional test.

Functional correctness of the SHM path is **still gated** — the `TryGetBlobRecordShm` / `TryReadBlobShm` REQUIREs earlier in the test are untouched. Only the relative-speed assertions are relaxed.

## Verification

Reproduced locally: across 3 runs, **2 sampled SHM slower than RPC** — which the old `REQUIRE` would have failed. Post-fix: **3/3 PASS**, those 2 emitting the "did not beat RPC this run" warning instead of failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)