### PR TITLE
ci(macos): pin ar/ranlib to Xcode, not conda's llvm-tools (#797)

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -61,8 +61,24 @@ jobs:
           export CMAKE_PREFIX_PATH="${CONDA_PREFIX}${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}"
           export PKG_CONFIG_PATH="${CONDA_PREFIX}/lib/pkgconfig:${CONDA_PREFIX}/share/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
 
+          # Pin ar/ranlib to the Xcode toolchain, NOT conda's llvm-tools (#797).
+          # The conda env puts llvm-ranlib on PATH; CMake's toolchain detection
+          # picks it up, but it is invoked from the conda *package cache*
+          # (~/miniconda3/pkgs/llvm-tools-.../bin/llvm-ranlib), where its sibling
+          # libLLVM.*.dylib does not exist — so archiving a static lib dies with
+          #   dyld: Library not loaded: @rpath/libLLVM.22.1.dylib
+          # intermittently (flakes boost + build-test macOS jobs; hit PR #764).
+          # The system ar/ranlib have no such dependency and are correct here:
+          # this project builds no LTO/bitcode archives (verified: no
+          # INTERPROCEDURAL_OPTIMIZATION / -flto anywhere), so plain Mach-O
+          # archiving is all that is needed.
+          AR_BIN="$(xcrun -f ar 2>/dev/null || echo /usr/bin/ar)"
+          RANLIB_BIN="$(xcrun -f ranlib 2>/dev/null || echo /usr/bin/ranlib)"
+
           # SITE/BUILDNAME label the CDash build (cnd = conda deps, d = debug).
           cmake --preset=debug \
+            -DCMAKE_AR="${AR_BIN}" \
+            -DCMAKE_RANLIB="${RANLIB_BIN}" \
             -DSITE="${{ matrix.os }}" \
             -DBUILDNAME="cnd/d" \
             -DCLIO_CORE_ENABLE_COVERAGE=OFF \
@@ -160,7 +176,13 @@ jobs:
             eval "$(conda shell.bash hook)"
           fi
           conda activate iowarp
-          cmake --preset boost
+          # Pin ar/ranlib to Xcode's, not conda's llvm-tools — see the
+          # "Configure and build" step above and #797.
+          AR_BIN="$(xcrun -f ar 2>/dev/null || echo /usr/bin/ar)"
+          RANLIB_BIN="$(xcrun -f ranlib 2>/dev/null || echo /usr/bin/ranlib)"
+          cmake --preset boost \
+            -DCMAKE_AR="${AR_BIN}" \
+            -DCMAKE_RANLIB="${RANLIB_BIN}"
           cmake --build build-boost -j"$(sysctl -n hw.ncpu)"
           # #619's fallback-runtime punting has no macOS support yet (#634);
           # those cases are excluded until it lands.

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -61,17 +61,15 @@ jobs:
           export CMAKE_PREFIX_PATH="${CONDA_PREFIX}${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}"
           export PKG_CONFIG_PATH="${CONDA_PREFIX}/lib/pkgconfig:${CONDA_PREFIX}/share/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
 
-          # Pin ar/ranlib to the Xcode toolchain, NOT conda's llvm-tools (#797).
-          # The conda env puts llvm-ranlib on PATH; CMake's toolchain detection
-          # picks it up, but it is invoked from the conda *package cache*
-          # (~/miniconda3/pkgs/llvm-tools-.../bin/llvm-ranlib), where its sibling
-          # libLLVM.*.dylib does not exist — so archiving a static lib dies with
-          #   dyld: Library not loaded: @rpath/libLLVM.22.1.dylib
-          # intermittently (flakes boost + build-test macOS jobs; hit PR #764).
-          # The system ar/ranlib have no such dependency and are correct here:
-          # this project builds no LTO/bitcode archives (verified: no
-          # INTERPROCEDURAL_OPTIMIZATION / -flto anywhere), so plain Mach-O
-          # archiving is all that is needed.
+          # Pin ar/ranlib to the Xcode toolchain, not conda's llvm-tools
+          # (issue #797 has the full rationale). Short version: CMake otherwise
+          # detects conda's llvm-ranlib from the package cache, which cannot
+          # load its own runtime dylib and aborts static-lib archiving
+          # intermittently. System ar/ranlib have no such dependency and are
+          # correct here (this project builds no LTO/bitcode archives). NOTE:
+          # keep this comment free of the literal dyld-error string — the step
+          # runs under `set -x`, so any such line is echoed into every macOS
+          # build log and reads like a live failure.
           AR_BIN="$(xcrun -f ar 2>/dev/null || echo /usr/bin/ar)"
           RANLIB_BIN="$(xcrun -f ranlib 2>/dev/null || echo /usr/bin/ranlib)"
 


### PR DESCRIPTION
Fixes #797 — the macOS conda-ranlib flake, currently red on PR #764.

## Symptom

macOS builds intermittently die while archiving a static library:

```
dyld: Library not loaded: @rpath/libLLVM.22.1.dylib
  Referenced from: ~/miniconda3/pkgs/llvm-tools-22-.../bin/llvm-ranlib-22
  Reason: tried '.../bin/../lib/libLLVM.22.1.dylib' (no such file)
Error running link command: Subprocess aborted
```

## Cause

The conda env puts `llvm-ranlib` on PATH; CMake's toolchain detection picks it up. But it resolves to the conda **package cache** copy (`pkgs/llvm-tools-.../bin/`), whose sibling `libLLVM.*.dylib` lives in a *different* package directory and isn't on `@rpath` there — so `ranlib` aborts. Non-deterministic, on both the debug and boost macOS builds.

## Fix

Pin `CMAKE_AR` / `CMAKE_RANLIB` to the Xcode toolchain (`xcrun -f ar` / `xcrun -f ranlib`, `/usr/bin` fallback) in both macOS configure steps. The system tools have no libLLVM dependency.

**Why it's safe:** this project builds no LTO / LLVM-bitcode archives — verified, no `INTERPROCEDURAL_OPTIMIZATION` or `-flto` anywhere in CMakeLists/cmake/presets — so plain Mach-O archiving via Apple's `ranlib` is all that's needed. This also **sidesteps the open symlink-vs-hardlink question** from #797: the system tool is used regardless of how conda linked llvm-ranlib into the env.

Scoped to `ci-macos.yml` only — no effect on Linux/Windows.

## Validation

I can't run macOS locally, but **this PR's own macOS CI runs the exact jobs that were flaking** (`boost (macos-*)`, `build-test (macos-*)`) — so its green/red result validates the fix directly, the same way #813 validated the GPU trigger. Watch the macOS checks on this PR.

## Context

This was the last flake still reddening open PRs that wasn't already fixed or fix-ready (per the current-PR-failure audit on #797). The others: GPU break → #812, Windows link-lock → #801 (on dev), conda 403 → #806 (on dev).

🤖 Generated with [Claude Code](https://claude.com/claude-code)