### PR TITLE
ci(gpu): run the CUDA compile-check on PRs, not only after merge

### DIFF
--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -3,7 +3,7 @@ name: GPU Tests (CUDA)
 on:
   push:
     branches: [main, dev]
-    paths:
+    paths: &gpu_paths
       - 'context-runtime/**'
       - 'context-transfer-engine/**'
       - 'context-transport-primitives/**'
@@ -11,7 +11,24 @@ on:
       - 'CMakePresets.json'
       - 'installers/conda/**'
       - '.github/workflows/gpu-tests.yml'
+  # Also run on PRs touching the same paths. Previously this workflow fired
+  # ONLY on push to main/dev, so a change that broke the CUDA device compile
+  # was invisible in PR review and only surfaced after merge, on dev — which
+  # is exactly how the shm_metadata_cache.h device-pass break (#812, from
+  # #788) landed. Running the same compile-only build on PRs catches these
+  # before merge. Same path filter, so PRs that don't touch buildable source
+  # still skip it.
+  pull_request:
+    branches: [main, dev]
+    paths: *gpu_paths
   workflow_dispatch:
+
+# One in-flight run per ref; a new push to a PR branch cancels the previous
+# GPU build rather than piling them up (the CUDA toolchain install + conda
+# build is ~15 min).
+concurrency:
+  group: gpu-tests-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-cuda-conda:


### PR DESCRIPTION
Closes the CI blind spot that let a dev-breaking GPU regression through review.

## The gap

`GPU Tests (CUDA)` triggered **only on push to `main`/`dev`** — never on pull requests. So a change that breaks the CUDA device compile is invisible during PR review and only surfaces *after* merge, on `dev`.

That's exactly how the `shm_metadata_cache.h` device-pass break got in:
- #788 called host-only IpcManager members (`GetMetadataAllocator`) in a header nvcc compiles for the **device** pass
- #788's PR CI never ran GPU, so review saw green
- the break appeared on `dev` only post-merge (now fixed by #812)

Right now, `dev`'s GPU job is red from that break, and it's the **only** failing thing across all of CI.

## The fix

Add a `pull_request` trigger with the **same path filter**, so any PR touching buildable source runs the same compile-only CUDA build and catches this class of break before merge. PRs that don't touch those paths still skip it (via the shared YAML anchor).

Plus a `concurrency` guard (`cancel-in-progress` per ref) — the CUDA toolchain install + conda build is ~15 min, so a new push to a PR branch cancels the previous GPU run instead of queuing another.

**No change to what the job builds — only when it runs.**

## Why this reduces flakes

Every GPU-breaking change currently lands on `dev` before anyone sees it, then shows as red on the branch until fixed. Validating on PRs moves that detection left, so `dev` stays green and PR authors get the signal directly. It's the structural counterpart to #812 (which fixes the specific break): #812 stops the bleeding, this stops the next one.

## Tradeoff for reviewers

This adds a ~15-min CUDA build to PRs that touch `context-*`/CMake/conda paths. That's real CI cost. The alternative — GPU validated only post-merge — is what just let a regression through. The path filter and concurrency guard keep the cost bounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)