### PR TITLE
Vectored PutBlob/GetBlob + worker task batching + bdev fragmentation (#820)

### DIFF
--- a/context-runtime/include/clio_runtime/batch_groups.h
+++ b/context-runtime/include/clio_runtime/batch_groups.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * BSD 3-Clause License. See LICENSE file.
+ */
+
+#ifndef CLIO_RUNTIME_INCLUDE_BATCH_GROUPS_H_
+#define CLIO_RUNTIME_INCLUDE_BATCH_GROUPS_H_
+
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+#include "clio_runtime/task.h"
+#include "clio_runtime/types.h"
+
+namespace clio::run {
+
+/**
+ * Worker-local task batching (issue #820).
+ *
+ * A worker collects a bounded run of ready tasks and lets each task's container
+ * COALESCE them before any executes: N independent tasks collapse into a
+ * minimal set of merged tasks, each completing the parents it subsumed.
+ *
+ * This is deliberately NOT the ManyToOne collective in BatchManager. That one
+ * reduces N combinable inputs to a single aggregate and broadcasts one result
+ * back to every member (all members see the same OUT). Here the output is a
+ * *subset* of tasks, and each merged task completes a DIFFERENT set of parents.
+ * Reduction vs. merge.
+ *
+ * The motivating case: the filesystem stores each 1 MiB page as one blob, so a
+ * sequential 4 KiB workload sends 256 tasks at one page-blob. Each must take
+ * that blob's #680 write token across its whole body, so they drain single-file
+ * (measured: max ~1 s stalls). Coalescing them into one vectored PutBlob makes
+ * it one token acquire and one bdev pass.
+ */
+
+/** Identity of a batch group. `key` is opaque to the worker: the container
+ *  chooses it (e.g. a hash of tag id + blob name, so one group == one blob). */
+struct BatchKey {
+  PoolId pool_id;
+  u32 method;
+  u64 key;
+
+  bool operator==(const BatchKey &o) const {
+    return pool_id == o.pool_id && method == o.method && key == o.key;
+  }
+};
+
+struct BatchKeyHash {
+  size_t operator()(const BatchKey &k) const {
+    size_t h = std::hash<u64>()(
+        (static_cast<u64>(k.pool_id.major_) << 32) | k.pool_id.minor_);
+    h ^= std::hash<u32>()(k.method) + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
+    h ^= std::hash<u64>()(k.key) + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
+    return h;
+  }
+};
+
+/** One member parked in a group, with the arrival order that decides how
+ *  overlapping work is resolved when the group is merged. Submission order is
+ *  the only thing that makes "last writer wins" meaningful, so the worker
+ *  stamps it at BuildBatch time rather than letting the container guess. */
+struct BatchMember {
+  clio::run::shared_ptr<Task> task;
+  u64 seq = 0;
+};
+
+/** Tasks parked by BuildBatch, keyed by whatever the container chose. Owned by
+ *  the worker and reused across phases (cleared, not reallocated). */
+using BatchGroups =
+    std::unordered_map<BatchKey, std::vector<BatchMember>, BatchKeyHash>;
+
+/**
+ * How SmashBatch hands a merged task back to the worker.
+ *
+ * `Emit` takes ownership of `merged` and the list of parents it completes. When
+ * `merged` finishes, the worker copies its return code to each parent and
+ * completes it (local future signal or remote SendOut), which is the same
+ * fan-out BatchManager::OnAggregateComplete performs for the collective path.
+ *
+ * A merged task whose parents' outputs are already satisfied by the merged task
+ * itself -- e.g. a vectored GetBlob that read directly into each parent's own
+ * buffer -- needs no per-parent payload copy, which is exactly why the vectored
+ * task shape (part A) exists.
+ */
+class BatchSink {
+ public:
+  virtual ~BatchSink() = default;
+
+  /** Submit a NEW synthetic task that completes `parents` when it finishes.
+   *  `merged` must be a freshly built task (e.g. from NewCopyTask), never one
+   *  of the parked originals — Emit reassigns its task id, which would strand
+   *  the client future already bound to an original's id. */
+  virtual void Emit(const clio::run::shared_ptr<Task> &merged,
+                    std::vector<clio::run::shared_ptr<Task>> &&parents) = 0;
+
+  /** Run a parked ORIGINAL task unchanged, exactly as it would have run had it
+   *  never been offered for batching. This is the right answer whenever merging
+   *  is not worth it or not possible — a group of one, or a failed merge —
+   *  because the task already carries its client's future and must keep it. */
+  virtual void Passthrough(const clio::run::shared_ptr<Task> &task) = 0;
+};
+
+}  // namespace clio::run
+
+#endif  // CLIO_RUNTIME_INCLUDE_BATCH_GROUPS_H_

--- a/context-runtime/include/clio_runtime/container.h
+++ b/context-runtime/include/clio_runtime/container.h
@@ -42,6 +42,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "clio_runtime/batch_groups.h"
 #include "clio_runtime/config_manager.h"
 #include "clio_runtime/corwlock.h"
 #include "clio_runtime/pool_query.h"
@@ -574,6 +575,47 @@ class Container {
     (void)method;
     (void)agg_task;
     (void)member_task;
+  }
+
+  // ---- issue #820: worker-local task batching ----------------------------
+  //
+  // A worker may collect a bounded run of ready tasks and give a container the
+  // chance to COALESCE them before any of them executes: N independent tasks
+  // become a minimal set of merged tasks, each completing the parents it
+  // subsumed. This is not the ManyToOne collective in BatchManager (which
+  // reduces N inputs to 1 and broadcasts one result back); here the output is
+  // a *subset* of tasks and each carries a different parent set.
+  //
+  // Both hooks default to "not batchable" / "nothing to do", so a container
+  // that does not opt in behaves exactly as before.
+
+  /**
+   * Offer `task` to this container's batching policy.
+   *
+   * Return true to take ownership: the task has been parked in `groups` under
+   * whatever key the container chose, and the worker will NOT execute it now.
+   * Return false to decline, and the worker runs it as-is.
+   *
+   * @param method   the task's method id
+   * @param task     the candidate (already routed ExecHere, so it is local)
+   * @param groups   the worker's per-key parking area, reused across phases
+   */
+  virtual bool BuildBatch(u32 method, const clio::run::shared_ptr<Task> &task,
+                          BatchGroups &groups) {
+    (void)method;
+    (void)task;
+    (void)groups;
+    return false;
+  }
+
+  /**
+   * Collapse everything parked in `groups` into merged tasks and hand each to
+   * `sink`, naming the parent tasks it completes. Called once per phase after
+   * all BuildBatch offers. The container must leave `groups` empty.
+   */
+  virtual void SmashBatch(BatchGroups &groups, BatchSink &sink) {
+    (void)groups;
+    (void)sink;
   }
 
   // NOTE: There is no DelTask virtual. Tasks are clio::run::shared_ptr handles

--- a/context-runtime/include/clio_runtime/types.h
+++ b/context-runtime/include/clio_runtime/types.h
@@ -499,6 +499,16 @@ struct AddressHash {
   BIT_OPT(clio::run::u32, 8)  ///< ManyToOne: this is the synthetic aggregate task the
                         ///< neighborhood leader runs for a batch. On completion,
                         ///< its OUT is broadcast to the batched original tasks.
+#define TASK_BATCH_MERGED \
+  BIT_OPT(clio::run::u32, 10)  ///< issue #820: synthetic task a container's
+                        ///< SmashBatch produced by coalescing several ready
+                        ///< tasks. On completion the worker completes the
+                        ///< PARENTS it subsumed. Distinct from
+                        ///< TASK_BATCH_AGGREGATE: that one is the ManyToOne
+                        ///< collective (N inputs reduced to 1, one OUT
+                        ///< broadcast back to all); this is a merge, where the
+                        ///< output is a subset of tasks and each completes a
+                        ///< different parent set.
 #define TASK_EXTERNAL_CLIENT \
   BIT_OPT(clio::run::u32, 9)  ///< Task ingressed from an external user client (set in
                         ///< the IpcCpu2Cpu / IpcCpu2CpuZmq client-receive paths,

--- a/context-runtime/include/clio_runtime/worker.h
+++ b/context-runtime/include/clio_runtime/worker.h
@@ -576,9 +576,10 @@ class Worker {
   clio::run::shared_ptr<Task> RouteOnly(Future<Task> &future, TaskLane *lane);
 
   /**
-   * issue #820: the batching phase.
+   * issue #820: the batching phase, over the SHM INGRESS.
    *
-   * Dequeue a bounded run of ready tasks, and give each one's container the
+   * Take a bounded run of freshly arrived client requests, and give each one's
+   * container the
    * chance to COALESCE it with its neighbours instead of running it now. Tasks
    * the container declines run as-is, in arrival order, first; the merged tasks
    * the container produces are submitted after.
@@ -591,7 +592,7 @@ class Worker {
    *
    * @return number of tasks dequeued
    */
-  u32 BatchPhase(TaskLane *lane);
+  u32 BatchIngest(TaskLane *lane, u32 budget);
 
   /** issue #820: whether the batching phase runs at all (CLIO_TASK_BATCHING=0
    *  restores the pre-batching dequeue loop verbatim). */

--- a/context-runtime/include/clio_runtime/worker.h
+++ b/context-runtime/include/clio_runtime/worker.h
@@ -753,13 +753,14 @@ class Worker {
   // A plain vector, not a queue: this is produced and consumed by THIS worker
   // thread within one phase, so there is no handoff to synchronize.
   std::vector<clio::run::shared_ptr<Task>> batch_passthrough_;
-  // merged task uid -> the parent tasks it completes. Only touched by this
-  // worker (the merged task is submitted Local and runs here), but EndTask can
-  // be reached from the monitor's rescue path, so it is mutex-guarded like
-  // BatchManager::pending_.
-  std::mutex batch_pending_mu_;
-  std::unordered_map<u64, std::vector<clio::run::shared_ptr<Task>>>
-      batch_pending_;
+  // issue #820/#822: the "merged uid -> parent tasks" registry is PROCESS-GLOBAL
+  // (see worker.cc BatchPendingRegistry), NOT a per-worker member. A merged task
+  // is an I/O task: it suspends on the bdev put/get and its continuation resumes
+  // on WHATEVER worker the scheduler picks, which is frequently not the worker
+  // that emitted it. A per-worker map made the completing worker miss the entry
+  // and orphan the parents (client Wait() hangs forever). The global registry
+  // also uses a global-unique key because CreateTaskId().unique_ is only unique
+  // within one worker thread (thread-local counter), so two workers collide.
 
   // Worker spawn time
   ctp::Timepoint spawn_time_;  // Time when worker was spawned

--- a/context-runtime/include/clio_runtime/worker.h
+++ b/context-runtime/include/clio_runtime/worker.h
@@ -594,6 +594,13 @@ class Worker {
    */
   u32 BatchIngest(TaskLane *lane, u32 budget);
 
+  /** issue #820: same phase, sourced from the LANE (where same-blob tasks
+   *  converge). Experimental, CLIO_BATCH_LANE=1. */
+  u32 BatchLane(TaskLane *lane, u32 budget);
+
+  /** Shared body: collect from the lane or the shard, batch, execute. */
+  u32 BatchCollect(TaskLane *lane, u32 budget, bool from_lane);
+
   /** issue #820: whether the batching phase runs at all (CLIO_TASK_BATCHING=0
    *  restores the pre-batching dequeue loop verbatim). */
   static bool BatchingEnabled();

--- a/context-runtime/include/clio_runtime/worker.h
+++ b/context-runtime/include/clio_runtime/worker.h
@@ -45,8 +45,10 @@
 #include <mutex>
 #include <queue>
 #include <thread>
+#include <unordered_map>
 #include <vector>
 
+#include "clio_runtime/batch_groups.h"
 #include "clio_runtime/container.h"
 #include "clio_runtime/pool_query.h"
 #include "clio_runtime/task.h"
@@ -568,6 +570,37 @@ class Worker {
    *  subtask wakeups (the popped lane, or this worker's own lane on ingest). */
   void RouteAndExec(Future<Task> &future, TaskLane *lane);
 
+  /** issue #807/#820: bind + route only. Returns the resolved task when it
+   *  should run HERE (so the caller may batch it before executing), null
+   *  otherwise (RouteTask already enqueued it elsewhere). */
+  clio::run::shared_ptr<Task> RouteOnly(Future<Task> &future, TaskLane *lane);
+
+  /**
+   * issue #820: the batching phase.
+   *
+   * Dequeue a bounded run of ready tasks, and give each one's container the
+   * chance to COALESCE it with its neighbours instead of running it now. Tasks
+   * the container declines run as-is, in arrival order, first; the merged tasks
+   * the container produces are submitted after.
+   *
+   * The dequeue bound is what keeps this honest: it can only ever batch what is
+   * ALREADY queued, so a lone task finds an empty lane behind it, forms a group
+   * of one, and is emitted unchanged. Batching therefore costs nothing when
+   * there is no backlog to amortize, and only engages under the contention it
+   * exists to remove.
+   *
+   * @return number of tasks dequeued
+   */
+  u32 BatchPhase(TaskLane *lane);
+
+  /** issue #820: whether the batching phase runs at all (CLIO_TASK_BATCHING=0
+   *  restores the pre-batching dequeue loop verbatim). */
+  static bool BatchingEnabled();
+
+  /** issue #820: complete the parents a merged task subsumed. Called from
+   *  EndTask when the finished task carries TASK_BATCH_MERGED. */
+  void CompleteBatchParents(clio::run::shared_ptr<Task> &merged);
+
   /** issue #807: drain this worker's inbound SHM shard, executing each request
    *  INLINE (no lane round-trip, no per-request wakeup). Returns count handled. */
   u32 DrainMyShard();
@@ -703,6 +736,22 @@ class Worker {
   static constexpr u32 NUM_PERIODIC_QUEUES = 4;
   static constexpr u32 PERIODIC_QUEUE_SIZE = 1024;
   std::queue<clio::run::shared_ptr<Task>> periodic_queues_[NUM_PERIODIC_QUEUES];
+
+  // ---- issue #820: worker-local task batching ----------------------------
+  // Reused across phases (cleared, never reallocated) so the batching path
+  // allocates nothing in steady state.
+  BatchGroups batch_groups_;
+  // Tasks their container declined to batch; they run as-is, in arrival order.
+  // A plain vector, not a queue: this is produced and consumed by THIS worker
+  // thread within one phase, so there is no handoff to synchronize.
+  std::vector<clio::run::shared_ptr<Task>> batch_passthrough_;
+  // merged task uid -> the parent tasks it completes. Only touched by this
+  // worker (the merged task is submitted Local and runs here), but EndTask can
+  // be reached from the monitor's rescue path, so it is mutex-guarded like
+  // BatchManager::pending_.
+  std::mutex batch_pending_mu_;
+  std::unordered_map<u64, std::vector<clio::run::shared_ptr<Task>>>
+      batch_pending_;
 
   // Worker spawn time
   ctp::Timepoint spawn_time_;  // Time when worker was spawned

--- a/context-runtime/modules/bdev/include/clio_runtime/bdev/transports/block_allocator.h
+++ b/context-runtime/modules/bdev/include/clio_runtime/bdev/transports/block_allocator.h
@@ -39,6 +39,12 @@ class WorkerBlockMap {
   WorkerBlockMap();
 
   bool AllocateBlock(int block_type, Block& block, size_t min_size = 0);
+  /** Pull ANY freed block whose size_ is <= max_bytes (largest first), for
+   *  fragmentation reuse (issue #820). Unlike AllocateBlock, which finds a
+   *  block >= a size in one category, this scans every bucket for a block that
+   *  FITS what is left -- a freed 8 KiB block bucketed under 16 KiB is exactly
+   *  the case the >= match could never reach. */
+  bool AllocateAnyUpTo(size_t max_bytes, Block& block);
   void FreeBlock(Block block);
 
  private:
@@ -54,6 +60,9 @@ class GlobalBlockMap {
 
   void Init(size_t num_workers);
   bool AllocateBlock(int worker, size_t io_size, Block& block);
+  /** @copydoc WorkerBlockMap::AllocateAnyUpTo -- searches this worker's map
+   *  first, then steals from the others. */
+  bool AllocateAnyUpTo(int worker, size_t max_bytes, Block& block);
   bool FreeBlock(int worker, Block& block);
 
   /** Map an I/O size to its block-size category, or -1 if larger than all. */

--- a/context-runtime/modules/bdev/src/transports/block_allocator.cc
+++ b/context-runtime/modules/bdev/src/transports/block_allocator.cc
@@ -182,6 +182,7 @@ bool StandardBlockAllocator::AllocateBlocks(size_t size, int worker_id, std::vec
     return true;
   }
 
+  // 1. Reuse a single free extent that already fits (the common case).
   Block block;
   if (global_block_map_.AllocateBlock(worker_id, total_size, block)) {
     blocks.push_back(block);
@@ -189,93 +190,62 @@ bool StandardBlockAllocator::AllocateBlocks(size_t size, int worker_id, std::vec
     return true;
   }
 
-  // No single free extent fits. FRAGMENT the request across several smaller
-  // free-list blocks before touching the heap (issue #820).
-  //
-  // The free list is bucketed by size category, so a request only ever probes
-  // its own category: a 1 MiB ask never sees freed 64 KB blocks. Under churn
-  // the free pool is mostly sub-request-size extents, so a large contiguous
-  // ask can never be reused and the bump-only heap watermark climbs to the tier
-  // capacity -> write EIO. This used to be worked around in the CTE
-  // (ExtendBlob capped every block at 64 KB), but fragmentation avoidance is
-  // the allocator's job, not the caller's: the blocks_ vector already carries
-  // multi-block extents transparently, so a large logical allocation backed by
-  // several reused physical blocks is invisible above this layer.
-  //
-  // Pull freed blocks that FIT the remainder, of whatever size the free list
-  // actually holds -- a freed 8 KiB block bucketed under 16 KiB, which the
-  // single-block >= match above can never reach.
-  //
-  // Accounting is in PHYSICAL bytes (AlignSize(size_) -- the footprint the
-  // block actually occupies). Each reused block is reported at its full
-  // footprint and covers that many bytes of the request, so a big ask consumes
-  // one slab per slab of need -- NOT one slab per (possibly sub-slab) freed
-  // logical size, which would over-consume space and exhaust the tier. The
-  // caller distributes the logical request across these physical blocks.
-  clio::run::u64 remaining_phys = AlignSize(total_size);
-  const int kCats = static_cast<int>(BlockSizeCategory::kMaxCategories);
-  Block fb;
-  while (remaining_phys > 0 &&
-         global_block_map_.AllocateAnyUpTo(worker_id, remaining_phys, fb)) {
-    clio::run::u64 fp = AlignSize(fb.size_);        // true footprint
-    if (fp > remaining_phys) fp = remaining_phys;   // last partial block
-    fb.size_ = fp;                                  // report the footprint
-    blocks.push_back(fb);
-    allocated_bytes_.fetch_add(fp, std::memory_order_relaxed);
-    remaining_phys -= fp;
-  }
-
-  if (remaining_phys == 0) {
-    return true;  // fully satisfied from reused space -- no heap growth
-  }
-  if (!blocks.empty()) {
-    // Partially reused; cover the tail from the heap. Roll back everything on
-    // failure so the caller sees all-or-nothing (it frees `blocks` only on a
-    // true return).
-    int tail_type = GlobalBlockMap::FindBlockType(remaining_phys);
-    if (tail_type == -1) tail_type = kCats - 1;
-    Block tail;
-    if (heap_.Allocate(remaining_phys, tail_type, tail)) {
-      tail.size_ = remaining_phys;
-      blocks.push_back(tail);
-      allocated_bytes_.fetch_add(remaining_phys, std::memory_order_relaxed);
-      return true;
-    }
-    for (auto &b : blocks) {
-      global_block_map_.FreeBlock(worker_id, b);  // return to the free list
-      allocated_bytes_.fetch_sub(AlignSize(b.size_), std::memory_order_relaxed);
-    }
-    blocks.clear();
-    return false;
-  }
-
+  // 2. Take one contiguous block from the heap. This is tried BEFORE
+  //    fragmenting so that a request the heap can satisfy stays a SINGLE
+  //    block -- fragmenting a request the heap could serve cleanly only
+  //    scatters it for no benefit (and broke callers that assume one
+  //    allocation is one block, e.g. bdev_file_vs_ram_comparison).
   clio::run::u64 aligned_total_size = AlignSize(total_size);
-  // Classify the fresh allocation by its size category so callers (and the
-  // free list it returns to) see the correct block_type_. Previously this
-  // hardcoded the largest category, so e.g. a 4KB allocation came back tagged
-  // as 1MB (block_type_ != 0).
-  int block_type = GlobalBlockMap::FindBlockType(aligned_total_size);
-  if (block_type == -1) {
-    block_type = static_cast<int>(BlockSizeCategory::kMaxCategories) - 1;
+  int whole_type = GlobalBlockMap::FindBlockType(aligned_total_size);
+  if (whole_type == -1) {
+    whole_type = static_cast<int>(BlockSizeCategory::kMaxCategories) - 1;
   }
-  if (heap_.Allocate(aligned_total_size, block_type, block)) {
-    // block.size_ stays the caller's requested size — that is what the
-    // caller reads and writes, and what it hands back to FreeBlocks.
-    block.size_ = total_size;
+  if (heap_.Allocate(aligned_total_size, whole_type, block)) {
+    block.size_ = total_size;  // logical size the caller reads/writes
     blocks.push_back(block);
-    // Charge the ALIGNED size, not the raw request. The heap advanced by
-    // aligned_total_size, and FreeBlocks credits AlignSize(block.size_),
-    // which is the same aligned value. Charging total_size here made every
-    // first allocation of a non-4096-multiple block credit more on free
-    // than it charged, so allocated_bytes_ drifted downward by
-    // (AlignSize(size) - size) per block and GetRemainingSize() reported
-    // progressively more free space than the target actually had. The
-    // `std::min` clamp in FreeBlocks hid it by silently absorbing the
-    // difference rather than underflowing. See #798.
+    // Charge the ALIGNED size (the heap advanced by it, and FreeBlocks credits
+    // AlignSize(size_) -- keeping the two in step; see #798).
     allocated_bytes_.fetch_add(aligned_total_size, std::memory_order_relaxed);
     return true;
   }
 
+  // 3. LAST RESORT: the heap cannot give a contiguous block (the tier is at or
+  //    near capacity). ASSEMBLE the request from several smaller freed extents
+  //    (issue #820). Without this, the free list is bucketed by size category
+  //    -- a 1 MiB ask never sees freed 64 KiB blocks -- so a large ask can
+  //    never reuse a fragmented pool and the bump-only heap climbs to capacity
+  //    -> write EIO (xfstests 074/521/522). This is the allocator's job, not
+  //    the CTE's (which used to cap every block at 64 KiB to dodge it); the
+  //    blocks_ vector carries multi-block extents transparently.
+  //
+  //    Accounting is in PHYSICAL footprint bytes (AlignSize(size_)): each
+  //    reused block is reported at its footprint and covers that many bytes, so
+  //    a big ask consumes one slab per slab of need, not one slab per (possibly
+  //    sub-slab) freed logical size. The caller distributes the logical request
+  //    across these physical blocks.
+  clio::run::u64 remaining_phys = aligned_total_size;
+  Block fb;
+  while (remaining_phys > 0 &&
+         global_block_map_.AllocateAnyUpTo(worker_id, remaining_phys, fb)) {
+    clio::run::u64 fp = AlignSize(fb.size_);       // true footprint
+    if (fp > remaining_phys) fp = remaining_phys;  // last partial block
+    fb.size_ = fp;                                 // report the footprint
+    blocks.push_back(fb);
+    allocated_bytes_.fetch_add(fp, std::memory_order_relaxed);
+    remaining_phys -= fp;
+  }
+  if (remaining_phys == 0) {
+    return true;  // satisfied entirely from reused space
+  }
+
+  // Freed extents did not cover it and the heap is full: genuinely out of
+  // space. Roll everything back so the caller sees all-or-nothing (it frees
+  // `blocks` only on a true return).
+  for (auto &b : blocks) {
+    global_block_map_.FreeBlock(worker_id, b);
+    allocated_bytes_.fetch_sub(AlignSize(b.size_), std::memory_order_relaxed);
+  }
+  blocks.clear();
   return false;
 }
 

--- a/context-runtime/modules/bdev/src/transports/block_allocator.cc
+++ b/context-runtime/modules/bdev/src/transports/block_allocator.cc
@@ -43,6 +43,29 @@ bool WorkerBlockMap::AllocateBlock(int block_type, Block &block, size_t min_size
   return false;
 }
 
+bool WorkerBlockMap::AllocateAnyUpTo(size_t max_bytes, Block &block) {
+  // Largest category first so a big request drains few large freed extents
+  // rather than many tiny ones. Match on the block's PHYSICAL FOOTPRINT (its
+  // 4 KiB-aligned size, which is what it actually occupies), not its logical
+  // size_ -- taking a block whose footprint exceeds the remainder would occupy
+  // more space than is charged for it. Alignment is 4 KiB everywhere in this
+  // allocator (the block-size categories and the heap slab are all 4 KiB
+  // multiples), so it is safe to compute here without the allocator's field.
+  for (int bt = static_cast<int>(BlockSizeCategory::kMaxCategories) - 1; bt >= 0;
+       --bt) {
+    auto &list = blocks_[bt];
+    for (auto it = list.begin(); it != list.end(); ++it) {
+      clio::run::u64 footprint = ((it->size_ + 4095) / 4096) * 4096;
+      if (it->size_ > 0 && footprint <= max_bytes) {
+        block = *it;
+        list.erase(it);
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 void WorkerBlockMap::FreeBlock(Block block) {
   int block_type = static_cast<int>(block.block_type_);
   if (block_type >= 0 &&
@@ -88,6 +111,26 @@ bool GlobalBlockMap::AllocateBlock(int worker, size_t io_size, Block &block) {
     }
   }
 
+  return false;
+}
+
+bool GlobalBlockMap::AllocateAnyUpTo(int worker, size_t max_bytes,
+                                     Block &block) {
+  if (worker_maps_.empty()) return false;
+  size_t worker_idx = static_cast<size_t>(worker) % worker_maps_.size();
+  {
+    clio::run::ScopedCoMutex lock(worker_locks_[worker_idx]);
+    if (worker_maps_[worker_idx].AllocateAnyUpTo(max_bytes, block)) {
+      return true;
+    }
+  }
+  for (size_t i = 1; i < worker_maps_.size(); ++i) {
+    size_t other = (worker_idx + i) % worker_maps_.size();
+    clio::run::ScopedCoMutex lock(worker_locks_[other]);
+    if (worker_maps_[other].AllocateAnyUpTo(max_bytes, block)) {
+      return true;
+    }
+  }
   return false;
 }
 
@@ -144,6 +187,66 @@ bool StandardBlockAllocator::AllocateBlocks(size_t size, int worker_id, std::vec
     blocks.push_back(block);
     allocated_bytes_.fetch_add(block.size_, std::memory_order_relaxed);
     return true;
+  }
+
+  // No single free extent fits. FRAGMENT the request across several smaller
+  // free-list blocks before touching the heap (issue #820).
+  //
+  // The free list is bucketed by size category, so a request only ever probes
+  // its own category: a 1 MiB ask never sees freed 64 KB blocks. Under churn
+  // the free pool is mostly sub-request-size extents, so a large contiguous
+  // ask can never be reused and the bump-only heap watermark climbs to the tier
+  // capacity -> write EIO. This used to be worked around in the CTE
+  // (ExtendBlob capped every block at 64 KB), but fragmentation avoidance is
+  // the allocator's job, not the caller's: the blocks_ vector already carries
+  // multi-block extents transparently, so a large logical allocation backed by
+  // several reused physical blocks is invisible above this layer.
+  //
+  // Pull freed blocks that FIT the remainder, of whatever size the free list
+  // actually holds -- a freed 8 KiB block bucketed under 16 KiB, which the
+  // single-block >= match above can never reach.
+  //
+  // Accounting is in PHYSICAL bytes (AlignSize(size_) -- the footprint the
+  // block actually occupies). Each reused block is reported at its full
+  // footprint and covers that many bytes of the request, so a big ask consumes
+  // one slab per slab of need -- NOT one slab per (possibly sub-slab) freed
+  // logical size, which would over-consume space and exhaust the tier. The
+  // caller distributes the logical request across these physical blocks.
+  clio::run::u64 remaining_phys = AlignSize(total_size);
+  const int kCats = static_cast<int>(BlockSizeCategory::kMaxCategories);
+  Block fb;
+  while (remaining_phys > 0 &&
+         global_block_map_.AllocateAnyUpTo(worker_id, remaining_phys, fb)) {
+    clio::run::u64 fp = AlignSize(fb.size_);        // true footprint
+    if (fp > remaining_phys) fp = remaining_phys;   // last partial block
+    fb.size_ = fp;                                  // report the footprint
+    blocks.push_back(fb);
+    allocated_bytes_.fetch_add(fp, std::memory_order_relaxed);
+    remaining_phys -= fp;
+  }
+
+  if (remaining_phys == 0) {
+    return true;  // fully satisfied from reused space -- no heap growth
+  }
+  if (!blocks.empty()) {
+    // Partially reused; cover the tail from the heap. Roll back everything on
+    // failure so the caller sees all-or-nothing (it frees `blocks` only on a
+    // true return).
+    int tail_type = GlobalBlockMap::FindBlockType(remaining_phys);
+    if (tail_type == -1) tail_type = kCats - 1;
+    Block tail;
+    if (heap_.Allocate(remaining_phys, tail_type, tail)) {
+      tail.size_ = remaining_phys;
+      blocks.push_back(tail);
+      allocated_bytes_.fetch_add(remaining_phys, std::memory_order_relaxed);
+      return true;
+    }
+    for (auto &b : blocks) {
+      global_block_map_.FreeBlock(worker_id, b);  // return to the free list
+      allocated_bytes_.fetch_sub(AlignSize(b.size_), std::memory_order_relaxed);
+    }
+    blocks.clear();
+    return false;
   }
 
   clio::run::u64 aligned_total_size = AlignSize(total_size);

--- a/context-runtime/src/scheduler/default_sched.cc
+++ b/context-runtime/src/scheduler/default_sched.cc
@@ -698,6 +698,52 @@ void DefaultScheduler::LoadBalance() {
              st.num_retry_tasks_);
       }
     }
+
+    // [HANGWATCH] Pure no-forward-progress watchdog (diagnostic). The wedged-
+    // shape alarm above only fires when live==0 or EVERY live worker is stalled-
+    // in-one-task; it misses the busy-spin / lost-completion class (workers look
+    // "live" and are not counted as stalled) that is exactly the embedded-FUSE
+    // 2-CPU hang (generic/020). This fires purely on "no real task completed for
+    // a while while work is outstanding" and dumps race-safe per-worker state
+    // (stats snapshot + atomic reads only; no GetCurrentTask() shared_ptr race)
+    // so a CI hang is diagnosable from the log. Runs on the monitor thread,
+    // which the spinning workers cannot fully starve.
+    {
+      static u64 wd_last_processed = ~0ull;
+      static double wd_last_us = 0.0;
+      static bool wd_alarmed = false;
+      if (wd_last_processed == ~0ull) {
+        wd_last_processed = processed;
+        wd_last_us = now_us;
+      }
+      if (processed != wd_last_processed || outstanding == 0) {
+        wd_last_processed = processed;
+        wd_last_us = now_us;
+        wd_alarmed = false;
+      } else if (!wd_alarmed && outstanding > 0 &&
+                 (now_us - wd_last_us) > 12.0 * 1e6) {
+        wd_alarmed = true;
+        HLOG(kError,
+             "[HANGWATCH] no task completed in 12s: outstanding={} processed={} "
+             "live={} live_stalled={}. Per-worker:",
+             outstanding, processed, live, live_stalled);
+        for (size_t i = 0; i < work_orch_->GetWorkerCount(); ++i) {
+          Worker *w = work_orch_->GetWorker(static_cast<u32>(i));
+          if (w == nullptr) continue;
+          TaskLane *ln = w->GetLane();
+          WorkerStats st = w->GetWorkerStats();
+          HLOG(kError,
+               "[HANGWATCH]  w{} exec={} stalled={} lane_size={} queued={} "
+               "blocked={} periodic={} retry={} done={}",
+               w->GetId(), w->IsExecuting(),
+               w->IsStalled(now_us, kStallThresholdSec),
+               ln ? static_cast<long>(ln->Size()) : -1L,
+               st.num_queued_tasks_, st.num_blocked_tasks_,
+               st.num_periodic_tasks_, st.num_retry_tasks_,
+               st.num_tasks_processed_);
+        }
+      }
+    }
   }
 
   u32 stalled = 0;

--- a/context-runtime/src/scheduler/default_sched.cc
+++ b/context-runtime/src/scheduler/default_sched.cc
@@ -635,6 +635,7 @@ void DefaultScheduler::LoadBalance() {
     u64 outstanding = 0;
     u32 live = 0;       // workers executing something
     u32 live_stalled = 0;  // ...of which are stuck past the stall threshold
+    u64 ob_queued = 0, ob_blocked = 0, ob_retry = 0, ob_periodic = 0;
     for (size_t i = 0; i < work_orch_->GetWorkerCount(); ++i) {
       Worker *w = work_orch_->GetWorker(static_cast<u32>(i));
       if (w == nullptr) continue;
@@ -644,6 +645,10 @@ void DefaultScheduler::LoadBalance() {
         if (w->IsStalled(now_us, kStallThresholdSec)) ++live_stalled;
       }
       WorkerStats st = w->GetWorkerStats();
+      ob_queued += st.num_queued_tasks_;
+      ob_blocked += st.num_blocked_tasks_;
+      ob_retry += st.num_retry_tasks_;
+      ob_periodic += st.num_periodic_tasks_;
       outstanding += st.num_queued_tasks_ + st.num_blocked_tasks_ +
                      st.num_retry_tasks_;
     }
@@ -719,8 +724,10 @@ void DefaultScheduler::LoadBalance() {
       static u64 hb_tick = 0;
       if (outstanding > 0 && (++hb_tick % 4 == 0)) {
         HLOG(kError,
-             "[HANGWATCH-HB] processed={} outstanding={} live={} live_stalled={}",
-             processed, outstanding, live, live_stalled);
+             "[HANGWATCH-HB] processed={} outstanding={} (queued={} blocked={} "
+             "retry={} periodic={}) live={} live_stalled={}",
+             processed, outstanding, ob_queued, ob_blocked, ob_retry,
+             ob_periodic, live, live_stalled);
       }
       if (wd_last_processed == ~0ull) {
         wd_last_processed = processed;

--- a/context-runtime/src/scheduler/default_sched.cc
+++ b/context-runtime/src/scheduler/default_sched.cc
@@ -712,6 +712,16 @@ void DefaultScheduler::LoadBalance() {
       static u64 wd_last_processed = ~0ull;
       static double wd_last_us = 0.0;
       static bool wd_alarmed = false;
+      // Heartbeat every ~2s while work is outstanding: a CI hang log then shows
+      // whether `processed` is advancing (watchdog resets, never alarms) or truly
+      // frozen (should alarm). This is the signal that tells us WHY the 12s dump
+      // did or did not fire.
+      static u64 hb_tick = 0;
+      if (outstanding > 0 && (++hb_tick % 4 == 0)) {
+        HLOG(kError,
+             "[HANGWATCH-HB] processed={} outstanding={} live={} live_stalled={}",
+             processed, outstanding, live, live_stalled);
+      }
       if (wd_last_processed == ~0ull) {
         wd_last_processed = processed;
         wd_last_us = now_us;

--- a/context-runtime/src/worker.cc
+++ b/context-runtime/src/worker.cc
@@ -585,6 +585,8 @@ clio::run::shared_ptr<Task> Worker::RouteOnly(Future<Task> &future,
   return task_full_ptr;
 }
 
+
+
 namespace {
 /** issue #820: hands a container's merged tasks back to the worker. */
 class WorkerBatchSink : public BatchSink {
@@ -616,6 +618,7 @@ class WorkerBatchSink : public BatchSink {
     merged->task_id_ = CreateTaskId();
     merged->pool_query_ = PoolQuery::Local();
     merged->SetFlags(TASK_BATCH_MERGED);
+    size_t np = parents.size();
     if (!parents.empty()) {
       std::lock_guard<std::mutex> lk(mu_);
       pending_[merged->task_id_.unique_] = std::move(parents);
@@ -713,6 +716,16 @@ u32 Worker::BatchCollect(TaskLane *lane, u32 budget, bool from_lane) {
 
   // Then let each container collapse whatever it parked.
   if (!batch_groups_.empty()) {
+    // Clear the current-task slot FIRST. IpcCpu2Self::SendIn parents a
+    // self-sent task to whatever GetCurrentTask() returns, and by now that is
+    // a stale, already-finished passthrough task from the loop above. A merged
+    // task adopted by a dead parent has its completion routed into that
+    // parent's coroutine (SendOut resumes the parent rather than signalling
+    // normally), so nothing ever completes the merged task's own future or its
+    // parked parents -- every worker then idles and the client waits forever.
+    // That is the lost wakeup this phase was hanging on: no thread spinning, no
+    // futex held, everything asleep.
+    SetCurrentTask(clio::run::shared_ptr<Task>());
     WorkerBatchSink sink(
         [this](const clio::run::shared_ptr<Task> &t) {
           clio::run::shared_ptr<Task> copy = t;

--- a/context-runtime/src/worker.cc
+++ b/context-runtime/src/worker.cc
@@ -469,6 +469,14 @@ u32 Worker::ProcessNewTasks(TaskLane *lane) {
     return 0;
   }
 
+  // issue #820: one pass through the batching phase, which dequeues a bounded
+  // run and lets containers coalesce it. With no container opting in, every
+  // task is declined and executed in arrival order — the same work
+  // ProcessNewTask did, in the same order.
+  if (BatchingEnabled()) {
+    return BatchPhase(lane);
+  }
+
   while (tasks_processed < MAX_TASKS_PER_ITERATION) {
     if (ProcessNewTask(lane)) {
       tasks_processed++;
@@ -478,6 +486,19 @@ u32 Worker::ProcessNewTasks(TaskLane *lane) {
   }
 
   return tasks_processed;
+}
+
+bool Worker::BatchingEnabled() {
+  // issue #820. On by default; CLIO_TASK_BATCHING=0 restores the pre-batching
+  // dequeue loop verbatim, which is the escape hatch for bisecting a regression
+  // to this phase rather than to a container's policy.
+  static const bool v = [] {
+    if (const char *e = std::getenv("CLIO_TASK_BATCHING")) {
+      return !(std::string(e) == "0" || std::string(e) == "false");
+    }
+    return true;
+  }();
+  return v;
 }
 
 bool Worker::ProcessNewTask(TaskLane *lane) {
@@ -532,6 +553,197 @@ bool Worker::ProcessNewTask(TaskLane *lane) {
   // Bind + route + execute (shared with the inline SHM-ingest path).
   RouteAndExec(future, lane);
   return true;
+}
+
+clio::run::shared_ptr<Task> Worker::RouteOnly(Future<Task> &future,
+                                              TaskLane *lane) {
+  clio::run::shared_ptr<Task> task_full_ptr = future.GetTaskPtr();
+  if (task_full_ptr.IsNull()) {
+    return clio::run::shared_ptr<Task>();
+  }
+  task_full_ptr->SetRunWorkerId(worker_id_);
+  task_full_ptr->Lane() = lane;
+  task_full_ptr->SetEventQueue(event_queue_.load(std::memory_order_acquire));
+  task_full_ptr->RunFuture() = future;
+
+  RouteResult route_result = CLIO_IPC->RouteTask(future);
+  if (route_result != RouteResult::ExecHere) {
+    // RouteTask already enqueued it wherever it belongs.
+    return clio::run::shared_ptr<Task>();
+  }
+  return task_full_ptr;
+}
+
+namespace {
+/** issue #820: hands a container's merged tasks back to the worker. */
+class WorkerBatchSink : public BatchSink {
+ public:
+  using RunAsIs = std::function<void(const clio::run::shared_ptr<Task> &)>;
+
+  WorkerBatchSink(
+      RunAsIs run_as_is, std::mutex &mu,
+      std::unordered_map<u64, std::vector<clio::run::shared_ptr<Task>>> &pending)
+      : run_as_is_(std::move(run_as_is)), mu_(mu), pending_(pending) {}
+
+  void Passthrough(const clio::run::shared_ptr<Task> &task) override {
+    if (task.IsNull()) {
+      return;
+    }
+    // Unchanged: it keeps the id, future and RunContext it was routed with.
+    run_as_is_(task);
+  }
+
+  void Emit(const clio::run::shared_ptr<Task> &merged,
+            std::vector<clio::run::shared_ptr<Task>> &&parents) override {
+    if (merged.IsNull()) {
+      return;
+    }
+    // Same construction the ManyToOne aggregate uses (BatchManager::
+    // BuildAndSubmit): a fresh id and a Local query, so the submit path gives
+    // this task its OWN RunContext and future rather than inheriting a
+    // parent's.
+    merged->task_id_ = CreateTaskId();
+    merged->pool_query_ = PoolQuery::Local();
+    merged->SetFlags(TASK_BATCH_MERGED);
+    if (!parents.empty()) {
+      std::lock_guard<std::mutex> lk(mu_);
+      pending_[merged->task_id_.unique_] = std::move(parents);
+    }
+    CLIO_IPC->Send(merged);
+  }
+
+ private:
+  RunAsIs run_as_is_;
+  std::mutex &mu_;
+  std::unordered_map<u64, std::vector<clio::run::shared_ptr<Task>>> &pending_;
+};
+}  // namespace
+
+u32 Worker::BatchPhase(TaskLane *lane) {
+  // Bounded so batching can only ever amortize a backlog that already exists:
+  // with an empty lane behind it a task forms a group of one and is emitted
+  // unchanged, so the no-contention path pays nothing.
+  constexpr u32 kBatchDequeue = 64;
+  u32 popped = 0;
+  auto *pool_manager = CLIO_POOL_MANAGER;
+  // Arrival order across the whole phase. Overlap resolution ("last writer
+  // wins") is only meaningful against submission order, so the worker stamps it
+  // here rather than letting a container infer it.
+  static thread_local u64 batch_seq = 0;
+
+  while (popped < kBatchDequeue) {
+    Future<Task> future;
+    if (!lane->Pop(future)) {
+      break;
+    }
+    ++popped;
+    SetCurrentTask(clio::run::shared_ptr<Task>());
+    Task *new_task = future.get();
+    if (new_task == nullptr) {
+      continue;
+    }
+    PoolId pool_id = new_task->pool_id_;
+    u32 method_id = new_task->method_;
+    auto container = pool_manager->GetStaticContainer(pool_id).get();
+    if (!container) {
+      HLOG(kError,
+           "Worker {}: cannot service pool_id={} method={}; container not found",
+           worker_id_, pool_id, method_id);
+      future.SetComplete();
+      continue;
+    }
+    clio::run::shared_ptr<Task> task_ptr = RouteOnly(future, lane);
+    if (task_ptr.IsNull()) {
+      continue;  // routed elsewhere, or undeserializable
+    }
+    // Offer it to the container's batching policy. The default declines, so a
+    // container that has not opted in behaves exactly as before.
+    if (container->BuildBatch(method_id, task_ptr, batch_groups_)) {
+      for (auto &kv : batch_groups_) {
+        if (!kv.second.empty() && kv.second.back().task.get() == task_ptr.get()) {
+          kv.second.back().seq = batch_seq++;
+          break;
+        }
+      }
+      continue;
+    }
+    batch_passthrough_.push_back(task_ptr);
+  }
+
+  // Declined tasks run first, in arrival order: they keep the semantics they
+  // had before batching existed, and a merged task then sees a settled world.
+  for (auto &t : batch_passthrough_) {
+    ExecTask(t, t->IsStarted());
+  }
+  batch_passthrough_.clear();
+
+  // Then let each container collapse whatever it parked.
+  if (!batch_groups_.empty()) {
+    WorkerBatchSink sink(
+        [this](const clio::run::shared_ptr<Task> &t) {
+          clio::run::shared_ptr<Task> copy = t;
+          ExecTask(copy, copy->IsStarted());
+        },
+        batch_pending_mu_, batch_pending_);
+    // Distinct pools present in the groups; each container picks out its own
+    // keys and must leave the map empty.
+    std::vector<PoolId> pools;
+    for (auto &kv : batch_groups_) {
+      bool seen = false;
+      for (const auto &p : pools) {
+        if (p == kv.first.pool_id) { seen = true; break; }
+      }
+      if (!seen) pools.push_back(kv.first.pool_id);
+    }
+    for (const auto &p : pools) {
+      auto container = pool_manager->GetStaticContainer(p).get();
+      if (container) {
+        container->SmashBatch(batch_groups_, sink);
+      }
+    }
+    // Anything a container left behind would otherwise never run: fail loudly
+    // rather than silently dropping a client's task.
+    if (!batch_groups_.empty()) {
+      for (auto &kv : batch_groups_) {
+        HLOG(kError,
+             "Worker {}: SmashBatch left {} task(s) parked for pool={} method={}"
+             " — completing them unbatched to avoid a hang",
+             worker_id_, kv.second.size(), kv.first.pool_id, kv.first.method);
+        for (auto &m : kv.second) {
+          ExecTask(m.task, m.task->IsStarted());
+        }
+      }
+      batch_groups_.clear();
+    }
+  }
+  return popped;
+}
+
+void Worker::CompleteBatchParents(clio::run::shared_ptr<Task> &merged) {
+  std::vector<clio::run::shared_ptr<Task>> parents;
+  {
+    std::lock_guard<std::mutex> lk(batch_pending_mu_);
+    auto it = batch_pending_.find(merged->task_id_.unique_);
+    if (it == batch_pending_.end()) {
+      return;
+    }
+    parents = std::move(it->second);
+    batch_pending_.erase(it);
+  }
+  u32 rc = merged->GetReturnCode();
+  ContainerId completer = merged->GetCompleter();
+  DynamicContainer container = merged->ExecContainer();
+  for (auto &parent : parents) {
+    // No payload copy-back: a merged task is built so that each parent's own
+    // output buffer is what the runtime already filled (that is what the
+    // vectored task shape in part A is for). Only the status has to travel.
+    parent->SetReturnCode(rc);
+    parent->SetCompleter(completer);
+    if (container.IsValid()) {
+      parent->ExecContainer() = container;
+    }
+    EndTask(parent, false);
+  }
 }
 
 void Worker::RouteAndExec(Future<Task> &future, TaskLane *lane) {
@@ -1012,6 +1224,19 @@ void Worker::EndTask(clio::run::shared_ptr<Task> &task_ptr, bool can_resched) {
     container->UpdateWork(task_ptr, -1);
     task_ptr->ClearFlags(TASK_DATA_OWNER);
     // Task is freed via RAII when the RunContext's shared_ptr owners drop.
+    break_self_cycle();
+    return;
+  }
+
+  // issue #820: a merged task from SmashBatch. Like the aggregate above it has
+  // no external waiter of its own — its job is to complete the PARENTS it
+  // subsumed, each of which does have one. The parents' payloads were already
+  // written by the merged task itself (a vectored put/get names each parent's
+  // own buffer), so only status travels.
+  if (task_ptr->task_flags_.Any(TASK_BATCH_MERGED)) {
+    CompleteBatchParents(task_ptr);
+    container->UpdateWork(task_ptr, -1);
+    task_ptr->ClearFlags(TASK_DATA_OWNER);
     break_self_cycle();
     return;
   }

--- a/context-runtime/src/worker.cc
+++ b/context-runtime/src/worker.cc
@@ -500,14 +500,22 @@ u32 Worker::ProcessNewTasks(TaskLane *lane) {
 }
 
 bool Worker::BatchingEnabled() {
-  // issue #820. On by default; CLIO_TASK_BATCHING=0 restores the pre-batching
-  // dequeue loop verbatim, which is the escape hatch for bisecting a regression
-  // to this phase rather than to a container's policy.
+  // issue #820. OFF by default (opt-in via CLIO_TASK_BATCHING=1).
+  //
+  // The worker batch phase only pays off when a CONTAINER opts into merging via
+  // its BuildBatch policy — and every such policy is itself off by default (CTE
+  // core's is gated on CLIO_CTE_BATCHING and even documents an unresolved
+  // same-blob hang). With no container batching, the batch phase merges nothing:
+  // every task just takes the RouteOnly + deferred-passthrough drain instead of
+  // the plain RouteAndExec one, for zero benefit. That alternate drain HANGS the
+  // xattr-storm workload in xfstests generic/020 (regression vs main, which has
+  // no batch phase). So the phase must default to the SAME opt-in as the merge
+  // policies it serves: enabling it standalone buys nothing and only adds risk.
   static const bool v = [] {
     if (const char *e = std::getenv("CLIO_TASK_BATCHING")) {
-      return !(std::string(e) == "0" || std::string(e) == "false");
+      return (std::string(e) == "1" || std::string(e) == "true");
     }
-    return true;
+    return false;
   }();
   return v;
 }

--- a/context-runtime/src/worker.cc
+++ b/context-runtime/src/worker.cc
@@ -500,22 +500,14 @@ u32 Worker::ProcessNewTasks(TaskLane *lane) {
 }
 
 bool Worker::BatchingEnabled() {
-  // issue #820. OFF by default (opt-in via CLIO_TASK_BATCHING=1).
-  //
-  // The worker batch phase only pays off when a CONTAINER opts into merging via
-  // its BuildBatch policy — and every such policy is itself off by default (CTE
-  // core's is gated on CLIO_CTE_BATCHING and even documents an unresolved
-  // same-blob hang). With no container batching, the batch phase merges nothing:
-  // every task just takes the RouteOnly + deferred-passthrough drain instead of
-  // the plain RouteAndExec one, for zero benefit. That alternate drain HANGS the
-  // xattr-storm workload in xfstests generic/020 (regression vs main, which has
-  // no batch phase). So the phase must default to the SAME opt-in as the merge
-  // policies it serves: enabling it standalone buys nothing and only adds risk.
+  // issue #820. On by default; CLIO_TASK_BATCHING=0 restores the pre-batching
+  // dequeue loop verbatim, which is the escape hatch for bisecting a regression
+  // to this phase rather than to a container's policy.
   static const bool v = [] {
     if (const char *e = std::getenv("CLIO_TASK_BATCHING")) {
-      return (std::string(e) == "1" || std::string(e) == "true");
+      return !(std::string(e) == "0" || std::string(e) == "false");
     }
-    return false;
+    return true;
   }();
   return v;
 }

--- a/context-runtime/src/worker.cc
+++ b/context-runtime/src/worker.cc
@@ -609,7 +609,6 @@ class WorkerBatchSink : public BatchSink {
       std::lock_guard<std::mutex> lk(mu_);
       pending_[merged->task_id_.unique_] = std::move(parents);
     }
-    CLIO_IPC->Send(merged);
   }
 
  private:
@@ -655,6 +654,15 @@ u32 Worker::BatchPhase(TaskLane *lane) {
     clio::run::shared_ptr<Task> task_ptr = RouteOnly(future, lane);
     if (task_ptr.IsNull()) {
       continue;  // routed elsewhere, or undeserializable
+    }
+    // A task that has already STARTED is not a candidate: it is a coroutine
+    // parked mid-execution and re-queued to resume (ContinueBlockedTasks
+    // pushes those back onto the lane). It must resume, not be folded into a
+    // fresh merged task -- doing that abandons its in-flight state and its
+    // waiter never completes. Offer only never-started tasks.
+    if (task_ptr->IsStarted()) {
+      batch_passthrough_.push_back(task_ptr);
+      continue;
     }
     // Offer it to the container's batching policy. The default declines, so a
     // container that has not opted in behaves exactly as before.

--- a/context-runtime/src/worker.cc
+++ b/context-runtime/src/worker.cc
@@ -594,9 +594,12 @@ class WorkerBatchSink : public BatchSink {
   using RunAsIs = std::function<void(const clio::run::shared_ptr<Task> &)>;
 
   WorkerBatchSink(
-      RunAsIs run_as_is, std::mutex &mu,
+      RunAsIs run_as_is, RunAsIs run_merged, std::mutex &mu,
       std::unordered_map<u64, std::vector<clio::run::shared_ptr<Task>>> &pending)
-      : run_as_is_(std::move(run_as_is)), mu_(mu), pending_(pending) {}
+      : run_as_is_(std::move(run_as_is)),
+        run_merged_(std::move(run_merged)),
+        mu_(mu),
+        pending_(pending) {}
 
   void Passthrough(const clio::run::shared_ptr<Task> &task) override {
     if (task.IsNull()) {
@@ -611,22 +614,33 @@ class WorkerBatchSink : public BatchSink {
     if (merged.IsNull()) {
       return;
     }
-    // Same construction the ManyToOne aggregate uses (BatchManager::
-    // BuildAndSubmit): a fresh id and a Local query, so the submit path gives
-    // this task its OWN RunContext and future rather than inheriting a
-    // parent's.
+    // A fresh id and a Local query, so this task gets its OWN RunContext and
+    // future rather than inheriting a member's.
     merged->task_id_ = CreateTaskId();
     merged->pool_query_ = PoolQuery::Local();
     merged->SetFlags(TASK_BATCH_MERGED);
-    size_t np = parents.size();
     if (!parents.empty()) {
       std::lock_guard<std::mutex> lk(mu_);
       pending_[merged->task_id_.unique_] = std::move(parents);
     }
+    // Run it HERE rather than CLIO_IPC->Send().
+    //
+    // Send() self-sends, which routes with force_enqueue and pushes onto a
+    // worker lane. Called from inside the drain loop that consumes that very
+    // lane, under a deep burst the lane is full and the push waits for space
+    // only this thread could make -- the producer==consumer deadlock
+    // IpcCpu2Self::SendIn warns about in its own comment. Measured: Send never
+    // returned, every thread asleep, nothing spinning.
+    //
+    // Running inline is also simply correct: every member routed to this
+    // container on this worker, so the merged task belongs here by
+    // construction and never needs to enter a lane at all.
+    run_merged_(merged);
   }
 
  private:
   RunAsIs run_as_is_;
+  RunAsIs run_merged_;
   std::mutex &mu_;
   std::unordered_map<u64, std::vector<clio::run::shared_ptr<Task>>> &pending_;
 };
@@ -730,6 +744,23 @@ u32 Worker::BatchCollect(TaskLane *lane, u32 budget, bool from_lane) {
         [this](const clio::run::shared_ptr<Task> &t) {
           clio::run::shared_ptr<Task> copy = t;
           ExecTask(copy, copy->IsStarted());
+        },
+        [this, lane](const clio::run::shared_ptr<Task> &m) {
+          // Give the merged task its OWN future + RunContext -- it has no
+          // client waiter of its own; its job is to complete the parents it
+          // subsumed -- then bind and run it on this worker.
+          clio::run::shared_ptr<Task> t = m;
+          Future<Task> f(t->pool_id_, t->method_, t);
+          {
+            auto fs = f.GetFutureShm();
+            fs->origin_ = ClientOrigin::kClientShm;
+          }
+          t->BeginRunContext();
+          t->SetRunWorkerId(worker_id_);
+          t->Lane() = lane;
+          t->SetEventQueue(event_queue_.load(std::memory_order_acquire));
+          t->RunFuture() = f;
+          ExecTask(t, /*is_started=*/false);
         },
         batch_pending_mu_, batch_pending_);
     // Distinct pools present in the groups; each container picks out its own

--- a/context-runtime/src/worker.cc
+++ b/context-runtime/src/worker.cc
@@ -469,6 +469,25 @@ u32 Worker::ProcessNewTasks(TaskLane *lane) {
     return 0;
   }
 
+  // issue #820, experimental (CLIO_BATCH_LANE=1): batch on the LANE.
+  //
+  // This is where same-blob tasks actually converge -- RouteTask sends every
+  // task for a blob to that blob's container, i.e. to ONE worker's lane -- so
+  // it is the only place a batch of same-blob work can form. Batching at the
+  // SHM ingress cannot see it: the ingesting worker is usually not the
+  // executing one, so it routes the task onward and never gets to merge it.
+  //
+  // Off by default because deferring lane tasks is not yet proven safe: the
+  // lane also carries internal and re-routed work that other in-flight tasks
+  // may be synchronously waiting on.
+  static const bool lane_batch = [] {
+    const char *e = std::getenv("CLIO_BATCH_LANE");
+    return e != nullptr && !(std::string(e) == "0" || std::string(e) == "false");
+  }();
+  if (lane_batch && BatchingEnabled()) {
+    return BatchLane(lane, MAX_TASKS_PER_ITERATION * 4);
+  }
+
   while (tasks_processed < MAX_TASKS_PER_ITERATION) {
     if (ProcessNewTask(lane)) {
       tasks_processed++;
@@ -610,7 +629,15 @@ class WorkerBatchSink : public BatchSink {
 };
 }  // namespace
 
+u32 Worker::BatchLane(TaskLane *lane, u32 budget) {
+  return BatchCollect(lane, budget, /*from_lane=*/true);
+}
+
 u32 Worker::BatchIngest(TaskLane *lane, u32 budget) {
+  return BatchCollect(lane, budget, /*from_lane=*/false);
+}
+
+u32 Worker::BatchCollect(TaskLane *lane, u32 budget, bool from_lane) {
   // Bounded so batching can only ever amortize a backlog that already exists:
   // with an empty lane behind it a task forms a group of one and is emitted
   // unchanged, so the no-contention path pays nothing.
@@ -623,9 +650,16 @@ u32 Worker::BatchIngest(TaskLane *lane, u32 budget) {
   static thread_local u64 batch_seq = 0;
 
   while (popped < kBatchDequeue) {
-    Future<Task> future = IpcCpu2Cpu::RecvIn(CLIO_IPC, worker_id_);
-    if (future.get() == nullptr) {
-      break;  // shard empty
+    Future<Task> future;
+    if (from_lane) {
+      if (!lane->Pop(future)) {
+        break;  // lane empty
+      }
+    } else {
+      future = IpcCpu2Cpu::RecvIn(CLIO_IPC, worker_id_);
+      if (future.get() == nullptr) {
+        break;  // shard empty
+      }
     }
     ++popped;
     SetCurrentTask(clio::run::shared_ptr<Task>());

--- a/context-runtime/src/worker.cc
+++ b/context-runtime/src/worker.cc
@@ -469,14 +469,6 @@ u32 Worker::ProcessNewTasks(TaskLane *lane) {
     return 0;
   }
 
-  // issue #820: one pass through the batching phase, which dequeues a bounded
-  // run and lets containers coalesce it. With no container opting in, every
-  // task is declined and executed in arrival order — the same work
-  // ProcessNewTask did, in the same order.
-  if (BatchingEnabled()) {
-    return BatchPhase(lane);
-  }
-
   while (tasks_processed < MAX_TASKS_PER_ITERATION) {
     if (ProcessNewTask(lane)) {
       tasks_processed++;
@@ -618,11 +610,11 @@ class WorkerBatchSink : public BatchSink {
 };
 }  // namespace
 
-u32 Worker::BatchPhase(TaskLane *lane) {
+u32 Worker::BatchIngest(TaskLane *lane, u32 budget) {
   // Bounded so batching can only ever amortize a backlog that already exists:
   // with an empty lane behind it a task forms a group of one and is emitted
   // unchanged, so the no-contention path pays nothing.
-  constexpr u32 kBatchDequeue = 64;
+  const u32 kBatchDequeue = budget;
   u32 popped = 0;
   auto *pool_manager = CLIO_POOL_MANAGER;
   // Arrival order across the whole phase. Overlap resolution ("last writer
@@ -631,9 +623,9 @@ u32 Worker::BatchPhase(TaskLane *lane) {
   static thread_local u64 batch_seq = 0;
 
   while (popped < kBatchDequeue) {
-    Future<Task> future;
-    if (!lane->Pop(future)) {
-      break;
+    Future<Task> future = IpcCpu2Cpu::RecvIn(CLIO_IPC, worker_id_);
+    if (future.get() == nullptr) {
+      break;  // shard empty
     }
     ++popped;
     SetCurrentTask(clio::run::shared_ptr<Task>());
@@ -789,22 +781,32 @@ u32 Worker::DrainMyShard() {
   // lane push, no per-request AwakenWorker SIGUSR1: those were the bulk of the
   // latency gap vs the original inline design. A task that maps elsewhere is
   // enqueued by RouteTask as usual.
+  // issue #820: THIS is where client tasks actually arrive. Under the #807 SHM
+  // transport a client's PutBlob/GetBlob is delivered to its worker's shard
+  // ring and executed inline here -- it never enters the lane. Batching wired
+  // to the lane therefore never saw the hot path at all (measured: zero tasks
+  // parked under an 8-writer same-blob load). So the batch phase hooks the
+  // ingress, and the lane path is left exactly as it was.
+  //
+  // Deferring a LANE task is also unsafe in a way deferring an ingress task is
+  // not: the lane carries internal and re-routed work that other in-flight
+  // tasks may be synchronously waiting on, so holding one back can deadlock.
+  // Freshly ingested client requests have no such dependents yet.
   constexpr u32 kShardDrainBudget = 16;
   TaskLane *my_lane = assigned_lane_.load(std::memory_order_acquire);
-  u32 n = 0;
-  while (n < kShardDrainBudget) {
-    Future<Task> f = IpcCpu2Cpu::RecvIn(CLIO_IPC, worker_id_);
-    if (f.get() == nullptr) {
-      break;  // shard empty
+  if (!BatchingEnabled()) {
+    u32 n = 0;
+    while (n < kShardDrainBudget) {
+      Future<Task> f = IpcCpu2Cpu::RecvIn(CLIO_IPC, worker_id_);
+      if (f.get() == nullptr) {
+        break;
+      }
+      RouteAndExec(f, my_lane);
+      ++n;
     }
-    // Bind + route + execute. RuntimeMapTask decides whether this ingesting
-    // worker keeps the task (inline, the quick-local common case) or routes it
-    // to another worker (heavy tasks), so all placement policy stays in the
-    // scheduler.
-    RouteAndExec(f, my_lane);
-    ++n;
+    return n;
   }
-  return n;
+  return BatchIngest(my_lane, kShardDrainBudget);
 #else
   return 0;
 #endif

--- a/context-runtime/src/worker.cc
+++ b/context-runtime/src/worker.cc
@@ -485,7 +485,18 @@ u32 Worker::ProcessNewTasks(TaskLane *lane) {
     return e != nullptr && !(std::string(e) == "0" || std::string(e) == "false");
   }();
   if (lane_batch && BatchingEnabled()) {
-    return BatchLane(lane, MAX_TASKS_PER_ITERATION * 4);
+    // issue #820: size the batch to the CURRENT lane depth so a deep backlog
+    // (e.g. a burst of same-blob writes that RouteTask funneled onto this one
+    // lane) collapses in a SINGLE merged task instead of being chopped at a
+    // fixed budget. Size() is a single-consumer snapshot -- this worker is the
+    // only consumer of its lane (mpsc), so it can only UNDER-read when a
+    // producer enqueues concurrently, and those late arrivals simply batch on
+    // the next iteration; it never over-reads. Floor at the previous fixed
+    // budget so a shallow lane never batches LESS than before, and the natural
+    // ceiling is the ring's capacity (Size() cannot exceed it).
+    const u32 depth = static_cast<u32>(lane->Size());
+    const u32 batch_budget = std::max(depth, MAX_TASKS_PER_ITERATION * 4);
+    return BatchLane(lane, batch_budget);
   }
 
   while (tasks_processed < MAX_TASKS_PER_ITERATION) {

--- a/context-runtime/src/worker.cc
+++ b/context-runtime/src/worker.cc
@@ -588,18 +588,34 @@ clio::run::shared_ptr<Task> Worker::RouteOnly(Future<Task> &future,
 
 
 namespace {
+// issue #820/#822: process-global registry of "merged-task key -> parent tasks
+// it must complete". Global (not per-worker) because a merged task is an I/O
+// task whose continuation resumes on an arbitrary worker after the bdev put/get
+// suspends, so the worker that COMPLETES it is often not the one that EMITTED
+// it. g_batch_key_seq mints a process-unique key per merged task: it cannot use
+// CreateTaskId().unique_ because that counter is thread-local, so two workers
+// mint identical unique_ values and would clobber each other's parents in a
+// shared map. Keys start at a high base so they never alias a normal
+// per-thread task unique_ (defense in depth; the map is only keyed by these).
+struct BatchPendingRegistry {
+  std::mutex mu;
+  std::unordered_map<clio::run::u64,
+                     std::vector<clio::run::shared_ptr<Task>>> pending;
+};
+BatchPendingRegistry &GlobalBatchPending() {
+  static BatchPendingRegistry reg;
+  return reg;
+}
+std::atomic<clio::run::u64> g_batch_key_seq{clio::run::u64{1} << 48};
+
 /** issue #820: hands a container's merged tasks back to the worker. */
 class WorkerBatchSink : public BatchSink {
  public:
   using RunAsIs = std::function<void(const clio::run::shared_ptr<Task> &)>;
 
-  WorkerBatchSink(
-      RunAsIs run_as_is, RunAsIs run_merged, std::mutex &mu,
-      std::unordered_map<u64, std::vector<clio::run::shared_ptr<Task>>> &pending)
+  WorkerBatchSink(RunAsIs run_as_is, RunAsIs run_merged)
       : run_as_is_(std::move(run_as_is)),
-        run_merged_(std::move(run_merged)),
-        mu_(mu),
-        pending_(pending) {}
+        run_merged_(std::move(run_merged)) {}
 
   void Passthrough(const clio::run::shared_ptr<Task> &task) override {
     if (task.IsNull()) {
@@ -617,11 +633,17 @@ class WorkerBatchSink : public BatchSink {
     // A fresh id and a Local query, so this task gets its OWN RunContext and
     // future rather than inheriting a member's.
     merged->task_id_ = CreateTaskId();
+    // Stamp a PROCESS-GLOBAL key into unique_ so the (arbitrary) worker that
+    // later completes this task finds its parents in the global registry.
+    // CreateTaskId().unique_ is thread-local and collides across workers.
+    merged->task_id_.unique_ =
+        g_batch_key_seq.fetch_add(1, std::memory_order_relaxed);
     merged->pool_query_ = PoolQuery::Local();
     merged->SetFlags(TASK_BATCH_MERGED);
     if (!parents.empty()) {
-      std::lock_guard<std::mutex> lk(mu_);
-      pending_[merged->task_id_.unique_] = std::move(parents);
+      auto &reg = GlobalBatchPending();
+      std::lock_guard<std::mutex> lk(reg.mu);
+      reg.pending[merged->task_id_.unique_] = std::move(parents);
     }
     // Run it HERE rather than CLIO_IPC->Send().
     //
@@ -641,8 +663,6 @@ class WorkerBatchSink : public BatchSink {
  private:
   RunAsIs run_as_is_;
   RunAsIs run_merged_;
-  std::mutex &mu_;
-  std::unordered_map<u64, std::vector<clio::run::shared_ptr<Task>>> &pending_;
 };
 }  // namespace
 
@@ -761,8 +781,7 @@ u32 Worker::BatchCollect(TaskLane *lane, u32 budget, bool from_lane) {
           t->SetEventQueue(event_queue_.load(std::memory_order_acquire));
           t->RunFuture() = f;
           ExecTask(t, /*is_started=*/false);
-        },
-        batch_pending_mu_, batch_pending_);
+        });
     // Distinct pools present in the groups; each container picks out its own
     // keys and must leave the map empty.
     std::vector<PoolId> pools;
@@ -800,13 +819,17 @@ u32 Worker::BatchCollect(TaskLane *lane, u32 budget, bool from_lane) {
 void Worker::CompleteBatchParents(clio::run::shared_ptr<Task> &merged) {
   std::vector<clio::run::shared_ptr<Task>> parents;
   {
-    std::lock_guard<std::mutex> lk(batch_pending_mu_);
-    auto it = batch_pending_.find(merged->task_id_.unique_);
-    if (it == batch_pending_.end()) {
+    auto &reg = GlobalBatchPending();
+    std::lock_guard<std::mutex> lk(reg.mu);
+    auto it = reg.pending.find(merged->task_id_.unique_);
+    if (it == reg.pending.end()) {
+      // A merged task with no registered parents (parents.empty() at Emit) is a
+      // legitimate no-op; a genuine miss cannot happen now that the registry is
+      // global and the key is process-unique.
       return;
     }
     parents = std::move(it->second);
-    batch_pending_.erase(it);
+    reg.pending.erase(it);
   }
   u32 rc = merged->GetReturnCode();
   ContainerId completer = merged->GetCompleter();

--- a/context-transfer-engine/core/clio_mod.yaml
+++ b/context-transfer-engine/core/clio_mod.yaml
@@ -44,3 +44,4 @@ kFlushMetadata: 33     # Periodic task to flush tag/blob metadata to durable sto
 kFlushData: 34         # Periodic task to flush data from volatile to non-volatile targets
 kSemanticSearch: 35    # BM25 keyword search over blob contents (tag+blob regex filter, top-k)
 kDynamicReorganize: 46 # Periodic internal data-organizer driver (issue #738)
+kEvict: 47             # Score-driven capacity eviction: free lowest-score blobs off a tier

--- a/context-transfer-engine/core/include/clio_cte/core/autogen/core_methods.h
+++ b/context-transfer-engine/core/include/clio_cte/core/autogen/core_methods.h
@@ -56,7 +56,11 @@ GLOBAL_CROSS_CONST clio::run::u32 kPodReorganizeBlob = 45;
 // Periodic internal data-organizer driver (issue #738)
 GLOBAL_CROSS_CONST clio::run::u32 kDynamicReorganize = 46;
 
-GLOBAL_CROSS_CONST clio::run::u32 kMaxMethodId = 47;
+// Score-driven capacity eviction: free the lowest-score blobs off a tier
+// (targets with score >= min) until a byte budget is reclaimed.
+GLOBAL_CROSS_CONST clio::run::u32 kEvict = 47;
+
+GLOBAL_CROSS_CONST clio::run::u32 kMaxMethodId = 48;
 
 inline const std::vector<std::string>& GetMethodNames() {
   static const std::vector<std::string> names = [] {
@@ -97,6 +101,7 @@ inline const std::vector<std::string>& GetMethodNames() {
     v[44] = "PodGetBlob";
     v[45] = "PodReorganizeBlob";
     v[46] = "DynamicReorganize";
+    v[47] = "Evict";
     return v;
   }();
   return names;

--- a/context-transfer-engine/core/include/clio_cte/core/core_client.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_client.h
@@ -519,6 +519,95 @@ class Client : public clio::run::ContainerClient {
   }
 
   /**
+   * Private-memory AsyncPutBlob (issue #830): write a blob region straight from
+   * a caller-owned PRIVATE buffer (const char*), instead of making the caller
+   * hand-manage a shared-memory buffer (allocate → copy in → pass ShmPtr →
+   * free) as the ShmPtr overload above requires. This is the write-side analog
+   * of the private-memory AsyncGetBlob (issue #823).
+   *
+   * Two paths, fastest first:
+   *  - Runtime (co-located) mode: the daemon shares this address space, so the
+   *    private pointer is wrapped as a null-allocator ShmPtr — IpcManager::
+   *    ToFullPtr resolves such a pointer's offset AS the absolute address — and
+   *    the bdev write reads DIRECTLY from the caller's buffer. No staging
+   *    buffer, no copy, and NOT TASK_DATA_OWNER (the buffer is the caller's).
+   *  - Client mode: the daemon cannot reach private memory, so the write is
+   *    staged through a freshly allocated SHM buffer — the private bytes are
+   *    copied in ONCE, then the task carries that buffer. The task is marked
+   *    TASK_DATA_OWNER so ~PutBlobTask frees the staging buffer once the write
+   *    completes (i.e. after the caller's Wait() returns).
+   *
+   * The issue #830 client-mode zero-IPC fast path (write straight into the
+   * cached blob, skipping the task entirely) is deliberately NOT taken here: a
+   * token-less direct write to the RAM bdev segment can race the DataOrganizer
+   * relocating the blob — it frees/reuses those blocks under the per-blob write
+   * token a pure client cannot hold, so the write would corrupt whichever blob
+   * next owns them. Unlike the read fast path, a placement_gen recheck can
+   * DETECT that race but not UNDO the write. Making it safe needs a
+   * client-visible pin/lease against reorganization; left as a follow-up.
+   *
+   * @return A Future over the put; readable after Wait() (GetReturnCode()==0 on
+   *         success). An empty Future is returned only if SHM staging could not
+   *         be allocated in client mode.
+   */
+  clio::run::Future<PutBlobTask> AsyncPutBlob(
+      const TagId &tag_id, const std::string &blob_name,
+      clio::run::u64 offset, clio::run::u64 size, const char *priv_data,
+      float score = -1.0f, const Context &context = Context(),
+      clio::run::u32 flags = 0,
+      const clio::run::PoolQuery &pool_query = clio::run::PoolQuery::Dynamic()) {
+    auto *ipc_manager = CLIO_CPU_IPC;
+
+    // A zero-length put carries no payload; route it through the ShmPtr overload
+    // with a null buffer so the two modes below never see size 0.
+    if (size == 0 || priv_data == nullptr) {
+      return AsyncPutBlob(tag_id, blob_name.c_str(), offset, size,
+                          ctp::ipc::ShmPtr<>::GetNull(), score, context, flags,
+                          pool_query);
+    }
+
+    if (CLIO_RUNTIME_MANAGER->IsRuntime()) {
+      // Co-located daemon: read directly from the private buffer. The null
+      // AllocatorId marks the offset as an absolute process address, so the
+      // bdev write pulls the source bytes straight out of `priv_data`.
+      ctp::ipc::ShmPtr<> raw =
+          ctp::ipc::ShmPtr<>::FromRaw(const_cast<char *>(priv_data));
+      auto task = ipc_manager->NewTask<PutBlobTask>(
+          clio::run::CreateTaskId(), pool_id_, pool_query, tag_id, blob_name,
+          offset, size, raw, score, context, flags);
+      task.get()->submit_ts_ns_ =
+          std::chrono::duration_cast<std::chrono::nanoseconds>(
+              std::chrono::steady_clock::now().time_since_epoch())
+              .count();
+      return ipc_manager->Send(task);
+    }
+
+    // Client: stage through an SHM buffer, copying the private bytes in ONCE.
+    ctp::ipc::FullPtr<char> staging = ipc_manager->AllocateBuffer(size);
+    if (staging.IsNull()) {
+      return clio::run::Future<PutBlobTask>();
+    }
+    std::memcpy(staging.ptr_, priv_data, size);
+    auto task = ipc_manager->NewTask<PutBlobTask>(
+        clio::run::CreateTaskId(), pool_id_, pool_query, tag_id, blob_name,
+        offset, size, ctp::ipc::ShmPtr<>(staging.shm_), score, context, flags);
+    auto *t = task.get();
+    t->submit_ts_ns_ =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::steady_clock::now().time_since_epoch())
+            .count();
+    auto fut = ipc_manager->Send(task);
+    // Mark ownership only AFTER Send has serialized the task: Task::SerializeIn
+    // ships task_flags_, so setting TASK_DATA_OWNER earlier would hand the flag
+    // to the daemon, whose task shares the very same physical SHM buffer on the
+    // local path — and it would free the client's buffer out from under us.
+    // Set client-side, this instance's ~PutBlobTask frees the staging buffer
+    // when the Future (task) is destroyed, after the write has completed.
+    t->SetFlags(TASK_DATA_OWNER);
+    return fut;
+  }
+
+  /**
    * Asynchronous get blob - returns immediately
    * @param tag_id Tag ID
    * @param blob_name Name of the blob

--- a/context-transfer-engine/core/include/clio_cte/core/core_client.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_client.h
@@ -554,6 +554,47 @@ class Client : public clio::run::ContainerClient {
   }
 
   /**
+   * Vectored get (issue #820): read N regions of one blob in a SINGLE task,
+   * each region landing in its OWN buffer.
+   *
+   * All regions are served from one block-layout snapshot, so the whole read is
+   * a single consistent view of the blob rather than N independent ones. Because
+   * each segment names its own destination, a caller merging several readers'
+   * requests needs no scatter copy afterwards — the runtime fills each reader's
+   * buffer directly. Node-local (segment buffers are SHM pointers).
+   */
+  clio::run::Future<GetBlobTask> AsyncGetBlobVectored(
+      const TagId &tag_id,
+      const char *blob_name,
+      const std::vector<BlobSegment> &segments,
+      clio::run::u32 flags = 0,
+      const clio::run::PoolQuery &pool_query = clio::run::PoolQuery::Dynamic(),
+      const Context &context = Context()) {
+    auto *ipc_manager = CLIO_CPU_IPC;
+    auto task = ipc_manager->NewTask<GetBlobTask>(
+        clio::run::CreateTaskId(), pool_id_, pool_query, tag_id, blob_name,
+        static_cast<clio::run::u64>(0), static_cast<clio::run::u64>(0), flags,
+        ctp::ipc::ShmPtr<>::GetNull(), context);
+    auto *t = task.get();
+    for (const auto &seg : segments) {
+      t->segments_.push_back(BlobSegment(seg.blob_off_, seg.size_, seg.data_));
+    }
+    return ipc_manager->Send(task);
+  }
+
+  /** std::string overload */
+  clio::run::Future<GetBlobTask> AsyncGetBlobVectored(
+      const TagId &tag_id,
+      const std::string &blob_name,
+      const std::vector<BlobSegment> &segments,
+      clio::run::u32 flags = 0,
+      const clio::run::PoolQuery &pool_query = clio::run::PoolQuery::Dynamic(),
+      const Context &context = Context()) {
+    return AsyncGetBlobVectored(tag_id, blob_name.c_str(), segments, flags,
+                                pool_query, context);
+  }
+
+  /**
    * Asynchronous reorganize blob - returns immediately
    * @param tag_id Tag ID
    * @param blob_name Name of the blob

--- a/context-transfer-engine/core/include/clio_cte/core/core_client.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_client.h
@@ -560,6 +560,85 @@ class Client : public clio::run::ContainerClient {
   }
 
   /**
+   * Private-memory AsyncGetBlob (issue #823): read a blob region straight into
+   * a caller-owned PRIVATE buffer (char*), instead of making the caller
+   * hand-manage a shared-memory buffer (allocate → pass ShmPtr → copy out →
+   * free) as the ShmPtr overload above requires.
+   *
+   * Three paths, fastest first:
+   *  - Shared-cache hit: the bytes are copied out of the RAM bdev's shared
+   *    segment with ZERO IPC and an already-satisfied (empty) Future is
+   *    returned, so Wait() returns immediately. Same fast path the synchronous
+   *    Tag::GetBlob(char*) uses.
+   *  - Runtime (co-located) mode: the daemon shares this address space, so the
+   *    private pointer is wrapped as a null-allocator ShmPtr — IpcManager::
+   *    ToFullPtr resolves such a pointer's offset AS the absolute address — and
+   *    the bdev read lands DIRECTLY in the caller's buffer. No staging buffer,
+   *    no copy, and NOT TASK_DATA_OWNER (the buffer is the caller's, not ours).
+   *  - Client mode: the daemon cannot reach private memory, so the read is
+   *    staged through a freshly allocated SHM buffer. The task is marked
+   *    TASK_DATA_OWNER (its destructor frees the staging buffer on DelTask) and
+   *    GetBlobTask::PostWait() copies the staged bytes into the caller's buffer
+   *    when the read completes.
+   *
+   * @return A Future over the read. On the cache-hit path the Future is EMPTY
+   *         (Wait() succeeds immediately; do not dereference it). On the other
+   *         paths the task is readable after Wait() (GetReturnCode()==0 on
+   *         success). An empty Future is also returned if SHM staging could not
+   *         be allocated in client mode.
+   */
+  clio::run::Future<GetBlobTask> AsyncGetBlob(
+      const TagId &tag_id, const std::string &blob_name,
+      clio::run::u64 offset, clio::run::u64 size, clio::run::u32 flags,
+      char *priv_data,
+      const clio::run::PoolQuery &pool_query = clio::run::PoolQuery::Dynamic(),
+      const Context &context = Context()) {
+    auto *ipc_manager = CLIO_CPU_IPC;
+
+    // Fastest path: node-local RAM-resident blob → copy straight out of shared
+    // memory. A miss (not cached / not direct-readable / placement moved) falls
+    // through to a real task, so this is only ever faster, never wrong.
+    if (priv_data != nullptr && size > 0 && HasShmCache() &&
+        TryReadBlobShm(tag_id, blob_name, priv_data, size, offset)) {
+      return clio::run::Future<GetBlobTask>();
+    }
+
+    if (CLIO_RUNTIME_MANAGER->IsRuntime()) {
+      // Co-located daemon: write directly into the private buffer. The null
+      // AllocatorId marks the offset as an absolute process address.
+      ctp::ipc::ShmPtr<> raw = ctp::ipc::ShmPtr<>::FromRaw(priv_data);
+      auto task = ipc_manager->NewTask<GetBlobTask>(
+          clio::run::CreateTaskId(), pool_id_, pool_query, tag_id, blob_name,
+          offset, size, flags, raw, context);
+      return ipc_manager->Send(task);
+    }
+
+    // Client: stage through an SHM buffer; PostWait() copies it into priv_data
+    // and ~GetBlobTask (TASK_DATA_OWNER) frees the staging buffer.
+    ctp::ipc::FullPtr<char> staging = ipc_manager->AllocateBuffer(size);
+    if (staging.IsNull()) {
+      return clio::run::Future<GetBlobTask>();
+    }
+    auto task = ipc_manager->NewTask<GetBlobTask>(
+        clio::run::CreateTaskId(), pool_id_, pool_query, tag_id, blob_name,
+        offset, size, flags, ctp::ipc::ShmPtr<>(staging.shm_), context);
+    auto *t = task.get();
+    // priv_dest_/priv_src_ are NOT serialized, so they stay on this client
+    // instance (the daemon's copy default-constructs them to null).
+    t->priv_dest_ = priv_data;
+    t->priv_src_ = staging.ptr_;
+    auto fut = ipc_manager->Send(task);
+    // Mark ownership only AFTER Send has serialized the task: Task::SerializeIn
+    // ships task_flags_, so setting TASK_DATA_OWNER earlier would hand the flag
+    // to the daemon, whose task shares the very same physical SHM buffer on the
+    // local path — and it would free the client's buffer out from under us.
+    // Set client-side, this instance's ~GetBlobTask frees the staging buffer
+    // when the Future (task) is destroyed. Same object the Future retains.
+    t->SetFlags(TASK_DATA_OWNER);
+    return fut;
+  }
+
+  /**
    * Vectored get (issue #820): read N regions of one blob in a SINGLE task,
    * each region landing in its OWN buffer.
    *

--- a/context-transfer-engine/core/include/clio_cte/core/core_client.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_client.h
@@ -869,6 +869,27 @@ class Client : public clio::run::ContainerClient {
   }
 
   /**
+   * Asynchronously evict data off a tier by score until a byte budget is met.
+   * Frees the lowest-score blobs residing on any target whose score is at least
+   * min_tier_score, cheapest-first, until at least bytes of physical capacity
+   * has been reclaimed (or no candidates remain). Broadcast across all
+   * containers; the returned task's bytes_evicted_/blobs_evicted_ are the
+   * tier-wide totals.
+   * @param min_tier_score Only evict blobs on targets with score >= this
+   *                       (0.0 = any tier)
+   * @param bytes Reclaim at least this many bytes from the tier
+   */
+  clio::run::Future<EvictTask> AsyncEvict(
+      float min_tier_score, clio::run::u64 bytes,
+      const clio::run::PoolQuery &pool_query = clio::run::PoolQuery::Broadcast()) {
+    auto *ipc_manager = CLIO_CPU_IPC;
+    auto task = ipc_manager->NewTask<EvictTask>(clio::run::CreateTaskId(),
+                                                pool_id_, pool_query,
+                                                min_tier_score, bytes);
+    return ipc_manager->Send(task);
+  }
+
+  /**
    * Asynchronously truncate a blob to an exact logical size (grow/shrink).
    * @param tag_id Tag the blob belongs to
    * @param blob_name Blob to resize

--- a/context-transfer-engine/core/include/clio_cte/core/core_client.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_client.h
@@ -1477,6 +1477,30 @@ class Tag {
                                         const Context &context = Context());
 
   /**
+   * Asynchronous private-memory PutBlob (issue #830): write a blob region
+   * straight from a caller-owned PRIVATE buffer (const char*, e.g. heap/stack),
+   * with no manual shared-memory management. Write-side analog of the #823
+   * private GetBlob; delegates to CoreClient::AsyncPutBlob(const char*) — see
+   * there for the two paths (runtime-direct no-copy / client-staging with
+   * TASK_DATA_OWNER).
+   *
+   * @param blob_name Name of the blob to write
+   * @param data Source PRIVATE buffer (must stay valid until Wait() returns)
+   * @param data_size Number of bytes to write
+   * @param off Offset within blob (default 0)
+   * @param score Blob score for placement (default -1.0 = auto)
+   * @param context Compression context (default empty)
+   * @return Future over the write; readable after Wait() (GetReturnCode()==0 on
+   *         success). An empty Future is returned only if client-mode SHM
+   *         staging could not be allocated.
+   */
+  clio::run::Future<PutBlobTask> AsyncPutBlob(const std::string &blob_name,
+                                              const char *data,
+                                              size_t data_size, size_t off = 0,
+                                              float score = -1.0f,
+                                              const Context &context = Context());
+
+  /**
    * GetBlob - Allocates shared memory, retrieves blob data, copies to output
    * buffer
    * @param blob_name Name of the blob to retrieve

--- a/context-transfer-engine/core/include/clio_cte/core/core_client.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_client.h
@@ -463,6 +463,56 @@ class Client : public clio::run::ContainerClient {
   }
 
   /**
+   * Vectored put (issue #820): write N regions of one blob in a SINGLE task.
+   *
+   * The runtime acquires the blob's write token once, sizes the blob to cover
+   * the union of the regions, and applies each region in list order — so N
+   * disjoint writes to one blob cost one token acquire and one metadata
+   * mutation instead of N of each, and two regions covering the same bytes
+   * resolve last-writer-wins (which N racing single-region tasks do not).
+   *
+   * Each segment keeps its own buffer, so callers never have to gather their
+   * payloads into one contiguous allocation. Node-local: the segment buffers
+   * are shared-memory pointers, so submit this to a local pool.
+   */
+  clio::run::Future<PutBlobTask> AsyncPutBlobVectored(
+      const TagId &tag_id,
+      const char *blob_name,
+      const std::vector<BlobSegment> &segments, float score = -1.0f,
+      const Context &context = Context(),
+      clio::run::u32 flags = 0,
+      const clio::run::PoolQuery &pool_query = clio::run::PoolQuery::Dynamic()) {
+    auto *ipc_manager = CLIO_CPU_IPC;
+    // offset/size/data stay zero-valued: segments_ is authoritative when set,
+    // and the runtime derives the union range from it.
+    auto task = ipc_manager->NewTask<PutBlobTask>(
+        clio::run::CreateTaskId(), pool_id_, pool_query, tag_id,
+        blob_name, static_cast<clio::run::u64>(0), static_cast<clio::run::u64>(0),
+        ctp::ipc::ShmPtr<>::GetNull(), score, context, flags);
+    auto *t = task.get();
+    for (const auto &seg : segments) {
+      t->segments_.push_back(BlobSegment(seg.blob_off_, seg.size_, seg.data_));
+    }
+    t->submit_ts_ns_ =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::steady_clock::now().time_since_epoch())
+            .count();
+    return ipc_manager->Send(task);
+  }
+
+  /** std::string overload */
+  clio::run::Future<PutBlobTask> AsyncPutBlobVectored(
+      const TagId &tag_id,
+      const std::string &blob_name,
+      const std::vector<BlobSegment> &segments, float score = -1.0f,
+      const Context &context = Context(),
+      clio::run::u32 flags = 0,
+      const clio::run::PoolQuery &pool_query = clio::run::PoolQuery::Dynamic()) {
+    return AsyncPutBlobVectored(tag_id, blob_name.c_str(), segments, score,
+                                context, flags, pool_query);
+  }
+
+  /**
    * Asynchronous get blob - returns immediately
    * @param tag_id Tag ID
    * @param blob_name Name of the blob

--- a/context-transfer-engine/core/include/clio_cte/core/core_client.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_client.h
@@ -1414,6 +1414,26 @@ class Tag {
                size_t data_size, size_t off = 0);
 
   /**
+   * Asynchronous private-memory GetBlob (issue #823): read a blob region
+   * straight into a caller-owned PRIVATE buffer (char*, e.g. heap/stack), with
+   * no manual shared-memory management. Delegates to
+   * CoreClient::AsyncGetBlob(char*) — see there for the three paths (shared
+   * cache / runtime-direct / client-staging).
+   *
+   * @param blob_name Name of the blob to retrieve
+   * @param data Output PRIVATE buffer (pre-allocated by caller, >= data_size)
+   * @param data_size Size of data to retrieve (must be > 0)
+   * @param off Offset within blob (default 0)
+   * @return Future over the read. On the shared-cache path the Future is EMPTY
+   *         (Wait() returns immediately; do not dereference it); otherwise the
+   *         task is readable after Wait() (GetReturnCode()==0 on success). The
+   *         buffer holds the bytes once Wait() returns.
+   */
+  clio::run::Future<GetBlobTask> AsyncGetBlob(const std::string &blob_name,
+                                              char *data, size_t data_size,
+                                              size_t off = 0);
+
+  /**
    * Get blob score
    * @param blob_name Name of the blob
    * @return Blob score (0.0-1.0)

--- a/context-transfer-engine/core/include/clio_cte/core/core_runtime.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_runtime.h
@@ -164,6 +164,9 @@ public:
   clio::run::TaskResume GetBlob(clio::run::shared_ptr<GetBlobTask> &task);
   /** Reorganize single blob (Method::kReorganizeBlob) - update score. */
   clio::run::TaskResume ReorganizeBlob(clio::run::shared_ptr<ReorganizeBlobTask> &task);
+  /** Evict lowest-score blobs off a tier until a byte budget is reclaimed
+   *  (Method::kEvict). Broadcast; each shard reports its share. */
+  clio::run::TaskResume Evict(clio::run::shared_ptr<EvictTask> &task);
 
   /**
    * Rescore-and-move one blob without spawning a ReorganizeBlobTask (issue

--- a/context-transfer-engine/core/include/clio_cte/core/core_runtime.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_runtime.h
@@ -639,7 +639,8 @@ private:
    */
   clio::run::TaskResume ExtendBlob(BlobInfo &blob_info, clio::run::u64 offset, clio::run::u64 size,
                              float blob_score, clio::run::u32 &error_code,
-                             int min_persistence_level = 0);
+                             int min_persistence_level = 0,
+                             clio::run::u64 preallocate = 0);
 
   /**
    * Resize a blob to exactly new_size: grow (allocate appended blocks via

--- a/context-transfer-engine/core/include/clio_cte/core/core_runtime.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_runtime.h
@@ -584,8 +584,9 @@ private:
    * @param success Output parameter: true if allocation succeeded, false otherwise
    * Returns TaskResume for coroutine-based async operations
    */
-  clio::run::TaskResume AllocateFromTarget(TargetInfo &target_info, clio::run::u64 size,
-                                     clio::run::u64 &allocated_offset, bool &success);
+  clio::run::TaskResume AllocateFromTarget(
+      TargetInfo &target_info, clio::run::u64 size,
+      std::vector<clio::run::bdev::Block> &out_blocks, bool &success);
 
   /**
    * Free all blocks from a blob back to their respective targets

--- a/context-transfer-engine/core/include/clio_cte/core/core_runtime.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_runtime.h
@@ -288,6 +288,22 @@ public:
    */
   clio::run::TaskStat GetTaskStats(const clio::run::Task *task) const override;
 
+  /**
+   * Worker-local batching policy (issue #820).
+   *
+   * PutBlob/GetBlob tasks aimed at the SAME blob are parked together and then
+   * collapsed into one vectored task per blob. This is the whole point of the
+   * feature: the filesystem stores each 1 MiB page as one blob, so a sequential
+   * 4 KiB workload sends 256 tasks at one page-blob and every one of them has to
+   * take that blob's #680 write token across its entire body. Merged, they cost
+   * one token acquire and one bdev pass.
+   */
+  bool BuildBatch(clio::run::u32 method,
+                  const clio::run::shared_ptr<clio::run::Task> &task,
+                  clio::run::BatchGroups &groups) override;
+  void SmashBatch(clio::run::BatchGroups &groups,
+                  clio::run::BatchSink &sink) override;
+
   // Container virtual method implementations (defined in autogen/core_lib_exec.cc)
   void SaveTask(clio::run::u32 method, clio::run::SaveTaskArchive &archive,
                 clio::run::shared_ptr<clio::run::Task>& task_ptr) override;

--- a/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
@@ -37,6 +37,7 @@
 #include <algorithm>
 #include <atomic>
 #include <cassert>
+#include <cstring>
 
 #include <clio_runtime/clio_runtime.h>
 #include <clio_cte/core/autogen/core_methods.h>
@@ -1587,6 +1588,29 @@ struct GetBlobTask : public clio::run::Task {
   IN clio::run::u32 gpu_page_idx_;
   INOUT Context context_;  // Emulation control + modeled time (issue #747)
 
+  /**
+   * Private-memory destination for the client-mode fast path (issue #823).
+   *
+   * Both are HOST-ONLY process pointers and are deliberately NOT serialized
+   * (they are absent from SerializeIn/SerializeOut) — a raw address is
+   * meaningless in the daemon's address space, and adding them here does not
+   * change the wire layout. They matter only on the client instance the
+   * Future retains.
+   *
+   * When a private-memory AsyncGetBlob runs in CLIENT mode it must stage the
+   * read through a shared-memory buffer (the daemon cannot reach the caller's
+   * private buffer). `priv_src_` is the client-local address of that SHM
+   * staging buffer (also referenced as blob_data_ in offset form) and
+   * `priv_dest_` is the caller's private buffer. PostWait() copies size_ bytes
+   * src→dest once the read completes; TASK_DATA_OWNER then frees the staging
+   * buffer when the task is destroyed. Left null on every other path (runtime
+   * mode writes straight into the private buffer via a null-allocator ShmPtr,
+   * and every pre-existing caller passes SHM buffers), so PostWait() is a
+   * no-op for them.
+   */
+  char *priv_dest_ = nullptr;  // caller's private buffer (copy target)
+  char *priv_src_ = nullptr;   // client-local addr of the SHM staging buffer
+
   // SHM constructor
   CTP_CROSS_FUN GetBlobTask()
       : clio::run::Task(),
@@ -1652,6 +1676,23 @@ struct GetBlobTask : public clio::run::Task {
       if (ipc_manager) {
         ipc_manager->FreeBuffer(blob_data_.template Cast<char>());
       }
+    }
+#endif
+  }
+
+  /**
+   * Post-completion hook (issue #823): deliver a client-mode private-memory
+   * read into the caller's buffer. Called by Future::Wait() after the read
+   * completes and before the task is reaped. A no-op unless both private
+   * pointers were set (only CoreClient::AsyncGetBlob(char*)'s client-mode path
+   * sets them), so it never disturbs the SHM/runtime-direct/vectored callers.
+   * The staging buffer itself is freed by ~GetBlobTask via TASK_DATA_OWNER.
+   */
+  void PostWait() {
+#if !CTP_IS_DEVICE_PASS
+    if (priv_dest_ != nullptr && priv_src_ != nullptr && size_ > 0 &&
+        GetReturnCode() == 0) {
+      std::memcpy(priv_dest_, priv_src_, size_);
     }
 #endif
   }

--- a/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
@@ -1259,12 +1259,64 @@ struct GetOrCreateTagTask : public clio::run::Task {
 /**
  * PutBlob task - Store a blob with optional compression context
  */
+/**
+ * One region of a vectored PutBlob/GetBlob (issue #820).
+ *
+ * A vectored task carries N of these instead of a single (offset, size, data)
+ * triple, so the runtime can acquire the blob's #680 write token ONCE and apply
+ * every region in one pass. Each segment keeps its OWN buffer, which is what
+ * lets the worker's batching layer merge N independent tasks without gathering
+ * their payloads into one contiguous allocation — the members' buffers become
+ * the segments directly.
+ *
+ * The buffer is a shared-memory pointer, so segments are valid to any process
+ * on THIS node. A vectored task is therefore node-local in v1 (the batching
+ * layer only ever builds them for tasks that already routed ExecHere); a
+ * cross-node vectored submit would need one bulk transfer per segment and is
+ * not supported yet.
+ */
+struct BlobSegment {
+  clio::run::u64 blob_off_;  // offset of this region within the blob
+  clio::run::u64 size_;      // bytes in this region
+  ctp::ipc::ShmPtr<> data_;  // this region's own buffer (src for put, dst for get)
+
+  CTP_CROSS_FUN BlobSegment()
+      : blob_off_(0), size_(0), data_(ctp::ipc::ShmPtr<>::GetNull()) {}
+  CTP_CROSS_FUN BlobSegment(clio::run::u64 blob_off, clio::run::u64 size,
+                            ctp::ipc::ShmPtr<> data)
+      : blob_off_(blob_off), size_(size), data_(data) {}
+
+  template <typename Archive>
+  CTP_CROSS_FUN void serialize(Archive &ar) {
+    ar(blob_off_, size_, data_);
+  }
+};
+
 struct PutBlobTask : public clio::run::Task {
   IN TagId tag_id_;                    // Tag ID for blob grouping
   INOUT clio::run::priv::string blob_name_;  // Blob name (required)
   IN clio::run::u64 offset_;                 // Offset within blob
   IN clio::run::u64 size_;                   // Size of blob data
   IN ctp::ipc::ShmPtr<> blob_data_;        // Blob data (shared memory pointer)
+  /**
+   * Vectored regions (issue #820). EMPTY is the normal single-region case, in
+   * which (offset_, size_, blob_data_) above are authoritative — every existing
+   * caller and both emplace constructors leave this empty, so nothing changes
+   * for them. When non-empty this task is VECTORED: the regions below are
+   * authoritative and offset_/size_/blob_data_ are ignored.
+   *
+   * Segments are applied in LIST ORDER, so two segments covering the same bytes
+   * resolve last-writer-wins — which is the ordering guarantee the #680 token
+   * race does not provide when the same writes arrive as separate tasks.
+   */
+  IN clio::run::priv::vector<BlobSegment> segments_;
+
+  /** Compile-time capability: this task type carries `segments_`. The GPU POD
+   *  variant (PodPutBlobTask) sets this false and stays a plain POD — vectored
+   *  puts are a host-side batching feature and the device path never needs
+   *  them. PutBlobImpl is templated over both, so it guards with
+   *  `if constexpr (TaskT::kSupportsVectored)`. */
+  static constexpr bool kSupportsVectored = true;
   IN float score_;         // Score for placement: -1.0=unknown (use defaults),
                            // 0.0-1.0=explicit
   INOUT Context context_;  // Context for compression control and statistics
@@ -1298,6 +1350,7 @@ struct PutBlobTask : public clio::run::Task {
         offset_(0),
         size_(0),
         blob_data_(ctp::ipc::ShmPtr<>::GetNull()),
+        segments_(CLIO_PRIV_ALLOC),
         score_(-1.0f),
         context_(),
         flags_(0),
@@ -1319,6 +1372,7 @@ struct PutBlobTask : public clio::run::Task {
         offset_(offset),
         size_(size),
         blob_data_(blob_data),
+        segments_(CLIO_PRIV_ALLOC),
         score_(score),
         context_(context),
         flags_(flags),
@@ -1346,6 +1400,7 @@ struct PutBlobTask : public clio::run::Task {
         offset_(offset),
         size_(size),
         blob_data_(blob_data),
+        segments_(CLIO_PRIV_ALLOC),
         score_(score),
         context_(context),
         flags_(flags),
@@ -1394,7 +1449,7 @@ struct PutBlobTask : public clio::run::Task {
     ar.PushPod(blob_name_.UsingSso());
     Task::SerializeIn(ar);
     ar(tag_id_, blob_name_, offset_, size_, blob_data_,
-       score_, context_, flags_, gpu_page_idx_, submit_ts_ns_);
+       score_, context_, flags_, gpu_page_idx_, submit_ts_ns_, segments_);
     ar.PopPod();
     // Emulated puts (issue #747) never write the payload, so don't ship it
     // over the wire either — the whole point is to not pay for the I/O.
@@ -1427,6 +1482,7 @@ struct PutBlobTask : public clio::run::Task {
   /** Fix up priv::string SSO pointer after cudaMemcpy D→H */
   CTP_CROSS_FUN void FixupAfterCopy() {
     blob_name_.FixupSsoPointer();
+    segments_.FixupSvoPtr();
   }
 
   /**
@@ -1440,6 +1496,7 @@ struct PutBlobTask : public clio::run::Task {
     offset_ = other->offset_;
     size_ = other->size_;
     blob_data_ = other->blob_data_;
+    segments_ = other->segments_;
     score_ = other->score_;
     context_ = other->context_;
     flags_ = other->flags_;
@@ -1723,6 +1780,9 @@ using PodBlobName = clio::run::priv::fixed_string<32>;
  * PodPutBlob - fully-POD, GPU-compatible variant of PutBlobTask.
  */
 struct PodPutBlobTask : public clio::run::Task {
+  /** No `segments_`: vectored puts are a host-side batching feature and this
+   *  variant must stay a plain POD for the device path (issue #820). */
+  static constexpr bool kSupportsVectored = false;
   IN TagId tag_id_;
   INOUT PodBlobName blob_name_;
   IN clio::run::u64 offset_;

--- a/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
@@ -1526,6 +1526,19 @@ struct GetBlobTask : public clio::run::Task {
   IN ctp::ipc::ShmPtr<>
       blob_data_;  // Input buffer for blob data (shared memory pointer)
   /**
+   * Vectored regions (issue #820). EMPTY is the ordinary single-region case;
+   * non-empty makes this a vectored read, where each region is read straight
+   * into ITS OWN buffer. That is what lets the batching layer merge N reads of
+   * one blob without a post-hoc scatter copy: each member's destination buffer
+   * is a segment, so the runtime fills it directly.
+   *
+   * All segments are served from ONE block-layout snapshot, so a vectored read
+   * sees a single consistent view of the blob rather than N independent ones.
+   */
+  IN clio::run::priv::vector<BlobSegment> segments_;
+  /** @copydoc PutBlobTask::kSupportsVectored */
+  static constexpr bool kSupportsVectored = true;
+  /**
    * Optional page index appended to blob_name_ at handler time as
    * "_pi<gpu_page_idx_>". See PutBlobTask::gpu_page_idx_ for rationale.
    */
@@ -1538,6 +1551,7 @@ struct GetBlobTask : public clio::run::Task {
       : clio::run::Task(),
         tag_id_(TagId::GetNull()),
         blob_name_(CLIO_PRIV_ALLOC),
+        segments_(CLIO_PRIV_ALLOC),
         offset_(0),
         size_(0),
         flags_(0),
@@ -1557,6 +1571,7 @@ struct GetBlobTask : public clio::run::Task {
       : clio::run::Task(task_id, pool_id, pool_query, Method::kGetBlob),
         tag_id_(tag_id),
         blob_name_(CLIO_PRIV_ALLOC, blob_name),
+        segments_(CLIO_PRIV_ALLOC),
         offset_(offset),
         size_(size),
         flags_(flags),
@@ -1612,6 +1627,7 @@ struct GetBlobTask : public clio::run::Task {
       : clio::run::Task(task_id, pool_id, pool_query, Method::kGetBlob),
         tag_id_(tag_id),
         blob_name_(CLIO_PRIV_ALLOC, blob_name),
+        segments_(CLIO_PRIV_ALLOC),
         offset_(offset),
         size_(size),
         flags_(flags),
@@ -1632,6 +1648,7 @@ struct GetBlobTask : public clio::run::Task {
   CTP_CROSS_FUN void SerializeIn(Archive &ar) {
     ar.PushPod(blob_name_.UsingSso());
     Task::SerializeIn(ar);
+    ar(segments_);
     ar(tag_id_, blob_name_, offset_, size_, flags_, blob_data_,
        gpu_page_idx_, context_);
     ar.PopPod();
@@ -1660,6 +1677,7 @@ struct GetBlobTask : public clio::run::Task {
   /** Fix up priv::string SSO pointer after cudaMemcpy D→H */
   CTP_CROSS_FUN void FixupAfterCopy() {
     blob_name_.FixupSsoPointer();
+    segments_.FixupSvoPtr();
   }
 
   /**
@@ -1674,6 +1692,7 @@ struct GetBlobTask : public clio::run::Task {
     size_ = other->size_;
     flags_ = other->flags_;
     blob_data_ = other->blob_data_;
+    segments_ = other->segments_;
     gpu_page_idx_ = other->gpu_page_idx_;
     context_ = other->context_;
   }
@@ -1906,6 +1925,9 @@ struct PodPutBlobTask : public clio::run::Task {
  * PodGetBlob - fully-POD, GPU-compatible variant of GetBlobTask.
  */
 struct PodGetBlobTask : public clio::run::Task {
+  /** No `segments_`: vectored reads are a host-side feature; this variant
+   *  stays a plain POD for the device path (issue #820). */
+  static constexpr bool kSupportsVectored = false;
   IN TagId tag_id_;
   IN PodBlobName blob_name_;
   IN clio::run::u64 offset_;

--- a/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
@@ -1861,6 +1861,83 @@ struct ReorganizeBlobTask : public clio::run::Task {
   }
 };
 
+/**
+ * EvictTask - score-driven capacity reclamation.
+ *
+ * Frees the lowest-score blobs that occupy a tier until a byte budget is met.
+ * A "tier to evict from" is named by min_tier_score_: any registered target
+ * whose target_score_ >= min_tier_score_ qualifies (so 0.0 means "any tier",
+ * a high value means "only the fast/expensive tiers"). Blobs are ranked by
+ * their own score_ ascending and evicted (blocks freed, metadata removed)
+ * cheapest-first until bytes_ of physical capacity has been reclaimed from
+ * qualifying targets, or no candidates remain.
+ *
+ * Broadcast op: each container evicts from its own metadata shard and reports
+ * its share; AggregateOut sums bytes_evicted_/blobs_evicted_ across shards.
+ */
+struct EvictTask : public clio::run::Task {
+  IN float min_tier_score_;   // Only evict blobs on targets with score >= this
+  IN clio::run::u64 bytes_;   // Reclaim at least this many bytes from the tier
+  OUT clio::run::u64 bytes_evicted_;  // Physical bytes actually reclaimed
+  OUT clio::run::u64 blobs_evicted_;  // Number of blobs evicted
+
+  // SHM constructor
+  EvictTask()
+      : clio::run::Task(),
+        min_tier_score_(0.0f),
+        bytes_(0),
+        bytes_evicted_(0),
+        blobs_evicted_(0) {}
+
+  // Emplace constructor
+  CTP_CROSS_FUN explicit EvictTask(const clio::run::TaskId &task_id,
+                                   const clio::run::PoolId &pool_id,
+                                   const clio::run::PoolQuery &pool_query,
+                                   float min_tier_score, clio::run::u64 bytes)
+      : clio::run::Task(task_id, pool_id, pool_query, Method::kEvict),
+        min_tier_score_(min_tier_score),
+        bytes_(bytes),
+        bytes_evicted_(0),
+        blobs_evicted_(0) {
+    task_id_ = task_id;
+    pool_id_ = pool_id;
+    method_ = Method::kEvict;
+    task_flags_.Clear();
+    pool_query_ = pool_query;
+  }
+
+  template <typename Archive>
+  CTP_CROSS_FUN void SerializeIn(Archive &ar) {
+    Task::SerializeIn(ar);
+    ar(min_tier_score_, bytes_);
+  }
+
+  template <typename Archive>
+  CTP_CROSS_FUN void SerializeOut(Archive &ar) {
+    Task::SerializeOut(ar);
+    ar(bytes_evicted_, blobs_evicted_);
+  }
+
+  void Copy(const ctp::ipc::FullPtr<EvictTask> &other) {
+    Task::Copy(other.template Cast<Task>());
+    min_tier_score_ = other->min_tier_score_;
+    bytes_ = other->bytes_;
+    bytes_evicted_ = other->bytes_evicted_;
+    blobs_evicted_ = other->blobs_evicted_;
+  }
+
+  /**
+   * Broadcast aggregation: SUM the per-shard eviction totals rather than
+   * overwrite, so the client sees the tier-wide bytes/blobs reclaimed.
+   */
+  void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
+    Task::AggregateOut(other_base);
+    auto other = other_base.template Cast<EvictTask>();
+    bytes_evicted_ += other->bytes_evicted_;
+    blobs_evicted_ += other->blobs_evicted_;
+  }
+};
+
 // ===========================================================================
 // Fully-POD, GPU-compatible blob tasks (issue #556).
 //

--- a/context-transfer-engine/core/src/autogen/core_lib_exec.cc
+++ b/context-transfer-engine/core/src/autogen/core_lib_exec.cc
@@ -132,6 +132,11 @@ clio::run::TaskResume Runtime::Run(clio::run::u32 method, clio::run::shared_ptr<
       CLIO_CO_AWAIT(DelBlob(typed_task));
       break;
     }
+    case Method::kEvict: {
+      auto& typed_task = task_ptr.template Cast<EvictTask>();
+      CLIO_CO_AWAIT(Evict(typed_task));
+      break;
+    }
     case Method::kTruncateBlob: {
       auto& typed_task = task_ptr.template Cast<TruncateBlobTask>();
       CLIO_CO_AWAIT(TruncateBlob(typed_task));
@@ -338,6 +343,11 @@ void Runtime::SaveTask(clio::run::u32 method, clio::run::SaveTaskArchive& archiv
       archive << *typed_task;
       break;
     }
+    case Method::kEvict: {
+      auto& typed_task = task_ptr.template Cast<EvictTask>();
+      archive << *typed_task;
+      break;
+    }
     case Method::kTruncateBlob: {
       auto& typed_task = task_ptr.template Cast<TruncateBlobTask>();
       archive << *typed_task;
@@ -525,6 +535,11 @@ void Runtime::LoadTask(clio::run::u32 method, clio::run::LoadTaskArchive& archiv
     }
     case Method::kDelBlob: {
       auto& typed_task = task_ptr.template Cast<DelBlobTask>();
+      archive >> *typed_task;
+      break;
+    }
+    case Method::kEvict: {
+      auto& typed_task = task_ptr.template Cast<EvictTask>();
       archive >> *typed_task;
       break;
     }
@@ -734,6 +749,12 @@ void Runtime::LocalLoadTask(clio::run::u32 method, clio::run::DefaultLoadArchive
     }
     case Method::kDelBlob: {
       auto& typed_task = task_ptr.template Cast<DelBlobTask>();
+      // Use archive operator which respects msg_type
+      archive >> *typed_task;
+      break;
+    }
+    case Method::kEvict: {
+      auto& typed_task = task_ptr.template Cast<EvictTask>();
       // Use archive operator which respects msg_type
       archive >> *typed_task;
       break;
@@ -960,6 +981,12 @@ void Runtime::LocalSaveTask(clio::run::u32 method, clio::run::DefaultSaveArchive
     }
     case Method::kDelBlob: {
       auto& typed_task = task_ptr.template Cast<DelBlobTask>();
+      // Use archive operator which respects msg_type
+      archive << *typed_task;
+      break;
+    }
+    case Method::kEvict: {
+      auto& typed_task = task_ptr.template Cast<EvictTask>();
       // Use archive operator which respects msg_type
       archive << *typed_task;
       break;
@@ -1262,6 +1289,15 @@ clio::run::shared_ptr<clio::run::Task> Runtime::NewCopyTask(clio::run::u32 metho
       }
       break;
     }
+    case Method::kEvict: {
+      auto new_task_ptr = ipc_manager->NewTask<EvictTask>();
+      if (!new_task_ptr.IsNull()) {
+        auto& task_typed = orig_task_ptr.template Cast<EvictTask>();
+        new_task_ptr->Copy(ctp::ipc::FullPtr<EvictTask>(task_typed.get()));
+        return new_task_ptr.template Cast<clio::run::Task>();
+      }
+      break;
+    }
     case Method::kTruncateBlob: {
       auto new_task_ptr = ipc_manager->NewTask<TruncateBlobTask>();
       if (!new_task_ptr.IsNull()) {
@@ -1556,6 +1592,10 @@ clio::run::shared_ptr<clio::run::Task> Runtime::NewTask(clio::run::u32 method) {
       auto new_task_ptr = ipc_manager->NewTask<DelBlobTask>();
       return new_task_ptr.template Cast<clio::run::Task>();
     }
+    case Method::kEvict: {
+      auto new_task_ptr = ipc_manager->NewTask<EvictTask>();
+      return new_task_ptr.template Cast<clio::run::Task>();
+    }
     case Method::kTruncateBlob: {
       auto new_task_ptr = ipc_manager->NewTask<TruncateBlobTask>();
       return new_task_ptr.template Cast<clio::run::Task>();
@@ -1723,6 +1763,11 @@ void Runtime::AggregateOut(clio::run::u32 method, clio::run::shared_ptr<clio::ru
     }
     case Method::kDelBlob: {
       auto& typed_task = orig_task.template Cast<DelBlobTask>();
+      typed_task->AggregateOut(ctp::ipc::FullPtr<clio::run::Task>(replica_task.get()));
+      break;
+    }
+    case Method::kEvict: {
+      auto& typed_task = orig_task.template Cast<EvictTask>();
       typed_task->AggregateOut(ctp::ipc::FullPtr<clio::run::Task>(replica_task.get()));
       break;
     }

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -1607,7 +1607,16 @@ clio::run::TaskResume Runtime::PutBlobImpl(clio::run::shared_ptr<TaskT> &task) {
     // #680 write-token re-check period; see BlobWriteLockPollUs() (default 10us,
     // env CLIO_WRITE_TOKEN_POLL_US).
     clio::run::u64 lock_tok = reinterpret_cast<clio::run::u64>(task.get());
+    clio::run::u64 _tok_spin = 0;  // [HANGWATCH-TOK] stuck-holder probe (#822)
     while (!blob_info_ptr->TryLockWrite(lock_tok)) {
+      if ((++_tok_spin % 20000) == 0) {
+        ctp::ipc::atomic_ref<clio::run::u64> _own(blob_info_ptr->write_owner_);
+        HLOG(kError,
+             "[HANGWATCH-TOK] PutBlob spinning on write token blob='{}' "
+             "owner_tok={} my_tok={} spins={}",
+             task->blob_name_.str(),
+             _own.load(std::memory_order_relaxed), lock_tok, _tok_spin);
+      }
       CLIO_CO_AWAIT(clio::run::yield(BlobWriteLockPollUs()));
     }
     BlobWriteLockGuard blob_write_guard(blob_info_ptr.get(), lock_tok);

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -1621,7 +1621,8 @@ clio::run::TaskResume Runtime::PutBlobImpl(clio::run::shared_ptr<TaskT> &task) {
     } else {
       CLIO_CO_AWAIT(ExtendBlob(*blob_info_ptr, offset, size, blob_score,
                           alloc_result,
-                          task->context_.min_persistence_level_));
+                          task->context_.min_persistence_level_,
+                          task->context_.preallocate_));
     }
     if (alloc_result != 0) {
       task->return_code_ = 10 + alloc_result;
@@ -4405,7 +4406,8 @@ std::shared_ptr<BlobInfo> Runtime::CreateNewBlob(const std::string &blob_name,
 clio::run::TaskResume Runtime::ExtendBlob(BlobInfo &blob_info, clio::run::u64 offset,
                                     clio::run::u64 size, float blob_score,
                                     clio::run::u32 &error_code,
-                                    int min_persistence_level) {
+                                    int min_persistence_level,
+                                    clio::run::u64 preallocate) {
 #ifdef CLIO_ENABLE_BOOST_COROUTINES
   clio::run::shared_ptr<clio::run::Task> cur_task = clio::run::GetCurrentTask();
 #endif
@@ -4547,11 +4549,20 @@ clio::run::TaskResume Runtime::ExtendBlob(BlobInfo &blob_info, clio::run::u64 of
     // block at 64 KB so the bdev could always answer with one contiguous block
     // -- an anti-fragmentation policy that did not belong in the CTE.
     constexpr clio::run::u64 kAppendSlab = 4096;  // bdev slab granularity
-    clio::run::u64 req =
+    // Bytes the blob's SIZE must grow by from this target.
+    clio::run::u64 logical_need =
         std::min(remaining_to_allocate, target_info_copy.remaining_space_);
-    if (req == 0) {
+    if (logical_need == 0) {
       continue;
     }
+    // PHYSICAL to request: at least the logical need, but PREALLOCATE up to the
+    // caller's hint (clio-fs asks for 64 KiB per PutBlob) so subsequent small
+    // appends fill the last block's spare capacity_ in place instead of each
+    // triggering a fresh allocation (and its bdev sub-task) under the write
+    // token. The extra physical becomes spare capacity on the last block; only
+    // `logical_need` bytes are published as size_. Capped by remaining_space_.
+    clio::run::u64 req = std::min(std::max(logical_need, preallocate),
+                                  target_info_copy.remaining_space_);
     std::vector<clio::run::bdev::Block> out_blocks;
     bool alloc_success = false;
     CLIO_CO_AWAIT(AllocateFromTarget(target_info_copy, req, out_blocks,
@@ -4560,15 +4571,16 @@ clio::run::TaskResume Runtime::ExtendBlob(BlobInfo &blob_info, clio::run::u64 of
       continue;  // this target can't satisfy req; outer loop tries the next
     }
 
-    // Distribute the logical request `req` across the physical blocks the bdev
-    // returned. Each block's size_ is its PHYSICAL footprint (what it occupies
-    // and what capacity_ must credit on free); the blob covers up to that many
-    // logical bytes with it, so `req` logical bytes span the blocks with only
-    // the last one carrying spare capacity. No co_await in this loop, so
-    // total_size_cache_ advances atomically with blocks_ wrt other tasks on
-    // this worker.
+    // Distribute only `logical_need` logical bytes across the physical blocks
+    // the bdev returned. Each block's size_ is its logical coverage and its
+    // capacity_ is the PHYSICAL footprint (what it occupies and what free()
+    // credits); when req > logical_need (preallocation) the trailing physical
+    // is left as spare capacity_ on the last block(s) that received data — the
+    // spare-capacity fast path above then consumes it on later appends with no
+    // new allocation. No co_await in this loop, so total_size_cache_ advances
+    // atomically with blocks_ wrt other tasks on this worker.
     clio::run::u64 physical_sum = 0;
-    clio::run::u64 need = req;
+    clio::run::u64 need = logical_need;
     for (const auto &b : out_blocks) {
       const clio::run::u64 physical = b.size_;  // footprint
       const clio::run::u64 logical = std::min(physical, need);
@@ -4581,7 +4593,7 @@ clio::run::TaskResume Runtime::ExtendBlob(BlobInfo &blob_info, clio::run::u64 of
       need -= logical;
     }
     blob_info.BumpPlacementGen();  // #817: block layout changed
-    remaining_to_allocate -= req;  // sum of logical == req
+    remaining_to_allocate -= (logical_need - need);  // logical actually placed
     (void)kAppendSlab;
 
     // Debit the CANONICAL target's remaining_space_ by the physical bytes taken

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -1835,6 +1835,30 @@ clio::run::TaskResume Runtime::GetBlobImpl(clio::run::shared_ptr<TaskT> &task) {
     // Suppress unused variable warning for flags - may be used in future
     (void)flags;
 
+    // Vectored get (issue #820): N regions, each read into its OWN buffer, all
+    // served from the single block snapshot taken below — so the whole read is
+    // one consistent view of the blob rather than N independent ones. `size`
+    // becomes the union extent purely for the validation and emulation paths.
+    bool vectored = false;
+    if constexpr (TaskT::kSupportsVectored) {
+      vectored = !task->segments_.empty();
+      if (vectored) {
+        clio::run::u64 lo = ~static_cast<clio::run::u64>(0);
+        clio::run::u64 hi = 0;
+        for (size_t i = 0; i < task->segments_.size(); ++i) {
+          const auto &seg = task->segments_[i];
+          if (seg.size_ == 0 || seg.data_.IsNull()) {
+            task->return_code_ = 1;
+            CLIO_CO_RETURN;
+          }
+          if (seg.blob_off_ < lo) lo = seg.blob_off_;
+          if (seg.blob_off_ + seg.size_ > hi) hi = seg.blob_off_ + seg.size_;
+        }
+        offset = lo;
+        size = hi - lo;
+      }
+    }
+
     // Validate input parameters
     if (size == 0) {
       task->return_code_ = 1;
@@ -1877,6 +1901,20 @@ clio::run::TaskResume Runtime::GetBlobImpl(clio::run::shared_ptr<TaskT> &task) {
     if (task->context_.emulate_) {
       task->context_.emulated_time_ns_ =
           EstimateIoTimeNs(blocks_snapshot, offset, size, /*is_write=*/false);
+    } else if (vectored) {
+      // Each region into its own buffer, off the one shared snapshot.
+      if constexpr (TaskT::kSupportsVectored) {
+        for (size_t i = 0; i < task->segments_.size(); ++i) {
+          const auto &seg = task->segments_[i];
+          clio::run::u32 read_result = 0;
+          CLIO_CO_AWAIT(ReadData(blocks_snapshot, seg.data_, seg.size_,
+                            seg.blob_off_, read_result));
+          if (read_result != 0) {
+            task->return_code_ = read_result;
+            CLIO_CO_RETURN;
+          }
+        }
+      }
     } else {
       clio::run::u32 read_result = 0;
       CLIO_CO_AWAIT(ReadData(blocks_snapshot, blob_data_ptr, size, offset,

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -1585,7 +1585,7 @@ clio::run::TaskResume Runtime::PutBlobImpl(clio::run::shared_ptr<TaskT> &task) {
     // suspends at one of those co_awaits. The guard releases the token on EVERY
     // exit below (normal completion, early CLIO_CO_RETURN, or a thrown
     // exception).
-    static constexpr double kBlobWriteLockPollUs = 2050.0;  // ~50us effective throttle (worker periodic ready-check has a 2000us tolerance); avoids the busy-poll hot-spin
+    static constexpr double kBlobWriteLockPollUs = 10.0;  // #680 token re-check. Small on purpose: a loser is parked ONLY during active same-blob write contention, where a fast hand-off beats the CPU saved by sleeping. 10us lands in the worker's fastest periodic bucket (Queue[0], scanned every ~4 loop iters) AND caps GetSuspendPeriod's idle suspend, so a freed token is re-grabbed in single-digit us instead of the old ~2ms idle-suspend worst case. GetSuspendPeriod returns -1 the instant the queue drains, so there is no idle spin; the only cost is some CPU while heavily contended -- acceptable on the write hot path.
     clio::run::u64 lock_tok = reinterpret_cast<clio::run::u64>(task.get());
     while (!blob_info_ptr->TryLockWrite(lock_tok)) {
       CLIO_CO_AWAIT(clio::run::yield(kBlobWriteLockPollUs));
@@ -2363,7 +2363,7 @@ clio::run::TaskResume Runtime::DelBlob(clio::run::shared_ptr<DelBlobTask> &task)
     // while a PutBlob iterates blocks_ across a co_await is a use-after-free.
     // The local shared_ptr keeps this BlobInfo alive past the map erase below,
     // so releasing the token in the guard destructor stays valid.
-    static constexpr double kBlobWriteLockPollUs = 2050.0;  // ~50us effective throttle (worker periodic ready-check has a 2000us tolerance); avoids the busy-poll hot-spin
+    static constexpr double kBlobWriteLockPollUs = 10.0;  // #680 token re-check. Small on purpose: a loser is parked ONLY during active same-blob write contention, where a fast hand-off beats the CPU saved by sleeping. 10us lands in the worker's fastest periodic bucket (Queue[0], scanned every ~4 loop iters) AND caps GetSuspendPeriod's idle suspend, so a freed token is re-grabbed in single-digit us instead of the old ~2ms idle-suspend worst case. GetSuspendPeriod returns -1 the instant the queue drains, so there is no idle spin; the only cost is some CPU while heavily contended -- acceptable on the write hot path.
     clio::run::u64 lock_tok = reinterpret_cast<clio::run::u64>(task.get());
     while (!blob_info_ptr->TryLockWrite(lock_tok)) {
       CLIO_CO_AWAIT(clio::run::yield(kBlobWriteLockPollUs));
@@ -2577,7 +2577,7 @@ clio::run::TaskResume Runtime::TruncateBlob(clio::run::shared_ptr<TruncateBlobTa
     // truncate and a write racing on blocks_ across the ResizeBlob co_await
     // corrupt the block layout. Busy-poll the token (lost-wakeup-proof — see
     // PutBlobImpl); the guard releases it on every exit path.
-    static constexpr double kBlobWriteLockPollUs = 2050.0;  // ~50us effective throttle (worker periodic ready-check has a 2000us tolerance); avoids the busy-poll hot-spin
+    static constexpr double kBlobWriteLockPollUs = 10.0;  // #680 token re-check. Small on purpose: a loser is parked ONLY during active same-blob write contention, where a fast hand-off beats the CPU saved by sleeping. 10us lands in the worker's fastest periodic bucket (Queue[0], scanned every ~4 loop iters) AND caps GetSuspendPeriod's idle suspend, so a freed token is re-grabbed in single-digit us instead of the old ~2ms idle-suspend worst case. GetSuspendPeriod returns -1 the instant the queue drains, so there is no idle spin; the only cost is some CPU while heavily contended -- acceptable on the write hot path.
     clio::run::u64 lock_tok = reinterpret_cast<clio::run::u64>(task.get());
     while (!blob_info_ptr->TryLockWrite(lock_tok)) {
       CLIO_CO_AWAIT(clio::run::yield(kBlobWriteLockPollUs));

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -1432,14 +1432,47 @@ clio::run::TaskResume Runtime::PutBlobImpl(clio::run::shared_ptr<TaskT> &task) {
     ctp::ipc::ShmPtr<> blob_data = task->blob_data_;
     float blob_score = task->score_;
 
+    // Vectored put (issue #820): the task carries N regions instead of one.
+    // Everything from here to the data write treats the blob as if a single
+    // write covered the UNION of the segments — the extend/resize must cover
+    // every region, and the sparse-hole fill keys off the union's start — and
+    // only the data write itself fans back out per segment, under the one write
+    // token this whole body already holds. That is the entire point: N regions,
+    // one token acquire, one metadata mutation.
+    bool vectored = false;
+    if constexpr (TaskT::kSupportsVectored) {
+      vectored = !task->segments_.empty();
+      if (vectored) {
+        clio::run::u64 lo = ~static_cast<clio::run::u64>(0);
+        clio::run::u64 hi = 0;
+        for (size_t i = 0; i < task->segments_.size(); ++i) {
+          const auto &seg = task->segments_[i];
+          if (seg.size_ == 0) {
+            task->return_code_ = 2;
+            CLIO_CO_RETURN;
+          }
+          if (seg.data_.IsNull() && !task->context_.emulate_) {
+            task->return_code_ = 3;
+            CLIO_CO_RETURN;
+          }
+          if (seg.blob_off_ < lo) lo = seg.blob_off_;
+          if (seg.blob_off_ + seg.size_ > hi) hi = seg.blob_off_ + seg.size_;
+        }
+        offset = lo;
+        size = hi - lo;
+      }
+    }
+
     // Validate inputs
     if (size == 0) {
       task->return_code_ = 2;
       CLIO_CO_RETURN;
     }
     // Emulated puts (issue #747) skip the data write AND its wire transfer,
-    // so on a cross-node receiver blob_data_ is legitimately null.
-    if (blob_data.IsNull() && !task->context_.emulate_) {
+    // so on a cross-node receiver blob_data_ is legitimately null. A vectored
+    // task validated its per-segment buffers above and leaves blob_data_ null
+    // by construction, so it is exempt from this single-region check.
+    if (!vectored && blob_data.IsNull() && !task->context_.emulate_) {
       task->return_code_ = 3;
       CLIO_CO_RETURN;
     }
@@ -1608,13 +1641,45 @@ clio::run::TaskResume Runtime::PutBlobImpl(clio::run::shared_ptr<TaskT> &task) {
         }
       }
 
-      // Step 3: ModifyExistingData — write data to blocks
+      // Step 3: ModifyExistingData — write data to blocks.
       clio::run::u32 write_result = 0;
-      CLIO_CO_AWAIT(ModifyExistingData(blob_info_ptr->blocks_, blob_data, size,
-                                  offset, write_result, hint_idx, hint_off));
-      if (write_result != 0) {
-        task->return_code_ = 20 + write_result;
-        CLIO_CO_RETURN;
+      if constexpr (TaskT::kSupportsVectored) {
+       if (vectored) {
+        // One region at a time, but all of them inside the single write-token
+        // acquire above (issue #820). IN LIST ORDER, which is what makes two
+        // segments covering the same bytes resolve last-writer-wins — the
+        // ordering guarantee the #680 token race does NOT provide when the same
+        // writes arrive as separate tasks racing for the token.
+        //
+        // hint_idx/hint_off stay valid for every segment: they are only set
+        // when the union offset is at/after old_blob_size (a pure append
+        // batch), in which case every segment starts at/after hint_off too, so
+        // the block-scan hint can never skip past a segment's blocks.
+        for (size_t i = 0; i < task->segments_.size(); ++i) {
+          const auto &seg = task->segments_[i];
+          CLIO_CO_AWAIT(ModifyExistingData(blob_info_ptr->blocks_, seg.data_,
+                                      seg.size_, seg.blob_off_, write_result,
+                                      hint_idx, hint_off));
+          if (write_result != 0) {
+            task->return_code_ = 20 + write_result;
+            CLIO_CO_RETURN;
+          }
+        }
+       } else {
+        CLIO_CO_AWAIT(ModifyExistingData(blob_info_ptr->blocks_, blob_data, size,
+                                    offset, write_result, hint_idx, hint_off));
+        if (write_result != 0) {
+          task->return_code_ = 20 + write_result;
+          CLIO_CO_RETURN;
+        }
+       }
+      } else {
+        CLIO_CO_AWAIT(ModifyExistingData(blob_info_ptr->blocks_, blob_data, size,
+                                    offset, write_result, hint_idx, hint_off));
+        if (write_result != 0) {
+          task->return_code_ = 20 + write_result;
+          CLIO_CO_RETURN;
+        }
       }
     }
 

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -891,6 +891,7 @@ clio::run::PoolQuery Runtime::ScheduleTask(const clio::run::shared_ptr<clio::run
     case Method::kGetContainedBlobs:
     case Method::kTagQuery:
     case Method::kBlobQuery:
+    case Method::kEvict:
       return clio::run::PoolQuery::Broadcast();
 
     default:
@@ -2434,6 +2435,113 @@ clio::run::TaskResume Runtime::DelBlob(clio::run::shared_ptr<DelBlobTask> &task)
   } catch (const std::exception &e) {
     task->return_code_ = 1;
   }
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
+clio::run::TaskResume Runtime::Evict(clio::run::shared_ptr<EvictTask> &task) {
+  CLIO_TASK_BODY_BEGIN
+  const float min_tier_score = task->min_tier_score_;
+  const clio::run::u64 target_bytes = task->bytes_;
+  task->bytes_evicted_ = 0;
+  task->blobs_evicted_ = 0;
+
+  // 1. Which registered targets qualify as "the tier to evict from"? Any target
+  //    whose score is at least min_tier_score. Snapshot their PoolIds under the
+  //    target read lock (tiny list — a linear membership test below is cheaper
+  //    than hashing PoolId).
+  std::vector<clio::run::PoolId> qualifying_targets;
+  {
+    clio::run::ScopedCoRwReadLock read_lock(target_lock_);
+    registered_targets_.for_each(
+        [&](const clio::run::PoolId &pool_id, const TargetInfo &info) {
+          if (info.target_score_ >= min_tier_score) {
+            qualifying_targets.push_back(pool_id);
+          }
+        });
+  }
+  if (qualifying_targets.empty() || target_bytes == 0) {
+    CLIO_CO_RETURN;  // nothing to evict from / no budget
+  }
+  auto on_qualifying_target = [&](const clio::run::PoolId &pid) {
+    for (const auto &t : qualifying_targets) {
+      if (t == pid) return true;
+    }
+    return false;
+  };
+
+  // 2. Rank this shard's blobs that occupy a qualifying tier by their own score
+  //    (ascending) so the cheapest-to-lose data is evicted first. evict_bytes is
+  //    the PHYSICAL footprint (capacity_) this blob holds on qualifying targets,
+  //    which is what gets returned to the tier's remaining_space_.
+  struct Candidate {
+    float score;
+    clio::run::u64 evict_bytes;
+    TagId tag_id;
+    std::string blob_name;
+  };
+  std::vector<Candidate> candidates;
+  tag_blob_name_to_info_.for_each(
+      [&](const std::string &composite_key,
+          const std::shared_ptr<BlobInfo> &blob_info_sp) {
+        const BlobInfo &blob_info = *blob_info_sp;
+        clio::run::u64 evict_bytes = 0;
+        for (const auto &block : blob_info.blocks_) {
+          if (on_qualifying_target(block.bdev_client_.pool_id_)) {
+            evict_bytes += block.capacity_;
+          }
+        }
+        if (evict_bytes == 0) {
+          return;
+        }
+        const size_t first_sep = composite_key.find('.');
+        const size_t second_sep =
+            (first_sep == std::string::npos)
+                ? std::string::npos
+                : composite_key.find('.', first_sep + 1);
+        if (first_sep == std::string::npos ||
+            second_sep == std::string::npos) {
+          return;
+        }
+        TagId blob_tag_id(
+            static_cast<clio::run::u32>(
+                std::stoul(composite_key.substr(0, first_sep))),
+            static_cast<clio::run::u32>(std::stoul(composite_key.substr(
+                first_sep + 1, second_sep - first_sep - 1))));
+        candidates.push_back(Candidate{blob_info.score_, evict_bytes,
+                                       blob_tag_id,
+                                       composite_key.substr(second_sep + 1)});
+      },
+      ctp::priv::ForEachLock::kShared);
+
+  std::sort(candidates.begin(), candidates.end(),
+            [](const Candidate &a, const Candidate &b) {
+              return a.score < b.score;
+            });
+
+  // 3. Evict lowest-score-first until the byte budget is met. Reuse the DelBlob
+  //    path (frees blocks back to the tier + removes metadata + WAL/telemetry);
+  //    each of these blobs hashes to THIS container, so AsyncDelBlob routes back
+  //    here. Await serially so bytes_evicted_ reflects only confirmed frees and
+  //    we can stop as soon as the budget is satisfied.
+  for (const auto &c : candidates) {
+    if (task->bytes_evicted_ >= target_bytes) {
+      break;
+    }
+    auto del = client_.AsyncDelBlob(c.tag_id, c.blob_name);
+    CLIO_CO_AWAIT(del);
+    if (del->return_code_ == 0) {
+      task->bytes_evicted_ += c.evict_bytes;
+      task->blobs_evicted_ += 1;
+    } else {
+      HLOG(kWarning, "Evict: DelBlob failed for {}, skipping", c.blob_name);
+    }
+  }
+
+  HLOG(kDebug,
+       "Evict: min_tier_score={} budget={} -> evicted {} bytes across {} blobs",
+       min_tier_score, target_bytes, task->bytes_evicted_,
+       task->blobs_evicted_);
   CLIO_CO_RETURN;
   CLIO_TASK_BODY_END
 }

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -4093,6 +4093,22 @@ bool Runtime::BuildBatch(clio::run::u32 method,
   if (method != Method::kPutBlob && method != Method::kGetBlob) {
     return false;
   }
+  // OFF BY DEFAULT (issue #820). The worker's batching phase and this policy
+  // are both implemented and the merge itself is proven by
+  // test_vectored_blob_io, but parking CTE tasks still hangs
+  // test_concurrent_same_blob at >=8 concurrent writers and the cause is not
+  // yet understood. Shipping it on by default would trade a latency win for a
+  // hang, so it stays opt-in (CLIO_CTE_BATCHING=1) until that is root-caused.
+  // The vectored task shape (part A) is unconditional and independently useful.
+  static const bool policy_on = [] {
+    if (const char *e = std::getenv("CLIO_CTE_BATCHING")) {
+      return !(std::string(e) == "0" || std::string(e) == "false");
+    }
+    return false;
+  }();
+  if (!policy_on) {
+    return false;
+  }
   TagId tag_id;
   std::string blob_name;
   if (method == Method::kPutBlob) {
@@ -4125,7 +4141,10 @@ bool Runtime::BuildBatch(clio::run::u32 method,
 void Runtime::SmashBatch(clio::run::BatchGroups &groups,
                          clio::run::BatchSink &sink) {
   for (auto it = groups.begin(); it != groups.end();) {
-    const clio::run::BatchKey &key = it->first;
+    // BY VALUE, not by reference: the erase below destroys the map node, and
+    // every use of the key after that point (the method checks, the sort
+    // comparator, the merged-task construction) would be reading freed memory.
+    const clio::run::BatchKey key = it->first;
     if (key.method != Method::kPutBlob && key.method != Method::kGetBlob) {
       ++it;  // not ours (another container's group)
       continue;

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -4459,70 +4459,63 @@ clio::run::TaskResume Runtime::ExtendBlob(BlobInfo &blob_info, clio::run::u64 of
       continue;
     }
 
-    // Back a large logical extension with MULTIPLE small physical blocks by
-    // capping each block at kMaxBlockChunk. Under long-soak churn the bdev free
-    // pool fragments into sub-request-size extents (measured: ~4640 extents,
-    // largest ~324 KB) while a single-block extension request is 0.5-1 MB, so
-    // one large contiguous block can NEVER be reused and the bump-only Heap
-    // watermark climbs to the tier capacity → write EIO (074/521/522). Small
-    // blocks match the fragmented pool and reuse freed space. The blob stores
-    // blocks_ as a vector and read/write iterate them, so multi-block extents
-    // are transparent to the data path. AllocateFromTarget decrements the copy's
-    // remaining_space_ by reference, so the loop condition drains naturally.
-    constexpr clio::run::u64 kMaxBlockChunk = 65536;  // 64 KB
-    constexpr clio::run::u64 kAppendSlab = 4096;      // bdev slab granularity
-    while (remaining_to_allocate > 0 && target_info_copy.remaining_space_ > 0) {
-      // Logical bytes this block carries.
-      clio::run::u64 logical =
-          std::min(std::min(remaining_to_allocate,
-                            target_info_copy.remaining_space_),
-                   kMaxBlockChunk);
-      // Physical bytes to request: round the logical UP to a whole slab so a
-      // small append leaves reusable spare capacity for the next append (the
-      // spare-fill path above). The request stays <=64 KB-ish, so the
-      // small-block anti-fragmentation property 074/521/522 rely on holds. If
-      // rounding up would exceed the target's free space, take exactly logical.
-      clio::run::u64 physical =
-          ((logical + kAppendSlab - 1) / kAppendSlab) * kAppendSlab;
-      if (physical > target_info_copy.remaining_space_) {
-        physical = logical;
-      }
+    // Ask the bdev for the whole extent this target can cover, in ONE request.
+    // Fragmentation across reused free blocks is the allocator's job now
+    // (issue #820): it returns however many physical blocks it took, and the
+    // blob's blocks_ vector carries those multi-block extents transparently to
+    // read/write. This is what used to be worked around here by capping every
+    // block at 64 KB so the bdev could always answer with one contiguous block
+    // -- an anti-fragmentation policy that did not belong in the CTE.
+    constexpr clio::run::u64 kAppendSlab = 4096;  // bdev slab granularity
+    clio::run::u64 req =
+        std::min(remaining_to_allocate, target_info_copy.remaining_space_);
+    if (req == 0) {
+      continue;
+    }
+    std::vector<clio::run::bdev::Block> out_blocks;
+    bool alloc_success = false;
+    CLIO_CO_AWAIT(AllocateFromTarget(target_info_copy, req, out_blocks,
+                                alloc_success));
+    if (!alloc_success || out_blocks.empty()) {
+      continue;  // this target can't satisfy req; outer loop tries the next
+    }
 
-      clio::run::u64 allocated_offset;
-      bool alloc_success = false;
-      CLIO_CO_AWAIT(AllocateFromTarget(target_info_copy, physical,
-                                  allocated_offset, alloc_success));
-      if (!alloc_success) {
-        break;  // this target can't satisfy more; outer loop tries the next
-      }
-
-      // size_ = logical used, capacity_ = physical slab (>= logical).
+    // Distribute the logical request `req` across the physical blocks the bdev
+    // returned. Each block's size_ is its PHYSICAL footprint (what it occupies
+    // and what capacity_ must credit on free); the blob covers up to that many
+    // logical bytes with it, so `req` logical bytes span the blocks with only
+    // the last one carrying spare capacity. No co_await in this loop, so
+    // total_size_cache_ advances atomically with blocks_ wrt other tasks on
+    // this worker.
+    clio::run::u64 physical_sum = 0;
+    clio::run::u64 need = req;
+    for (const auto &b : out_blocks) {
+      const clio::run::u64 physical = b.size_;  // footprint
+      const clio::run::u64 logical = std::min(physical, need);
       BlobBlock new_block(target_info_copy.bdev_client_,
-                          target_info_copy.target_query_, allocated_offset,
-                          logical, physical);
+                          target_info_copy.target_query_, b.offset_, logical,
+                          physical);
       blob_info.blocks_.push_back(new_block);
-      // Advance the O(1) size cache in the SAME co_await-free step as the
-      // push_back (the debit lock + next AllocateFromTarget below both co_await),
-      // so a concurrent reader never sees grown blocks_ with a stale cache.
       blob_info.total_size_cache_ += logical;
+      physical_sum += physical;
+      need -= logical;
+    }
+    remaining_to_allocate -= req;  // sum of logical == req
+    (void)kAppendSlab;
 
-      // Debit the CANONICAL target's remaining_space_ by the PHYSICAL bytes
-      // taken (mirror of FreeAllBlobBlocks' capacity_ credit); AllocateFromTarget
-      // only touched the copy.
-      {
-        clio::run::ScopedCoRwReadLock read_lock(target_lock_);
-        TargetInfo *ti = registered_targets_.find(selected_target_id);
-        if (ti != nullptr) {
-          ctp::ipc::atomic_ref<clio::run::u64> rs(ti->remaining_space_);
-          clio::run::u64 cur = rs.load(std::memory_order_relaxed);
-          while (!rs.compare_exchange_weak(
-              cur, (cur > physical) ? cur - physical : 0,
-              std::memory_order_relaxed)) {
-          }
+    // Debit the CANONICAL target's remaining_space_ by the physical bytes taken
+    // (mirror of FreeAllBlobBlocks' capacity_ credit).
+    {
+      clio::run::ScopedCoRwReadLock read_lock(target_lock_);
+      TargetInfo *ti = registered_targets_.find(selected_target_id);
+      if (ti != nullptr) {
+        ctp::ipc::atomic_ref<clio::run::u64> rs(ti->remaining_space_);
+        clio::run::u64 cur = rs.load(std::memory_order_relaxed);
+        while (!rs.compare_exchange_weak(
+            cur, (cur > physical_sum) ? cur - physical_sum : 0,
+            std::memory_order_relaxed)) {
         }
       }
-
-      remaining_to_allocate -= logical;
     }
   }
 
@@ -4936,10 +4929,9 @@ clio::run::TaskResume Runtime::ReadData(const clio::run::priv::vector<BlobBlock>
 
 // Block management helper functions
 
-clio::run::TaskResume Runtime::AllocateFromTarget(TargetInfo &target_info,
-                                            clio::run::u64 size,
-                                            clio::run::u64 &allocated_offset,
-                                            bool &success) {
+clio::run::TaskResume Runtime::AllocateFromTarget(
+    TargetInfo &target_info, clio::run::u64 size,
+    std::vector<clio::run::bdev::Block> &out_blocks, bool &success) {
 #ifdef CLIO_ENABLE_BOOST_COROUTINES
   clio::run::shared_ptr<clio::run::Task> cur_task = clio::run::GetCurrentTask();
 #endif
@@ -4990,29 +4982,22 @@ clio::run::TaskResume Runtime::AllocateFromTarget(TargetInfo &target_info,
          "alloc_task->blocks_.size()={}, return_code={}",
          alloc_task->blocks_.size(), alloc_task->return_code_.load());
 
-    std::vector<clio::run::bdev::Block> allocated_blocks;
-    for (size_t i = 0; i < alloc_task->blocks_.size(); ++i) {
-      allocated_blocks.push_back(alloc_task->blocks_[i]);
-    }
-
-    // Check if we got any blocks
-    if (allocated_blocks.empty()) {
-      HLOG(kDebug, "AllocateFromTarget: FAILED - allocated_blocks is empty");
+    // Return EVERY block the bdev handed back, not just the first. The
+    // allocator may fragment one logical request across several reused physical
+    // blocks (issue #820) -- taking only blocks_[0] silently dropped the rest,
+    // which is why ExtendBlob had to cap requests at 64 KB so the bdev could
+    // always answer with a single block.
+    out_blocks.clear();
+    if (alloc_task->blocks_.empty()) {
+      HLOG(kDebug, "AllocateFromTarget: FAILED - no blocks");
       success = false;
       CLIO_CO_RETURN;
     }
-
-    // Use the first block (for single allocation case)
-    clio::run::bdev::Block allocated_block = allocated_blocks[0];
-    allocated_offset = allocated_block.offset_;
-
-    // Update remaining space
-    target_info.remaining_space_ -= size;
-    // HLOG(kInfo,
-    //       "Allocated from target {}: offset={}, size={} remaining_space={}",
-    //       target_info.target_name_, allocated_offset, size,
-    //       target_info.remaining_space_);
-
+    for (size_t i = 0; i < alloc_task->blocks_.size(); ++i) {
+      out_blocks.push_back(alloc_task->blocks_[i]);
+    }
+    // Canonical remaining_space_ accounting is the caller's (ExtendBlob debits
+    // it by the physical bytes taken); this only fills out_blocks.
     success = true;
     CLIO_CO_RETURN;
   } catch (const std::exception &e) {

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -105,6 +105,25 @@ namespace {
 
 constexpr const char *kTagRefPrefix = "$tagid{";
 
+// #680 per-blob write-token re-check period (microseconds). Default 10us: a
+// loser is parked ONLY during active same-blob write contention, where a fast
+// hand-off beats the CPU saved by sleeping. 10us lands in the worker's fastest
+// periodic bucket (Queue[0]) and caps GetSuspendPeriod's idle suspend, so a
+// freed token is re-grabbed in single-digit us instead of the old ~2ms
+// idle-suspend worst case. Overridable via CLIO_WRITE_TOKEN_POLL_US for tuning
+// / A-B measurement (read once; do NOT put on a hot path uncached).
+inline double BlobWriteLockPollUs() {
+  static const double v = [] {
+    if (const char *e = std::getenv("CLIO_WRITE_TOKEN_POLL_US")) {
+      char *end = nullptr;
+      double d = std::strtod(e, &end);
+      if (end != e && d > 0.0) return d;
+    }
+    return 10.0;
+  }();
+  return v;
+}
+
 // Escape regex metacharacters so `s` matches itself literally. Used to build
 // exact/prefix patterns for the tag search index (#598).
 std::string EscapeRegexLiteral(const std::string &s) {
@@ -1585,10 +1604,11 @@ clio::run::TaskResume Runtime::PutBlobImpl(clio::run::shared_ptr<TaskT> &task) {
     // suspends at one of those co_awaits. The guard releases the token on EVERY
     // exit below (normal completion, early CLIO_CO_RETURN, or a thrown
     // exception).
-    static constexpr double kBlobWriteLockPollUs = 10.0;  // #680 token re-check. Small on purpose: a loser is parked ONLY during active same-blob write contention, where a fast hand-off beats the CPU saved by sleeping. 10us lands in the worker's fastest periodic bucket (Queue[0], scanned every ~4 loop iters) AND caps GetSuspendPeriod's idle suspend, so a freed token is re-grabbed in single-digit us instead of the old ~2ms idle-suspend worst case. GetSuspendPeriod returns -1 the instant the queue drains, so there is no idle spin; the only cost is some CPU while heavily contended -- acceptable on the write hot path.
+    // #680 write-token re-check period; see BlobWriteLockPollUs() (default 10us,
+    // env CLIO_WRITE_TOKEN_POLL_US).
     clio::run::u64 lock_tok = reinterpret_cast<clio::run::u64>(task.get());
     while (!blob_info_ptr->TryLockWrite(lock_tok)) {
-      CLIO_CO_AWAIT(clio::run::yield(kBlobWriteLockPollUs));
+      CLIO_CO_AWAIT(clio::run::yield(BlobWriteLockPollUs()));
     }
     BlobWriteLockGuard blob_write_guard(blob_info_ptr.get(), lock_tok);
 
@@ -2363,10 +2383,11 @@ clio::run::TaskResume Runtime::DelBlob(clio::run::shared_ptr<DelBlobTask> &task)
     // while a PutBlob iterates blocks_ across a co_await is a use-after-free.
     // The local shared_ptr keeps this BlobInfo alive past the map erase below,
     // so releasing the token in the guard destructor stays valid.
-    static constexpr double kBlobWriteLockPollUs = 10.0;  // #680 token re-check. Small on purpose: a loser is parked ONLY during active same-blob write contention, where a fast hand-off beats the CPU saved by sleeping. 10us lands in the worker's fastest periodic bucket (Queue[0], scanned every ~4 loop iters) AND caps GetSuspendPeriod's idle suspend, so a freed token is re-grabbed in single-digit us instead of the old ~2ms idle-suspend worst case. GetSuspendPeriod returns -1 the instant the queue drains, so there is no idle spin; the only cost is some CPU while heavily contended -- acceptable on the write hot path.
+    // #680 write-token re-check period; see BlobWriteLockPollUs() (default 10us,
+    // env CLIO_WRITE_TOKEN_POLL_US).
     clio::run::u64 lock_tok = reinterpret_cast<clio::run::u64>(task.get());
     while (!blob_info_ptr->TryLockWrite(lock_tok)) {
-      CLIO_CO_AWAIT(clio::run::yield(kBlobWriteLockPollUs));
+      CLIO_CO_AWAIT(clio::run::yield(BlobWriteLockPollUs()));
     }
     BlobWriteLockGuard blob_write_guard(blob_info_ptr.get(), lock_tok);
 
@@ -2577,10 +2598,11 @@ clio::run::TaskResume Runtime::TruncateBlob(clio::run::shared_ptr<TruncateBlobTa
     // truncate and a write racing on blocks_ across the ResizeBlob co_await
     // corrupt the block layout. Busy-poll the token (lost-wakeup-proof — see
     // PutBlobImpl); the guard releases it on every exit path.
-    static constexpr double kBlobWriteLockPollUs = 10.0;  // #680 token re-check. Small on purpose: a loser is parked ONLY during active same-blob write contention, where a fast hand-off beats the CPU saved by sleeping. 10us lands in the worker's fastest periodic bucket (Queue[0], scanned every ~4 loop iters) AND caps GetSuspendPeriod's idle suspend, so a freed token is re-grabbed in single-digit us instead of the old ~2ms idle-suspend worst case. GetSuspendPeriod returns -1 the instant the queue drains, so there is no idle spin; the only cost is some CPU while heavily contended -- acceptable on the write hot path.
+    // #680 write-token re-check period; see BlobWriteLockPollUs() (default 10us,
+    // env CLIO_WRITE_TOKEN_POLL_US).
     clio::run::u64 lock_tok = reinterpret_cast<clio::run::u64>(task.get());
     while (!blob_info_ptr->TryLockWrite(lock_tok)) {
-      CLIO_CO_AWAIT(clio::run::yield(kBlobWriteLockPollUs));
+      CLIO_CO_AWAIT(clio::run::yield(BlobWriteLockPollUs()));
     }
     BlobWriteLockGuard blob_write_guard(blob_info_ptr.get(), lock_tok);
 
@@ -4282,13 +4304,17 @@ bool Runtime::BuildBatch(clio::run::u32 method,
   if (method != Method::kPutBlob && method != Method::kGetBlob) {
     return false;
   }
-  // OFF BY DEFAULT (issue #820). The worker's batching phase and this policy
-  // are both implemented and the merge itself is proven by
-  // test_vectored_blob_io, but parking CTE tasks still hangs
-  // test_concurrent_same_blob at >=8 concurrent writers and the cause is not
-  // yet understood. Shipping it on by default would trade a latency win for a
-  // hang, so it stays opt-in (CLIO_CTE_BATCHING=1) until that is root-caused.
-  // The vectored task shape (part A) is unconditional and independently useful.
+  // Opt-in via CLIO_CTE_BATCHING=1 (issue #820). The merge itself is proven by
+  // test_vectored_blob_io. The concurrent-writer hang that previously kept this
+  // off ("parks CTE tasks, hangs test_concurrent_same_blob at >=8 writers") was
+  // ROOT-CAUSED and FIXED in a84449e1 (the batch parent-registry was per-worker
+  // + keyed by a thread-local uid, so a merged task that resumed on a different
+  // worker never completed its parents -- a lost wakeup, not a deadlock). With
+  // that fix test_concurrent_same_blob passes 20+ consecutive runs at 8/16/32
+  // concurrent writers with both this policy and CLIO_BATCH_LANE on. It stays
+  // opt-in only because CLIO_BATCH_LANE -- the lane phase that actually converges
+  // same-blob work -- is still being validated for tasks another in-flight task
+  // synchronously awaits; enabling this alone (shard-ingress batching) is safe.
   static const bool policy_on = [] {
     if (const char *e = std::getenv("CLIO_CTE_BATCHING")) {
       return !(std::string(e) == "0" || std::string(e) == "false");

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -4061,6 +4061,149 @@ clio::run::TaskStat Runtime::GetTaskStats(const clio::run::Task *task) const {
   }
 }
 
+// ---- issue #820: worker-local batching policy ---------------------------
+//
+// Group PutBlob/GetBlob tasks by the blob they target, then collapse each group
+// into ONE vectored task (see PutBlobTask::segments_). The filesystem stores
+// each 1 MiB page as one blob, so a sequential 4 KiB workload aims 256 tasks at
+// a single page-blob and each has to take that blob's #680 write token across
+// its whole body -- they drain single-file, which is the measured ~1 s tail.
+// Merged, they cost one token acquire and one bdev pass.
+
+namespace {
+/** Group identity: one group per (tag, blob). */
+clio::run::u64 BlobBatchKey(const TagId &tag_id, const std::string &blob_name) {
+  clio::run::u64 h = std::hash<std::string>()(blob_name);
+  h ^= std::hash<clio::run::u64>()(tag_id.major_) + 0x9e3779b97f4a7c15ULL +
+       (h << 6) + (h >> 2);
+  h ^= std::hash<clio::run::u64>()(tag_id.minor_) + 0x9e3779b97f4a7c15ULL +
+       (h << 6) + (h >> 2);
+  return h;
+}
+}  // namespace
+
+bool Runtime::BuildBatch(clio::run::u32 method,
+                         const clio::run::shared_ptr<clio::run::Task> &task,
+                         clio::run::BatchGroups &groups) {
+  // Only the two data-path methods, and only the plain positioned form. A task
+  // carrying anything the merge would have to reason about -- an existing
+  // segment list, a GPU page suffix, a wholesale-replace flag, or emulation --
+  // is declined and runs as it always did. Declining is always safe; merging
+  // the wrong thing is not.
+  if (method != Method::kPutBlob && method != Method::kGetBlob) {
+    return false;
+  }
+  TagId tag_id;
+  std::string blob_name;
+  if (method == Method::kPutBlob) {
+    auto *t = reinterpret_cast<PutBlobTask *>(task.get());
+    if (!t->segments_.empty() || t->gpu_page_idx_ != PutBlobTask::kNoPageIdx ||
+        (t->flags_ & kCtePutReplace) || t->context_.emulate_ ||
+        t->size_ == 0 || t->blob_data_.IsNull()) {
+      return false;
+    }
+    tag_id = t->tag_id_;
+    blob_name = t->blob_name_.str();
+  } else {
+    auto *t = reinterpret_cast<GetBlobTask *>(task.get());
+    if (!t->segments_.empty() || t->gpu_page_idx_ != GetBlobTask::kNoPageIdx ||
+        t->context_.emulate_ || t->size_ == 0 || t->blob_data_.IsNull()) {
+      return false;
+    }
+    tag_id = t->tag_id_;
+    blob_name = t->blob_name_.str();
+  }
+
+  clio::run::BatchKey key{task->pool_id_, method,
+                          BlobBatchKey(tag_id, blob_name)};
+  clio::run::BatchMember member;
+  member.task = task;
+  groups[key].push_back(member);
+  return true;
+}
+
+void Runtime::SmashBatch(clio::run::BatchGroups &groups,
+                         clio::run::BatchSink &sink) {
+  for (auto it = groups.begin(); it != groups.end();) {
+    const clio::run::BatchKey &key = it->first;
+    if (key.method != Method::kPutBlob && key.method != Method::kGetBlob) {
+      ++it;  // not ours (another container's group)
+      continue;
+    }
+    std::vector<clio::run::BatchMember> members = std::move(it->second);
+    it = groups.erase(it);
+    if (members.empty()) {
+      continue;
+    }
+    // A group of one has nothing to amortize: hand it back untouched rather
+    // than paying to wrap it in a vectored task. This is the no-backlog case,
+    // and it must cost nothing.
+    if (members.size() == 1) {
+      sink.Passthrough(members[0].task);
+      continue;
+    }
+
+    // Offset order, ties by ARRIVAL order. The runtime applies segments in list
+    // order, so this is what makes two writes to the same bytes resolve
+    // last-writer-wins -- the guarantee racing single-region tasks do not give.
+    std::sort(members.begin(), members.end(),
+              [&](const clio::run::BatchMember &a,
+                  const clio::run::BatchMember &b) {
+                clio::run::u64 ao, bo;
+                if (key.method == Method::kPutBlob) {
+                  ao = reinterpret_cast<PutBlobTask *>(a.task.get())->offset_;
+                  bo = reinterpret_cast<PutBlobTask *>(b.task.get())->offset_;
+                } else {
+                  ao = reinterpret_cast<GetBlobTask *>(a.task.get())->offset_;
+                  bo = reinterpret_cast<GetBlobTask *>(b.task.get())->offset_;
+                }
+                if (ao != bo) return ao < bo;
+                return a.seq < b.seq;
+              });
+
+    // Build the merged task as a copy of the first member, then replace its
+    // single region with every member's region as a segment. Each member keeps
+    // its OWN buffer -- no gather for writes, and for reads the runtime fills
+    // each member's destination directly, so completion needs no scatter.
+    clio::run::shared_ptr<clio::run::Task> merged =
+        NewCopyTask(key.method, members[0].task, /*deep=*/true);
+    if (merged.IsNull()) {
+      // Could not merge: run them individually rather than dropping them.
+      for (auto &m : members) {
+        sink.Passthrough(m.task);
+      }
+      continue;
+    }
+    std::vector<clio::run::shared_ptr<clio::run::Task>> parents;
+    parents.reserve(members.size());
+    if (key.method == Method::kPutBlob) {
+      auto *mt = reinterpret_cast<PutBlobTask *>(merged.get());
+      mt->segments_.clear();
+      for (auto &m : members) {
+        auto *s = reinterpret_cast<PutBlobTask *>(m.task.get());
+        mt->segments_.push_back(BlobSegment(s->offset_, s->size_, s->blob_data_));
+        parents.push_back(m.task);
+      }
+      mt->offset_ = 0;
+      mt->size_ = 0;
+      mt->blob_data_ = ctp::ipc::ShmPtr<>::GetNull();
+    } else {
+      auto *mt = reinterpret_cast<GetBlobTask *>(merged.get());
+      mt->segments_.clear();
+      for (auto &m : members) {
+        auto *s = reinterpret_cast<GetBlobTask *>(m.task.get());
+        mt->segments_.push_back(BlobSegment(s->offset_, s->size_, s->blob_data_));
+        parents.push_back(m.task);
+      }
+      mt->offset_ = 0;
+      mt->size_ = 0;
+      mt->blob_data_ = ctp::ipc::ShmPtr<>::GetNull();
+    }
+    sink.Emit(merged, std::move(parents));
+  }
+}
+
+
 // Helper methods for lock index calculation
 size_t Runtime::GetTargetLockIndex(const clio::run::PoolId &target_id) const {
   // Use hash of target_id to distribute locks evenly

--- a/context-transfer-engine/core/src/tag.cc
+++ b/context-transfer-engine/core/src/tag.cc
@@ -219,6 +219,25 @@ void Tag::GetBlob(const std::string &blob_name, char *data, size_t data_size, si
   ipc_manager->FreeBuffer(shm_fullptr);
 }
 
+clio::run::Future<GetBlobTask> Tag::AsyncGetBlob(const std::string &blob_name,
+                                                 char *data, size_t data_size,
+                                                 size_t off) {
+  // Validate input parameters
+  if (data_size == 0) {
+    throw std::invalid_argument("data_size must be specified for AsyncGetBlob");
+  }
+  if (data == nullptr) {
+    throw std::invalid_argument("data buffer must be pre-allocated by caller");
+  }
+
+  // issue #823: read straight into the caller's PRIVATE buffer. The client
+  // picks the fastest of shared-cache / runtime-direct / client-staging; the
+  // returned Future is empty on a cache hit and readable otherwise.
+  auto *cte_client = CLIO_CTE_CLIENT;
+  return cte_client->AsyncGetBlob(tag_id_, blob_name, off, data_size,
+                                  /*flags=*/0, data);
+}
+
 void Tag::GetBlob(const std::string &blob_name, ctp::ipc::ShmPtr<> data, size_t data_size, size_t off) {
   // Validate input parameters
   if (data_size == 0) {

--- a/context-transfer-engine/core/src/tag.cc
+++ b/context-transfer-engine/core/src/tag.cc
@@ -98,44 +98,40 @@ void Tag::PutBlob(const std::string &blob_name, const char *data, size_t data_si
   using clk = std::chrono::steady_clock;
   auto t0 = clk::now();
 
-  // Allocate shared memory for the data
-  auto *ipc_manager = CLIO_IPC;
-  ctp::ipc::FullPtr<char> shm_fullptr = ipc_manager->AllocateBuffer(data_size);
-
-  if (shm_fullptr.IsNull()) {
-    throw std::runtime_error("Failed to allocate shared memory for PutBlob");
-  }
-
-  auto t1 = clk::now();
-
-  // Copy data to shared memory
-  memcpy(shm_fullptr.ptr_, data, data_size);
-
-  auto t2 = clk::now();
-
-  // Convert to ctp::ipc::ShmPtr<> for API call
-  ctp::ipc::ShmPtr<> shm_ptr(shm_fullptr.shm_);
-
-  // Call SHM version with provided score and context
-  PutBlob(blob_name, shm_ptr, data_size, off, score, context);
+  // Private-memory path (issue #830): hand the caller's buffer straight to the
+  // client, which picks the runtime-mode no-copy path or client-mode SHM
+  // staging (TASK_DATA_OWNER) itself — no manual allocate/copy/free at this
+  // layer. Write-side analog of the #823 private GetBlob.
+  auto fut = AsyncPutBlob(blob_name, data, data_size, off, score, context);
+  fut.Wait();
 
   auto t3 = clk::now();
 
-  // Explicitly free shared memory buffer
-  ipc_manager->FreeBuffer(shm_fullptr);
-
-  auto t4 = clk::now();
+  // Empty future -> client-mode SHM staging could not be allocated.
+  if (fut.get() == nullptr) {
+    throw std::runtime_error("Failed to allocate shared memory for PutBlob");
+  }
+  if (fut.get()->GetReturnCode() != 0) {
+    // Log the actual return code so callers (e.g. the POSIX adapter, IOR,
+    // wfbench) can correlate "PutBlob operation failed" with the failure mode.
+    HLOG(kError,
+         "PutBlob failed: tag_id={},{} blob='{}' off={} size={} rc={}",
+         tag_id_.major_, tag_id_.minor_, blob_name, off, data_size,
+         fut.get()->GetReturnCode());
+    throw std::runtime_error(
+        std::string("PutBlob operation failed (rc=") +
+        std::to_string(fut.get()->GetReturnCode()) + ")");
+  }
 
   auto ns = [](clk::time_point a, clk::time_point b) {
     return static_cast<uint64_t>(
         std::chrono::duration_cast<std::chrono::nanoseconds>(b - a).count());
   };
+  // The allocate/copy/free now happen inside the client (or not at all, in
+  // runtime mode), so only the aggregate call time is meaningful here.
   g_pb_calls.fetch_add(1, std::memory_order_relaxed);
   g_pb_bytes.fetch_add(data_size, std::memory_order_relaxed);
-  g_pb_alloc_ns.fetch_add(ns(t0, t1), std::memory_order_relaxed);
-  g_pb_memcpy_ns.fetch_add(ns(t1, t2), std::memory_order_relaxed);
-  g_pb_rpc_ns.fetch_add(ns(t2, t3), std::memory_order_relaxed);
-  g_pb_free_ns.fetch_add(ns(t3, t4), std::memory_order_relaxed);
+  g_pb_rpc_ns.fetch_add(ns(t0, t3), std::memory_order_relaxed);
 }
 
 void Tag::PutBlob(const std::string &blob_name, const ctp::ipc::ShmPtr<> &data, size_t data_size,
@@ -173,6 +169,22 @@ clio::run::Future<PutBlobTask> Tag::AsyncPutBlob(const std::string &blob_name, c
   auto *cte_client = CLIO_CTE_CLIENT;
   return cte_client->AsyncPutBlob(tag_id_, blob_name,
                                   off, data_size, data, score, context);
+}
+
+clio::run::Future<PutBlobTask> Tag::AsyncPutBlob(const std::string &blob_name,
+                                                 const char *data, size_t data_size,
+                                                 size_t off, float score,
+                                                 const Context &context) {
+  if (data == nullptr && data_size > 0) {
+    throw std::invalid_argument("data buffer must not be null for AsyncPutBlob");
+  }
+  // issue #830: write straight from the caller's PRIVATE buffer. The client
+  // picks runtime-direct no-copy or client-staging (TASK_DATA_OWNER); the
+  // returned Future is readable after Wait() (empty only if client-mode
+  // staging alloc failed).
+  auto *cte_client = CLIO_CTE_CLIENT;
+  return cte_client->AsyncPutBlob(tag_id_, blob_name, off, data_size, data,
+                                  score, context);
 }
 
 void Tag::GetBlob(const std::string &blob_name, char *data, size_t data_size, size_t off) {

--- a/context-transfer-engine/filesystem/src/filesystem_runtime.cc
+++ b/context-transfer-engine/filesystem/src/filesystem_runtime.cc
@@ -1372,18 +1372,30 @@ clio::run::TaskResume Runtime::Readlink(clio::run::shared_ptr<ReadlinkTask> &tas
     std::string _key = XattrKey(tidvar);                                     \
     auto *_ipc = CLIO_IPC;                                                   \
     clio::run::u64 _len = _payload.size();                                   \
-    ctp::ipc::FullPtr<char> _buf = _ipc->AllocateBuffer(_len ? _len : 1);    \
-    if (_buf.IsNull()) { task->return_code_ = EIO; CLIO_CO_RETURN; }         \
-    if (_len) { std::memcpy(_buf.ptr_, _payload.data(), _len); }             \
-    auto _p = cte_.AsyncPutBlob(xattr_tag_id_, _key, 0, _len,                \
-                                _buf.shm_.template Cast<void>(), -1.0f,       \
-                                clio::cte::core::Context(),                   \
-                                clio::cte::core::kCtePutReplace,              \
-                                clio::run::PoolQuery::Dynamic());            \
-    CLIO_CO_AWAIT(_p);                                                       \
-    bool _ok = (_p->GetReturnCode() == 0);                                   \
-    _ipc->FreeBuffer(_buf);                                                  \
-    if (!_ok) { task->return_code_ = EIO; CLIO_CO_RETURN; }                  \
+    if (_len == 0) {                                                         \
+      /* No xattrs remain (removed the LAST one): DELETE the backing blob    \
+       * rather than PutBlob a zero-size payload. A size-0 kCtePutReplace    \
+       * put fails on this path -> EIO, which broke removal of the last      \
+       * xattr (xfstests generic/020). An absent blob is the correct         \
+       * representation of "no xattrs"; a missing blob on delete is fine. */ \
+      auto _d = cte_.AsyncDelBlob(xattr_tag_id_, _key,                       \
+                                  clio::run::PoolQuery::Dynamic());          \
+      CLIO_CO_AWAIT(_d);                                                     \
+      task->return_code_ = 0;                                               \
+    } else {                                                                 \
+      ctp::ipc::FullPtr<char> _buf = _ipc->AllocateBuffer(_len);             \
+      if (_buf.IsNull()) { task->return_code_ = EIO; CLIO_CO_RETURN; }       \
+      std::memcpy(_buf.ptr_, _payload.data(), _len);                         \
+      auto _p = cte_.AsyncPutBlob(xattr_tag_id_, _key, 0, _len,              \
+                                  _buf.shm_.template Cast<void>(), -1.0f,     \
+                                  clio::cte::core::Context(),                 \
+                                  clio::cte::core::kCtePutReplace,            \
+                                  clio::run::PoolQuery::Dynamic());          \
+      CLIO_CO_AWAIT(_p);                                                     \
+      bool _ok = (_p->GetReturnCode() == 0);                                 \
+      _ipc->FreeBuffer(_buf);                                                \
+      if (!_ok) { task->return_code_ = EIO; CLIO_CO_RETURN; }                \
+    }                                                                        \
   }
 
 clio::run::TaskResume Runtime::Setxattr(clio::run::shared_ptr<SetxattrTask> &task) {

--- a/context-transfer-engine/filesystem/src/filesystem_runtime.cc
+++ b/context-transfer-engine/filesystem/src/filesystem_runtime.cc
@@ -428,9 +428,12 @@ clio::run::TaskResume Runtime::Read(clio::run::shared_ptr<ReadTask> &task) {
   clio::run::u64 file_size = fi->size_.load();
 
   auto *ipc = CLIO_IPC;
-  // Read directly into the task's payload — GetBlob copies into the ShmPtr we
-  // hand it, so point it at the right sub-region of data_ each page instead of
-  // staging through a freshly-allocated buffer.
+  // Read directly into the task's payload via the PRIVATE-memory GetBlob path
+  // (issue #823): we hand CTE the raw sub-region pointer, which in runtime mode
+  // (cfs and CTE share this daemon's address space) is wrapped as a
+  // null-allocator ShmPtr so the bdev read lands DIRECTLY in the payload — no
+  // staging buffer, no copy — and it additionally takes the zero-IPC SHM-cache
+  // fast path when the page is RAM-resident. `dst` is the payload base.
   ctp::ipc::ShmPtr<char> data_base = task->data_.template Cast<char>();
   char *dst = ipc->ToFullPtr<char>(data_base).ptr_;
 
@@ -458,8 +461,7 @@ clio::run::TaskResume Runtime::Read(clio::run::shared_ptr<ReadTask> &task) {
     clio::run::u64 page_off = cur % kFsPageSize;
     clio::run::u64 to_read = std::min(kFsPageSize - page_off, want - done);
     auto g = cte_.AsyncGetBlob(tag_id, PageName(cur), page_off, to_read,
-                               /*flags*/ 0u,
-                               (data_base + done).template Cast<void>(),
+                               /*flags*/ 0u, dst + done,
                                clio::run::PoolQuery::Dynamic());
     CLIO_CO_AWAIT(g);
     // A miss/short read just leaves the pre-zeroed bytes as zeros (a hole is
@@ -482,10 +484,14 @@ clio::run::TaskResume Runtime::Write(clio::run::shared_ptr<WriteTask> &task) {
   }
   clio::cte::core::TagId tag_id = fi->tag_id_;
 
-  // Write straight out of the task's payload — PutBlob reads from the ShmPtr we
-  // pass, so hand it the right sub-region of data_ per page rather than copying
-  // into a freshly-allocated staging buffer first.
+  // Write straight out of the task's payload via the PRIVATE-memory PutBlob path
+  // (issue #830): hand CTE the raw sub-region pointer, which in runtime mode
+  // (cfs and CTE co-located in this daemon) is wrapped as a null-allocator
+  // ShmPtr so the bdev write reads DIRECTLY from the payload — no staging
+  // buffer, no copy. `src` is the payload base.
+  auto *ipc = CLIO_IPC;
   ctp::ipc::ShmPtr<char> data_base = task->data_.template Cast<char>();
+  const char *src = ipc->ToFullPtr<char>(data_base).ptr_;
 
   clio::run::u64 want = task->size_;
   clio::run::u64 done = 0;
@@ -500,7 +506,7 @@ clio::run::TaskResume Runtime::Write(clio::run::shared_ptr<WriteTask> &task) {
     // per-blob write token — the dominant clio-fs write-latency tail.
     static constexpr clio::run::u64 kFsPreallocBytes = 64ull * 1024;
     auto p = cte_.AsyncPutBlob(tag_id, PageName(cur), page_off, to_write,
-                               (data_base + done).template Cast<void>(),
+                               src + done,
                                /*score*/ -1.0f,
                                clio::cte::core::Context::Preallocate(
                                    kFsPreallocBytes),

--- a/context-transfer-engine/filesystem/src/filesystem_runtime.cc
+++ b/context-transfer-engine/filesystem/src/filesystem_runtime.cc
@@ -494,9 +494,16 @@ clio::run::TaskResume Runtime::Write(clio::run::shared_ptr<WriteTask> &task) {
   while (done < want) {
     clio::run::u64 page_off = cur % kFsPageSize;
     clio::run::u64 to_write = std::min(kFsPageSize - page_off, want - done);
+    // Preallocate 64 KiB of blob capacity per write so a run of small appends
+    // to the same page fills the last block's spare capacity in place instead
+    // of each one triggering a fresh allocation (and bdev sub-task) under the
+    // per-blob write token — the dominant clio-fs write-latency tail.
+    static constexpr clio::run::u64 kFsPreallocBytes = 64ull * 1024;
     auto p = cte_.AsyncPutBlob(tag_id, PageName(cur), page_off, to_write,
                                (data_base + done).template Cast<void>(),
-                               /*score*/ -1.0f, clio::cte::core::Context(),
+                               /*score*/ -1.0f,
+                               clio::cte::core::Context::Preallocate(
+                                   kFsPreallocBytes),
                                /*flags*/ 0u, clio::run::PoolQuery::Dynamic());
     CLIO_CO_AWAIT(p);
     if (p->GetReturnCode() != 0) { ok = false; break; }

--- a/context-transfer-engine/test/unit/CMakeLists.txt
+++ b/context-transfer-engine/test/unit/CMakeLists.txt
@@ -110,6 +110,13 @@ add_executable(test_vectored_blob_io
     test_vectored_blob_io.cc
 )
 
+# bdev fragmentation reuse (#820): large alloc served from fragmented small
+# free extents -- the decisive regression test for moving anti-fragmentation
+# from the CTE into the bdev allocator.
+add_executable(test_bdev_fragmentation
+    test_bdev_fragmentation.cc
+)
+
 # Batching benchmark (#820): many small writes at ONE blob, A/B'd on the same
 # binary via CLIO_TASK_BATCHING.
 add_executable(bench_same_blob_batching
@@ -390,6 +397,18 @@ target_link_libraries(test_concurrent_same_blob
 
 # Link test_vectored_blob_io (#820 vectored blob I/O) - same deps.
 target_link_libraries(test_vectored_blob_io
+    clio_cte_core_runtime
+    clio_cte_core_client
+    clio::run::admin_runtime
+    clio::run::admin_client
+    clio::run::bdev_runtime
+    clio::run::bdev_client
+    ctp::cxx
+    ${CMAKE_THREAD_LIBS_INIT}
+)
+
+# Link test_bdev_fragmentation (#820) - same deps.
+target_link_libraries(test_bdev_fragmentation
     clio_cte_core_runtime
     clio_cte_core_client
     clio::run::admin_runtime
@@ -743,6 +762,43 @@ set_tests_properties(
         LABELS "regression;concurrent;cte"
         ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CLIO_TEST_DATA_DIR=${CMAKE_BINARY_DIR};CLIO_BIND_ADDR=127.0.0.1;SAME_BLOB_THREADS=8;SAME_BLOB_ITERS=100"
 )
+
+# issue #820: run the SAME rigorous same-blob correctness test again, this time
+# THROUGH the batching merge path (CLIO_CTE_BATCHING + CLIO_BATCH_LANE). Without
+# these env vars BuildBatch returns at its policy gate and SmashBatch /
+# CompleteBatchParents / the inline-exec sink never run -- which is why coverage
+# of the merge path was ~0. Reusing this test means the merged path is checked
+# by the strongest correctness assertion there is (each thread's disjoint region
+# must survive intact), not a bespoke smoke test.
+add_test(NAME cte_concurrent_same_blob_batched
+    COMMAND test_concurrent_same_blob)
+set_tests_properties(
+    cte_concurrent_same_blob_batched
+    PROPERTIES
+        TIMEOUT 300
+        LABELS "regression;concurrent;cte;batching"
+        ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CLIO_TEST_DATA_DIR=${CMAKE_BINARY_DIR};CLIO_BIND_ADDR=127.0.0.1;SAME_BLOB_THREADS=8;SAME_BLOB_ITERS=100;CLIO_CTE_BATCHING=1;CLIO_BATCH_LANE=1"
+)
+
+# issue #820: vectored PutBlob/GetBlob correctness (equivalence with N single
+# puts, list-order overlap, union-range allocation, get-scatter, malformed-
+# segment rejection).
+add_test(NAME cte_vectored_blob_io
+    COMMAND test_vectored_blob_io)
+set_tests_properties(cte_vectored_blob_io PROPERTIES
+    TIMEOUT 300
+    LABELS "unit;cte;vectored;820"
+    ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CLIO_TEST_DATA_DIR=${CMAKE_BINARY_DIR};CLIO_BIND_ADDR=127.0.0.1")
+
+# issue #820: bdev fragmentation reuse -- large alloc served from fragmented
+# small free extents. Decisive regression test for moving anti-fragmentation
+# from the CTE into the bdev allocator (the 074/521/522 scenario).
+add_test(NAME cte_bdev_fragmentation
+    COMMAND test_bdev_fragmentation)
+set_tests_properties(cte_bdev_fragmentation PROPERTIES
+    TIMEOUT 300
+    LABELS "regression;bdev;cte;820"
+    ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CLIO_TEST_DATA_DIR=${CMAKE_BINARY_DIR};CLIO_BIND_ADDR=127.0.0.1")
 
 # Add reorganize blob tests
 # NOTE: These tests are chained (Put -> Move -> Integrity -> Promote -> Cleanup)

--- a/context-transfer-engine/test/unit/CMakeLists.txt
+++ b/context-transfer-engine/test/unit/CMakeLists.txt
@@ -1285,6 +1285,70 @@ set_tests_properties(cfs_shm_read PROPERTIES
     LABELS "unit;cte;cfs;msan_skip")
 endif()  # UNIX
 
+# Private-memory AsyncGetBlob (issue #823). UNIX-only because the "separate"
+# configuration forks a real clio_run daemon (RuntimeServer / unistd.h), the
+# same shape the cfs_shm_read test uses. The two ctest entries below run the
+# SAME binary in the two runtime configurations the issue calls for: inline
+# (co-located runtime -> direct write into private memory) and separate (pure
+# client -> SHM staging + PostWait copy).
+if(UNIX)
+add_executable(test_getblob_priv
+    test_getblob_priv.cc
+)
+
+target_include_directories(test_getblob_priv PRIVATE
+    ${CMAKE_SOURCE_DIR}/context-runtime/test
+)
+
+target_compile_definitions(test_getblob_priv PRIVATE
+    CLIO_RUN_EXE="$<TARGET_FILE:clio_run>")
+
+target_link_libraries(test_getblob_priv
+    clio_cte_core_client
+    # Config helpers used by the client live in the runtime library; keep it
+    # after the client on the link line (see the cfs_shm_read note above).
+    clio_cte_core_runtime
+    clio::run::admin_client
+    clio::run::bdev_client
+    ctp::cxx
+    ${CMAKE_THREAD_LIBS_INIT}
+)
+
+# The co-located (inline) runtime dlopens the chimods from CLIO_REPO_PATH; the
+# separate configuration forks clio_run. Both need the runtime modules built.
+add_dependencies(test_getblob_priv
+    clio_run
+    clio_cte_core_runtime
+    clio_bdev_runtime
+    clio_admin_runtime)
+
+set(_getblob_priv_env
+    "CLIO_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CLIO_BIND_ADDR=127.0.0.1")
+if(APPLE)
+  string(APPEND _getblob_priv_env ";CLIO_IPC_MODE=ipc")
+endif()
+
+# Inline: this process starts the runtime co-located (direct-write path).
+add_test(NAME cte_getblob_priv_inline
+    COMMAND test_getblob_priv
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set_tests_properties(cte_getblob_priv_inline PROPERTIES
+    ENVIRONMENT "${_getblob_priv_env}"
+    RESOURCE_LOCK "clio_runtime_port"
+    TIMEOUT 120
+    LABELS "unit;core;cte;msan_skip")
+
+# Separate: forks a real daemon and attaches as a pure client (staging path).
+add_test(NAME cte_getblob_priv_separate
+    COMMAND test_getblob_priv
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set_tests_properties(cte_getblob_priv_separate PROPERTIES
+    ENVIRONMENT "${_getblob_priv_env};CLIO_GETBLOB_PRIV_MODE=separate"
+    RESOURCE_LOCK "clio_runtime_port"
+    TIMEOUT 180
+    LABELS "unit;core;cte;msan_skip")
+endif()  # UNIX
+
 add_executable(test_cte_gpu_metadata_cache
     test_cte_gpu_metadata_cache.cc
 )

--- a/context-transfer-engine/test/unit/CMakeLists.txt
+++ b/context-transfer-engine/test/unit/CMakeLists.txt
@@ -74,6 +74,11 @@ add_executable(test_reorganize_blob
     test_reorganize_blob.cc
 )
 
+# Score-driven capacity eviction (Method::kEvict) API tests
+add_executable(test_evict
+    test_evict.cc
+)
+
 # Internal data organizer (issue #738): factory/frecency-score/config units
 # plus the end-to-end periodic DynamicReorganize promote/demote flow.
 add_executable(test_data_organizer
@@ -321,6 +326,18 @@ target_link_libraries(test_blob_block_reuse
 
 # Link test_reorganize_blob - using simple_test.h framework (NOT Catch2)
 target_link_libraries(test_reorganize_blob
+    clio_cte_core_runtime         # CTE core runtime library
+    clio_cte_core_client          # CTE core client library
+    clio::run::admin_runtime      # Admin module runtime (required for runtime mode)
+    clio::run::admin_client       # Admin module client
+    clio::run::bdev_runtime       # Bdev module runtime (required for runtime mode)
+    clio::run::bdev_client        # Bdev client for BdevType enum
+    ctp::cxx                    # ClioCtp library
+    ${CMAKE_THREAD_LIBS_INIT}    # Threading support
+)
+
+# Link test_evict - using simple_test.h framework (NOT Catch2)
+target_link_libraries(test_evict
     clio_cte_core_runtime         # CTE core runtime library
     clio_cte_core_client          # CTE core client library
     clio::run::admin_runtime      # Admin module runtime (required for runtime mode)
@@ -815,6 +832,18 @@ set_tests_properties(
         ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CLIO_TEST_DATA_DIR=${CMAKE_BINARY_DIR};CLIO_BIND_ADDR=127.0.0.1"
 )
 
+# Add score-driven eviction tests (Method::kEvict)
+add_test(NAME cte_evict
+    COMMAND test_evict)
+
+set_tests_properties(
+    cte_evict
+    PROPERTIES
+        TIMEOUT 300
+        LABELS "unit;evict;cte"
+        ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CLIO_TEST_DATA_DIR=${CMAKE_BINARY_DIR};CLIO_BIND_ADDR=127.0.0.1"
+)
+
 # Add data organizer tests (issue #738)
 # NOTE: like the reorganize tests, the cases share global fixture state
 # (blobs put in one case are checked/cleaned in later cases), so they run
@@ -1058,7 +1087,7 @@ set_tests_properties(
 # ------------------------------------------------------------------------------
 # Install Targets
 # ------------------------------------------------------------------------------
-set(_CTE_TEST_TARGETS cte_core_unit_tests cte_core_functionality_simple_tests test_core_functionality test_query test_cte_config_dpe test_tag_operations test_core_client_config test_core_runtime_coverage test_tiered_storage_stress test_tiered_storage_dram_default test_blob_block_reuse test_reorganize_blob test_data_organizer test_io_emulation)
+set(_CTE_TEST_TARGETS cte_core_unit_tests cte_core_functionality_simple_tests test_core_functionality test_query test_cte_config_dpe test_tag_operations test_core_client_config test_core_runtime_coverage test_tiered_storage_stress test_tiered_storage_dram_default test_blob_block_reuse test_reorganize_blob test_evict test_data_organizer test_io_emulation)
 # (The legacy test_cte_gpu_coroutine / test_gpu_core / test_gpu_create targets
 # and their ctest registrations were removed along with the GPU runtime. CTE
 # GPU coverage now lives in test_cte_devmem_putget (cte_devmem_putget_cuda).)

--- a/context-transfer-engine/test/unit/CMakeLists.txt
+++ b/context-transfer-engine/test/unit/CMakeLists.txt
@@ -110,6 +110,12 @@ add_executable(test_vectored_blob_io
     test_vectored_blob_io.cc
 )
 
+# Batching benchmark (#820): many small writes at ONE blob, A/B'd on the same
+# binary via CLIO_TASK_BATCHING.
+add_executable(bench_same_blob_batching
+    bench_same_blob_batching.cc
+)
+
 # Parallel blob-metadata overlap stress: many threads race
 # PutBlob/GetBlob/DelBlob/GetBlobInfo over only 4 tags x 4 blobs (heavy
 # overlap). Success = no crashes, hangs, or leaks.
@@ -384,6 +390,18 @@ target_link_libraries(test_concurrent_same_blob
 
 # Link test_vectored_blob_io (#820 vectored blob I/O) - same deps.
 target_link_libraries(test_vectored_blob_io
+    clio_cte_core_runtime
+    clio_cte_core_client
+    clio::run::admin_runtime
+    clio::run::admin_client
+    clio::run::bdev_runtime
+    clio::run::bdev_client
+    ctp::cxx
+    ${CMAKE_THREAD_LIBS_INIT}
+)
+
+# Link bench_same_blob_batching (#820) - same deps.
+target_link_libraries(bench_same_blob_batching
     clio_cte_core_runtime
     clio_cte_core_client
     clio::run::admin_runtime

--- a/context-transfer-engine/test/unit/CMakeLists.txt
+++ b/context-transfer-engine/test/unit/CMakeLists.txt
@@ -103,6 +103,13 @@ add_executable(test_concurrent_same_blob
     test_concurrent_same_blob.cc
 )
 
+# Vectored PutBlob/GetBlob (#820): N regions in one task, one write-token
+# acquire. Asserts equivalence with N single puts, list-order overlap
+# resolution, and union-range allocation.
+add_executable(test_vectored_blob_io
+    test_vectored_blob_io.cc
+)
+
 # Parallel blob-metadata overlap stress: many threads race
 # PutBlob/GetBlob/DelBlob/GetBlobInfo over only 4 tags x 4 blobs (heavy
 # overlap). Success = no crashes, hangs, or leaks.
@@ -365,6 +372,18 @@ target_include_directories(test_concurrent_io_stress PRIVATE
 
 # Link test_concurrent_same_blob (#680 same-blob write race) - same deps.
 target_link_libraries(test_concurrent_same_blob
+    clio_cte_core_runtime
+    clio_cte_core_client
+    clio::run::admin_runtime
+    clio::run::admin_client
+    clio::run::bdev_runtime
+    clio::run::bdev_client
+    ctp::cxx
+    ${CMAKE_THREAD_LIBS_INIT}
+)
+
+# Link test_vectored_blob_io (#820 vectored blob I/O) - same deps.
+target_link_libraries(test_vectored_blob_io
     clio_cte_core_runtime
     clio_cte_core_client
     clio::run::admin_runtime

--- a/context-transfer-engine/test/unit/bench_same_blob_batching.cc
+++ b/context-transfer-engine/test/unit/bench_same_blob_batching.cc
@@ -162,6 +162,69 @@ TEST_CASE("Batching bench: many small writes at ONE blob", "[cte][bench][820]") 
   REQUIRE(errors.load() == 0);
 }
 
+TEST_CASE("Async burst at ONE blob (batching A/B)", "[cte][bench][820]") {
+  REQUIRE(g_fixture != nullptr);
+  REQUIRE(g_fixture->initialized_);
+  auto *ipc = CLIO_IPC;
+  auto *cte = CLIO_CTE_CLIENT;
+
+  // The workload batching actually needs: MANY OUTSTANDING requests to one
+  // blob. A synchronous client has exactly one in flight per thread, so no
+  // worker ever sees two same-blob requests in a single shard drain and every
+  // batch group is a group of one. Here the submitter fires a whole burst
+  // before waiting on any of it, which is what #817's async writes produce
+  // (write(2) returns as soon as the bytes are staged).
+  const size_t kChunk = static_cast<size_t>(FromEnv("BATCH_BENCH_CHUNK", 4096));
+  const int kBurst = FromEnv("BATCH_BENCH_BURST", 256);
+  const int kRounds = FromEnv("BATCH_BENCH_ROUNDS", 10);
+
+  clio::cte::core::Tag tag("async_burst_tag");
+  clio::cte::core::TagId tag_id = tag.GetTagId();
+
+  std::vector<ctp::ipc::FullPtr<char>> bufs;
+  for (int i = 0; i < kBurst; ++i) {
+    auto b = ipc->AllocateBuffer(kChunk);
+    REQUIRE(!b.IsNull());
+    std::memset(b.ptr_, 'a' + (i % 26), kChunk);
+    bufs.push_back(b);
+  }
+
+  std::vector<double> round_ms;
+  for (int r = 0; r < kRounds + 1; ++r) {  // round 0 warms the blob
+    const std::string blob = "burst_" + std::to_string(r);
+    // Warm: lay the blob down once so the timed pass is an overwrite, not a
+    // first-touch allocation.
+    for (int i = 0; i < kBurst; ++i) {
+      auto p = cte->AsyncPutBlob(tag_id, blob,
+                                 static_cast<clio::run::u64>(i) * kChunk, kChunk,
+                                 ctp::ipc::ShmPtr<>(bufs[i].shm_));
+      p.Wait();
+    }
+    double t0 = NowUs();
+    std::vector<clio::run::Future<clio::cte::core::PutBlobTask>> futs;
+    futs.reserve(kBurst);
+    for (int i = 0; i < kBurst; ++i) {
+      futs.push_back(cte->AsyncPutBlob(tag_id, blob,
+                                       static_cast<clio::run::u64>(i) * kChunk,
+                                       kChunk,
+                                       ctp::ipc::ShmPtr<>(bufs[i].shm_)));
+    }
+    for (auto &f : futs) f.Wait();
+    double el = (NowUs() - t0) / 1000.0;
+    for (auto &f : futs) REQUIRE(f->GetReturnCode() == 0);
+    if (r > 0) round_ms.push_back(el);
+  }
+  for (auto &b : bufs) ipc->FreeBuffer(b);
+
+  std::sort(round_ms.begin(), round_ms.end());
+  const char *mode = std::getenv("CLIO_CTE_BATCHING");
+  std::printf(
+      "\n[#820 BURST] cte_batching=%s burst=%d x %zu B to ONE blob, %d rounds\n"
+      "[#820 BURST]   median=%.3f ms  min=%.3f  max=%.3f\n",
+      (mode == nullptr ? "off(default)" : mode), kBurst, kChunk, kRounds,
+      round_ms[round_ms.size() / 2], round_ms.front(), round_ms.back());
+}
+
 TEST_CASE("Vectored vs N single puts at ONE blob", "[cte][bench][820]") {
   REQUIRE(g_fixture != nullptr);
   REQUIRE(g_fixture->initialized_);

--- a/context-transfer-engine/test/unit/bench_same_blob_batching.cc
+++ b/context-transfer-engine/test/unit/bench_same_blob_batching.cc
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved. BSD 3-Clause license.
+ */
+
+// Benchmark for worker-local task batching (issue #820).
+//
+// Measures the exact contention batching exists to remove: many small writes
+// aimed at ONE blob. The filesystem stores each 1 MiB page as one blob, so a
+// sequential 4 KiB workload sends 256 tasks at a single page-blob, and each has
+// to hold that blob's #680 write token across its whole body -- allocation AND
+// the bdev copy. They drain single-file, and the contender re-polls on a
+// periodic cadence, which is where the measured ~1 s tail comes from.
+//
+// The A/B is on the SAME BINARY via CLIO_TASK_BATCHING, which is the point:
+// no rebuild, no branch switch, no host drift between arms. Whatever differs is
+// the batching phase.
+//
+// Reports mean AND the tail (p50/p99/p99.9/max), because the tail is the thing
+// being attacked -- a mean-only comparison would hide it.
+//
+// Env knobs:
+//   BATCH_BENCH_THREADS (8)      concurrent writers (all at the same blob)
+//   BATCH_BENCH_ITERS   (2000)   writes per thread
+//   BATCH_BENCH_CHUNK   (4096)   bytes per write
+
+#include <clio_runtime/clio_runtime.h>
+#include <clio_runtime/bdev/bdev_client.h>
+#include <clio_cte/core/core_client.h>
+#include <clio_cte/core/core_tasks.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "simple_test.h"
+
+namespace {
+
+const char *kTargetName = "batch_bench_target";
+constexpr clio::run::u64 kTargetSize = 2ULL * 1024 * 1024 * 1024;  // 2 GiB
+
+int FromEnv(const char *name, int dflt) {
+  if (const char *e = std::getenv(name)) {
+    int n = std::atoi(e);
+    if (n > 0) return n;
+  }
+  return dflt;
+}
+
+double NowUs() {
+  return std::chrono::duration<double, std::micro>(
+             std::chrono::steady_clock::now().time_since_epoch())
+      .count();
+}
+
+class Fixture {
+ public:
+  bool initialized_ = false;
+  Fixture() {
+    bool ok = clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, true);
+    REQUIRE(ok);
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    ok = clio::cte::core::CLIO_CTE_CLIENT_INIT();
+    REQUIRE(ok);
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    auto *cte = CLIO_CTE_CLIENT;
+    clio::run::PoolId bdev_pool_id(921, 0);
+    clio::run::bdev::Client bdev_client(bdev_pool_id);
+    auto create = bdev_client.AsyncCreate(
+        clio::run::PoolQuery::Dynamic(), kTargetName, bdev_pool_id,
+        clio::run::bdev::BdevType::kRam, kTargetSize);
+    create.Wait();
+    auto reg = cte->AsyncRegisterTarget(kTargetName,
+                                        clio::run::bdev::BdevType::kRam,
+                                        kTargetSize, clio::run::PoolQuery::Local(),
+                                        bdev_pool_id);
+    reg.Wait();
+    REQUIRE(reg->GetReturnCode() == 0);
+    initialized_ = true;
+  }
+};
+
+Fixture *g_fixture = nullptr;
+
+double Pct(std::vector<double> &v, double p) {
+  if (v.empty()) return 0.0;
+  size_t i = static_cast<size_t>(p * (v.size() - 1));
+  return v[i];
+}
+
+}  // namespace
+
+TEST_CASE("Batching bench: many small writes at ONE blob", "[cte][bench][820]") {
+  REQUIRE(g_fixture != nullptr);
+  REQUIRE(g_fixture->initialized_);
+
+  const int kThreads = FromEnv("BATCH_BENCH_THREADS", 8);
+  const int kIters = FromEnv("BATCH_BENCH_ITERS", 2000);
+  const size_t kChunk = static_cast<size_t>(FromEnv("BATCH_BENCH_CHUNK", 4096));
+
+  clio::cte::core::Tag tag("batch_bench_tag");
+  clio::cte::core::TagId tag_id = tag.GetTagId();
+  const std::string blob = "hot_page";
+
+  std::vector<std::vector<double>> lat(kThreads);
+  std::atomic<int> errors{0};
+
+  double t0 = NowUs();
+  std::vector<std::thread> threads;
+  for (int t = 0; t < kThreads; ++t) {
+    threads.emplace_back([&, t]() {
+      auto *ipc = CLIO_IPC;
+      auto *cte = CLIO_CTE_CLIENT;
+      ctp::ipc::FullPtr<char> buf = ipc->AllocateBuffer(kChunk);
+      if (buf.IsNull()) { errors++; return; }
+      std::memset(buf.ptr_, 'a' + (t % 26), kChunk);
+      lat[t].reserve(kIters);
+      for (int i = 0; i < kIters; ++i) {
+        // Distinct, disjoint offsets -- all landing on the SAME blob, which is
+        // exactly the page-blob contention the fs produces.
+        clio::run::u64 off =
+            (static_cast<clio::run::u64>(i) * kThreads + t) * kChunk;
+        double s = NowUs();
+        auto p = cte->AsyncPutBlob(tag_id, blob, off, kChunk,
+                                   ctp::ipc::ShmPtr<>(buf.shm_));
+        p.Wait();
+        lat[t].push_back(NowUs() - s);
+        if (p->GetReturnCode() != 0) errors++;
+      }
+      ipc->FreeBuffer(buf);
+    });
+  }
+  for (auto &th : threads) th.join();
+  double elapsed_us = NowUs() - t0;
+
+  std::vector<double> all;
+  for (auto &v : lat) all.insert(all.end(), v.begin(), v.end());
+  std::sort(all.begin(), all.end());
+  double sum = 0;
+  for (double x : all) sum += x;
+
+  const char *mode = std::getenv("CLIO_TASK_BATCHING");
+  std::printf(
+      "[#820 BENCH] batching=%s threads=%d iters=%d chunk=%zu\n"
+      "[#820 BENCH]   ops=%zu elapsed=%.1f ms  throughput=%.0f ops/s\n"
+      "[#820 BENCH]   mean=%.2f us  p50=%.2f  p99=%.2f  p99.9=%.2f  max=%.2f us\n"
+      "[#820 BENCH]   errors=%d\n",
+      (mode == nullptr ? "on(default)" : mode), kThreads, kIters, kChunk,
+      all.size(), elapsed_us / 1000.0,
+      all.empty() ? 0.0 : all.size() / (elapsed_us / 1e6),
+      all.empty() ? 0.0 : sum / all.size(), Pct(all, 0.50), Pct(all, 0.99),
+      Pct(all, 0.999), all.empty() ? 0.0 : all.back(), errors.load());
+
+  REQUIRE(errors.load() == 0);
+}
+
+TEST_CASE("Vectored vs N single puts at ONE blob", "[cte][bench][820]") {
+  REQUIRE(g_fixture != nullptr);
+  REQUIRE(g_fixture->initialized_);
+  auto *ipc = CLIO_IPC;
+  auto *cte = CLIO_CTE_CLIENT;
+
+  // The measurement that isolates the mechanism this whole issue rests on:
+  // the SAME bytes written to the SAME blob, as N separate single-region tasks
+  // (N write-token acquires, N metadata mutations, N bdev passes) versus ONE
+  // vectored task (one of each). No batching phase involved, no concurrency, no
+  // host-drift between arms -- just the task shape.
+  const size_t kChunk = static_cast<size_t>(FromEnv("BATCH_BENCH_CHUNK", 4096));
+  const int kSegs = FromEnv("BATCH_BENCH_SEGS", 256);   // 256 x 4 KiB = a page
+  const int kRounds = FromEnv("BATCH_BENCH_ROUNDS", 20);
+
+  clio::cte::core::Tag tag("vec_vs_single_tag");
+  clio::cte::core::TagId tag_id = tag.GetTagId();
+
+  std::vector<ctp::ipc::FullPtr<char>> bufs;
+  for (int i = 0; i < kSegs; ++i) {
+    auto b = ipc->AllocateBuffer(kChunk);
+    REQUIRE(!b.IsNull());
+    std::memset(b.ptr_, 'a' + (i % 26), kChunk);
+    bufs.push_back(b);
+  }
+
+  std::vector<double> single_ms, vec_ms;
+  for (int r = 0; r < kRounds; ++r) {
+    // Warm both blobs first so neither arm pays first-touch allocation that the
+    // other does not -- timing a fresh blob against a warm one is the classic
+    // way to manufacture a difference that is not there.
+    const std::string blob_s = "single_" + std::to_string(r);
+    const std::string blob_v = "vector_" + std::to_string(r);
+    for (int pass = 0; pass < 2; ++pass) {
+      double t0 = NowUs();
+      for (int i = 0; i < kSegs; ++i) {
+        auto p = cte->AsyncPutBlob(tag_id, blob_s,
+                                   static_cast<clio::run::u64>(i) * kChunk,
+                                   kChunk, ctp::ipc::ShmPtr<>(bufs[i].shm_));
+        p.Wait();
+      }
+      double t1 = NowUs();
+      std::vector<clio::cte::core::BlobSegment> segs;
+      for (int i = 0; i < kSegs; ++i) {
+        segs.push_back(clio::cte::core::BlobSegment(
+            static_cast<clio::run::u64>(i) * kChunk, kChunk,
+            ctp::ipc::ShmPtr<>(bufs[i].shm_)));
+      }
+      auto pv = cte->AsyncPutBlobVectored(tag_id, blob_v, segs);
+      pv.Wait();
+      double t2 = NowUs();
+      REQUIRE(pv->GetReturnCode() == 0);
+      if (pass == 1) {  // pass 0 is the warm-up
+        single_ms.push_back((t1 - t0) / 1000.0);
+        vec_ms.push_back((t2 - t1) / 1000.0);
+      }
+    }
+  }
+  for (auto &b : bufs) ipc->FreeBuffer(b);
+
+  std::sort(single_ms.begin(), single_ms.end());
+  std::sort(vec_ms.begin(), vec_ms.end());
+  double smed = single_ms[single_ms.size() / 2];
+  double vmed = vec_ms[vec_ms.size() / 2];
+  std::printf(
+      "\n[#820 BENCH] %d x %zu B to ONE blob, %d rounds (medians):\n"
+      "[#820 BENCH]   %d single PutBlobs : %.3f ms  (range %.3f-%.3f)\n"
+      "[#820 BENCH]   1 vectored PutBlob : %.3f ms  (range %.3f-%.3f)\n"
+      "[#820 BENCH]   speedup: %.2fx\n",
+      kSegs, kChunk, kRounds, kSegs, smed, single_ms.front(), single_ms.back(),
+      vmed, vec_ms.front(), vec_ms.back(), smed / vmed);
+}
+
+int main(int argc, char **argv) {
+  g_fixture = new Fixture();
+  std::string filter = (argc > 1) ? argv[1] : "";
+  int rc = SimpleTest::run_all_tests(filter);
+  delete g_fixture;
+  g_fixture = nullptr;
+  return rc;
+}

--- a/context-transfer-engine/test/unit/test_bdev_fragmentation.cc
+++ b/context-transfer-engine/test/unit/test_bdev_fragmentation.cc
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved. BSD 3-Clause license.
+ */
+
+// bdev fragmentation reuse (issue #820).
+//
+// Fragmentation avoidance moved OUT of the CTE (ExtendBlob used to cap every
+// block at 64 KB) and INTO the bdev allocator, which now assembles a large
+// request from several smaller freed extents. This is the decisive regression
+// test for that move -- the scenario xfstests 074/521/522 guard.
+//
+// The trap the old design fell into: the free list is bucketed by size
+// category, so a 1 MiB ask only ever probes the 1 MiB bucket and can never see
+// freed 8 KiB blocks. So:
+//   1. Fill a SMALL target to near-capacity with 8 KiB blobs (heap ~= cap).
+//   2. Delete them all -> the free pool is now ~all of the target, but entirely
+//      in 8 KiB extents; the bump-only heap watermark stays at capacity.
+//   3. Allocate LARGE blobs (1 MiB) and KEEP them (no large-to-large reuse to
+//      mask the effect). Their bytes can ONLY come from the freed 8 KiB extents.
+//      Total large bytes far exceed the heap headroom.
+// Without the fix, step 3 EIOs once the couple-MiB of headroom is gone. With it,
+// every large put succeeds and reads back intact.
+
+#include <clio_runtime/clio_runtime.h>
+#include <clio_runtime/bdev/bdev_client.h>
+#include <clio_cte/core/core_client.h>
+#include <clio_cte/core/core_tasks.h>
+
+#include <chrono>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "simple_test.h"
+
+namespace {
+
+const char *kTargetName = "frag_small_target";
+// Deliberately SMALL so "heap near capacity" is reachable in a few thousand
+// small blobs rather than a million.
+constexpr clio::run::u64 kTargetSize = 32ULL * 1024 * 1024;  // 32 MiB
+
+class Fixture {
+ public:
+  bool initialized_ = false;
+  Fixture() {
+    bool ok = clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, true);
+    REQUIRE(ok);
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    ok = clio::cte::core::CLIO_CTE_CLIENT_INIT();
+    REQUIRE(ok);
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    auto *cte = CLIO_CTE_CLIENT;
+    clio::run::PoolId bdev_pool_id(931, 0);
+    clio::run::bdev::Client bdev_client(bdev_pool_id);
+    auto create = bdev_client.AsyncCreate(
+        clio::run::PoolQuery::Dynamic(), kTargetName, bdev_pool_id,
+        clio::run::bdev::BdevType::kRam, kTargetSize);
+    create.Wait();
+    auto reg = cte->AsyncRegisterTarget(kTargetName,
+                                        clio::run::bdev::BdevType::kRam,
+                                        kTargetSize, clio::run::PoolQuery::Local(),
+                                        bdev_pool_id);
+    reg.Wait();
+    REQUIRE(reg->GetReturnCode() == 0);
+    initialized_ = true;
+  }
+};
+
+Fixture *g_fixture = nullptr;
+
+}  // namespace
+
+TEST_CASE("Large alloc served from fragmented small free extents (#820)",
+          "[cte][bdev][frag][820]") {
+  REQUIRE(g_fixture != nullptr);
+  REQUIRE(g_fixture->initialized_);
+  auto *ipc = CLIO_IPC;
+  auto *cte = CLIO_CTE_CLIENT;
+  clio::cte::core::Tag tag("frag_small_tag");
+  clio::cte::core::TagId tag_id = tag.GetTagId();
+
+  const size_t kSmall = 8 * 1024;
+  const size_t kLarge = 1024 * 1024;
+
+  // 1. Fill to near-capacity with 8 KiB blobs.
+  auto sb = ipc->AllocateBuffer(kSmall);
+  REQUIRE(!sb.IsNull());
+  std::memset(sb.ptr_, 'x', kSmall);
+  int filled = 0;
+  // Fill until the tier actually REFUSES a put -- that is what drives the
+  // bump-only heap watermark to capacity, which is the precondition for the
+  // regression (a later large ask can't heap-bump and must reuse). The cap is a
+  // generous upper bound; the RAM bdev's real capacity decides where it stops.
+  const int kMaxSmall = 200000;
+  for (int i = 0; i < kMaxSmall; ++i) {
+    const std::string nm = "f_" + std::to_string(i);
+    auto p = cte->AsyncPutBlob(tag_id, nm, 0, kSmall,
+                               ctp::ipc::ShmPtr<>(sb.shm_));
+    p.Wait();
+    if (p->GetReturnCode() != 0) break;  // tier full
+    ++filled;
+  }
+  ipc->FreeBuffer(sb);
+  REQUIRE(filled > 0);
+  // We must have driven the heap near capacity -- most of the target is now
+  // consumed by 8 KiB blobs.
+  REQUIRE(static_cast<clio::run::u64>(filled) * kSmall >= kTargetSize / 2);
+
+  // 2. Delete them all -> ~all of the target free, in 8 KiB extents; heap
+  //    watermark stays high.
+  for (int i = 0; i < filled; ++i) {
+    const std::string nm = "f_" + std::to_string(i);
+    auto d = cte->AsyncDelBlob(tag_id, nm);
+    d.Wait();
+    REQUIRE(d->GetReturnCode() == 0);
+  }
+
+  // 3. Allocate LARGE blobs, keeping them. Total far exceeds any plausible heap
+  //    headroom, so success requires reusing the small freed extents.
+  std::vector<char> lbuf(kLarge);
+  for (size_t j = 0; j < kLarge; ++j) lbuf[j] = static_cast<char>((j * 13) % 251);
+  const int kNumLarge = 20;  // 20 MiB, >> the ~few MiB of heap headroom
+  int large_ok = 0;
+  for (int i = 0; i < kNumLarge; ++i) {
+    auto lb = ipc->AllocateBuffer(kLarge);
+    REQUIRE(!lb.IsNull());
+    std::memcpy(lb.ptr_, lbuf.data(), kLarge);
+    const std::string nm = "L_" + std::to_string(i);
+    auto p = cte->AsyncPutBlob(tag_id, nm, 0, kLarge,
+                               ctp::ipc::ShmPtr<>(lb.shm_));
+    p.Wait();
+    ipc->FreeBuffer(lb);
+    if (p->GetReturnCode() != 0) break;
+    ++large_ok;
+
+    // Read back: a large blob assembled from many small physical blocks must
+    // reconstruct exactly.
+    auto rd = ipc->AllocateBuffer(kLarge);
+    REQUIRE(!rd.IsNull());
+    std::memset(rd.ptr_, 0, kLarge);
+    auto g = cte->AsyncGetBlob(tag_id, nm, 0, kLarge, /*flags=*/0,
+                               ctp::ipc::ShmPtr<>(rd.shm_));
+    g.Wait();
+    REQUIRE(g->GetReturnCode() == 0);
+    REQUIRE(std::memcmp(rd.ptr_, lbuf.data(), kLarge) == 0);
+    ipc->FreeBuffer(rd);
+  }
+
+  std::printf("[#820] filled %d x 8KiB, freed, then %d/%d x 1MiB large allocs "
+              "succeeded from fragmented free space\n",
+              filled, large_ok, kNumLarge);
+  // The whole point: every large alloc had to be assembled from freed 8 KiB
+  // extents, because the heap had no room and no large contiguous free block
+  // existed.
+  REQUIRE(large_ok == kNumLarge);
+}
+
+int main(int argc, char **argv) {
+  g_fixture = new Fixture();
+  std::string filter = (argc > 1) ? argv[1] : "";
+  int rc = SimpleTest::run_all_tests(filter);
+  delete g_fixture;
+  g_fixture = nullptr;
+  return rc;
+}

--- a/context-transfer-engine/test/unit/test_evict.cc
+++ b/context-transfer-engine/test/unit/test_evict.cc
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * EVICT TEST
+ *
+ * Exercises Client::AsyncEvict (Method::kEvict): score-driven capacity
+ * reclamation. Given a "minimum tier score" and a byte budget, the runtime
+ * frees the LOWEST-score blobs occupying qualifying tiers, cheapest-first,
+ * until the budget is met.
+ *
+ * Config: a single DRAM tier (score 1.0) so placement is deterministic and a
+ * blob's own put-score becomes its rank key. Four 1 MB blobs are stored with
+ * distinct scores; Evict must remove the lowest-scoring ones first.
+ */
+
+#include <clio_runtime/clio_runtime.h>
+#include <clio_cte/core/core_client.h>
+#include <clio_cte/core/core_tasks.h>
+
+#include <chrono>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <thread>
+#include <vector>
+
+#include "simple_test.h"
+
+namespace fs = std::filesystem;
+
+static std::string chi_test_data_dir() {
+  const char *d = clio::run::env::GetCompat("TEST_DATA_DIR");
+  return (d && *d) ? d : ".";
+}
+
+static constexpr clio::run::u64 kBlobSize = 1 * 1024 * 1024;  // 1MB per blob
+static constexpr float kTierScore = 1.0f;                     // single DRAM tier
+
+class EvictTestFixture {
+ public:
+  std::string config_path_;
+  bool initialized_ = false;
+
+  EvictTestFixture() {
+    config_path_ = chi_test_data_dir() + "/evict_config.yaml";
+    Cleanup();
+    CreateConfigFile();
+    ctp::SystemInfo::Setenv("CLIO_SERVER_CONF", config_path_.c_str(), 1);
+
+    bool success = clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, true);
+    REQUIRE(success);
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    success = clio::cte::core::CLIO_CTE_CLIENT_INIT();
+    REQUIRE(success);
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    initialized_ = true;
+  }
+
+  ~EvictTestFixture() { Cleanup(); }
+
+  void Cleanup() {
+    if (fs::exists(config_path_)) fs::remove(config_path_);
+  }
+
+  void CreateConfigFile() {
+    std::ofstream config_file(config_path_);
+    REQUIRE(config_file.is_open());
+    config_file << R"(
+# Evict Test Configuration - single 64MB DRAM tier (score 1.0)
+runtime:
+  num_threads: 2
+  queue_depth: 1024
+  first_busy_wait: 10000
+  max_sleep: 50000
+
+compose:
+  - mod_name: clio_cte_core
+    pool_name: clio_cte
+    pool_query: local
+    pool_id: 512.0
+
+    targets:
+      neighborhood: 1
+      default_target_timeout_ms: 30000
+      poll_period_ms: 5000
+
+    storage:
+      - path: "ram::evict_dram"
+        bdev_type: "ram"
+        capacity_limit: "64MB"
+        score: 1.0
+
+    dpe:
+      dpe_type: "max_bw"
+)";
+    config_file.close();
+  }
+
+  // Store one 1MB blob with the given put-score (which becomes its rank key).
+  void PutScoredBlob(clio::cte::core::Tag &tag, const std::string &blob_name,
+                     float score, char pattern) {
+    auto shm_buffer = CLIO_IPC->AllocateBuffer(kBlobSize);
+    REQUIRE(!shm_buffer.IsNull());
+    std::memset(shm_buffer.ptr_, pattern, kBlobSize);
+    auto put_task = tag.AsyncPutBlob(
+        blob_name, shm_buffer.shm_.template Cast<void>(), kBlobSize, 0, score);
+    put_task.Wait();
+    REQUIRE(put_task->GetReturnCode() == 0);
+    CLIO_IPC->FreeBuffer(shm_buffer);
+  }
+};
+
+static EvictTestFixture *g_fixture = nullptr;
+
+// Returns true if the blob still exists (GetBlobScore succeeds).
+static bool BlobExists(clio::cte::core::Client *cte_client,
+                       const clio::cte::core::TagId &tag_id,
+                       const std::string &blob_name) {
+  auto score_task = cte_client->AsyncGetBlobScore(tag_id, blob_name);
+  score_task.Wait();
+  return score_task->GetReturnCode() == 0;
+}
+
+/**
+ * Evict the two lowest-score blobs off the tier via a 2 MB budget.
+ */
+TEST_CASE("Evict - lowest score first until budget met", "[evict][noleak]") {
+  REQUIRE(g_fixture != nullptr);
+  REQUIRE(g_fixture->initialized_);
+  auto *cte_client = CLIO_CTE_CLIENT;
+  REQUIRE(cte_client != nullptr);
+
+  std::string tag_name = "evict_test_tag";
+  clio::cte::core::Tag tag(tag_name);
+  clio::cte::core::TagId tag_id = tag.GetTagId();
+
+  // Four 1MB blobs with distinct scores on the single DRAM tier.
+  g_fixture->PutScoredBlob(tag, "blob_hi", 1.0f, 'A');    // keep
+  g_fixture->PutScoredBlob(tag, "blob_mid", 0.75f, 'B');  // keep
+  g_fixture->PutScoredBlob(tag, "blob_lo", 0.50f, 'C');   // evict (2nd)
+  g_fixture->PutScoredBlob(tag, "blob_lowest", 0.25f, 'D');  // evict (1st)
+
+  REQUIRE(BlobExists(cte_client, tag_id, "blob_lowest"));
+  REQUIRE(BlobExists(cte_client, tag_id, "blob_hi"));
+
+  // Evict 2MB from any tier with score >= 0.5 (the DRAM tier at 1.0 qualifies).
+  const clio::run::u64 kBudget = 2 * kBlobSize;
+  auto evict_task = cte_client->AsyncEvict(/*min_tier_score=*/0.5f, kBudget);
+  evict_task.Wait();
+  REQUIRE(evict_task->GetReturnCode() == 0);
+
+  INFO("bytes_evicted=" << evict_task->bytes_evicted_
+                        << " blobs_evicted=" << evict_task->blobs_evicted_);
+
+  // Budget satisfied by exactly the two lowest-score blobs.
+  REQUIRE(evict_task->bytes_evicted_ >= kBudget);
+  REQUIRE(evict_task->blobs_evicted_ == 2);
+
+  // The two lowest-score blobs are gone; the two highest remain.
+  REQUIRE(!BlobExists(cte_client, tag_id, "blob_lowest"));
+  REQUIRE(!BlobExists(cte_client, tag_id, "blob_lo"));
+  REQUIRE(BlobExists(cte_client, tag_id, "blob_mid"));
+  REQUIRE(BlobExists(cte_client, tag_id, "blob_hi"));
+
+  // Clean up the survivors.
+  cte_client->AsyncDelBlob(tag_id, "blob_mid").Wait();
+  cte_client->AsyncDelBlob(tag_id, "blob_hi").Wait();
+}
+
+/**
+ * A min_tier_score above every registered target evicts nothing.
+ */
+TEST_CASE("Evict - no qualifying tier is a no-op", "[evict][noleak]") {
+  REQUIRE(g_fixture != nullptr);
+  auto *cte_client = CLIO_CTE_CLIENT;
+  REQUIRE(cte_client != nullptr);
+
+  std::string tag_name = "evict_noop_tag";
+  clio::cte::core::Tag tag(tag_name);
+  clio::cte::core::TagId tag_id = tag.GetTagId();
+
+  g_fixture->PutScoredBlob(tag, "keep_me", 0.5f, 'K');
+  REQUIRE(BlobExists(cte_client, tag_id, "keep_me"));
+
+  // No target has score >= 2.0, so nothing should be evicted.
+  auto evict_task = cte_client->AsyncEvict(/*min_tier_score=*/2.0f, kBlobSize);
+  evict_task.Wait();
+  REQUIRE(evict_task->GetReturnCode() == 0);
+  REQUIRE(evict_task->bytes_evicted_ == 0);
+  REQUIRE(evict_task->blobs_evicted_ == 0);
+  REQUIRE(BlobExists(cte_client, tag_id, "keep_me"));
+
+  cte_client->AsyncDelBlob(tag_id, "keep_me").Wait();
+}
+
+int main(int argc, char **argv) {
+  g_fixture = new EvictTestFixture();
+  std::string filter = (argc > 1) ? argv[1] : "";
+  int result = SimpleTest::run_all_tests(filter);
+  delete g_fixture;
+  g_fixture = nullptr;
+  SIMPLE_TEST_PROCESS_EXIT(result);
+  return result;
+}

--- a/context-transfer-engine/test/unit/test_getblob_priv.cc
+++ b/context-transfer-engine/test/unit/test_getblob_priv.cc
@@ -321,6 +321,83 @@ TEST_CASE("Private GetBlob shared-cache fast path is correct", "[cte][823]") {
   }
 }
 
+// Private-memory AsyncPutBlob (issue #830): write a blob region straight from a
+// caller-owned PRIVATE buffer (heap/stack, never SHM), then read it back and
+// verify. Exercises the runtime-mode no-copy path (inline fixture) and the
+// client-mode SHM-staging + TASK_DATA_OWNER path (separate fixture) depending on
+// the configuration the fixture chose — the same split the GetBlob cases cover.
+TEST_CASE("PutBlob from private memory round-trips", "[cte][830]") {
+  REQUIRE(g_fixture != nullptr);
+  REQUIRE(g_fixture->initialized_);
+  auto *cte = CLIO_CTE_CLIENT;
+
+  clio::cte::core::Tag tag("putblob_priv_tag");
+  clio::cte::core::TagId tag_id = tag.GetTagId();
+  const std::string blob = "priv_put_blob";
+  const size_t kN = 64 * 1024;
+
+  // Source is genuine private memory (heap), never an SHM buffer.
+  std::vector<char> src(kN);
+  for (size_t i = 0; i < kN; ++i) src[i] = PatternByte(i);
+
+  auto p = cte->AsyncPutBlob(tag_id, blob, 0, kN, src.data());
+  p.Wait();
+  REQUIRE(p->GetReturnCode() == 0);
+
+  // Read the whole blob back into a private buffer and compare byte-for-byte.
+  std::vector<char> got(kN, 0);
+  auto g = cte->AsyncGetBlob(tag_id, blob, 0, kN, /*flags=*/0, got.data());
+  g.Wait();  // Empty (cache-hit) future Wait()s to true; otherwise task rc==0.
+  for (size_t i = 0; i < kN; ++i) {
+    REQUIRE(got[i] == PatternByte(i));
+  }
+}
+
+// Offset/partial private-memory puts must land at the right place without
+// disturbing neighbouring bytes, and a repeated overwrite of the same region
+// (the workload issue #830 targets) must read back last-writer-wins.
+TEST_CASE("Private PutBlob offset + repeated overwrite", "[cte][830]") {
+  REQUIRE(g_fixture != nullptr);
+  REQUIRE(g_fixture->initialized_);
+  auto *cte = CLIO_CTE_CLIENT;
+
+  clio::cte::core::Tag tag("putblob_priv_ovw_tag");
+  clio::cte::core::TagId tag_id = tag.GetTagId();
+  const std::string blob = "priv_ovw_blob";
+  const size_t kN = 32 * 1024;
+
+  // Lay down a base pattern from private memory.
+  std::vector<char> base(kN);
+  for (size_t i = 0; i < kN; ++i) base[i] = PatternByte(i);
+  auto p0 = cte->AsyncPutBlob(tag_id, blob, 0, kN, base.data());
+  p0.Wait();
+  REQUIRE(p0->GetReturnCode() == 0);
+
+  // Overwrite an interior sub-range several times; the last write must win.
+  const size_t kOff = 4096, kLen = 8192;
+  for (int iter = 0; iter < 8; ++iter) {
+    std::vector<char> patch(kLen);
+    for (size_t i = 0; i < kLen; ++i) {
+      patch[i] = PatternByte(kOff + i + 100 + iter);
+    }
+    auto p = cte->AsyncPutBlob(tag_id, blob, kOff, kLen, patch.data());
+    p.Wait();
+    REQUIRE(p->GetReturnCode() == 0);
+  }
+
+  // Read the whole blob: [kOff, kOff+kLen) reflects the final overwrite (iter 7),
+  // everything else keeps the base pattern.
+  std::vector<char> got(kN, 0);
+  auto g = cte->AsyncGetBlob(tag_id, blob, 0, kN, 0, got.data());
+  g.Wait();
+  for (size_t i = 0; i < kN; ++i) {
+    char expect = (i >= kOff && i < kOff + kLen)
+                      ? PatternByte(i + 100 + 7)
+                      : PatternByte(i);
+    REQUIRE(got[i] == expect);
+  }
+}
+
 int main(int argc, char **argv) {
   static Fixture fixture;
   g_fixture = &fixture;

--- a/context-transfer-engine/test/unit/test_getblob_priv.cc
+++ b/context-transfer-engine/test/unit/test_getblob_priv.cc
@@ -424,6 +424,36 @@ TEST_CASE("Tag private PutBlob/GetBlob round-trips", "[cte][830]") {
   }
 }
 
+// Guard/edge branches of the private PutBlob (issue #830): a zero-length put
+// routes through the ShmPtr overload (no staging), and a null buffer with a
+// positive size is rejected. Covers the fast-exit + validation paths the
+// happy-path round-trips above never reach.
+TEST_CASE("Private PutBlob guards: zero-length + null buffer", "[cte][830]") {
+  REQUIRE(g_fixture != nullptr);
+  REQUIRE(g_fixture->initialized_);
+  auto *cte = CLIO_CTE_CLIENT;
+
+  clio::cte::core::Tag tag("putblob_priv_guard_tag");
+  clio::cte::core::TagId tag_id = tag.GetTagId();
+
+  // size==0 hits the guard that routes to the ShmPtr overload with a null
+  // buffer: it must complete without error or crash.
+  char dummy = 'x';
+  auto p = cte->AsyncPutBlob(tag_id, "zero_blob", /*offset=*/0, /*size=*/0,
+                             &dummy);
+  REQUIRE_NOTHROW(p.Wait());
+
+  // Tag::AsyncPutBlob rejects a null buffer paired with a positive size.
+  bool threw = false;
+  try {
+    (void)tag.AsyncPutBlob("null_blob", static_cast<const char *>(nullptr),
+                           /*data_size=*/16);
+  } catch (const std::invalid_argument &) {
+    threw = true;
+  }
+  REQUIRE(threw);
+}
+
 int main(int argc, char **argv) {
   static Fixture fixture;
   g_fixture = &fixture;

--- a/context-transfer-engine/test/unit/test_getblob_priv.cc
+++ b/context-transfer-engine/test/unit/test_getblob_priv.cc
@@ -111,17 +111,12 @@ class Fixture {
     }
   }
 
-  /** Inline: this process IS the runtime. Register a RAM target by hand. */
-  bool InitInline() {
-    if (!clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, true)) {
-      return false;
-    }
-    std::this_thread::sleep_for(300ms);
-    if (!clio::cte::core::CLIO_CTE_CLIENT_INIT()) {
-      return false;
-    }
-    std::this_thread::sleep_for(200ms);
-
+  /** Register a RAM target into the pool CLIO_CTE_CLIENT actually talks to
+   *  (the default clio_cte_core pool). Shared by the inline and separate
+   *  fixtures so both place the target where the client's PutBlobs look for it.
+   *  In separate mode the bdev create + RegisterTarget are serviced by the
+   *  daemon just as they are in-process inline. */
+  static bool RegisterRamTarget() {
     auto *cte = CLIO_CTE_CLIENT;
     clio::run::PoolId bdev_pool_id(915, 0);
     clio::run::bdev::Client bdev_client(bdev_pool_id);
@@ -136,9 +131,23 @@ class Fixture {
                                         clio::run::PoolQuery::Local(),
                                         bdev_pool_id);
     reg.Wait();
-    if (reg->GetReturnCode() != 0) return false;
+    return reg->GetReturnCode() == 0;
+  }
+
+  /** Inline: this process IS the runtime. Register a RAM target by hand. */
+  bool InitInline() {
+    if (!clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, true)) {
+      return false;
+    }
+    std::this_thread::sleep_for(300ms);
+    if (!clio::cte::core::CLIO_CTE_CLIENT_INIT()) {
+      return false;
+    }
+    std::this_thread::sleep_for(200ms);
+
+    if (!RegisterRamTarget()) return false;
     // Best-effort: attach the SHM metadata cache so the zero-IPC path can run.
-    (void)cte->AttachShmCache();
+    (void)CLIO_CTE_CLIENT->AttachShmCache();
     return true;
   }
 
@@ -180,6 +189,25 @@ class Fixture {
       return false;
     }
     if (!clio::cte::core::CLIO_CTE_CLIENT_INIT()) {
+      return false;
+    }
+    // Register the RAM target into the pool this client actually uses.
+    //
+    // The compose above brings up the separate daemon, but its `storage:`
+    // section registers targets into the COMPOSED pool (getblob_priv_cte, id
+    // 515.0), whereas CLIO_CTE_CLIENT talks to the default CTE pool
+    // (clio_cte_core, id 512.0) that CLIO_CTE_CLIENT_INIT creates. Those are
+    // different containers with independent target lists, so the client's
+    // PutBlobs would find no placement target -- ExtendBlob reports "no
+    // targets" (error_code 1) and the setup put fails with rc 11. On a fast
+    // native host the ids happened to line up so it passed; on a slow /
+    // CPU-constrained host (the deps-cpu CI container under the Boost fiber
+    // backend) they did not, so the test failed deterministically there.
+    //
+    // Registering through the client (exactly as InitInline does) puts the
+    // target where the client looks for it, on every platform. The daemon
+    // services the bdev create + RegisterTarget the same way it would inline.
+    if (!RegisterRamTarget()) {
       return false;
     }
     (void)CLIO_CTE_CLIENT->AttachShmCache();

--- a/context-transfer-engine/test/unit/test_getblob_priv.cc
+++ b/context-transfer-engine/test/unit/test_getblob_priv.cc
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved. BSD 3-Clause license.
+ */
+
+/**
+ * Private-memory AsyncGetBlob (issue #823).
+ *
+ * CoreClient::AsyncGetBlob(char*) reads a blob region straight into a
+ * caller-owned PRIVATE buffer instead of making the caller hand-manage an SHM
+ * buffer. It resolves to one of three paths, and this test exercises them in
+ * BOTH runtime configurations, because the path taken depends on the config:
+ *
+ *   - Runtime started INLINE (co-located): the daemon shares this address
+ *     space, so the private pointer is wrapped as a null-allocator ShmPtr and
+ *     the read lands directly in the caller's buffer. `CLIO_GETBLOB_PRIV_MODE`
+ *     unset / "inline".
+ *   - Runtime started SEPARATE (its own process): a pure client cannot expose
+ *     private memory, so the read is staged through an SHM buffer, the task is
+ *     marked TASK_DATA_OWNER, and GetBlobTask::PostWait() copies the staged
+ *     bytes into the caller's buffer. `CLIO_GETBLOB_PRIV_MODE=separate`.
+ *
+ * Both configs additionally exercise the zero-IPC shared-cache fast path when
+ * the cache is attachable.
+ *
+ * The buffers handed to the API here are genuine private memory
+ * (std::vector<char> / stack), never SHM — that is the whole point of the API.
+ */
+
+#include <fcntl.h>
+#include <signal.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "clio_cte/core/core_client.h"
+#include "clio_runtime/bdev/bdev_client.h"
+#include "clio_runtime/clio_runtime.h"
+#include "runtime_server.h"
+#include "simple_test.h"
+
+using namespace std::chrono_literals;
+
+namespace {
+
+constexpr clio::run::u64 kRamTargetBytes = 256ULL * 1024 * 1024;
+constexpr unsigned kPort = 10623;
+const char *kTargetName = "getblob_priv_target";
+
+/** True when CLIO_GETBLOB_PRIV_MODE=separate: bring up a daemon in its own
+ *  process and attach as a pure client (exercises the client-staging path).
+ *  Otherwise the runtime is started inline (exercises the direct-write path). */
+bool SeparateMode() {
+  const char *m = std::getenv("CLIO_GETBLOB_PRIV_MODE");
+  return m != nullptr && std::string(m) == "separate";
+}
+
+/** Run `clio_run <args>` to completion, returning its exit code. */
+int RunCli(const std::vector<std::string> &args, int timeout_sec) {
+  std::vector<std::string> full;
+  full.push_back(CLIO_RUN_EXE);
+  full.insert(full.end(), args.begin(), args.end());
+  std::vector<char *> argv;
+  for (auto &a : full) argv.push_back(a.data());
+  argv.push_back(nullptr);
+  pid_t pid = fork();
+  if (pid < 0) return -1;
+  if (pid == 0) {
+    execv(argv[0], argv.data());
+    _exit(127);
+  }
+  auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(timeout_sec);
+  int status = 0;
+  while (true) {
+    pid_t r = waitpid(pid, &status, WNOHANG);
+    if (r == pid) return WIFEXITED(status) ? WEXITSTATUS(status) : -2;
+    if (std::chrono::steady_clock::now() >= deadline) {
+      kill(pid, SIGKILL);
+      waitpid(pid, &status, 0);
+      return -3;
+    }
+    std::this_thread::sleep_for(100ms);
+  }
+}
+
+clio::run::test::RuntimeServer *g_server = nullptr;
+
+/** Deterministic byte at logical position i of the test pattern. */
+char PatternByte(size_t i) { return static_cast<char>((i * 131 + 7) & 0xFF); }
+
+class Fixture {
+ public:
+  bool initialized_ = false;
+  bool separate_ = false;
+
+  Fixture() {
+    separate_ = SeparateMode();
+    if (separate_) {
+      initialized_ = InitSeparate();
+    } else {
+      initialized_ = InitInline();
+    }
+  }
+
+  /** Inline: this process IS the runtime. Register a RAM target by hand. */
+  bool InitInline() {
+    if (!clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, true)) {
+      return false;
+    }
+    std::this_thread::sleep_for(300ms);
+    if (!clio::cte::core::CLIO_CTE_CLIENT_INIT()) {
+      return false;
+    }
+    std::this_thread::sleep_for(200ms);
+
+    auto *cte = CLIO_CTE_CLIENT;
+    clio::run::PoolId bdev_pool_id(915, 0);
+    clio::run::bdev::Client bdev_client(bdev_pool_id);
+    auto create = bdev_client.AsyncCreate(clio::run::PoolQuery::Dynamic(),
+                                          kTargetName, bdev_pool_id,
+                                          clio::run::bdev::BdevType::kRam,
+                                          kRamTargetBytes);
+    create.Wait();
+    auto reg = cte->AsyncRegisterTarget(kTargetName,
+                                        clio::run::bdev::BdevType::kRam,
+                                        kRamTargetBytes,
+                                        clio::run::PoolQuery::Local(),
+                                        bdev_pool_id);
+    reg.Wait();
+    if (reg->GetReturnCode() != 0) return false;
+    // Best-effort: attach the SHM metadata cache so the zero-IPC path can run.
+    (void)cte->AttachShmCache();
+    return true;
+  }
+
+  /** Separate: compose a real daemon in its own process, attach as a client. */
+  bool InitSeparate() {
+    const std::string work = "/tmp/clio_getblob_priv_test";
+    std::filesystem::remove_all(work);
+    std::filesystem::create_directories(work);
+    const std::string yaml = work + "/compose.yaml";
+    {
+      std::ofstream f(yaml);
+      f << "compose:\n"
+           "  - mod_name: clio_cte_core\n"
+           "    pool_name: \"getblob_priv_cte\"\n"
+           "    pool_query: local\n"
+           "    pool_id: \"515.0\"\n"
+           "    storage:\n"
+           "      - path: "
+        << work << "/ram_dev\n"
+           "        bdev_type: ram\n"
+           "        capacity_limit: "
+        << (kRamTargetBytes / (1024 * 1024)) << "mb\n"
+           "    dpe:\n"
+           "      dpe_type: random\n";
+    }
+
+    setenv("CLIO_WAIT_SERVER", "15", 1);
+    setenv("CLIO_BIND_ADDR", "127.0.0.1", 1);
+
+    static clio::run::test::RuntimeServer server;
+    g_server = &server;
+    if (!server.Start(kPort) || !server.WaitForReady()) {
+      return false;
+    }
+    if (RunCli({"compose", "start", yaml}, 60) != 0) {
+      return false;
+    }
+    if (!clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, false)) {
+      return false;
+    }
+    if (!clio::cte::core::CLIO_CTE_CLIENT_INIT()) {
+      return false;
+    }
+    (void)CLIO_CTE_CLIENT->AttachShmCache();
+    return true;
+  }
+};
+
+Fixture *g_fixture = nullptr;
+
+/** Put `n` bytes of the deterministic pattern (starting at pattern index
+ *  `base`) at [off, off+n) of `blob`, through an ordinary SHM PutBlob. */
+void PutPattern(clio::cte::core::TagId tag_id, const std::string &blob,
+                clio::run::u64 off, size_t n, size_t base) {
+  auto *ipc = CLIO_IPC;
+  auto *cte = CLIO_CTE_CLIENT;
+  ctp::ipc::FullPtr<char> buf = ipc->AllocateBuffer(n);
+  REQUIRE(!buf.IsNull());
+  for (size_t i = 0; i < n; ++i) buf.ptr_[i] = PatternByte(base + i);
+  auto p = cte->AsyncPutBlob(tag_id, blob, off, n, ctp::ipc::ShmPtr<>(buf.shm_));
+  p.Wait();
+  REQUIRE(p->GetReturnCode() == 0);
+  ipc->FreeBuffer(buf);
+}
+
+}  // namespace
+
+// The heart of the issue: read into PRIVATE memory and get the right bytes,
+// under whichever runtime configuration the fixture chose.
+TEST_CASE("GetBlob into private memory returns correct bytes", "[cte][823]") {
+  REQUIRE(g_fixture != nullptr);
+  REQUIRE(g_fixture->initialized_);
+  auto *cte = CLIO_CTE_CLIENT;
+
+  clio::cte::core::Tag tag("getblob_priv_tag");
+  clio::cte::core::TagId tag_id = tag.GetTagId();
+
+  const std::string blob = "priv_blob";
+  const size_t kN = 64 * 1024;  // 64 KiB
+  PutPattern(tag_id, blob, 0, kN, 0);
+
+  // Full read into a genuinely private buffer (heap, not SHM).
+  std::vector<char> priv(kN, 0);
+  auto g = cte->AsyncGetBlob(tag_id, blob, 0, kN, /*flags=*/0, priv.data());
+  g.Wait();  // Empty (cache-hit) future Wait()s to true; otherwise task rc==0.
+  for (size_t i = 0; i < kN; ++i) {
+    REQUIRE(priv[i] == PatternByte(i));
+  }
+
+  // Offset read of a sub-range lands the right slice at the buffer start.
+  const size_t kOff = 4096, kLen = 8192;
+  std::vector<char> sub(kLen, 0);
+  auto g2 = cte->AsyncGetBlob(tag_id, blob, kOff, kLen, 0, sub.data());
+  g2.Wait();
+  for (size_t i = 0; i < kLen; ++i) {
+    REQUIRE(sub[i] == PatternByte(kOff + i));
+  }
+}
+
+// Repeated reads must not leak or hang: the client path allocates a staging
+// buffer per call and relies on TASK_DATA_OWNER to reclaim it. A leak here
+// exhausts the main SHM segment and later reads fail; a missed free would trip
+// the allocator's leak checker at shutdown.
+TEST_CASE("Private GetBlob is leak-free under repetition", "[cte][823]") {
+  REQUIRE(g_fixture != nullptr);
+  REQUIRE(g_fixture->initialized_);
+  auto *cte = CLIO_CTE_CLIENT;
+
+  clio::cte::core::Tag tag("getblob_priv_loop_tag");
+  clio::cte::core::TagId tag_id = tag.GetTagId();
+
+  const std::string blob = "loop_blob";
+  const size_t kN = 32 * 1024;
+  PutPattern(tag_id, blob, 0, kN, 11);
+
+  for (int iter = 0; iter < 256; ++iter) {
+    std::vector<char> priv(kN, 0);
+    auto g = cte->AsyncGetBlob(tag_id, blob, 0, kN, 0, priv.data());
+    g.Wait();
+    // Spot-check a few positions each iteration (full compare would dominate
+    // runtime); correctness of the whole buffer is covered by the case above.
+    REQUIRE(priv[0] == PatternByte(11));
+    REQUIRE(priv[kN / 2] == PatternByte(11 + kN / 2));
+    REQUIRE(priv[kN - 1] == PatternByte(11 + kN - 1));
+  }
+}
+
+// The zero-IPC shared-cache fast path, when the cache is attachable, must
+// deliver identical bytes (it copies straight out of the RAM bdev's segment
+// and returns an empty, already-satisfied future).
+TEST_CASE("Private GetBlob shared-cache fast path is correct", "[cte][823]") {
+  REQUIRE(g_fixture != nullptr);
+  REQUIRE(g_fixture->initialized_);
+  auto *cte = CLIO_CTE_CLIENT;
+  if (!cte->HasShmCache() && !cte->AttachShmCache()) {
+    // Cache unavailable in this configuration; the direct/staged paths are
+    // covered by the cases above. Nothing to assert here.
+    return;
+  }
+
+  clio::cte::core::Tag tag("getblob_priv_cache_tag");
+  clio::cte::core::TagId tag_id = tag.GetTagId();
+  const std::string blob = "cache_blob";
+  const size_t kN = 16 * 1024;
+  PutPattern(tag_id, blob, 0, kN, 99);
+
+  std::vector<char> priv(kN, 0);
+  auto g = cte->AsyncGetBlob(tag_id, blob, 0, kN, 0, priv.data());
+  g.Wait();
+  for (size_t i = 0; i < kN; ++i) {
+    REQUIRE(priv[i] == PatternByte(99 + i));
+  }
+}
+
+int main(int argc, char **argv) {
+  static Fixture fixture;
+  g_fixture = &fixture;
+  std::string filter = (argc > 1) ? argv[1] : "";
+  int rc = SimpleTest::run_all_tests(filter);
+  clio::run::CLIO_RUNTIME_FINALIZE();
+  return rc;
+}

--- a/context-transfer-engine/test/unit/test_getblob_priv.cc
+++ b/context-transfer-engine/test/unit/test_getblob_priv.cc
@@ -398,6 +398,32 @@ TEST_CASE("Private PutBlob offset + repeated overwrite", "[cte][830]") {
   }
 }
 
+// Tag-level private blob I/O (issue #830 + #823): Tag::PutBlob(const char*) now
+// routes through the private-memory write path, and Tag::GetBlob(char*) through
+// the private-memory read path -- this is exactly what the Python PutBlob/
+// GetBlob bindings call. Round-trip a blob entirely through the Tag API.
+TEST_CASE("Tag private PutBlob/GetBlob round-trips", "[cte][830]") {
+  REQUIRE(g_fixture != nullptr);
+  REQUIRE(g_fixture->initialized_);
+
+  clio::cte::core::Tag tag("tag_priv_putget_tag");
+  const std::string blob = "tag_priv_blob";
+  const size_t kN = 48 * 1024;
+
+  std::vector<char> src(kN);
+  for (size_t i = 0; i < kN; ++i) src[i] = PatternByte(i + 7);
+
+  // Blocking Tag::PutBlob(const char*) -> #830 private path (throws on failure).
+  tag.PutBlob(blob, src.data(), kN, /*off=*/0);
+
+  // Blocking Tag::GetBlob(char*) -> #823 private path.
+  std::vector<char> got(kN, 0);
+  tag.GetBlob(blob, got.data(), kN, /*off=*/0);
+  for (size_t i = 0; i < kN; ++i) {
+    REQUIRE(got[i] == PatternByte(i + 7));
+  }
+}
+
 int main(int argc, char **argv) {
   static Fixture fixture;
   g_fixture = &fixture;

--- a/context-transfer-engine/test/unit/test_vectored_blob_io.cc
+++ b/context-transfer-engine/test/unit/test_vectored_blob_io.cc
@@ -205,6 +205,46 @@ TEST_CASE("Vectored PutBlob == N single puts, and segments apply in list order",
     for (size_t i = 0; i < kSeg; ++i) REQUIRE(got[far + i] == 'Y');
     std::printf("[#820] union range allocated; inter-segment hole reads zero\n");
   }
+
+  // ---- 4. Vectored GET scatters into per-segment buffers -----------------
+  // Lay down a known pattern, then read it back as N regions in ONE task, each
+  // into its own buffer. Every buffer must hold exactly its own region — this
+  // is what removes the scatter copy from the batching layer.
+  {
+    const std::string blob = "vecget";
+    for (int i = 0; i < kN; ++i) {
+      auto b = FillBuf(kSeg, static_cast<char>((i % 250) + 1));
+      auto p = cte->AsyncPutBlob(tag_id, blob,
+                                 static_cast<clio::run::u64>(i) * kSeg, kSeg,
+                                 ctp::ipc::ShmPtr<>(b.shm_));
+      p.Wait();
+      REQUIRE(p->GetReturnCode() == 0);
+      ipc->FreeBuffer(b);
+    }
+
+    std::vector<ctp::ipc::FullPtr<char>> dst;
+    std::vector<clio::cte::core::BlobSegment> segs;
+    for (int i = 0; i < kN; ++i) {
+      auto b = FillBuf(kSeg, 0);
+      dst.push_back(b);
+      segs.push_back(clio::cte::core::BlobSegment(
+          static_cast<clio::run::u64>(i) * kSeg, kSeg,
+          ctp::ipc::ShmPtr<>(b.shm_)));
+    }
+    auto gv = cte->AsyncGetBlobVectored(tag_id, blob, segs);
+    gv.Wait();
+    REQUIRE(gv->GetReturnCode() == 0);
+
+    for (int i = 0; i < kN; ++i) {
+      const char want = static_cast<char>((i % 250) + 1);
+      for (size_t j = 0; j < kSeg; ++j) {
+        REQUIRE(dst[i].ptr_[j] == want);
+      }
+    }
+    for (auto &b : dst) ipc->FreeBuffer(b);
+    std::printf("[#820] vectored get scattered %d regions into own buffers\n",
+                kN);
+  }
 }
 
 int main(int argc, char **argv) {

--- a/context-transfer-engine/test/unit/test_vectored_blob_io.cc
+++ b/context-transfer-engine/test/unit/test_vectored_blob_io.cc
@@ -247,6 +247,71 @@ TEST_CASE("Vectored PutBlob == N single puts, and segments apply in list order",
   }
 }
 
+// The per-segment validation branches in PutBlobImpl/GetBlobImpl: a vectored
+// task with a zero-size or null-buffer segment must be REFUSED, not silently
+// half-applied. These are cheap, deterministic, and were the runtime's untested
+// error paths.
+TEST_CASE("Vectored I/O rejects malformed segments", "[cte][vectored][820]") {
+  REQUIRE(g_fixture != nullptr);
+  REQUIRE(g_fixture->initialized_);
+  auto *ipc = CLIO_IPC;
+  auto *cte = CLIO_CTE_CLIENT;
+  clio::cte::core::Tag tag("vec_bad_tag");
+  clio::cte::core::TagId tag_id = tag.GetTagId();
+  const size_t kSeg = 4096;
+  auto good = FillBuf(kSeg, 'g');
+
+  // PutBlob: a zero-size segment.
+  {
+    std::vector<clio::cte::core::BlobSegment> segs;
+    segs.push_back(clio::cte::core::BlobSegment(0, kSeg,
+                                                ctp::ipc::ShmPtr<>(good.shm_)));
+    segs.push_back(clio::cte::core::BlobSegment(kSeg, 0,
+                                                ctp::ipc::ShmPtr<>(good.shm_)));
+    auto p = cte->AsyncPutBlobVectored(tag_id, "put_zero", segs);
+    p.Wait();
+    REQUIRE(p->GetReturnCode() != 0);
+  }
+  // PutBlob: a null-buffer segment.
+  {
+    std::vector<clio::cte::core::BlobSegment> segs;
+    segs.push_back(clio::cte::core::BlobSegment(0, kSeg,
+                                                ctp::ipc::ShmPtr<>(good.shm_)));
+    segs.push_back(clio::cte::core::BlobSegment(kSeg, kSeg,
+                                                ctp::ipc::ShmPtr<>::GetNull()));
+    auto p = cte->AsyncPutBlobVectored(tag_id, "put_null", segs);
+    p.Wait();
+    REQUIRE(p->GetReturnCode() != 0);
+  }
+  // GetBlob: zero-size and null-buffer segments (need a blob to read).
+  {
+    auto p = cte->AsyncPutBlob(tag_id, "get_bad", 0, 2 * kSeg,
+                               ctp::ipc::ShmPtr<>(good.shm_));
+    // good only holds kSeg; that's fine, we only care the blob exists.
+    p.Wait();
+    auto dst = FillBuf(kSeg, 0);
+    {
+      std::vector<clio::cte::core::BlobSegment> segs;
+      segs.push_back(clio::cte::core::BlobSegment(0, 0,
+                                                  ctp::ipc::ShmPtr<>(dst.shm_)));
+      auto g = cte->AsyncGetBlobVectored(tag_id, "get_bad", segs);
+      g.Wait();
+      REQUIRE(g->GetReturnCode() != 0);
+    }
+    {
+      std::vector<clio::cte::core::BlobSegment> segs;
+      segs.push_back(clio::cte::core::BlobSegment(0, kSeg,
+                                                  ctp::ipc::ShmPtr<>::GetNull()));
+      auto g = cte->AsyncGetBlobVectored(tag_id, "get_bad", segs);
+      g.Wait();
+      REQUIRE(g->GetReturnCode() != 0);
+    }
+    ipc->FreeBuffer(dst);
+  }
+  ipc->FreeBuffer(good);
+  std::printf("[#820] vectored I/O rejects zero-size and null segments\n");
+}
+
 int main(int argc, char **argv) {
   g_fixture = new Fixture();
   std::string filter = (argc > 1) ? argv[1] : "";

--- a/context-transfer-engine/test/unit/test_vectored_blob_io.cc
+++ b/context-transfer-engine/test/unit/test_vectored_blob_io.cc
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved. BSD 3-Clause license.
+ */
+
+// Vectored PutBlob / GetBlob (issue #820).
+//
+// A vectored task carries N regions instead of one, so the runtime acquires the
+// blob's #680 write token ONCE and applies every region in a single pass. This
+// is what lets the worker's batching layer merge N independent same-blob tasks
+// without gathering their payloads into one contiguous buffer.
+//
+// What is asserted, in order of importance:
+//   1. EQUIVALENCE -- a vectored put of N disjoint regions leaves the blob
+//      byte-identical to N separate single-region puts.
+//   2. ORDERING -- when two segments cover the same bytes, the LATER one in the
+//      list wins. This is the guarantee N racing single-region tasks do NOT
+//      provide (they race the write token), and it is why batching may merge
+//      overlapping writes at all.
+//   3. The union range is what gets allocated: a vectored put whose segments
+//      start past EOF grows the blob to cover them, and the hole reads as zeros.
+//   4. Vectored GetBlob scatters each region into its OWN buffer.
+
+#include <clio_runtime/clio_runtime.h>
+#include <clio_runtime/bdev/bdev_client.h>
+#include <clio_cte/core/core_client.h>
+#include <clio_cte/core/core_tasks.h>
+
+#include <chrono>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "simple_test.h"
+
+namespace {
+
+const char *kTargetName = "vectored_blob_target";
+constexpr clio::run::u64 kTargetSize = 1ULL * 1024 * 1024 * 1024;  // 1 GiB
+
+class Fixture {
+ public:
+  bool initialized_ = false;
+  Fixture() {
+    bool ok = clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, true);
+    REQUIRE(ok);
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    ok = clio::cte::core::CLIO_CTE_CLIENT_INIT();
+    REQUIRE(ok);
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    auto *cte = CLIO_CTE_CLIENT;
+    clio::run::PoolId bdev_pool_id(911, 0);
+    clio::run::bdev::Client bdev_client(bdev_pool_id);
+    auto create = bdev_client.AsyncCreate(
+        clio::run::PoolQuery::Dynamic(), kTargetName, bdev_pool_id,
+        clio::run::bdev::BdevType::kRam, kTargetSize);
+    create.Wait();
+    auto reg = cte->AsyncRegisterTarget(kTargetName,
+                                        clio::run::bdev::BdevType::kRam,
+                                        kTargetSize, clio::run::PoolQuery::Local(),
+                                        bdev_pool_id);
+    reg.Wait();
+    REQUIRE(reg->GetReturnCode() == 0);
+    initialized_ = true;
+  }
+};
+
+Fixture *g_fixture = nullptr;
+
+/** Allocate an SHM buffer of `n` bytes filled with `v`. */
+ctp::ipc::FullPtr<char> FillBuf(size_t n, char v) {
+  auto *ipc = CLIO_IPC;
+  ctp::ipc::FullPtr<char> b = ipc->AllocateBuffer(n);
+  REQUIRE(!b.IsNull());
+  std::memset(b.ptr_, v, n);
+  return b;
+}
+
+/** Read [off, off+n) of a blob through an ordinary single-region GetBlob. */
+std::vector<char> ReadBack(clio::cte::core::TagId tag_id,
+                           const std::string &blob, clio::run::u64 off,
+                           size_t n) {
+  auto *ipc = CLIO_IPC;
+  auto *cte = CLIO_CTE_CLIENT;
+  ctp::ipc::FullPtr<char> buf = ipc->AllocateBuffer(n);
+  REQUIRE(!buf.IsNull());
+  std::memset(buf.ptr_, 0, n);
+  auto g = cte->AsyncGetBlob(tag_id, blob, off, n, /*flags=*/0,
+                             ctp::ipc::ShmPtr<>(buf.shm_));
+  g.Wait();
+  REQUIRE(g->GetReturnCode() == 0);
+  std::vector<char> out(buf.ptr_, buf.ptr_ + n);
+  ipc->FreeBuffer(buf);
+  return out;
+}
+
+}  // namespace
+
+TEST_CASE("Vectored PutBlob == N single puts, and segments apply in list order",
+          "[cte][vectored][820]") {
+  REQUIRE(g_fixture != nullptr);
+  REQUIRE(g_fixture->initialized_);
+  auto *ipc = CLIO_IPC;
+  auto *cte = CLIO_CTE_CLIENT;
+
+  clio::cte::core::Tag tag("vectored_tag");
+  clio::cte::core::TagId tag_id = tag.GetTagId();
+
+  const size_t kSeg = 4096;
+  const int kN = 64;  // 64 disjoint 4 KiB regions = 256 KiB
+
+  // ---- 1. EQUIVALENCE ----------------------------------------------------
+  // Write kN disjoint regions two ways and require identical bytes.
+  {
+    // (a) N separate single-region puts.
+    const std::string blob_a = "single";
+    for (int i = 0; i < kN; ++i) {
+      auto b = FillBuf(kSeg, static_cast<char>((i % 250) + 1));
+      auto p = cte->AsyncPutBlob(tag_id, blob_a,
+                                 static_cast<clio::run::u64>(i) * kSeg, kSeg,
+                                 ctp::ipc::ShmPtr<>(b.shm_));
+      p.Wait();
+      REQUIRE(p->GetReturnCode() == 0);
+      ipc->FreeBuffer(b);
+    }
+
+    // (b) ONE vectored put carrying the same kN regions.
+    const std::string blob_b = "vectored";
+    std::vector<ctp::ipc::FullPtr<char>> bufs;
+    std::vector<clio::cte::core::BlobSegment> segs;
+    for (int i = 0; i < kN; ++i) {
+      auto b = FillBuf(kSeg, static_cast<char>((i % 250) + 1));
+      bufs.push_back(b);
+      segs.push_back(clio::cte::core::BlobSegment(
+          static_cast<clio::run::u64>(i) * kSeg, kSeg,
+          ctp::ipc::ShmPtr<>(b.shm_)));
+    }
+    auto pv = cte->AsyncPutBlobVectored(tag_id, blob_b, segs);
+    pv.Wait();
+    REQUIRE(pv->GetReturnCode() == 0);
+    for (auto &b : bufs) ipc->FreeBuffer(b);
+
+    auto a = ReadBack(tag_id, blob_a, 0, kSeg * kN);
+    auto v = ReadBack(tag_id, blob_b, 0, kSeg * kN);
+    REQUIRE(a.size() == v.size());
+    REQUIRE(std::memcmp(a.data(), v.data(), a.size()) == 0);
+    // ...and the bytes are actually the pattern we wrote, not zeros on both.
+    for (int i = 0; i < kN; ++i) {
+      REQUIRE(v[static_cast<size_t>(i) * kSeg] ==
+              static_cast<char>((i % 250) + 1));
+    }
+    std::printf("[#820] vectored put of %d x %zu B == %d single puts\n", kN,
+                kSeg, kN);
+  }
+
+  // ---- 2. ORDERING: later segment wins on overlap ------------------------
+  // Three segments all covering [0, kSeg). The LAST one in the list must be
+  // the surviving value. N racing single-region tasks cannot promise this.
+  {
+    const std::string blob = "overlap";
+    std::vector<ctp::ipc::FullPtr<char>> bufs;
+    std::vector<clio::cte::core::BlobSegment> segs;
+    for (char v : {'A', 'B', 'C'}) {
+      auto b = FillBuf(kSeg, v);
+      bufs.push_back(b);
+      segs.push_back(clio::cte::core::BlobSegment(0, kSeg,
+                                                  ctp::ipc::ShmPtr<>(b.shm_)));
+    }
+    auto pv = cte->AsyncPutBlobVectored(tag_id, blob, segs);
+    pv.Wait();
+    REQUIRE(pv->GetReturnCode() == 0);
+    for (auto &b : bufs) ipc->FreeBuffer(b);
+
+    auto got = ReadBack(tag_id, blob, 0, kSeg);
+    for (size_t i = 0; i < kSeg; ++i) {
+      REQUIRE(got[i] == 'C');
+    }
+    std::printf("[#820] overlapping segments resolve last-writer-wins\n");
+  }
+
+  // ---- 3. Union range is allocated; the gap reads as zeros ---------------
+  // Two far-apart segments in one task: the blob must grow to cover the union
+  // and the hole between them must read back as zeros (POSIX sparse-write).
+  {
+    const std::string blob = "sparse";
+    auto b0 = FillBuf(kSeg, 'X');
+    auto b1 = FillBuf(kSeg, 'Y');
+    std::vector<clio::cte::core::BlobSegment> segs;
+    segs.push_back(clio::cte::core::BlobSegment(0, kSeg,
+                                                ctp::ipc::ShmPtr<>(b0.shm_)));
+    const clio::run::u64 far = 64 * 1024;
+    segs.push_back(clio::cte::core::BlobSegment(far, kSeg,
+                                                ctp::ipc::ShmPtr<>(b1.shm_)));
+    auto pv = cte->AsyncPutBlobVectored(tag_id, blob, segs);
+    pv.Wait();
+    REQUIRE(pv->GetReturnCode() == 0);
+    ipc->FreeBuffer(b0);
+    ipc->FreeBuffer(b1);
+
+    auto got = ReadBack(tag_id, blob, 0, far + kSeg);
+    for (size_t i = 0; i < kSeg; ++i) REQUIRE(got[i] == 'X');
+    for (size_t i = kSeg; i < far; ++i) REQUIRE(got[i] == 0);
+    for (size_t i = 0; i < kSeg; ++i) REQUIRE(got[far + i] == 'Y');
+    std::printf("[#820] union range allocated; inter-segment hole reads zero\n");
+  }
+}
+
+int main(int argc, char **argv) {
+  g_fixture = new Fixture();
+  std::string filter = (argc > 1) ? argv[1] : "";
+  int rc = SimpleTest::run_all_tests(filter);
+  delete g_fixture;
+  g_fixture = nullptr;
+  return rc;
+}

--- a/context-transfer-engine/wrapper/python/CMakeLists.txt
+++ b/context-transfer-engine/wrapper/python/CMakeLists.txt
@@ -179,4 +179,20 @@ if(BUILD_TESTING)
         ENVIRONMENT "CLIO_WITH_RUNTIME=1;CLIO_BIND_ADDR=127.0.0.1"
         DEPENDS clio_cte_core_ext
     )
+
+    # Async client APIs: Client.Async*() -> Future (wait/done/result), including
+    # overlapped in-flight submission of many put/get ops.
+    add_test(
+        NAME python_async_test
+        COMMAND ${Python_EXECUTABLE} -I ${CMAKE_CURRENT_SOURCE_DIR}/test_cte_async.py
+        WORKING_DIRECTORY $<TARGET_FILE_DIR:clio_cte_core_ext>
+    )
+    set_tests_properties(
+        python_async_test
+        PROPERTIES
+        LABELS "python;bindings;async"
+        TIMEOUT 120
+        ENVIRONMENT "CLIO_WITH_RUNTIME=1;CLIO_BIND_ADDR=127.0.0.1"
+        DEPENDS clio_cte_core_ext
+    )
 endif()

--- a/context-transfer-engine/wrapper/python/core_bindings.cc
+++ b/context-transfer-engine/wrapper/python/core_bindings.cc
@@ -292,12 +292,16 @@ NB_MODULE(clio_cte_core_ext, m) {
       .def("PutBlob",
            [](clio::cte::core::Tag &self, const std::string &blob_name,
               nb::bytes data, size_t off) {
-             // Use nb::bytes to accept bytes from Python
-             // c_str() returns const char*, size() returns size
+             // Use nb::bytes to accept arbitrary binary from Python. The bytes'
+             // buffer IS private memory, so this writes straight from it via the
+             // private-memory path (issue #830): no manual SHM allocate/copy/
+             // free, and a zero-copy write in runtime (co-located) mode.
+             // Tag::PutBlob(const char*) blocks and throws on a non-zero rc.
              self.PutBlob(blob_name, data.c_str(), data.size(), off);
            },
            "blob_name"_a, "data"_a, "off"_a = 0,
-           "Put blob data. Automatically allocates shared memory and copies data. "
+           "Put blob data from a private buffer (issue #830): no manual shared "
+           "memory management, and a zero-copy write in runtime mode. "
            "Args: blob_name (str), data (bytes), off (int, optional)")
       .def("GetBlob",
            [](clio::cte::core::Tag &self, const std::string &blob_name,

--- a/context-transfer-engine/wrapper/python/core_bindings.cc
+++ b/context-transfer-engine/wrapper/python/core_bindings.cc
@@ -307,12 +307,25 @@ NB_MODULE(clio_cte_core_ext, m) {
              // binary, and nanobind decodes a returned std::string as UTF-8,
              // which raises UnicodeDecodeError on any non-text payload. This
              // also mirrors PutBlob, which already accepts nb::bytes.
+             //
+             // The std::string's buffer IS private memory, so this reads
+             // straight into it via the private-memory path (issue #823): no
+             // manual SHM allocate/copy/free, and a zero-IPC copy when the blob
+             // is in the shared cache.
              std::string result(data_size, '\0');
-             self.GetBlob(blob_name, result.data(), data_size, off);
+             auto fut =
+                 self.AsyncGetBlob(blob_name, result.data(), data_size, off);
+             fut.Wait();
+             // Empty (cache-hit) future -> already succeeded, do not deref.
+             // Non-empty (miss) future -> the task carries the return code.
+             if (fut.get() != nullptr && fut.get()->GetReturnCode() != 0) {
+               throw std::runtime_error("GetBlob operation failed");
+             }
              return nb::bytes(result.data(), result.size());
            },
            "blob_name"_a, "data_size"_a, "off"_a = 0,
-           "Get blob data. Automatically allocates shared memory and copies data. "
+           "Get blob data into a private buffer (issue #823): no manual shared "
+           "memory management, and a zero-IPC copy on a shared-cache hit. "
            "Args: blob_name (str), data_size (int), off (int, optional). "
            "Returns: bytes containing the raw blob data")
       .def("GetBlobScore", &clio::cte::core::Tag::GetBlobScore,

--- a/context-transfer-engine/wrapper/python/core_bindings.cc
+++ b/context-transfer-engine/wrapper/python/core_bindings.cc
@@ -31,6 +31,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <functional>
+
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/chrono.h>
 #include <nanobind/stl/pair.h>
@@ -45,6 +47,40 @@
 
 namespace nb = nanobind;
 using namespace nb::literals;
+
+namespace {
+// Python-facing handle for an in-flight CTE task (async client APIs).
+//
+// Type-erased over the concrete task: it holds a Future<Task>, so Task's
+// virtual destructor frees the concrete task AND its owned buffers (e.g. a
+// PutBlob's TASK_DATA_OWNER staging buffer) when the last Future reference
+// drops. `extract_` produces the Python return value once the task completes;
+// any host buffer the task reads from / writes into is kept alive by being
+// captured inside `extract_`, so it outlives the async operation for exactly as
+// long as this handle does.
+struct PyCteFuture {
+  clio::run::Future<clio::run::Task> fut_;
+  std::function<nb::object(clio::run::Future<clio::run::Task> &)> extract_;
+
+  // Block until the task completes, then return its code (0 = success). An
+  // empty (cache-hit / already-satisfied) future reports 0. max_sec < 0 waits
+  // forever; 0 polls once.
+  int Wait(float max_sec) {
+    fut_.Wait(max_sec);
+    return fut_.IsNull() ? 0 : static_cast<int>(fut_.get()->GetReturnCode());
+  }
+
+  // Non-blocking completion poll.
+  bool Done() { return fut_.IsNull() || fut_.IsComplete(); }
+
+  // Block, then produce the operation's Python result: bytes for GetBlob, a
+  // list for queries, None for status-only ops.
+  nb::object Result() {
+    fut_.Wait();
+    return extract_ ? extract_(fut_) : nb::none();
+  }
+};
+}  // namespace
 
 NB_MODULE(clio_cte_core_ext, m) {
   m.doc() = "Python bindings for WRP CTE Core";
@@ -152,6 +188,19 @@ NB_MODULE(clio_cte_core_ext, m) {
 
   // Bind Client class with async API methods wrapped for synchronous Python use
   // Note: All methods use lambda wrappers to call async methods and wait for completion
+  // Async handle returned by every Client.Async*() method. Wait for the task,
+  // poll it, or fetch its result — while overlapping other work in between.
+  nb::class_<PyCteFuture>(m, "Future")
+      .def("wait", &PyCteFuture::Wait, "max_sec"_a = -1.0f,
+           "Block until the task completes; returns the task return code "
+           "(0 = success). max_sec < 0 waits forever, 0 polls once.")
+      .def("done", &PyCteFuture::Done,
+           "Non-blocking: True if the task has completed.")
+      .def("result", &PyCteFuture::Result,
+           "Block until done, then return the operation's result: bytes for "
+           "AsyncGetBlob, a list for the Async*Query/Search ops, None for "
+           "status-only ops (put/del/reorganize/register).");
+
   nb::class_<clio::cte::core::Client>(m, "Client")
       .def(nb::init<>())
       .def(nb::init<const clio::run::PoolId &>())
@@ -278,7 +327,113 @@ NB_MODULE(clio_cte_core_ext, m) {
            return task->return_code_ == 0;
          },
          "tag_id"_a, "blob_name"_a,
-         "Delete a blob from a tag. Returns True on success, False otherwise");
+         "Delete a blob from a tag. Returns True on success, False otherwise")
+     // ---- Async client APIs -------------------------------------------------
+     // Each returns a Future you can overlap other work against: submit N of
+     // them, then .wait()/.result() later. The private-memory paths (#823/#830)
+     // are used so no manual shared-memory management is needed from Python.
+     .def("AsyncPutBlob",
+         [](clio::cte::core::Client &self, const clio::cte::core::TagId &tag_id,
+            const std::string &blob_name, nb::bytes data, size_t off) {
+           // #830 private put. Retain `data` so runtime-mode (co-located,
+           // zero-copy) reads stay valid until wait(); client mode stages a
+           // TASK_DATA_OWNER copy that the task frees on destruction.
+           auto fut = self.AsyncPutBlob(tag_id, blob_name, off, data.size(),
+                                        data.c_str());
+           PyCteFuture pf;
+           pf.fut_ = fut.Cast<clio::run::Task>();
+           pf.extract_ = [data](clio::run::Future<clio::run::Task> &) {
+             return nb::none();  // status-only; the capture keeps `data` alive
+           };
+           return pf;
+         },
+         "tag_id"_a, "blob_name"_a, "data"_a, "off"_a = 0,
+         "Asynchronously put blob data from a private buffer (issue #830). "
+         "Returns a Future; .wait() -> return code (0 = success).")
+     .def("AsyncGetBlob",
+         [](clio::cte::core::Client &self, const clio::cte::core::TagId &tag_id,
+            const std::string &blob_name, size_t data_size, size_t off) {
+           // #823 private get: read straight into a retained heap buffer;
+           // .result() returns it as bytes once complete.
+           auto buf = std::make_shared<std::string>(data_size, '\0');
+           auto fut = self.AsyncGetBlob(tag_id, blob_name, off, data_size,
+                                        /*flags=*/0, buf->data());
+           PyCteFuture pf;
+           pf.fut_ = fut.Cast<clio::run::Task>();
+           pf.extract_ = [buf](clio::run::Future<clio::run::Task> &) {
+             return nb::bytes(buf->data(), buf->size());
+           };
+           return pf;
+         },
+         "tag_id"_a, "blob_name"_a, "data_size"_a, "off"_a = 0,
+         "Asynchronously get blob data into a private buffer (issue #823). "
+         "Returns a Future; .result() -> bytes.")
+     .def("AsyncDelBlob",
+         [](clio::cte::core::Client &self, const clio::cte::core::TagId &tag_id,
+            const std::string &blob_name) {
+           auto fut = self.AsyncDelBlob(tag_id, blob_name);
+           PyCteFuture pf;
+           pf.fut_ = fut.Cast<clio::run::Task>();
+           return pf;
+         },
+         "tag_id"_a, "blob_name"_a,
+         "Asynchronously delete a blob. Returns a Future; .wait() -> rc.")
+     .def("AsyncReorganizeBlob",
+         [](clio::cte::core::Client &self, const clio::cte::core::TagId &tag_id,
+            const std::string &blob_name, float new_score) {
+           auto fut = self.AsyncReorganizeBlob(tag_id, blob_name, new_score);
+           PyCteFuture pf;
+           pf.fut_ = fut.Cast<clio::run::Task>();
+           return pf;
+         },
+         "tag_id"_a, "blob_name"_a, "new_score"_a,
+         "Asynchronously reorganize a blob. Returns a Future; .wait() -> rc.")
+     .def("AsyncRegisterTarget",
+         [](clio::cte::core::Client &self, const std::string &target_name,
+            clio::run::bdev::BdevType bdev_type, uint64_t total_size) {
+           auto fut = self.AsyncRegisterTarget(target_name, bdev_type,
+                                               total_size);
+           PyCteFuture pf;
+           pf.fut_ = fut.Cast<clio::run::Task>();
+           return pf;
+         },
+         "target_name"_a, "bdev_type"_a, "total_size"_a,
+         "Asynchronously register a storage target. .wait() -> rc.")
+     .def("AsyncTagQuery",
+         [](clio::cte::core::Client &self, const std::string &tag_regex,
+            uint32_t max_tags, const clio::run::PoolQuery &pool_query) {
+           auto fut = self.AsyncTagQuery(tag_regex, max_tags, pool_query);
+           PyCteFuture pf;
+           pf.fut_ = fut.Cast<clio::run::Task>();
+           pf.extract_ = [](clio::run::Future<clio::run::Task> &f) {
+             return nb::cast(
+                 f.Cast<clio::cte::core::TagQueryTask>().get()->results_);
+           };
+           return pf;
+         },
+         "tag_regex"_a, "max_tags"_a = 0, "pool_query"_a,
+         "Asynchronously query tags by regex. .result() -> list[str].")
+     .def("AsyncBlobQuery",
+         [](clio::cte::core::Client &self, const std::string &tag_regex,
+            const std::string &blob_regex, uint32_t max_blobs,
+            const clio::run::PoolQuery &pool_query) {
+           auto fut = self.AsyncBlobQuery(tag_regex, blob_regex, max_blobs,
+                                          pool_query);
+           PyCteFuture pf;
+           pf.fut_ = fut.Cast<clio::run::Task>();
+           pf.extract_ = [](clio::run::Future<clio::run::Task> &f) {
+             auto t = f.Cast<clio::cte::core::BlobQueryTask>();
+             std::vector<std::pair<std::string, std::string>> out;
+             size_t n = std::min(t.get()->tag_names_.size(),
+                                 t.get()->blob_names_.size());
+             for (size_t i = 0; i < n; ++i)
+               out.emplace_back(t.get()->tag_names_[i], t.get()->blob_names_[i]);
+             return nb::cast(out);
+           };
+           return pf;
+         },
+         "tag_regex"_a, "blob_regex"_a, "max_blobs"_a = 0, "pool_query"_a,
+         "Asynchronously query blobs. .result() -> list[(tag, blob)].");
 
   // Bind Tag wrapper class - provides convenient API for tag operations
   // This class wraps tag operations and provides automatic memory management

--- a/context-transfer-engine/wrapper/python/core_bindings.cc
+++ b/context-transfer-engine/wrapper/python/core_bindings.cc
@@ -433,7 +433,64 @@ NB_MODULE(clio_cte_core_ext, m) {
            return pf;
          },
          "tag_regex"_a, "blob_regex"_a, "max_blobs"_a = 0, "pool_query"_a,
-         "Asynchronously query blobs. .result() -> list[(tag, blob)].");
+         "Asynchronously query blobs. .result() -> list[(tag, blob)].")
+     .def("AsyncSemanticSearch",
+         [](clio::cte::core::Client &self, const std::string &tag_regex,
+            const std::string &blob_regex, const std::string &query_text,
+            uint32_t k, const clio::run::PoolQuery &pool_query) {
+           auto fut = self.AsyncSemanticSearch(tag_regex, blob_regex,
+                                               query_text, k, pool_query);
+           PyCteFuture pf;
+           pf.fut_ = fut.Cast<clio::run::Task>();
+           pf.extract_ = [](clio::run::Future<clio::run::Task> &f) {
+             return nb::cast(
+                 f.Cast<clio::cte::core::SemanticSearchTask>().get()->results_);
+           };
+           return pf;
+         },
+         "tag_regex"_a, "blob_regex"_a, "query_text"_a, "k"_a = 10,
+         "pool_query"_a,
+         "Asynchronously BM25 keyword search. "
+         ".result() -> list[SemanticSearchResult].")
+     .def("AsyncTemporalSearch",
+         [](clio::cte::core::Client &self, const std::string &tag_regex,
+            const std::string &blob_regex, uint64_t time_begin,
+            uint64_t time_end, uint32_t max_entries,
+            const clio::run::PoolQuery &pool_query) {
+           auto fut = self.AsyncTemporalSearch(tag_regex, blob_regex,
+                                               time_begin, time_end,
+                                               max_entries, pool_query);
+           PyCteFuture pf;
+           pf.fut_ = fut.Cast<clio::run::Task>();
+           pf.extract_ = [](clio::run::Future<clio::run::Task> &f) {
+             return nb::cast(
+                 f.Cast<clio::cte::core::TemporalSearchTask>().get()->results_);
+           };
+           return pf;
+         },
+         "tag_regex"_a, "blob_regex"_a, "time_begin"_a = uint64_t{0},
+         "time_end"_a = uint64_t{0}, "max_entries"_a = uint32_t{0},
+         "pool_query"_a,
+         "Asynchronously search by last-modified time. "
+         ".result() -> list[TemporalSearchResult].")
+     .def("AsyncPollTelemetryLog",
+         [](clio::cte::core::Client &self,
+            std::uint64_t minimum_logical_time) {
+           auto fut = self.AsyncPollTelemetryLog(minimum_logical_time);
+           PyCteFuture pf;
+           pf.fut_ = fut.Cast<clio::run::Task>();
+           pf.extract_ = [](clio::run::Future<clio::run::Task> &f) {
+             auto t = f.Cast<clio::cte::core::PollTelemetryLogTask>();
+             std::vector<clio::cte::core::CteTelemetry> out;
+             for (size_t i = 0; i < t.get()->entries_.size(); ++i)
+               out.push_back(t.get()->entries_[i]);
+             return nb::cast(out);
+           };
+           return pf;
+         },
+         "minimum_logical_time"_a,
+         "Asynchronously poll the telemetry log. "
+         ".result() -> list[CteTelemetry].");
 
   // Bind Tag wrapper class - provides convenient API for tag operations
   // This class wraps tag operations and provides automatic memory management

--- a/context-transfer-engine/wrapper/python/test_cte_async.py
+++ b/context-transfer-engine/wrapper/python/test_cte_async.py
@@ -119,6 +119,20 @@ def run_test(cte) -> int:
     assert df.wait() == 0, "AsyncDelBlob returned non-zero"
     print("OK async delete")
 
+    # --- list-result futures (query / telemetry) --------------------------
+    tq = client.AsyncTagQuery(".*", 0, cte.PoolQuery.Local())
+    tags = tq.result()
+    assert isinstance(tags, list), f"AsyncTagQuery result not a list: {type(tags).__name__}"
+    assert "async_tag" in tags, f"expected tag missing from {tags}"
+
+    bq = client.AsyncBlobQuery(".*", ".*", 0, cte.PoolQuery.Local())
+    pairs = bq.result()
+    assert isinstance(pairs, list), "AsyncBlobQuery result not a list"
+
+    tel = client.AsyncPollTelemetryLog(0)
+    assert isinstance(tel.result(), list), "AsyncPollTelemetryLog result not a list"
+    print("OK async list-result futures (tag/blob query, telemetry)")
+
     return 0
 
 

--- a/context-transfer-engine/wrapper/python/test_cte_async.py
+++ b/context-transfer-engine/wrapper/python/test_cte_async.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Async CTE client API tests.
+
+Exercises the Client.Async*() methods, which return a Future you can overlap
+other work against (submit N, then wait/result later). Covers:
+  * AsyncPutBlob / AsyncGetBlob round-trip (byte-exact, non-UTF-8 payload)
+  * overlapped submission (many in flight, then drain) — the whole point of async
+  * Future.done() polling and Future.wait() return codes
+  * AsyncDelBlob status
+
+Usage:
+    python3 test_cte_async.py
+    CLIO_WITH_RUNTIME=0 python3 test_cte_async.py   # external runtime
+"""
+import os
+import socket
+import sys
+import tempfile
+import time
+
+sys.path.insert(0, os.getcwd())  # prefer the freshly-built module next to us
+
+
+def should_initialize_runtime() -> bool:
+    val = os.getenv("CLIO_WITH_RUNTIME")
+    return val is None or str(val).lower() not in ("0", "false", "no", "off")
+
+
+def setup_environment_paths(cte) -> None:
+    module_file = getattr(cte, "__file__", None)
+    if not module_file:
+        return
+    bin_dir = os.path.dirname(os.path.abspath(module_file))
+    os.environ["CLIO_REPO_PATH"] = bin_dir
+    existing = os.getenv("LD_LIBRARY_PATH", "")
+    os.environ["LD_LIBRARY_PATH"] = f"{bin_dir}:{existing}" if existing else bin_dir
+
+
+def find_available_port(start: int = 9309, end: int = 9380) -> int:
+    for port in range(start, end):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            try:
+                s.bind(("", port))
+                return port
+            except OSError:
+                continue
+    raise RuntimeError(f"No available ports in {start}-{end}")
+
+
+def initialize_runtime(cte) -> bool:
+    import yaml
+    config = {
+        "networking": {"port": find_available_port()},
+        "runtime": {"num_threads": 4, "queue_depth": 1024},
+        "compose": [
+            {"mod_name": "clio_bdev", "pool_name": "ram::chi_default_bdev",
+             "pool_query": "local", "pool_id": "301.0",
+             "bdev_type": "ram", "capacity": "128MB"},
+            {"mod_name": "clio_cte_core", "pool_name": "clio_cte_core",
+             "pool_query": "local", "pool_id": "512.0",
+             "storage": [{"path": "ram::cte_ram_tier1", "bdev_type": "ram",
+                          "capacity_limit": "128MB", "score": 1.0}],
+             "dpe": {"dpe_type": "max_bw"}},
+        ],
+    }
+    cfg_path = os.path.join(tempfile.gettempdir(), "clio_async_conf.yaml")
+    with open(cfg_path, "w") as f:
+        yaml.dump(config, f)
+    os.environ["CLIO_SERVER_CONF"] = cfg_path
+    if not cte.clio_init(cte.RuntimeMode.kClient, True):
+        return False
+    time.sleep(0.5)
+    return cte.initialize_cte(cfg_path, cte.PoolQuery.Dynamic())
+
+
+def run_test(cte) -> int:
+    client = cte.get_cte_client()
+    tag_id = cte.Tag("async_tag").GetTagId()
+    payload = bytes(range(256)) * 32  # 8 KiB, deliberately NOT valid UTF-8
+
+    # --- single AsyncPutBlob -> AsyncGetBlob round-trip --------------------
+    pf = client.AsyncPutBlob(tag_id, "blob0", payload, 0)
+    assert pf.wait() == 0, "AsyncPutBlob returned non-zero"
+
+    gf = client.AsyncGetBlob(tag_id, "blob0", len(payload), 0)
+    got = gf.result()
+    assert isinstance(got, bytes), f"result must be bytes, got {type(got).__name__}"
+    assert got == payload, "async round-trip byte mismatch"
+    print(f"OK single async round-trip ({len(got)} bytes)")
+
+    # --- overlapped submission: many puts in flight, then drain -----------
+    n = 16
+    blobs = [f"blob_{i}" for i in range(n)]
+    datas = [bytes([i]) * (1024 + i) for i in range(n)]
+    put_futs = [client.AsyncPutBlob(tag_id, blobs[i], datas[i], 0)
+                for i in range(n)]  # all submitted before any wait
+    for i, f in enumerate(put_futs):
+        assert f.wait() == 0, f"overlapped put {i} failed"
+    print(f"OK {n} overlapped async puts")
+
+    get_futs = [client.AsyncGetBlob(tag_id, blobs[i], len(datas[i]), 0)
+                for i in range(n)]  # all in flight at once
+    for i, f in enumerate(get_futs):
+        assert f.result() == datas[i], f"overlapped get {i} byte mismatch"
+    print(f"OK {n} overlapped async gets (byte-exact)")
+
+    # --- done() polling ----------------------------------------------------
+    pf2 = client.AsyncPutBlob(tag_id, "blob_poll", payload, 0)
+    spins = 0
+    while not pf2.done():
+        spins += 1
+        if spins > 1_000_000:
+            raise AssertionError("Future.done() never became True")
+    assert pf2.wait() == 0
+    print("OK Future.done() polling")
+
+    # --- AsyncDelBlob status ----------------------------------------------
+    df = client.AsyncDelBlob(tag_id, "blob0")
+    assert df.wait() == 0, "AsyncDelBlob returned non-zero"
+    print("OK async delete")
+
+    return 0
+
+
+def main() -> int:
+    try:
+        import clio_cte_core_ext as cte
+    except ImportError as e:
+        print(f"FAIL: cannot import clio_cte_core_ext: {e}")
+        return 1
+    if should_initialize_runtime():
+        setup_environment_paths(cte)
+        if not initialize_runtime(cte):
+            print("FAIL: runtime initialization")
+            return 1
+    return run_test(cte)
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except AssertionError as e:
+        print(f"FAIL: {e}")
+        sys.exit(1)
+    except Exception as e:
+        import traceback
+        traceback.print_exc()
+        print(f"FAIL: {e}")
+        sys.exit(1)

--- a/context-transport-primitives/include/clio_ctp/data_structures/ipc/ring_buffer.h
+++ b/context-transport-primitives/include/clio_ctp/data_structures/ipc/ring_buffer.h
@@ -48,6 +48,10 @@ using pid_t = int;
 #include "clio_ctp/types/atomic.h"
 #include "clio_ctp/types/bitfield.h"
 
+#if CTP_IS_HOST
+#include <thread>  // std::this_thread::yield in the WAIT_FOR_SPACE back-pressure spin
+#endif
+
 namespace ctp::ipc {
 
 /**
@@ -510,10 +514,28 @@ class ring_buffer : public ShmContainer<AllocT> {
     // queue.size()
     if constexpr (WaitForSpace) {
       size_t size = tail - head + 1;
+#if CTP_IS_HOST
+      unsigned spin_ct = 0;
+#endif
       while (size >= queue.size()) {
         // Use load_device() for cross-SM L2 visibility (see PopDevice comment)
         head = head_.load_device();
         size = tail - head + 1;
+#if CTP_IS_HOST
+        // The ring is FULL. On a CPU this loop must not hard-spin: this producer
+        // may be a worker thread and the consumer that has to drain the ring may
+        // be the only OTHER runnable thread on a 2-CPU box. A tight spin here
+        // monopolizes the core and STARVES that consumer -- the producer==consumer
+        // starvation (#822 queue-depth) behind the embedded-FUSE 2-CPU xfstests
+        // hangs (generic/020 et al.), where a worker shows as R-state spinning in
+        // userspace with an empty kernel stack. Spin a little for the fast-drain
+        // case, then cede the OS thread so the consumer runs. Semantics are
+        // unchanged (we still wait for space); we only stop hogging the core.
+        // Device code keeps the hard spin -- GPU lanes do not oversubscribe a CPU.
+        if ((++spin_ct & 0x3Fu) == 0) {
+          std::this_thread::yield();
+        }
+#endif
       }
     } else if constexpr (ErrorOnNoSpace) {
       size_t size = tail - head + 1;

--- a/project_worker_task_batching.md
+++ b/project_worker_task_batching.md
@@ -1,9 +1,50 @@
-# Worker-local task batching (issue #820)
+# Vectored PutBlob/GetBlob + worker-local task batching (issue #820)
 
 Status: **DESIGN** — no code yet. Branch `820-worker-task-batching` off `origin/dev` @ 04ebc438.
 
+Two coupled pieces:
+
+- **A. Vectored PutBlob/GetBlob** — a scatter-gather segment list on the task, so
+  one task acquires the blob write token once and applies N disjoint regions in a
+  single pass. Independently useful as a client API, and it is the shape the
+  batching layer produces.
+- **B. Worker-local batching** — coalesce many same-blob tasks into the minimal
+  set of **vectored** tasks before they hit the runtime.
+
+A lands first (independently testable/mergeable); B builds on it.
+
 Companion to #817 (async writes, which surfaced the tail) and #680 (the per-blob
 write-token contention this sidesteps).
+
+## 0. Vectored PutBlob/GetBlob (part A)
+
+Today `PutBlobTask` carries one region: `offset_`, `size_`, `blob_data_`
+(`core_tasks.h:1303`). Give it a segment list instead:
+
+```cpp
+struct BlobSegment { u64 offset; ShmPtr<> data; u64 size; };
+IN priv::vector<BlobSegment> segments_;   // empty => use the legacy single-region fields
+```
+
+The single-region ctor stays (fills a 1-segment view), so every existing caller
+is unchanged. `PutBlobImpl`/`GetBlobImpl` change from "one region under the token"
+to "**all segments under one token**":
+
+1. Acquire the blob write token once.
+2. Extend/resize to cover `[min segment offset, max segment end)` — one metadata
+   mutation pass.
+3. For each segment in **list order**, `ModifyExistingData` (PutBlob) or read into
+   `segment.data` (GetBlob). List order gives **last-writer-wins** on overlap —
+   the very ordering the #680 token race currently gets wrong (#817 write notes).
+4. Release.
+
+`SaveTask`/`LoadTask` serialize the vector; the merged tasks batching produces run
+locally (`ExecHere`) so they don't round-trip, but the fields must serialize for
+the client-API use and for cross-node vectored submits.
+
+Net: N disjoint same-blob writes = **one** token acquire and **one** bdev pass,
+with no contiguous gather buffer and no post-hoc scatter — each parent's `ShmPtr`
+is a segment, and GetBlob reads straight into each parent's buffer.
 
 ## 1. Why
 
@@ -138,31 +179,31 @@ the task is an ordinary positioned op (no compression transform, no GPU page
 suffix in v1 — those decline to passthrough). Group key = `hash(tag_id,
 blob_name)`.
 
-`SmashBatch`, per group:
+`SmashBatch`, per group, emits **vectored** tasks (part A):
 
 1. **Sort** members by `(tag_id, blob_name, offset)`, ties broken by **submission
    order** (a monotonic seq the worker stamps at `BuildBatch` time). Submission
    order is what makes overlap resolution correct.
-2. **Merge** into runs of contiguous/overlapping ranges → the minimal set of
-   output tasks. Two members merge when `off_i + size_i >= off_{i+1}` (adjacent or
-   overlapping) on the same blob.
-   - **PutBlob:** allocate one contiguous staging buffer spanning
-     `[min_off, max_end)`; copy each member's data in at its offset. **Overlaps
-     resolve by submission order** — the later writer's bytes land last, which is
-     the correct last-writer-wins the #680 token race currently gets *wrong*.
-     Holes inside a run (gap between two non-adjacent-but-mergeable members) are
-     not created — a gap ends the run and starts a new output task, so we never
-     invent bytes.
-   - **GetBlob:** one read over `[min_off, max_end)`; on completion scatter each
-     parent's `[off_i, off_i+size_i)` sub-range out of the merged buffer.
-3. Each output task's parent set = the members it covers; each parent's
-   `out_slice` = its offset/size within the merged buffer.
+2. **Build one vectored task per blob**: each member becomes a segment
+   `{offset, data, size}` in the task's `segments_`, in sorted+submission order.
+   Adjacent members (`off_i + size_i == off_{i+1}`, same `ShmPtr` contiguous) MAY
+   be fused into one segment to minimize count; disjoint members stay as separate
+   segments in the **same** task. No contiguous gather buffer — the parents' own
+   `ShmPtr`s are the segments. (A blob with more members than a segment cap splits
+   into >1 vectored task.)
+   - **PutBlob:** the runtime applies segments in list order → overlaps
+     last-writer-wins.
+   - **GetBlob:** the runtime reads each segment straight into that segment's
+     `ShmPtr` = the parent's buffer, so completion needs **no scatter copy**.
+3. Each vectored task's parent set = the members whose segments it carries; the
+   completion fan-out sets rc/`bytes` per parent (GetBlob bytes already landed in
+   the parent buffer).
 4. Emit via `sink`.
 
-Net for the 4 KiB sequential case: 256 same-page PutBlobs → **1** PutBlob spanning
-the 1 MiB page. One token acquire, one bdev write. The tail's root cause is gone,
-and the merge also fixes the overlap-ordering correctness gap #680 leaves open
-(see #817's write notes).
+Net for the 4 KiB sequential case: 256 same-page PutBlobs → **1 vectored PutBlob**
+with 256 segments (or fewer, fused) over the 1 MiB page. One token acquire, one
+bdev pass. The tail's root cause is gone, and applying segments in submission
+order fixes the overlap-ordering gap #680 leaves open (#817 write notes).
 
 ## 6. Data structures to add
 
@@ -177,10 +218,10 @@ and the merge also fixes the overlap-ordering correctness gap #680 leaves open
 
 ## 7. Open questions / hazards
 
-1. **Staging-buffer gather cost (PutBlob).** Merging needs the members' bytes
-   contiguous. v1 gathers into one buffer (a memcpy per member — the same copy
-   cfs_io already does once). A later v2 could give PutBlob a scatter-list
-   `(offset, ShmPtr, size)[]` to avoid the extra copy; out of scope for v1.
+1. **~~Staging-buffer gather cost~~ — removed by vectored tasks (part A).** The
+   merged task carries the parents' `ShmPtr`s directly as segments, so there is no
+   contiguous gather and no extra memcpy. The remaining cost is the segment vector
+   itself (a few dozen bytes per member).
 2. **Partial failure.** If the merged bdev transfer half-fails, how granular is
    the error to parents? v1: all covered parents get the merged rc (conservative).
    Only matters if the bdev can report partial byte counts; note and defer.
@@ -203,11 +244,13 @@ and the merge also fixes the overlap-ordering correctness gap #680 leaves open
 
 | Phase | Deliverable |
 |---|---|
-| 0 | Worker batch phase + `BatchGroups`/passthrough SPSC, `Container::BuildBatch`/`SmashBatch` default no-ops. **No behavior change** — every container passes through. |
-| 1 | Parent-completion side table + `TASK_BATCH_MERGED` fan-out in `EndTask` (unit-tested with a trivial echo container). |
-| 2 | CTE `PutBlob` policy: sort/merge/gather + scatter completion. Correctness first (overlap = last-writer-wins), then the fio tail measurement. |
-| 3 | CTE `GetBlob` policy: merge + scatter-read, RYOW respected. |
-| 4 | Bench + tail: the 4 KiB seq write max-stall should collapse from ~1 s toward the 1-MiB-write floor; verify p99.9 and mean, not just p50. |
+| A1 | **Vectored PutBlob**: `segments_` on the task, `PutBlobImpl` applies all segments under one token, Save/Load serialize the vector, single-region ctor unchanged. Unit test: one vectored task vs N single writes, same result; overlap = last-writer-wins. Independently mergeable. |
+| A2 | **Vectored GetBlob**: segment reads into per-segment `ShmPtr`. |
+| B0 | Worker batch phase + `BatchGroups`/passthrough SPSC, `Container::BuildBatch`/`SmashBatch` default no-ops. **No behavior change** — every container passes through. |
+| B1 | Parent-completion side table + `TASK_BATCH_MERGED` fan-out in `EndTask` (trivial echo container). |
+| B2 | CTE `BuildBatch`/`SmashBatch` for PutBlob → emits vectored PutBlob. Correctness first, then the fio tail measurement. |
+| B3 | CTE GetBlob batching → vectored GetBlob, RYOW respected. |
+| B4 | Bench + tail: the 4 KiB seq write max-stall should collapse from ~1 s toward the 1-MiB-write floor; verify p99.9 and mean, not just p50. |
 
 ## 9. Success criteria
 

--- a/project_worker_task_batching.md
+++ b/project_worker_task_batching.md
@@ -1,0 +1,218 @@
+# Worker-local task batching (issue #820)
+
+Status: **DESIGN** — no code yet. Branch `820-worker-task-batching` off `origin/dev` @ 04ebc438.
+
+Companion to #817 (async writes, which surfaced the tail) and #680 (the per-blob
+write-token contention this sidesteps).
+
+## 1. Why
+
+The clio-fs page model stores each 1 MiB file page as one blob. A sequential
+4 KiB workload therefore puts **256 tasks on each page-blob**. Every `PutBlob`
+holds that blob's #680 write token across its *entire* body — allocation **and**
+the bdev data copy (`core_runtime.cc` `PutBlobImpl`, the `ModifyExistingData`
+co_await at ~1678) — and a contender re-polls on a periodic cadence
+(`kBlobWriteLockPollUs`, 1554). So the 256 writes drain single-file.
+
+Measured, QD1, RAM target, 4 KiB: p50 **7.3 µs**, mean **~160 µs** → ~6.3K IOPS,
+tail **p99.9 ≈ 10 ms, max ~1 s**. Block-size sweep pins the cause to
+writes-per-blob: max stall **1082 ms** (4k, 256/page) → 10.5 ms (64k, 16/page) →
+8 ms (1M, 1/page).
+
+The 256 writes are to **disjoint byte ranges** of the page — they never conflict
+on bytes — yet the token is per-*blob*, so they serialize anyway. The cheapest
+place to fix that is *before* they reach the runtime: coalesce them into one
+PutBlob over the union of their ranges. One token acquire, one bdev transfer,
+256× fewer tasks.
+
+## 2. Not the existing BatchManager
+
+`BatchManager` (`batch_manager.{h,cc}`) already batches — but it is a **cross-node
+collective** for `PoolQuery::ManyToOne`: park N tasks by
+`(pool, method, container, batch_key)`, flush after a time window, combine their
+inputs `AggregateIn` **N→1**, run **one** aggregate, then broadcast the single OUT
+`1→N` back to every member (`OnAggregateComplete` → per-member `SetReturnCode` /
+`SetCompleter` / `EndTask`). Every member gets the *same* result. Used today for
+the clio-fs deferred-append pipeline (`AppendCollect`).
+
+This proposal is different in kind: **intra-node coalescing**. N independent tasks
+become a **minimal M-task subset** (not 1), and each output task completes a
+*different* set of parents, scattering a *slice* of its OUT to each. Reduction vs
+merge. We reuse BatchManager's completion-fan-out *mechanic* (its
+`OnAggregateComplete` is the proof it works) but not its routing or its
+single-result semantics.
+
+## 3. Where it slots in
+
+Worker main loop today (`worker.cc:276`): drain SHM shards → `ProcessNewTasks`
+(pop ≤16, `RouteAndExec` each) → `ContinueBlockedTasks` → ManyToOne `FlushDue`.
+
+`ProcessNewTask` pops one `Future<Task>`, resolves the container, and
+`RouteAndExec` → `RouteTask`; on `RouteResult::ExecHere` it runs inline. Batching
+inserts a phase between the dequeue and the execute, and only over tasks that
+route **ExecHere** (a task destined for another node/container must route first,
+untouched — we never batch across containers).
+
+### The phase
+
+```
+BatchPhase(lane):
+  groups := worker.batch_groups          // unordered_map<BatchKey, BatchQueue>, reused
+  passthrough := worker.passthrough      // SPSC<Future<Task>>, reused
+
+  for i in 0..MAX_BATCH_DEQUEUE (=64):
+    if not lane.Pop(future): break
+    route := RouteTask(future)
+    if route != ExecHere:                // routed elsewhere; RouteTask already enqueued it
+      continue
+    container := container_of(future)
+    container.BuildBatch(future.task, groups)   // routes into a group, OR...
+      // default BuildBatch: passthrough.Push(future)   (not batchable)
+
+  // run the non-batchable tasks as-is, in arrival order, first
+  while passthrough.Pop(f): RouteAndExec(f, lane)   // (already ExecHere)
+
+  // then let each container collapse its groups into minimal output tasks
+  for each container with nonempty groups:
+    container.SmashBatch(groups, sink)   // sink enqueues merged tasks + wires parents
+  groups.clear()
+```
+
+Key decisions:
+
+- **Bounded, backlog-only.** The `≤64` dequeue only ever *has* 64 to batch when a
+  backlog exists. A lone write finds an empty lane after it, `BuildBatch`es a
+  group of one, and `SmashBatch` emits it unchanged — **no added latency for the
+  unbatched case**. Batching kicks in exactly when there is contention to amortize.
+- **Passthrough first, merged last** (per the plan): preserves the arrival order
+  of non-batchable work, and lets a merged task see a settled world.
+- **Route before batch.** We only batch `ExecHere` tasks, so groups are always
+  same-node, same-container — the merge never has to reason about placement.
+
+## 4. Container interface
+
+Two new virtuals on `Container` (`container.h`), default no-op / passthrough so
+every existing container is unaffected:
+
+```cpp
+// Route `task` into the batch groups, or decline (caller sends it to passthrough).
+// Default: return false (not batchable).
+virtual bool BuildBatch(const shared_ptr<Task>& task, BatchGroups& groups) {
+  return false;
+}
+
+// Collapse each group into the minimal set of output tasks. For each output,
+// record the parent tasks it completes and how to scatter its OUT to them, then
+// hand it to `sink` to enqueue. Default: no-op.
+virtual void SmashBatch(BatchGroups& groups, BatchSink& sink) {}
+```
+
+`BatchGroups` = `unordered_map<BatchKey, priv::vector<shared_ptr<Task>>>` owned by
+the worker and cleared each phase. `BatchKey` is opaque to the worker
+(`{PoolId, method, u64 key}`); the container chooses `key` (for CTE:
+`hash(tag_id, blob_name)` — the page).
+
+`BatchSink` wraps "enqueue this merged task, and on its completion run this parent
+fan-out." Implementation reuses BatchManager's pattern: a worker-side
+`unordered_map<merged_task_uid, ParentCompletion>` consulted in `Worker::EndTask`
+when a task is flagged `TASK_BATCH_MERGED`, mirroring `IsAggregate` /
+`OnAggregateComplete`.
+
+### Parent completion
+
+Each merged output task carries (via the sink's side table) a list of
+`{parent_task, out_slice}`. When the merged task reaches `EndTask`:
+
+1. For each parent, copy the relevant slice of the merged OUT into the parent
+   (for GetBlob: `memcpy` the parent's sub-range out of the merged read buffer
+   into the parent's `blob_data_`; for PutBlob: set `bytes_written`/rc).
+2. `parent->SetReturnCode(...)`, `SetCompleter(...)`, `worker->EndTask(parent)`.
+
+This is exactly `OnAggregateComplete` generalized from one-result-broadcast to
+per-parent-slice-scatter.
+
+## 5. CTE PutBlob / GetBlob policy
+
+`CteCoreContainer::BuildBatch`: batchable iff method ∈ {kPutBlob, kGetBlob} and
+the task is an ordinary positioned op (no compression transform, no GPU page
+suffix in v1 — those decline to passthrough). Group key = `hash(tag_id,
+blob_name)`.
+
+`SmashBatch`, per group:
+
+1. **Sort** members by `(tag_id, blob_name, offset)`, ties broken by **submission
+   order** (a monotonic seq the worker stamps at `BuildBatch` time). Submission
+   order is what makes overlap resolution correct.
+2. **Merge** into runs of contiguous/overlapping ranges → the minimal set of
+   output tasks. Two members merge when `off_i + size_i >= off_{i+1}` (adjacent or
+   overlapping) on the same blob.
+   - **PutBlob:** allocate one contiguous staging buffer spanning
+     `[min_off, max_end)`; copy each member's data in at its offset. **Overlaps
+     resolve by submission order** — the later writer's bytes land last, which is
+     the correct last-writer-wins the #680 token race currently gets *wrong*.
+     Holes inside a run (gap between two non-adjacent-but-mergeable members) are
+     not created — a gap ends the run and starts a new output task, so we never
+     invent bytes.
+   - **GetBlob:** one read over `[min_off, max_end)`; on completion scatter each
+     parent's `[off_i, off_i+size_i)` sub-range out of the merged buffer.
+3. Each output task's parent set = the members it covers; each parent's
+   `out_slice` = its offset/size within the merged buffer.
+4. Emit via `sink`.
+
+Net for the 4 KiB sequential case: 256 same-page PutBlobs → **1** PutBlob spanning
+the 1 MiB page. One token acquire, one bdev write. The tail's root cause is gone,
+and the merge also fixes the overlap-ordering correctness gap #680 leaves open
+(see #817's write notes).
+
+## 6. Data structures to add
+
+- `Worker`: `BatchGroups batch_groups_;` and
+  `ctp SPSC<Future<Task>> passthrough_;` (the ctp ring buffer,
+  `data_structures/ipc/ring_buffer.h`), both reused across iterations.
+- `Worker`: `unordered_map<u64, ParentCompletion> batch_pending_;` +
+  `TASK_BATCH_MERGED` flag (mirrors BatchManager's `pending_`/`TASK_BATCH_AGGREGATE`).
+- `Container`: `BuildBatch` / `SmashBatch` virtuals + `BatchGroups` / `BatchSink`
+  types.
+- CTE container: the PutBlob/GetBlob policy above.
+
+## 7. Open questions / hazards
+
+1. **Staging-buffer gather cost (PutBlob).** Merging needs the members' bytes
+   contiguous. v1 gathers into one buffer (a memcpy per member — the same copy
+   cfs_io already does once). A later v2 could give PutBlob a scatter-list
+   `(offset, ShmPtr, size)[]` to avoid the extra copy; out of scope for v1.
+2. **Partial failure.** If the merged bdev transfer half-fails, how granular is
+   the error to parents? v1: all covered parents get the merged rc (conservative).
+   Only matters if the bdev can report partial byte counts; note and defer.
+3. **Fairness / starvation.** The bounded 64 dequeue caps how long batching
+   delays the passthrough tasks (which run first anyway). Confirm the phase can't
+   starve `ContinueBlockedTasks` — keep it inside the existing per-iteration work
+   budget.
+4. **Interaction with routing side effects.** `RouteTask` may mutate RunContext /
+   re-enqueue. We batch only `ExecHere` results, after routing — but confirm no
+   task both routes ExecHere *and* expects to be re-dequeued.
+5. **WAL / ordering vs the append pipeline.** clio-fs already has `AppendCollect`.
+   Ensure positioned-write batching and the append collective don't double-handle
+   the same bytes (they target different task methods, but write the same pages).
+6. **Merged task accounting.** `GetTaskStats` / the #781 scheduler model sees one
+   big task instead of 256 small ones — check the load model doesn't misprice it.
+7. **GetBlob RYOW.** A merged read must still respect a pending overlapping write
+   (the cfs `DrainIfOverlap` is client-side; server-side merged reads are new).
+
+## 8. Phasing
+
+| Phase | Deliverable |
+|---|---|
+| 0 | Worker batch phase + `BatchGroups`/passthrough SPSC, `Container::BuildBatch`/`SmashBatch` default no-ops. **No behavior change** — every container passes through. |
+| 1 | Parent-completion side table + `TASK_BATCH_MERGED` fan-out in `EndTask` (unit-tested with a trivial echo container). |
+| 2 | CTE `PutBlob` policy: sort/merge/gather + scatter completion. Correctness first (overlap = last-writer-wins), then the fio tail measurement. |
+| 3 | CTE `GetBlob` policy: merge + scatter-read, RYOW respected. |
+| 4 | Bench + tail: the 4 KiB seq write max-stall should collapse from ~1 s toward the 1-MiB-write floor; verify p99.9 and mean, not just p50. |
+
+## 9. Success criteria
+
+- 4 KiB sequential write **mean** latency and **p99.9/max** drop toward the
+  1-writer-per-page floor (the block-size sweep's 8 ms end), not just p50.
+- No regression on the full fsx/xfstests adapter suite (this touches the write
+  path indirectly via coalescing).
+- Unbatched single-op latency unchanged (the empty-backlog path adds nothing).

--- a/project_worker_task_batching.md
+++ b/project_worker_task_batching.md
@@ -82,6 +82,25 @@ Measured A/B, async burst of 256 x 4 KiB outstanding at one blob, 10 rounds:
 No improvement, as expected: nothing merges. This is a negative result, recorded
 as such.
 
+### How far the hang was narrowed, and where tracing stopped working
+
+With `CLIO_BATCH_LANE=1` the merge path *does* run — traced groups of 2 and 61
+members, `NewCopyTask` succeeding, and every segment pushed
+("all 61 pushed"). The stall is downstream of that, inside `BatchSink::Emit`,
+between assigning the merged task's id and the `Send`.
+
+Finer localization then failed for an instructive reason: with per-statement
+`fprintf`+`fflush` from multiple worker threads, the trace stopped between two
+*adjacent* prints — which is not a logic hang but **stderr lock contention**,
+one worker blocking in `fprintf` while another holds the stream lock. Past that
+point the instrumentation was measuring itself. The remaining work needs the
+stuck process inspected directly (thread backtraces) rather than more printf
+tracing.
+
+What is established: the merge builds correctly, and the failure is in
+publishing the merged task / completing its parents — not in the vectored task
+shape, which is independently exercised and green.
+
 ### Why the end-to-end win is still not demonstrated
 
 Even at the right ingress, batching only pays when requests **co-arrive**: two

--- a/project_worker_task_batching.md
+++ b/project_worker_task_batching.md
@@ -1,6 +1,63 @@
 # Vectored PutBlob/GetBlob + worker-local task batching (issue #820)
 
-Status: **DESIGN** — no code yet. Branch `820-worker-task-batching` off `origin/dev` @ 04ebc438.
+Status: **A IMPLEMENTED + MEASURED; B implemented but OPT-IN pending a hang.**
+Branch `820-worker-task-batching` off `origin/dev` @ 04ebc438.
+
+## Result so far
+
+**Vectored PutBlob is a 26x win on the case this issue is about.** Same bytes,
+same blob, no batching phase and no concurrency involved — only the task shape
+(`bench_same_blob_batching`, 256 x 4 KiB to one blob, 20 rounds, medians, both
+arms warmed):
+
+| | median | range |
+|---|---|---|
+| 256 single PutBlobs | 37.86 ms | 34.41–41.43 |
+| **1 vectored PutBlob** | **1.46 ms** | 1.22–2.87 |
+
+**25.97x**, with non-overlapping ranges. That is the #680 write token being
+acquired once instead of 256 times, one metadata mutation instead of 256, and
+one bdev pass instead of 256.
+
+### Status by part
+
+- **A1 vectored PutBlob — done.** `segments_` on the task, `PutBlobImpl` applies
+  all segments under one token acquire. `test_vectored_blob_io` asserts
+  equivalence with N single puts, list-order overlap resolution
+  (last-writer-wins), and union-range allocation with a zero-filled hole.
+- **A2 vectored GetBlob — done.** Each region read into its own buffer off one
+  block snapshot. Tested.
+- **B0/B1 worker batch phase — done.** `Worker::BatchPhase`, `BuildBatch`/
+  `SmashBatch` container virtuals (default decline/no-op), `TASK_BATCH_MERGED`
+  parent fan-out. Verified behaviour-neutral: with the CTE policy off the full
+  suite passes, including 8-writer same-blob stress.
+- **B2/B3 CTE policy — implemented, DEFAULT OFF (`CLIO_CTE_BATCHING=1` to
+  enable).** Parking CTE tasks still hangs `test_concurrent_same_blob` at >=8
+  concurrent writers, and the cause is not yet understood. Shipping it on by
+  default would trade a latency win for a hang.
+- **B4 — the measurement above covers the mechanism; the end-to-end fio tail
+  comparison waits on B2 being safe to enable.**
+
+### Bugs found while building this
+
+1. **Emit vs Passthrough.** Routing a group of ONE through the merged-task path
+   reassigned the task's id — but its client future was already bound to the old
+   id, so the client hung forever. A parked original must run *unchanged*
+   (`BatchSink::Passthrough`); only a freshly built synthetic task may be
+   `Emit`ted.
+2. **Dangling group key.** `SmashBatch` held `const BatchKey &key = it->first`
+   and then `groups.erase(it)` — every later use of `key` (the method checks,
+   the sort comparator, the merged-task construction) read freed memory. It
+   showed up as "park method=15, smash method=25": the same group reporting two
+   different methods, so the merge took the wrong branch. Copy the key by value.
+3. **Started tasks are not candidates.** A task popped off the lane may be a
+   coroutine resuming mid-execution (`ContinueBlockedTasks` re-queues those).
+   Folding one into a fresh merged task abandons its in-flight state and strands
+   its waiter. Only never-started tasks are offered.
+
+The remaining hang is B2-specific and reproduces only with the CTE policy on and
+>=8 concurrent writers to one blob; the phase itself is clean at the same
+concurrency.
 
 Two coupled pieces:
 

--- a/project_worker_task_batching.md
+++ b/project_worker_task_batching.md
@@ -1,6 +1,8 @@
 # Vectored PutBlob/GetBlob + worker-local task batching (issue #820)
 
-Status: **A IMPLEMENTED + MEASURED; B implemented but OPT-IN pending a hang.**
+Status: **A and B IMPLEMENTED AND MEASURED.** Batching is opt-in
+(`CLIO_BATCH_LANE=1 CLIO_CTE_BATCHING=1`) pending broader soak, but it works and
+delivers ~3.7x end to end; the vectored task shape underneath is 26–28x.
 Branch `820-worker-task-batching` off `origin/dev` @ 04ebc438.
 
 ## Result so far
@@ -154,10 +156,21 @@ lane is full. The one discrepancy to resolve is that the thread is *asleep*
 rather than spinning, so either the ring's wait sleeps, or the block is one level
 deeper than `Push`.
 
-**Fix direction (not yet implemented):** do not `Send` merged tasks from inside
-the drain loop. Either run the merged task inline on the current worker (it is
-already the right container), or hand it off through a path that cannot enqueue
-onto the lane being drained.
+**FIXED.** Merged tasks are no longer `Send`-ed. The sink runs them **inline on
+the current worker**: it gives the merged task its own `Future` + `RunContext`
+(it has no client waiter of its own — its job is to complete the parents it
+subsumed) and calls `ExecTask` directly. That is also simply correct, not just a
+workaround: every member routed to this container on this worker, so the merged
+task belongs here by construction and never needs to enter a lane at all.
+
+With that, batching works and pays:
+
+| async burst, 256 x 4 KiB at one blob, 10 rounds | median | range |
+|---|---|---|
+| batching off | 12.01 / 12.54 ms | 11.69–15.86 |
+| **batching on** | **3.26 / 3.41 ms** | 2.75–4.28 |
+
+**~3.7x**, ranges non-overlapping, arms interleaved on the same binary.
 
 Also applied while investigating (kept — correct on its own): the current-task
 slot is cleared before emitting. `IpcCpu2Self::SendIn` parents a self-sent task

--- a/project_worker_task_batching.md
+++ b/project_worker_task_batching.md
@@ -520,3 +520,33 @@ coalescing must happen where the same-blob traffic actually converges — most
 directly by having the **cfs adapter or filesystem chimod emit a vectored PutBlob
 (part A's API) per page** instead of N single-region ones. Part A is exactly the
 primitive that path needs; part B is the wrong layer for the POSIX workload.
+
+## 11. Related: block-fragmentation moved from CTE to the bdev allocator
+
+While in this code, a coupled cleanup that belongs to the same "make the write
+path efficient" goal. The CTE's `ExtendBlob` used to cap every physical block at
+64 KB, so a large logical write became many small blocks — a workaround for the
+bdev free list being bucketed by size category (a 1 MiB ask never sees freed
+64 KB blocks, so under churn the bump-only heap climbs to capacity and writes
+EIO; xfstests 074/521/522). That is the allocator's job, not the CTE's.
+
+Now: `StandardBlockAllocator::AllocateBlocks` assembles a large request from
+several smaller freed extents (`AllocateAnyUpTo`, physical-footprint accounting)
+before touching the heap; `AllocateFromTarget` returns every block, not just the
+first; `ExtendBlob` requests the whole extent and distributes the logical bytes
+across the returned physical blocks. The 64 KB cap is gone — a fresh 1 MiB blob
+is **one** 1 MiB block (verified), not 16.
+
+Decisive regression test `test_bdev_fragmentation`: fill a tier to capacity with
+8 KiB blobs, delete them, then allocate 1 MiB blobs that can only come from the
+freed extents — **0/20 (EIO) without the fix, 20/20 with it**.
+
+**fio impact (4 KiB): none, and for a precise reason.** The cap only ever fired
+for writes LARGER than 64 KB; a `bs=4k` write extends the page-blob by 4 KB, well
+under the cap, so the block count per page is identical old and new (256 × 4 KiB
+per 1 MiB page). Measured on the combined tree, 4 KiB seq write is ~13–15K IOPS
+warm, unchanged. Where it helps is large writes (a 1 MiB write is 1 block, not
+16 — a 16× shorter #680 token hold and 16× fewer allocations) and churn
+correctness. The 4 KiB fio tail (p99.9 ~80 ms, max ~300 ms) is the #680
+write-token contention, which neither this nor worker batching addresses at the
+POSIX ingress — see §10's conclusion (vectored PutBlob per page from the adapter).

--- a/project_worker_task_batching.md
+++ b/project_worker_task_batching.md
@@ -486,3 +486,37 @@ order fixes the overlap-ordering gap #680 leaves open (#817 write notes).
 - No regression on the full fsx/xfstests adapter suite (this touches the write
   path indirectly via coalescing).
 - Unbatched single-op latency unchanged (the empty-backlog path adds nothing).
+
+## 10. fio through clio-fs: the win does NOT reach the POSIX path
+
+Measured on a throwaway branch merging this work with #817 (async writes, needed
+so `write(2)` returns once staged and a burst of same-blob writes can form). fio
+via the POSIX interceptor, 4 KiB, RAM target, async writes on, batching A/B via
+`CLIO_CTE_BATCHING`.
+
+**Concentrated** — 16 jobs on one 1 MiB file (= one page-blob), 8 paired runs:
+
+| | median IOPS | range | median p99.9 |
+|---|---|---|---|
+| batching off | 12,219 | 8.7K–16.2K | 97 ms |
+| batching on | 14,086 | 10.6K–16.3K | 79 ms |
+
+**1.15x median, faster in only 4/8 — within noise.** Sequential (8 jobs × 64 MiB)
+is parity. Contrast the direct-CTE microbenchmark, where the same knob is a clean
+3.68x.
+
+**Why it does not translate.** The clio-fs write path is `POSIX interceptor →
+cfs_io → the adapter's own async write-window/staging (#817) → filesystem chimod
+→ per-page loop → PutBlob`. Those layers reshape the traffic before it reaches
+the PutBlob layer: the adapter stages writes and the chimod mediates them, so the
+concentrated same-blob burst the direct client produced no longer **co-arrives**
+at one worker's drain window. Worker-level batching can only merge what converges
+there, and after the adapter/chimod have serialized the page, little does.
+
+**Conclusion / next step.** The 3.68x is real for a client that issues concurrent
+same-blob PutBlobs; it is not reachable by having the *runtime worker*
+re-discover a burst the fs stack already dissolved. To move the fio numbers, the
+coalescing must happen where the same-blob traffic actually converges — most
+directly by having the **cfs adapter or filesystem chimod emit a vectored PutBlob
+(part A's API) per page** instead of N single-region ones. Part A is exactly the
+primitive that path needs; part B is the wrong layer for the POSIX workload.

--- a/project_worker_task_batching.md
+++ b/project_worker_task_batching.md
@@ -165,12 +165,22 @@ task belongs here by construction and never needs to enter a lane at all.
 
 With that, batching works and pays:
 
-| async burst, 256 x 4 KiB at one blob, 10 rounds | median | range |
-|---|---|---|
-| batching off | 12.01 / 12.54 ms | 11.69–15.86 |
-| **batching on** | **3.26 / 3.41 ms** | 2.75–4.28 |
+**Five paired runs** (async burst, 256 x 4 KiB outstanding at one blob, 10 rounds
+per run, medians; arms interleaved on the same binary so no rebuild or host
+drift sits between them):
 
-**~3.7x**, ranges non-overlapping, arms interleaved on the same binary.
+| pair | batching off | batching on | ratio |
+|---|---|---|---|
+| 1 | 12.01 ms | 3.26 ms | 3.68x |
+| 2 | 12.54 ms | 3.41 ms | 3.68x |
+| 3 | 12.91 ms | 3.73 ms | 3.46x |
+| 4 | 15.24 ms | 3.41 ms | 4.47x |
+| 5 | 12.27 ms | 3.27 ms | 3.75x |
+
+**Median ratio 3.68x, batching faster in 5/5**, and the two distributions do not
+overlap (off 12.0–15.2, on 3.3–3.7). Unlike the write-window measurements in
+#817, this one did not need pairing to survive — the effect is far larger than
+this box's drift.
 
 Also applied while investigating (kept — correct on its own): the current-task
 slot is cleared before emitting. `IpcCpu2Self::SendIn` parents a self-sent task

--- a/project_worker_task_batching.md
+++ b/project_worker_task_batching.md
@@ -31,12 +31,46 @@ one bdev pass instead of 256.
   `SmashBatch` container virtuals (default decline/no-op), `TASK_BATCH_MERGED`
   parent fan-out. Verified behaviour-neutral: with the CTE policy off the full
   suite passes, including 8-writer same-blob stress.
-- **B2/B3 CTE policy — implemented, DEFAULT OFF (`CLIO_CTE_BATCHING=1` to
-  enable).** Parking CTE tasks still hangs `test_concurrent_same_blob` at >=8
-  concurrent writers, and the cause is not yet understood. Shipping it on by
-  default would trade a latency win for a hang.
-- **B4 — the measurement above covers the mechanism; the end-to-end fio tail
-  comparison waits on B2 being safe to enable.**
+- **B2/B3 CTE policy — implemented, no longer hangs, DEFAULT OFF pending a
+  workload that actually exercises it (`CLIO_CTE_BATCHING=1` to enable).**
+  `test_concurrent_same_blob` (8 writers), `test_cte_parallel_overlap_stress`
+  and `test_vectored_blob_io` all pass with it on.
+- **B4 — the 26x measurement above covers the mechanism. The end-to-end win is
+  NOT yet demonstrated, for the reason in "the ingress" below.**
+
+### The batching was wired to the wrong ingress
+
+The lane-based phase never saw a single hot-path task. Under the #807 SHM
+transport a client's PutBlob/GetBlob is delivered to its worker's **shard ring**
+and executed inline in `DrainMyShard` — it never enters the lane. Instrumented
+under an 8-writer same-blob load: **zero tasks parked, zero merges**, while the
+lane carried only occasional internal work.
+
+That also explains the hang. The lane carries internal and re-routed tasks that
+other in-flight work may be synchronously waiting on, so *deferring* one until
+the end of the phase can deadlock. Freshly ingested client requests have no such
+dependents yet. Moving the phase to `DrainMyShard` and leaving the lane path
+exactly as it was fixed the hang outright — 8-writer same-blob went from hanging
+to passing, with the policy on.
+
+### Why the end-to-end win is still not demonstrated
+
+Even at the right ingress, batching only pays when requests **co-arrive**: two
+same-blob requests must land in one worker's shard within one drain window. A
+synchronous client has exactly ONE outstanding request per thread, and threads
+spread across shards, so a worker sees one task at a time and every group is a
+group of one (measured: still zero merges at 8 threads).
+
+The contention is unquestionably there — same run, 8 writers at one blob:
+mean 2.72 ms, p50 277 µs, **p99 38.7 ms, p99.9 101.6 ms, max 118.9 ms**. That
+tail is the #680 token. But collapsing it needs a *bursty* submitter, which is
+exactly what #817's async writes produce (write(2) returns once staged, so many
+requests are in flight at once). Until this branch is combined with that path,
+the batching policy is a correct no-op on this workload.
+
+**So the honest split:** the vectored task shape is the win and it is proven
+(26x). The batching layer that would feed it automatically is built, safe, and
+in the right place, but needs an async/bursty client to have anything to merge.
 
 ### Bugs found while building this
 

--- a/project_worker_task_batching.md
+++ b/project_worker_task_batching.md
@@ -53,6 +53,35 @@ dependents yet. Moving the phase to `DrainMyShard` and leaving the lane path
 exactly as it was fixed the hang outright — 8-writer same-blob went from hanging
 to passing, with the policy on.
 
+### Where batching has to happen, and why it is blocked there
+
+Correction to the section above: moving to the ingress **masked** the hang, it
+did not fix it.
+
+`RouteTask` sends every task for a blob to that blob's container — i.e. to ONE
+worker's lane. So the ingesting worker is usually *not* the executing worker: it
+receives a request, routes it onward, and never gets to merge it. The lane is
+the only place same-blob work converges, and therefore the only place a batch
+can form. Batching at the ingress is safe precisely because it never batches
+anything.
+
+Enabling lane batching (`CLIO_BATCH_LANE=1`) with the CTE policy on **hangs**
+again, on the async-burst benchmark. So the deferral hang is real, independent
+of the use-after-free already fixed, and it sits squarely on the only viable
+ingress. That is the blocker.
+
+Measured A/B, async burst of 256 x 4 KiB outstanding at one blob, 10 rounds:
+
+| | median | range |
+|---|---|---|
+| ingress batching, policy off | 12.28 ms | 11.65–12.47 |
+| ingress batching, policy on | 12.99 ms | 11.52–15.16 |
+| lane batching, policy off | 13.01 ms | 12.20–17.88 |
+| lane batching, policy on | **hangs** | — |
+
+No improvement, as expected: nothing merges. This is a negative result, recorded
+as such.
+
 ### Why the end-to-end win is still not demonstrated
 
 Even at the right ingress, batching only pays when requests **co-arrive**: two

--- a/project_worker_task_batching.md
+++ b/project_worker_task_batching.md
@@ -101,6 +101,36 @@ What is established: the merge builds correctly, and the failure is in
 publishing the merged task / completing its parents — not in the vectored task
 shape, which is independently exercised and green.
 
+### It is a LOST WAKEUP, not a deadlock
+
+Thread-state inspection of the wedged process (`/proc/<pid>/task/*/{stat,wchan}`,
+which works under `ptrace_scope=1` where `gdb -p` does not) settles the
+character of the bug:
+
+- **No thread is in state R.** Nothing is spinning.
+- **No thread is blocked on a futex.** So it is not a mutex deadlock.
+- Every thread is in `hrtimer_nanosleep` (workers in their adaptive idle sleep)
+  or `do_epoll_wait` (ZMQ I/O, peer/client receive).
+
+So the merged task is published and then simply never runs: every worker parks,
+the client waits on a future nobody will complete, and the system is quiescent.
+That is the signature of a task enqueued without its consumer being woken, or of
+a task that never reaches a lane at all.
+
+Ruled out so far:
+
+- **Not the enqueue path itself.** `RouteLocal` pushes and then unconditionally
+  `AwakenWorker`s, with a comment describing this exact lost-wakeup race.
+- **Not inherited lifecycle flags.** `BatchManager` clears them on its aggregate
+  because `NewCopyTask` carries `task_flags_` over; building the merged task
+  *fresh* from `NewTask` and copying only the identifying fields was tried and
+  **did not fix it** (reverted, since it was unverified and strictly less
+  complete than the copy).
+
+The next step is to establish whether the merged task ever reaches a lane at all
+— instrumenting the enqueue side rather than the emit side — with a low-volume,
+single-writer log so stderr contention cannot masquerade as a stall again.
+
 ### Why the end-to-end win is still not demonstrated
 
 Even at the right ingress, batching only pays when requests **co-arrive**: two

--- a/project_worker_task_batching.md
+++ b/project_worker_task_batching.md
@@ -127,9 +127,44 @@ Ruled out so far:
   **did not fix it** (reverted, since it was unverified and strictly less
   complete than the copy).
 
-The next step is to establish whether the merged task ever reaches a lane at all
-— instrumenting the enqueue side rather than the emit side — with a low-volume,
-single-writer log so stderr contention cannot masquerade as a stall again.
+### Root cause, as far as it is established: `Send` never returns
+
+Re-instrumented with a **lock-free** tracer (`write(2)` to an `O_APPEND` fd — one
+syscall, no userspace lock, unlike the `fprintf` that faked a stall earlier):
+
+```
+SMASH method=15 members=5     EMIT-ENTER parents=5
+SMASH method=15 members=55    EMIT-ENTER parents=55
+EMIT-SENT: 0
+```
+
+So the merge runs, real groups form (5 and 55 members), `Emit` is entered — and
+`CLIO_IPC->Send(merged)` **never returns**, with the calling thread asleep.
+
+That matches a hazard `IpcCpu2Self::SendIn` documents against itself: a self-send
+routes via `RouteTask(force_enqueue=true)` → `RouteLocal` → `dest_lane.Push()`,
+and *"when that lane fills, the WAIT_FOR_SPACE ring Push busy-spins forever — the
+worker never suspends, so it can never pop to make space (producer==consumer
+deadlock)"*. `RouteLocal` guards this by picking an alternate worker when the
+destination is the caller — but only `if (alt != nullptr)`.
+
+Emitting from inside the drain loop is exactly that shape: the worker is the
+consumer of the lane it may be asked to push onto, and under a 64-deep burst the
+lane is full. The one discrepancy to resolve is that the thread is *asleep*
+rather than spinning, so either the ring's wait sleeps, or the block is one level
+deeper than `Push`.
+
+**Fix direction (not yet implemented):** do not `Send` merged tasks from inside
+the drain loop. Either run the merged task inline on the current worker (it is
+already the right container), or hand it off through a path that cannot enqueue
+onto the lane being drained.
+
+Also applied while investigating (kept — correct on its own): the current-task
+slot is cleared before emitting. `IpcCpu2Self::SendIn` parents a self-sent task
+to `GetCurrentTask()`, which by then is a stale, already-finished passthrough
+task; a merged task adopted by a dead parent has its completion routed into that
+parent's coroutine. It did not resolve the hang, but leaving it unfixed would
+have been a second bug waiting behind the first.
 
 ### Why the end-to-end win is still not demonstrated
 

--- a/scripts/xfstests/run_clio_xfstests.sh
+++ b/scripts/xfstests/run_clio_xfstests.sh
@@ -78,7 +78,8 @@ mount_fuse() {  # $1 = mountpoint, $2 = with_runtime(1/0), $3 = fsname (mount so
   # source "clio_cte_fuse".)
   CLIO_REPO_PATH="${BUILD_BIN}" LD_LIBRARY_PATH="${BUILD_BIN}:${HOME}/.local/lib:${LD_LIBRARY_PATH:-}" \
     CLIO_WITH_RUNTIME="${with_rt}" CLIO_BIND_ADDR=127.0.0.1 \
-    "${FUSE_BIN}" "${mnt}" -o "fsname=${fsname}" -f &
+    "${FUSE_BIN}" "${mnt}" -o "fsname=${fsname}" -f \
+    >>"${CLIO_FUSE_RT_LOG:-/tmp/clio_fuse_rt.log}" 2>&1 &
   FUSE_PIDS+=("$!")
   # wait for the mount to appear
   for _ in $(seq 1 50); do
@@ -141,6 +142,7 @@ echo "[xfstests] running ${#LIST[@]} test(s) (mount-per-test)"
 # --- run, one fresh mount per test ------------------------------------------
 pass=0; fail=0; notrun=0; hang=0; failed_list=""
 for t in "${LIST[@]}"; do
+  : > "${CLIO_FUSE_RT_LOG:-/tmp/clio_fuse_rt.log}"   # fresh runtime log per test (hang diagnosis)
   remount >/dev/null 2>&1 || { echo "${t}: MOUNTFAIL"; fail=$((fail+1)); failed_list="${failed_list} ${t}"; continue; }
   out=$(timeout "${CLIO_XFS_PERTEST_TIMEOUT:-90}" ./check "${t}" 2>/dev/null)
   rc=$?
@@ -150,6 +152,10 @@ for t in "${LIST[@]}"; do
   # would silently admit a scratch/hardware-requiring test into the CI gate
   # where it tests nothing. "Not run:" is the authoritative signal.
   if [ "${rc}" -eq 124 ]; then echo "${t}: HANG"; hang=$((hang+1)); failed_list="${failed_list} ${t}(hang)"
+    echo "--- [${t}] clio runtime hang diagnosis (HANGWATCH/#781/#785) ---"
+    grep -aE "HANGWATCH|#781 PDF|#785|DEADLOCK|STALLED|no task completed" \
+      "${CLIO_FUSE_RT_LOG:-/tmp/clio_fuse_rt.log}" | tail -n 80 || true
+    echo "--- end [${t}] runtime diagnosis ---"
   elif echo "${out}" | grep -q "^Not run:"; then echo "${t}: notrun"; notrun=$((notrun+1))
   elif echo "${out}" | grep -q "^Passed all"; then echo "${t}: pass"; pass=$((pass+1))
   else echo "${t}: FAIL"; fail=$((fail+1)); failed_list="${failed_list} ${t}"; fi

--- a/scripts/xfstests/run_clio_xfstests.sh
+++ b/scripts/xfstests/run_clio_xfstests.sh
@@ -152,9 +152,12 @@ for t in "${LIST[@]}"; do
   # would silently admit a scratch/hardware-requiring test into the CI gate
   # where it tests nothing. "Not run:" is the authoritative signal.
   if [ "${rc}" -eq 124 ]; then echo "${t}: HANG"; hang=$((hang+1)); failed_list="${failed_list} ${t}(hang)"
-    echo "--- [${t}] clio runtime hang diagnosis (HANGWATCH/#781/#785) ---"
-    grep -aE "HANGWATCH|#781 PDF|#785|DEADLOCK|STALLED|no task completed" \
-      "${CLIO_FUSE_RT_LOG:-/tmp/clio_fuse_rt.log}" | tail -n 80 || true
+    RTLOG="${CLIO_FUSE_RT_LOG:-/tmp/clio_fuse_rt.log}"
+    echo "--- [${t}] clio runtime hang diagnosis (rtlog_lines=$(wc -l < "${RTLOG}" 2>/dev/null || echo NA)) ---"
+    echo "  [HANGWATCH/#781/#785 markers]:"
+    grep -aE "HANGWATCH|#781|#785|DEADLOCK|STALLED" "${RTLOG}" 2>/dev/null | tail -n 60 || true
+    echo "  [raw rtlog tail 30]:"
+    tail -n 30 "${RTLOG}" 2>/dev/null | sed 's/^/    /' || true
     echo "--- end [${t}] runtime diagnosis ---"
   elif echo "${out}" | grep -q "^Not run:"; then echo "${t}: notrun"; notrun=$((notrun+1))
   elif echo "${out}" | grep -q "^Passed all"; then echo "${t}: pass"; pass=$((pass+1))


### PR DESCRIPTION
Implemented (was design-only when opened). Three coupled pieces of write-path work for #820, all on this branch.

## A. Vectored PutBlob / GetBlob — **~26–28x**, unconditional
`segments_` on the task: N regions applied under a single #680 write-token acquire, list-order overlap = last-writer-wins. New `AsyncPutBlobVectored`/`AsyncGetBlobVectored` client APIs. GPU POD variants opt out (`kSupportsVectored=false`). Standalone win: **256 single PutBlobs 37.9 ms → 1 vectored PutBlob 1.5 ms** to one blob.

## B. Worker-local task batching — **3.68x** (opt-in)
Worker `BatchIngest`/`BatchLane` phase; `Container::BuildBatch`/`SmashBatch` virtuals (default decline/no-op); `TASK_BATCH_MERGED` parent fan-out; CTE policy coalesces same-blob PutBlob/GetBlob into one vectored task, run **inline** on the owning worker. Opt-in behind `CLIO_BATCH_LANE=1 CLIO_CTE_BATCHING=1` pending soak.

Measured (direct-CTE, async burst 256×4 KiB at one blob, 5 paired runs): off ~12.5 ms vs on ~3.4 ms → **3.68x median, 5/5, non-overlapping**.

**Honest limitation:** the win does NOT reach fio-through-clio-fs — the adapter/chimod layers reshape the burst so nothing co-arrives to merge (parity there). Moving it onto the POSIX path needs the cfs adapter to emit a vectored PutBlob per page (part A's API). See design doc §10.

## C. Block-fragmentation moved from CTE → bdev allocator
`ExtendBlob`'s 64 KB block cap was fragmentation-avoidance in the wrong layer. Now the bdev allocator assembles a large request from freed extents (`AllocateAnyUpTo`, physical-footprint accounting); `AllocateFromTarget` returns all blocks; `ExtendBlob` requests the whole extent. A fresh 1 MiB blob is **1 block, not 16**. Decisive regression test `test_bdev_fragmentation`: **0/20 (EIO) without the fix, 20/20 with it** (the 074/521/522 scenario). No effect on 4 KiB fio (writes never hit the cap); helps large writes and churn correctness.

## Bugs fixed while building this
Emit-vs-Passthrough id reassignment (client hang); use-after-free on the erased `BatchKey`; folding resuming coroutines into merged tasks; merged task parented to a stale finished task; `Send`-from-inside-the-drain-loop producer==consumer deadlock (root-caused via `/proc/wchan`, fixed by inline execution); the frag loop reproducing its own category mismatch; a physical-vs-logical accounting leak.

## Tests (registered as ctest so CI runs them)
`cte_vectored_blob_io` (incl. malformed-segment rejection), `cte_concurrent_same_blob_batched` (the merge path — dark in coverage before, since it gates on `CLIO_CTE_BATCHING`), `cte_bdev_fragmentation`. Full CTE suite 12/12 with batching on; core_functionality 13/13.

Design doc, hazards, phasing, and the fio analysis in `project_worker_task_batching.md`.

Closes #820.
