### PR TITLE
fix(cte): guard the SHM metadata cache Create() from the CUDA device pass (#783)

### DIFF
--- a/context-transfer-engine/core/include/clio_cte/core/shm_metadata_cache.h
+++ b/context-transfer-engine/core/include/clio_cte/core/shm_metadata_cache.h
@@ -264,6 +264,19 @@ class ShmMetadataCache {
    */
   bool Create(size_t tag_capacity, size_t blob_capacity,
               const clio::run::PoolId &owner_pool) {
+#if !CTP_IS_HOST
+    // The metadata cache lives in the runtime's host-side segment and is
+    // constructed by the runtime. GetMetadataAllocator()/GetMetadataDirectory()
+    // are host-only IpcManager members, absent in the device (nvcc) pass — so
+    // this body does not compile there. Device code never owns or builds the
+    // cache; report "caching off", which callers already treat as a valid,
+    // non-error state (see the docstring above). Without this guard the whole
+    // header failed the CUDA build (GPU Tests workflow).
+    (void)tag_capacity;
+    (void)blob_capacity;
+    (void)owner_pool;
+    return false;
+#else
     auto *ipc = CLIO_IPC;
     if (ipc == nullptr) {
       return false;
@@ -309,6 +322,7 @@ class ShmMetadataCache {
       alloc_ = nullptr;
       return false;
     }
+#endif  // CTP_IS_HOST
   }
 
   bool IsEnabled() const { return root_ != nullptr && alloc_ != nullptr; }


### PR DESCRIPTION
A CUDA build break I introduced in #788, now red on every `dev` GPU run. Found by enumerating **all** workflow failure rates — GPU Tests (CUDA) was at 10% (4/4 recent, all `dev`, all Jul 22 after #788 merged), a workflow the CPU-focused CI never exercises.

## The break

`ShmMetadataCache::Create()` calls host-only IpcManager members — `GetMetadataAllocator()`, `GetMetadataDirectory()` — but the header is compiled in nvcc's **device pass** too, where those are guarded out (`CTP_IS_HOST == 0`):

```
shm_metadata_cache.h(271): error: class ... has no member GetMetadataAllocator
shm_metadata_cache.h(302): error: ... GetMetadataDirectory
```

It didn't show on CPU CI or in local CUDA-off builds — which is exactly why #788 landed with it.

## The fix

The metadata cache is host/runtime-owned; device code never builds it. Guard `Create()`'s body with `#if !CTP_IS_HOST → return false` ("caching off" on device), which callers already treat as a valid non-error state per the method's own docstring. Only `Create()` touches `CLIO_IPC`; every other method operates on already-resolved `root_`/`alloc_` pointers and compiles fine for device — so this is the whole fix.

## Verification — real device compile, not reasoning

`nvcc` is available locally (release 12.6). Isolated the header in a device pass:

| | errors in `shm_metadata_cache.h` |
|---|---|
| **without fix** | 3 — `GetMetadataAllocator`, `GetMetadataDirectory` (matches CI) |
| **with fix** | **0** |

CPU build (`clio_cte_core_runtime`) unaffected. The full CUDA conda build is confirmed by the GPU Tests workflow itself, which I can't run locally.

## Note

This is the last of the regressions #788 introduced that were invisible to the CPU CI it was tested against — alongside #805 (heap-overflow, caught by ASan) and #811 (benchmark timing flake, caught by retry-masked scan). All three were surfaced by looking at CI signal the pass/fail column didn't show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)