### PR TITLE
fix(aarch64): align Singleton static storage for atomic members

### DIFF
--- a/context-transport-primitives/include/clio_ctp/util/singleton.h
+++ b/context-transport-primitives/include/clio_ctp/util/singleton.h
@@ -68,12 +68,19 @@ class SingletonBase {
   }
 
   static ctp::SpinLock &GetSpinLock() {
-    static char spinlock_data_[sizeof(ctp::SpinLock)] = {0};
+    // alignas: SpinLock holds ipc::atomic<u64> members needing 8-byte
+    // alignment. A bare char[] is only 1-byte aligned, so on aarch64 the
+    // atomic load/fetch_add instructions (LDADD/LDAXR) fault with SIGBUS when
+    // this storage lands off an 8-byte boundary (as it does inside the python
+    // extension .so). x86 tolerates the misalignment; ARM does not.
+    alignas(ctp::SpinLock) static char spinlock_data_[sizeof(ctp::SpinLock)] = {0};
     return *(ctp::SpinLock *)spinlock_data_;
   }
 
   static T *GetData() {
-    static char data_[sizeof(T)] = {0};
+    // alignas(T): a bare char[] is 1-byte aligned; if T contains atomics
+    // (e.g. SystemInfo) an unaligned atomic access SIGBUSes on aarch64.
+    alignas(T) static char data_[sizeof(T)] = {0};
     return (T *)data_;
   }
 
@@ -115,13 +122,20 @@ class CrossSingletonBase {
 
   CTP_INLINE_CROSS_FUN
   static ctp::SpinLock &GetSpinLock() {
-    static char spinlock_data_[sizeof(ctp::SpinLock)] = {0};
+    // alignas: SpinLock holds ipc::atomic<u64> members needing 8-byte
+    // alignment. A bare char[] is only 1-byte aligned, so on aarch64 the
+    // atomic load/fetch_add instructions (LDADD/LDAXR) fault with SIGBUS when
+    // this storage lands off an 8-byte boundary (as it does inside the python
+    // extension .so). x86 tolerates the misalignment; ARM does not.
+    alignas(ctp::SpinLock) static char spinlock_data_[sizeof(ctp::SpinLock)] = {0};
     return *(ctp::SpinLock *)spinlock_data_;
   }
 
   CTP_INLINE_CROSS_FUN
   static T *GetData() {
-    static char data_[sizeof(T)] = {0};
+    // alignas(T): a bare char[] is 1-byte aligned; if T contains atomics
+    // (e.g. SystemInfo) an unaligned atomic access SIGBUSes on aarch64.
+    alignas(T) static char data_[sizeof(T)] = {0};
     return (T *)data_;
   }
 


### PR DESCRIPTION
Fixes #824.

On aarch64, `SingletonBase`/`CrossSingletonBase` in `clio_ctp/util/singleton.h`
backed their singleton and spin-lock storage with a bare `static char[sizeof(X)]`
(1-byte aligned). `ctp::SpinLock` holds `ipc::atomic<u64>` members needing 8-byte
alignment, so the atomic instructions (`LDADD`/`LDAXR`/`STXR`) fault with `SIGBUS`
when the storage lands off a natural boundary. This bus-errored the Python
extension (`clio_cte_core_ext`) inside `SpinLock::Lock()` via
`CrossSingleton<Pthread>` during `Future::Wait()`. x86 tolerated the misalignment,
so it only showed up on ARM.

**Fix:** add `alignas(ctp::SpinLock)` to `spinlock_data_` and `alignas(T)` to
`data_` in both classes. No logic change; guarantees natural alignment everywhere.

**Verification (Vista GH200, aarch64, CUDA 12.5, Python 3.12):** all 5
previously-SIGBUS-ing tests pass after rebuild:

```
python_bindings_test ............ Passed
python_telemetry_test ........... Passed
python_semantic_search_test ..... Passed
python_temporal_search_test ..... Passed
cee_python_retrieve_roundtrip ... Passed
100% tests passed, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
