### PR TITLE
Make the main segment size configurable, auto-size from the memory budget

### DIFF
--- a/context-runtime/include/clio_runtime/config_manager.h
+++ b/context-runtime/include/clio_runtime/config_manager.h
@@ -203,9 +203,9 @@ class ConfigManager : public ctp::BaseConfig {
   /**
    * Size of the main task-data segment (issue #727).
    * @return The explicit size when main_segment_size_ > 0 (yaml
-   *         `runtime: main_segment_size` or CLIO_MAIN_SEGMENT_SIZE), or 0
-   *         meaning "auto" — the creation site (IpcManager::ServerInitShm)
-   *         then sizes it from the process's cgroup-aware memory budget.
+   *         `runtime: main_segment_size` or CLIO_MAIN_SEGMENT_SIZE), else the
+   *         auto default: a quarter of the process's cgroup-aware memory
+   *         budget, capped at 1 GiB and floored at 64 MiB. Never 0.
    */
   size_t CalculateMainSegmentSize() const;
 

--- a/context-runtime/include/clio_runtime/config_manager.h
+++ b/context-runtime/include/clio_runtime/config_manager.h
@@ -201,8 +201,11 @@ class ConfigManager : public ctp::BaseConfig {
   u32 GetQueueDepth() const { return queue_depth_; }
 
   /**
-   * Calculate main segment size based on queue_depth and num_threads
-   * @return Calculated size in bytes, or explicit size if main_segment_size_ > 0
+   * Size of the main task-data segment (issue #727).
+   * @return The explicit size when main_segment_size_ > 0 (yaml
+   *         `runtime: main_segment_size` or CLIO_MAIN_SEGMENT_SIZE), or 0
+   *         meaning "auto" — the creation site (IpcManager::ServerInitShm)
+   *         then sizes it from the process's cgroup-aware memory budget.
    */
   size_t CalculateMainSegmentSize() const;
 
@@ -397,15 +400,19 @@ class ConfigManager : public ctp::BaseConfig {
    */
   void ParseYAML(YAML::Node& yaml_conf) override;
 
+ public:
   /**
    * Apply environment-variable overrides (CLIO_PORT, CLIO_SERVER_ADDR, etc.).
    * Must run after every (re)load: LoadFromFile resets to defaults via
    * LoadDefault, so a config reload (e.g. parsing a compose file into this
    * manager) would otherwise silently drop the env-configured port — which on
-   * the force-net path retargets every forward at the wrong port.
+   * the force-net path retargets every forward at the wrong port. Public so
+   * external reloaders (and tests) can restore env semantics after a bare
+   * LoadYaml.
    */
   void ApplyEnvOverrides();
 
+ private:
   bool is_initialized_ = false;
   std::string config_file_path_;
 
@@ -423,7 +430,10 @@ class ConfigManager : public ctp::BaseConfig {
   u32 shm_client_spin_us_ = 50;  // issue #807/#784: waiter spin before park
   u32 queue_depth_ = 1024;
 
-  size_t main_segment_size_ = ctp::Unit<size_t>::Gigabytes(1);
+  // issue #727: 0 = auto (sized from the memory budget at segment creation).
+  // Settable via yaml `runtime: main_segment_size` or CLIO_MAIN_SEGMENT_SIZE;
+  // LoadDefault() also installs 0, this initializer just matches it.
+  size_t main_segment_size_ = 0;
   size_t client_data_segment_size_ = ctp::Unit<size_t>::Megabytes(256);
   // issue #783: metadata segment. Deliberately huge and never pre-faulted --
   // shm_open + ftruncate + mmap is lazily populated, so the 8 GB reservation

--- a/context-runtime/src/config_manager.cc
+++ b/context-runtime/src/config_manager.cc
@@ -38,6 +38,8 @@
 #include "clio_runtime/config_manager.h"
 #include "clio_runtime/task.h"
 #include "clio_runtime/ipc_manager.h"
+#include <clio_ctp/introspect/system_info.h>
+#include <algorithm>
 #include <cctype>
 #include <cstdlib>
 #include <filesystem>
@@ -614,12 +616,22 @@ size_t ConfigManager::CalculateMainSegmentSize() const {
   }
 
   // 0 = auto. The main segment holds task data (FutureShm, BuddyAllocator
-  // metadata); the actual size is decided at the creation site
-  // (IpcManager::ServerInitShm), which knows the process's real memory
-  // budget — cgroup-aware, not host RAM (issue #727). Returning the sentinel
-  // instead of a flat 1 GiB keeps this config-layer function free of
-  // platform introspection.
-  return 0;
+  // metadata). Size it from the process's real memory budget — cgroup-aware,
+  // not host RAM (issue #727): a quarter of the budget, capped at the
+  // historical 1 GiB so real nodes see no change, floored at 64 MiB so
+  // task/FutureShm traffic keeps flowing on tiny budgets. When the budget is
+  // unknown, keep the historical flat default.
+  //
+  // Resolved here rather than at the creation site so that every reader of
+  // this value — GetMemorySegmentSize(kMainSegment) included — sees the size
+  // the segment will actually get, never a bare sentinel.
+  const size_t budget = ctp::SystemInfo::GetProcessMemoryBudget();
+  size_t auto_size = ctp::Unit<size_t>::Gigabytes(1);
+  if (budget > 0) {
+    auto_size = std::min(auto_size,
+                         std::max(ctp::Unit<size_t>::Megabytes(64), budget / 4));
+  }
+  return auto_size;
 }
 
 size_t ConfigManager::CalculateMetadataSegmentSize() const {

--- a/context-runtime/src/config_manager.cc
+++ b/context-runtime/src/config_manager.cc
@@ -63,15 +63,8 @@ namespace {
  * a config file should not take the runtime down, and the recognised suffixes
  * are checked here first.
  */
-bool ParseSegmentSizeNode(const YAML::Node &node, const char *key,
+bool ParseSegmentSizeText(const std::string &text, const char *key,
                           size_t &out) {
-  std::string text;
-  try {
-    text = node.as<std::string>();
-  } catch (const std::exception &) {
-    HLOG(kError, "Config: {} is not a scalar value; ignoring", key);
-    return false;
-  }
   if (text.empty()) {
     HLOG(kError, "Config: {} is empty; ignoring", key);
     return false;
@@ -120,6 +113,19 @@ bool ParseSegmentSizeNode(const YAML::Node &node, const char *key,
       (!suffix.empty() && suffix[0] == 'b') ? text.substr(0, i) : text;
   out = static_cast<size_t>(ctp::ConfigParse::ParseSize(for_parse));
   return true;
+}
+
+/** YAML wrapper over ParseSegmentSizeText — same semantics for config keys. */
+bool ParseSegmentSizeNode(const YAML::Node &node, const char *key,
+                          size_t &out) {
+  std::string text;
+  try {
+    text = node.as<std::string>();
+  } catch (const std::exception &) {
+    HLOG(kError, "Config: {} is not a scalar value; ignoring", key);
+    return false;
+  }
+  return ParseSegmentSizeText(text, key, out);
 }
 
 }  // namespace
@@ -212,6 +218,17 @@ void ConfigManager::ApplyEnvOverrides() {
     unsigned long n = std::strtoul(env, &end, 10);
     if (end != env) {
       shm_client_spin_us_ = static_cast<u32>(n);
+    }
+  }
+
+  // issue #727: CLIO_MAIN_SEGMENT_SIZE bounds the main task-data segment
+  // (byte count or size string, e.g. "512m"). Last word after any config
+  // file, so a deployment can cap the daemon's footprint without editing
+  // yaml; 0 restores the auto default.
+  if (const char *env = clio::run::env::GetCompat("MAIN_SEGMENT_SIZE")) {
+    size_t parsed = 0;
+    if (ParseSegmentSizeText(env, "CLIO_MAIN_SEGMENT_SIZE", parsed)) {
+      main_segment_size_ = parsed;
     }
   }
 }
@@ -435,6 +452,21 @@ void ConfigManager::ParseYAML(YAML::Node &yaml_conf) {
       }
     }
 
+    // Size of the main task-data segment (issue #727): FutureShm + task
+    // payload allocations (BuddyAllocator). Accepts a byte count or a size
+    // string ("512m", "1g"); 0 restores the auto default. Tunable because
+    // this segment dominates the daemon's commit charge on Windows and the
+    // shmem live-set exposure in memory-limited containers regardless of
+    // actual data volume — the previous flat 1 GiB could be several times
+    // an embedded deployment's whole budget.
+    if (runtime["main_segment_size"]) {
+      size_t parsed = 0;
+      if (ParseSegmentSizeNode(runtime["main_segment_size"],
+                               "main_segment_size", parsed)) {
+        main_segment_size_ = parsed;
+      }
+    }
+
     // Note: stack_size parameter removed (was never used)
     // Note: heartbeat_interval parsing removed (not used by runtime)
   }
@@ -576,14 +608,18 @@ void ConfigManager::ParseYAML(YAML::Node &yaml_conf) {
 }
 
 size_t ConfigManager::CalculateMainSegmentSize() const {
-  // If main_segment_size is explicitly set (non-zero), use it
+  // Explicit (yaml main_segment_size / CLIO_MAIN_SEGMENT_SIZE) wins verbatim.
   if (main_segment_size_ > 0) {
     return main_segment_size_;
   }
 
-  // Main segment holds task data (FutureShm, BuddyAllocator metadata) — no queues
-  // Use 1 GB default for task/data allocations
-  return ctp::Unit<size_t>::Gigabytes(1);
+  // 0 = auto. The main segment holds task data (FutureShm, BuddyAllocator
+  // metadata); the actual size is decided at the creation site
+  // (IpcManager::ServerInitShm), which knows the process's real memory
+  // budget — cgroup-aware, not host RAM (issue #727). Returning the sentinel
+  // instead of a flat 1 GiB keeps this config-layer function free of
+  // platform introspection.
+  return 0;
 }
 
 size_t ConfigManager::CalculateMetadataSegmentSize() const {

--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -837,57 +837,6 @@ ctp::lbm::ShmMpscTransport *IpcManager::GetOrCreateShmConn(
 }
 
 /**
- * Memory limit imposed on this process by its cgroup, or 0 when unlimited or
- * unreadable (cgroup v2 first, then v1).
- *
- * Needed because SystemInfo::GetRamCapacity() reports the HOST's physical
- * memory even inside a container -- sizing a shared-memory reservation off
- * that number over-commits badly in CI images and constrained deployments.
- */
-static size_t ReadCgroupMemoryLimit() {
-#ifdef __linux__
-  const char *paths[] = {"/sys/fs/cgroup/memory.max",
-                         "/sys/fs/cgroup/memory/memory.limit_in_bytes"};
-  for (const char *path : paths) {
-    std::ifstream f(path);
-    if (!f.is_open()) {
-      continue;
-    }
-    std::string v;
-    if (!(f >> v)) {
-      continue;
-    }
-    if (v == "max") {
-      return 0;  // explicitly unlimited
-    }
-    try {
-      unsigned long long n = std::stoull(v);
-      // cgroup v1 reports a sentinel near SIZE_MAX when unlimited.
-      if (n > 0 && n < (1ULL << 62)) {
-        return static_cast<size_t>(n);
-      }
-    } catch (...) {
-    }
-  }
-#endif
-  return 0;
-}
-
-/**
- * The memory this process may actually use: the cgroup limit when running in
- * a container, physical RAM otherwise; 0 when neither is known. The shared
- * basis for sizing/clamping the shm segments (issues #783, #727).
- */
-static size_t ProcessMemoryBudget() {
-  size_t budget = ctp::SystemInfo::GetRamCapacity();
-  size_t cgroup_limit = ReadCgroupMemoryLimit();
-  if (cgroup_limit > 0 && (budget == 0 || cgroup_limit < budget)) {
-    budget = cgroup_limit;
-  }
-  return budget;
-}
-
-/**
  * Keep a large shared mapping out of core dumps (Linux MADV_DONTDUMP).
  *
  * The runtime shuts down via std::abort() (admin_runtime.cc), so every clean
@@ -934,29 +883,22 @@ bool IpcManager::ServerInitShm() {
     std::string main_segment_name =
         config->GetSharedMemorySegmentName(kMainSegment);
 
-    // Explicit main_segment_size (yaml / CLIO_MAIN_SEGMENT_SIZE) or 0 = auto
-    // (issue #727). On Linux the segment is a sparse memfd, so the exposure is
-    // not the reservation but the LIVE SET in memory-limited containers — and
-    // on Windows the whole size is commit charge up front. The old flat 1 GiB
-    // default could be several times a small deployment's entire budget.
+    // Main segment size (issue #727): yaml `runtime: main_segment_size` /
+    // CLIO_MAIN_SEGMENT_SIZE when set, otherwise the budget-aware auto default
+    // CalculateMainSegmentSize() resolves. On Linux the segment is a sparse
+    // memfd, so the exposure is not the reservation but the LIVE SET in
+    // memory-limited containers — and on Windows the whole size is commit
+    // charge up front. The old flat 1 GiB default could be several times a
+    // small deployment's entire budget.
     //
-    // Auto: a quarter of the budget, capped at the historical 1 GiB (real
-    // nodes see no change) and floored at 64 MiB (enough task/FutureShm
-    // headroom to keep traffic flowing). Explicit values are respected up to
-    // the same half-budget guard the metadata segment uses — beyond that the
-    // live set can only end in SIGBUS/OOM, so clamp loudly instead of booting
-    // a time bomb.
+    // Explicit values are respected up to the same half-budget guard the
+    // metadata segment uses — beyond that the live set can only end in
+    // SIGBUS/OOM, so clamp loudly instead of booting a time bomb. The auto
+    // default is already a quarter of the budget, so it never trips this.
     size_t main_segment_size = config->CalculateMainSegmentSize();
     {
-      const size_t budget = ProcessMemoryBudget();
-      if (main_segment_size == 0) {
-        main_segment_size = ctp::Unit<size_t>::Gigabytes(1);
-        if (budget > 0) {
-          main_segment_size =
-              std::min(main_segment_size,
-                       std::max(ctp::Unit<size_t>::Megabytes(64), budget / 4));
-        }
-      } else if (budget > 0 && main_segment_size > budget / 2) {
+      const size_t budget = ctp::SystemInfo::GetProcessMemoryBudget();
+      if (budget > 0 && main_segment_size > budget / 2) {
         HLOG(kWarning,
              "Main segment: requested {} bytes exceeds half the memory "
              "budget ({} bytes); clamping to {} bytes",
@@ -1036,7 +978,7 @@ bool IpcManager::ServerInitShm() {
     // RAM keeps the default a no-op on real nodes while protecting small
     // dev boxes and constrained containers.
     {
-      size_t budget = ProcessMemoryBudget();
+      size_t budget = ctp::SystemInfo::GetProcessMemoryBudget();
       if (budget > 0 && metadata_segment_size > budget / 2) {
         size_t clamped = budget / 2;
         HLOG(kWarning,

--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -874,6 +874,20 @@ static size_t ReadCgroupMemoryLimit() {
 }
 
 /**
+ * The memory this process may actually use: the cgroup limit when running in
+ * a container, physical RAM otherwise; 0 when neither is known. The shared
+ * basis for sizing/clamping the shm segments (issues #783, #727).
+ */
+static size_t ProcessMemoryBudget() {
+  size_t budget = ctp::SystemInfo::GetRamCapacity();
+  size_t cgroup_limit = ReadCgroupMemoryLimit();
+  if (cgroup_limit > 0 && (budget == 0 || cgroup_limit < budget)) {
+    budget = cgroup_limit;
+  }
+  return budget;
+}
+
+/**
  * Keep a large shared mapping out of core dumps (Linux MADV_DONTDUMP).
  *
  * The runtime shuts down via std::abort() (admin_runtime.cc), so every clean
@@ -920,8 +934,36 @@ bool IpcManager::ServerInitShm() {
     std::string main_segment_name =
         config->GetSharedMemorySegmentName(kMainSegment);
 
-    // Use calculated or explicit main_segment_size
+    // Explicit main_segment_size (yaml / CLIO_MAIN_SEGMENT_SIZE) or 0 = auto
+    // (issue #727). On Linux the segment is a sparse memfd, so the exposure is
+    // not the reservation but the LIVE SET in memory-limited containers — and
+    // on Windows the whole size is commit charge up front. The old flat 1 GiB
+    // default could be several times a small deployment's entire budget.
+    //
+    // Auto: a quarter of the budget, capped at the historical 1 GiB (real
+    // nodes see no change) and floored at 64 MiB (enough task/FutureShm
+    // headroom to keep traffic flowing). Explicit values are respected up to
+    // the same half-budget guard the metadata segment uses — beyond that the
+    // live set can only end in SIGBUS/OOM, so clamp loudly instead of booting
+    // a time bomb.
     size_t main_segment_size = config->CalculateMainSegmentSize();
+    {
+      const size_t budget = ProcessMemoryBudget();
+      if (main_segment_size == 0) {
+        main_segment_size = ctp::Unit<size_t>::Gigabytes(1);
+        if (budget > 0) {
+          main_segment_size =
+              std::min(main_segment_size,
+                       std::max(ctp::Unit<size_t>::Megabytes(64), budget / 4));
+        }
+      } else if (budget > 0 && main_segment_size > budget / 2) {
+        HLOG(kWarning,
+             "Main segment: requested {} bytes exceeds half the memory "
+             "budget ({} bytes); clamping to {} bytes",
+             main_segment_size, budget, budget / 2);
+        main_segment_size = budget / 2;
+      }
+    }
 
     HLOG(kInfo, "Initializing main shared memory segment: {} bytes ({} MB)",
          main_segment_size, main_segment_size / (1024 * 1024));
@@ -994,17 +1036,13 @@ bool IpcManager::ServerInitShm() {
     // RAM keeps the default a no-op on real nodes while protecting small
     // dev boxes and constrained containers.
     {
-      size_t budget = ctp::SystemInfo::GetRamCapacity();
-      size_t cgroup_limit = ReadCgroupMemoryLimit();
-      if (cgroup_limit > 0 && (budget == 0 || cgroup_limit < budget)) {
-        budget = cgroup_limit;
-      }
+      size_t budget = ProcessMemoryBudget();
       if (budget > 0 && metadata_segment_size > budget / 2) {
         size_t clamped = budget / 2;
         HLOG(kWarning,
              "Metadata segment: requested {} bytes exceeds half the memory "
-             "budget ({} bytes; cgroup_limit={}); clamping to {} bytes",
-             metadata_segment_size, budget, cgroup_limit, clamped);
+             "budget ({} bytes); clamping to {} bytes",
+             metadata_segment_size, budget, clamped);
         metadata_segment_size = clamped;
       }
     }

--- a/context-runtime/test/unit/internals/test_ipc_manager_internals.cc
+++ b/context-runtime/test/unit/internals/test_ipc_manager_internals.cc
@@ -13,6 +13,7 @@
 
 #include "simple_test.h"
 
+#include <algorithm>
 #include <cstdio>
 #include <filesystem>
 #include <fstream>
@@ -274,13 +275,28 @@ TEST_CASE("IpcInternals - main segment size is configurable (issue #727)",
   REQUIRE(config->CalculateMainSegmentSize() ==
           ctp::Unit<size_t>::Megabytes(128));
 
-  SECTION("0 selects the auto default (sized at segment creation)");
+  // The auto default: a quarter of the process's memory budget, capped at the
+  // historical 1 GiB and floored at 64 MiB (1 GiB flat when the budget is
+  // unknown). Recomputed here rather than hardcoded so the expectation holds
+  // on tiny CI containers as well as real nodes.
+  const size_t budget = ctp::SystemInfo::GetProcessMemoryBudget();
+  size_t expect_auto = ctp::Unit<size_t>::Gigabytes(1);
+  if (budget > 0) {
+    expect_auto = std::min(
+        expect_auto, std::max(ctp::Unit<size_t>::Megabytes(64), budget / 4));
+  }
+
+  SECTION("0 selects the auto default");
   {
     std::ofstream f(cfg);
     f << "runtime:\n  main_segment_size: 0\n";
   }
   REQUIRE(config->LoadYaml(cfg.string()));
-  REQUIRE(config->CalculateMainSegmentSize() == 0);
+  REQUIRE(config->CalculateMainSegmentSize() == expect_auto);
+  // Whatever the budget, the auto default must be a usable segment — callers
+  // (GetMemorySegmentSize included) never see a 0 sentinel.
+  REQUIRE(config->CalculateMainSegmentSize() >=
+          ctp::Unit<size_t>::Megabytes(64));
 
   SECTION("an unparseable value keeps the default instead of dying");
   {
@@ -288,7 +304,7 @@ TEST_CASE("IpcInternals - main segment size is configurable (issue #727)",
     f << "runtime:\n  main_segment_size: \"lots\"\n";
   }
   REQUIRE(config->LoadYaml(cfg.string()));
-  REQUIRE(config->CalculateMainSegmentSize() == 0);
+  REQUIRE(config->CalculateMainSegmentSize() == expect_auto);
 
   SECTION("CLIO_MAIN_SEGMENT_SIZE env wins over yaml");
   {

--- a/context-runtime/test/unit/internals/test_ipc_manager_internals.cc
+++ b/context-runtime/test/unit/internals/test_ipc_manager_internals.cc
@@ -248,4 +248,68 @@ TEST_CASE("IpcInternals - ConfigManager yaml sections and env overrides",
   fs::remove(empty_cfg);
 }
 
+TEST_CASE("IpcInternals - main segment size is configurable (issue #727)",
+          "[ipc][config]") {
+  EnsureInitialized();
+  auto *config = CLIO_CONFIG_MANAGER;
+  REQUIRE(config != nullptr);
+
+  fs::path cfg = fs::temp_directory_path() / "clio_test_mainseg_cfg.yaml";
+
+  SECTION("yaml size string is honored verbatim");
+  {
+    std::ofstream f(cfg);
+    f << "runtime:\n  main_segment_size: \"256m\"\n";
+  }
+  REQUIRE(config->LoadYaml(cfg.string()));
+  REQUIRE(config->CalculateMainSegmentSize() ==
+          ctp::Unit<size_t>::Megabytes(256));
+
+  SECTION("bare byte count is honored");
+  {
+    std::ofstream f(cfg);
+    f << "runtime:\n  main_segment_size: 134217728\n";
+  }
+  REQUIRE(config->LoadYaml(cfg.string()));
+  REQUIRE(config->CalculateMainSegmentSize() ==
+          ctp::Unit<size_t>::Megabytes(128));
+
+  SECTION("0 selects the auto default (sized at segment creation)");
+  {
+    std::ofstream f(cfg);
+    f << "runtime:\n  main_segment_size: 0\n";
+  }
+  REQUIRE(config->LoadYaml(cfg.string()));
+  REQUIRE(config->CalculateMainSegmentSize() == 0);
+
+  SECTION("an unparseable value keeps the default instead of dying");
+  {
+    std::ofstream f(cfg);
+    f << "runtime:\n  main_segment_size: \"lots\"\n";
+  }
+  REQUIRE(config->LoadYaml(cfg.string()));
+  REQUIRE(config->CalculateMainSegmentSize() == 0);
+
+  SECTION("CLIO_MAIN_SEGMENT_SIZE env wins over yaml");
+  {
+    std::ofstream f(cfg);
+    f << "runtime:\n  main_segment_size: \"256m\"\n";
+  }
+  ctp::SystemInfo::Setenv("CLIO_MAIN_SEGMENT_SIZE", "128m", 1);
+  REQUIRE(config->LoadYaml(cfg.string()));
+  config->ApplyEnvOverrides();
+  ctp::SystemInfo::Unsetenv("CLIO_MAIN_SEGMENT_SIZE");
+  REQUIRE(config->CalculateMainSegmentSize() ==
+          ctp::Unit<size_t>::Megabytes(128));
+
+  // Restore default-ish config for any later singleton users (LoadYaml
+  // resets to defaults first, so omitting the key restores auto).
+  {
+    std::ofstream f(cfg);
+    f << "runtime:\n  num_threads: 2\n";
+  }
+  (void)config->LoadYaml(cfg.string());
+  fs::remove(cfg);
+}
+
 SIMPLE_TEST_MAIN()

--- a/context-transport-primitives/include/clio_ctp/introspect/system_info.h
+++ b/context-transport-primitives/include/clio_ctp/introspect/system_info.h
@@ -188,6 +188,18 @@ class SystemInfo {
 
   CTP_DLL static size_t GetRamAvailable();
 
+  /**
+   * The memory this process may actually use: the cgroup limit when running
+   * in a container, physical RAM otherwise; 0 when neither is known.
+   *
+   * GetRamCapacity() reports the HOST's physical memory even inside a
+   * container, so sizing a shared-memory reservation off that number
+   * over-commits badly in CI images and constrained deployments. This is the
+   * shared basis for sizing/clamping the runtime's shm segments (issues #783,
+   * #727).
+   */
+  CTP_DLL static size_t GetProcessMemoryBudget();
+
   CTP_DLL static CpuTimes GetCpuTimes();
 
   static float ComputeCpuUtilization(const CpuTimes &prev,

--- a/context-transport-primitives/src/system_info.cc
+++ b/context-transport-primitives/src/system_info.cc
@@ -406,6 +406,48 @@ size_t SystemInfo::GetRamAvailable() {
 #endif
 }
 
+/**
+ * Memory limit imposed on this process by its cgroup, or 0 when unlimited or
+ * unreadable (cgroup v2 first, then v1).
+ */
+static size_t ReadCgroupMemoryLimit() {
+#ifdef __linux__
+  const char *paths[] = {"/sys/fs/cgroup/memory.max",
+                         "/sys/fs/cgroup/memory/memory.limit_in_bytes"};
+  for (const char *path : paths) {
+    std::ifstream f(path);
+    if (!f.is_open()) {
+      continue;
+    }
+    std::string v;
+    if (!(f >> v)) {
+      continue;
+    }
+    if (v == "max") {
+      return 0;  // explicitly unlimited
+    }
+    try {
+      unsigned long long n = std::stoull(v);
+      // cgroup v1 reports a sentinel near SIZE_MAX when unlimited.
+      if (n > 0 && n < (1ULL << 62)) {
+        return static_cast<size_t>(n);
+      }
+    } catch (...) {
+    }
+  }
+#endif
+  return 0;
+}
+
+size_t SystemInfo::GetProcessMemoryBudget() {
+  size_t budget = GetRamCapacity();
+  size_t cgroup_limit = ReadCgroupMemoryLimit();
+  if (cgroup_limit > 0 && (budget == 0 || cgroup_limit < budget)) {
+    budget = cgroup_limit;
+  }
+  return budget;
+}
+
 CpuTimes SystemInfo::GetCpuTimes() {
   CpuTimes ct = {};
 #if CTP_ENABLE_PROCFS_SYSINFO


### PR DESCRIPTION
## Summary
- New yaml key `runtime: main_segment_size` (byte count or size string, e.g. `"512m"`) and env override `CLIO_MAIN_SEGMENT_SIZE`, mirroring `metadata_segment_size`; `0` keeps the auto default
- The auto default is now budget-aware instead of a flat 1 GiB: a quarter of the process's memory budget (cgroup limit when containerized, physical RAM otherwise — shared `ProcessMemoryBudget()` helper, deduped from the metadata clamp), capped at the historical 1 GiB so real nodes see no change, floored at 64 MiB
- Explicit values are clamped loudly at half the budget, the same guard the metadata segment already had — an over-budget live set only ever ends in SIGBUS or the OOM killer

## Motivation
Fixes #727. The main task-data segment was hardcoded at 1 GiB with no config or env path. On Linux it is a sparse memfd (not `/dev/shm`, so the mount size never mattered), but the live set still counts against a container's cgroup limit — and on Windows the whole reservation is commit charge up front (~1.18 GiB committed under any write load regardless of data volume, measured in iowarp/clio-agent#893), several times an embedded deployment's entire budget.

## Test plan
- [x] New regression test passes: `ctest -R cr_ipc_internals` (`clio_run_ipc_internals_tests` 7/7 — size string, bare bytes, 0-auto, unparseable-keeps-default, env-wins-over-yaml)
- [x] End-to-end: daemon boots with 1 GiB by default on a large-budget box (unchanged behavior) and with 256 MB under `CLIO_MAIN_SEGMENT_SIZE=256m`; `cr_cli_cfs_parallel_stress` workload passes 100% both ways
- [x] No new compiler warnings; cpplint clean

## Breaking changes
None. Default behavior is unchanged on hosts whose memory budget is ≥ 4 GiB; smaller-budget containers get a proportionally smaller segment instead of an over-committed one. `ConfigManager::ApplyEnvOverrides()` is now public (was private) so external reloaders can restore env semantics after a bare `LoadYaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
