### PR TITLE
Private-memory AsyncGetBlob (#823)

### DIFF
--- a/context-transfer-engine/core/include/clio_cte/core/core_client.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_client.h
@@ -560,6 +560,85 @@ class Client : public clio::run::ContainerClient {
   }
 
   /**
+   * Private-memory AsyncGetBlob (issue #823): read a blob region straight into
+   * a caller-owned PRIVATE buffer (char*), instead of making the caller
+   * hand-manage a shared-memory buffer (allocate → pass ShmPtr → copy out →
+   * free) as the ShmPtr overload above requires.
+   *
+   * Three paths, fastest first:
+   *  - Shared-cache hit: the bytes are copied out of the RAM bdev's shared
+   *    segment with ZERO IPC and an already-satisfied (empty) Future is
+   *    returned, so Wait() returns immediately. Same fast path the synchronous
+   *    Tag::GetBlob(char*) uses.
+   *  - Runtime (co-located) mode: the daemon shares this address space, so the
+   *    private pointer is wrapped as a null-allocator ShmPtr — IpcManager::
+   *    ToFullPtr resolves such a pointer's offset AS the absolute address — and
+   *    the bdev read lands DIRECTLY in the caller's buffer. No staging buffer,
+   *    no copy, and NOT TASK_DATA_OWNER (the buffer is the caller's, not ours).
+   *  - Client mode: the daemon cannot reach private memory, so the read is
+   *    staged through a freshly allocated SHM buffer. The task is marked
+   *    TASK_DATA_OWNER (its destructor frees the staging buffer on DelTask) and
+   *    GetBlobTask::PostWait() copies the staged bytes into the caller's buffer
+   *    when the read completes.
+   *
+   * @return A Future over the read. On the cache-hit path the Future is EMPTY
+   *         (Wait() succeeds immediately; do not dereference it). On the other
+   *         paths the task is readable after Wait() (GetReturnCode()==0 on
+   *         success). An empty Future is also returned if SHM staging could not
+   *         be allocated in client mode.
+   */
+  clio::run::Future<GetBlobTask> AsyncGetBlob(
+      const TagId &tag_id, const std::string &blob_name,
+      clio::run::u64 offset, clio::run::u64 size, clio::run::u32 flags,
+      char *priv_data,
+      const clio::run::PoolQuery &pool_query = clio::run::PoolQuery::Dynamic(),
+      const Context &context = Context()) {
+    auto *ipc_manager = CLIO_CPU_IPC;
+
+    // Fastest path: node-local RAM-resident blob → copy straight out of shared
+    // memory. A miss (not cached / not direct-readable / placement moved) falls
+    // through to a real task, so this is only ever faster, never wrong.
+    if (priv_data != nullptr && size > 0 && HasShmCache() &&
+        TryReadBlobShm(tag_id, blob_name, priv_data, size, offset)) {
+      return clio::run::Future<GetBlobTask>();
+    }
+
+    if (CLIO_RUNTIME_MANAGER->IsRuntime()) {
+      // Co-located daemon: write directly into the private buffer. The null
+      // AllocatorId marks the offset as an absolute process address.
+      ctp::ipc::ShmPtr<> raw = ctp::ipc::ShmPtr<>::FromRaw(priv_data);
+      auto task = ipc_manager->NewTask<GetBlobTask>(
+          clio::run::CreateTaskId(), pool_id_, pool_query, tag_id, blob_name,
+          offset, size, flags, raw, context);
+      return ipc_manager->Send(task);
+    }
+
+    // Client: stage through an SHM buffer; PostWait() copies it into priv_data
+    // and ~GetBlobTask (TASK_DATA_OWNER) frees the staging buffer.
+    ctp::ipc::FullPtr<char> staging = ipc_manager->AllocateBuffer(size);
+    if (staging.IsNull()) {
+      return clio::run::Future<GetBlobTask>();
+    }
+    auto task = ipc_manager->NewTask<GetBlobTask>(
+        clio::run::CreateTaskId(), pool_id_, pool_query, tag_id, blob_name,
+        offset, size, flags, ctp::ipc::ShmPtr<>(staging.shm_), context);
+    auto *t = task.get();
+    // priv_dest_/priv_src_ are NOT serialized, so they stay on this client
+    // instance (the daemon's copy default-constructs them to null).
+    t->priv_dest_ = priv_data;
+    t->priv_src_ = staging.ptr_;
+    auto fut = ipc_manager->Send(task);
+    // Mark ownership only AFTER Send has serialized the task: Task::SerializeIn
+    // ships task_flags_, so setting TASK_DATA_OWNER earlier would hand the flag
+    // to the daemon, whose task shares the very same physical SHM buffer on the
+    // local path — and it would free the client's buffer out from under us.
+    // Set client-side, this instance's ~GetBlobTask frees the staging buffer
+    // when the Future (task) is destroyed. Same object the Future retains.
+    t->SetFlags(TASK_DATA_OWNER);
+    return fut;
+  }
+
+  /**
    * Vectored get (issue #820): read N regions of one blob in a SINGLE task,
    * each region landing in its OWN buffer.
    *

--- a/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
@@ -37,6 +37,7 @@
 #include <algorithm>
 #include <atomic>
 #include <cassert>
+#include <cstring>
 
 #include <clio_runtime/clio_runtime.h>
 #include <clio_cte/core/autogen/core_methods.h>
@@ -1587,6 +1588,29 @@ struct GetBlobTask : public clio::run::Task {
   IN clio::run::u32 gpu_page_idx_;
   INOUT Context context_;  // Emulation control + modeled time (issue #747)
 
+  /**
+   * Private-memory destination for the client-mode fast path (issue #823).
+   *
+   * Both are HOST-ONLY process pointers and are deliberately NOT serialized
+   * (they are absent from SerializeIn/SerializeOut) — a raw address is
+   * meaningless in the daemon's address space, and adding them here does not
+   * change the wire layout. They matter only on the client instance the
+   * Future retains.
+   *
+   * When a private-memory AsyncGetBlob runs in CLIENT mode it must stage the
+   * read through a shared-memory buffer (the daemon cannot reach the caller's
+   * private buffer). `priv_src_` is the client-local address of that SHM
+   * staging buffer (also referenced as blob_data_ in offset form) and
+   * `priv_dest_` is the caller's private buffer. PostWait() copies size_ bytes
+   * src→dest once the read completes; TASK_DATA_OWNER then frees the staging
+   * buffer when the task is destroyed. Left null on every other path (runtime
+   * mode writes straight into the private buffer via a null-allocator ShmPtr,
+   * and every pre-existing caller passes SHM buffers), so PostWait() is a
+   * no-op for them.
+   */
+  char *priv_dest_ = nullptr;  // caller's private buffer (copy target)
+  char *priv_src_ = nullptr;   // client-local addr of the SHM staging buffer
+
   // SHM constructor
   CTP_CROSS_FUN GetBlobTask()
       : clio::run::Task(),
@@ -1652,6 +1676,23 @@ struct GetBlobTask : public clio::run::Task {
       if (ipc_manager) {
         ipc_manager->FreeBuffer(blob_data_.template Cast<char>());
       }
+    }
+#endif
+  }
+
+  /**
+   * Post-completion hook (issue #823): deliver a client-mode private-memory
+   * read into the caller's buffer. Called by Future::Wait() after the read
+   * completes and before the task is reaped. A no-op unless both private
+   * pointers were set (only CoreClient::AsyncGetBlob(char*)'s client-mode path
+   * sets them), so it never disturbs the SHM/runtime-direct/vectored callers.
+   * The staging buffer itself is freed by ~GetBlobTask via TASK_DATA_OWNER.
+   */
+  void PostWait() {
+#if !CTP_IS_DEVICE_PASS
+    if (priv_dest_ != nullptr && priv_src_ != nullptr && size_ > 0 &&
+        GetReturnCode() == 0) {
+      std::memcpy(priv_dest_, priv_src_, size_);
     }
 #endif
   }

--- a/context-transfer-engine/test/unit/CMakeLists.txt
+++ b/context-transfer-engine/test/unit/CMakeLists.txt
@@ -1285,6 +1285,70 @@ set_tests_properties(cfs_shm_read PROPERTIES
     LABELS "unit;cte;cfs;msan_skip")
 endif()  # UNIX
 
+# Private-memory AsyncGetBlob (issue #823). UNIX-only because the "separate"
+# configuration forks a real clio_run daemon (RuntimeServer / unistd.h), the
+# same shape the cfs_shm_read test uses. The two ctest entries below run the
+# SAME binary in the two runtime configurations the issue calls for: inline
+# (co-located runtime -> direct write into private memory) and separate (pure
+# client -> SHM staging + PostWait copy).
+if(UNIX)
+add_executable(test_getblob_priv
+    test_getblob_priv.cc
+)
+
+target_include_directories(test_getblob_priv PRIVATE
+    ${CMAKE_SOURCE_DIR}/context-runtime/test
+)
+
+target_compile_definitions(test_getblob_priv PRIVATE
+    CLIO_RUN_EXE="$<TARGET_FILE:clio_run>")
+
+target_link_libraries(test_getblob_priv
+    clio_cte_core_client
+    # Config helpers used by the client live in the runtime library; keep it
+    # after the client on the link line (see the cfs_shm_read note above).
+    clio_cte_core_runtime
+    clio::run::admin_client
+    clio::run::bdev_client
+    ctp::cxx
+    ${CMAKE_THREAD_LIBS_INIT}
+)
+
+# The co-located (inline) runtime dlopens the chimods from CLIO_REPO_PATH; the
+# separate configuration forks clio_run. Both need the runtime modules built.
+add_dependencies(test_getblob_priv
+    clio_run
+    clio_cte_core_runtime
+    clio_bdev_runtime
+    clio_admin_runtime)
+
+set(_getblob_priv_env
+    "CLIO_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CLIO_BIND_ADDR=127.0.0.1")
+if(APPLE)
+  string(APPEND _getblob_priv_env ";CLIO_IPC_MODE=ipc")
+endif()
+
+# Inline: this process starts the runtime co-located (direct-write path).
+add_test(NAME cte_getblob_priv_inline
+    COMMAND test_getblob_priv
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set_tests_properties(cte_getblob_priv_inline PROPERTIES
+    ENVIRONMENT "${_getblob_priv_env}"
+    RESOURCE_LOCK "clio_runtime_port"
+    TIMEOUT 120
+    LABELS "unit;core;cte;msan_skip")
+
+# Separate: forks a real daemon and attaches as a pure client (staging path).
+add_test(NAME cte_getblob_priv_separate
+    COMMAND test_getblob_priv
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set_tests_properties(cte_getblob_priv_separate PROPERTIES
+    ENVIRONMENT "${_getblob_priv_env};CLIO_GETBLOB_PRIV_MODE=separate"
+    RESOURCE_LOCK "clio_runtime_port"
+    TIMEOUT 180
+    LABELS "unit;core;cte;msan_skip")
+endif()  # UNIX
+
 add_executable(test_cte_gpu_metadata_cache
     test_cte_gpu_metadata_cache.cc
 )

--- a/context-transfer-engine/test/unit/test_getblob_priv.cc
+++ b/context-transfer-engine/test/unit/test_getblob_priv.cc
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved. BSD 3-Clause license.
+ */
+
+/**
+ * Private-memory AsyncGetBlob (issue #823).
+ *
+ * CoreClient::AsyncGetBlob(char*) reads a blob region straight into a
+ * caller-owned PRIVATE buffer instead of making the caller hand-manage an SHM
+ * buffer. It resolves to one of three paths, and this test exercises them in
+ * BOTH runtime configurations, because the path taken depends on the config:
+ *
+ *   - Runtime started INLINE (co-located): the daemon shares this address
+ *     space, so the private pointer is wrapped as a null-allocator ShmPtr and
+ *     the read lands directly in the caller's buffer. `CLIO_GETBLOB_PRIV_MODE`
+ *     unset / "inline".
+ *   - Runtime started SEPARATE (its own process): a pure client cannot expose
+ *     private memory, so the read is staged through an SHM buffer, the task is
+ *     marked TASK_DATA_OWNER, and GetBlobTask::PostWait() copies the staged
+ *     bytes into the caller's buffer. `CLIO_GETBLOB_PRIV_MODE=separate`.
+ *
+ * Both configs additionally exercise the zero-IPC shared-cache fast path when
+ * the cache is attachable.
+ *
+ * The buffers handed to the API here are genuine private memory
+ * (std::vector<char> / stack), never SHM — that is the whole point of the API.
+ */
+
+#include <fcntl.h>
+#include <signal.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "clio_cte/core/core_client.h"
+#include "clio_runtime/bdev/bdev_client.h"
+#include "clio_runtime/clio_runtime.h"
+#include "runtime_server.h"
+#include "simple_test.h"
+
+using namespace std::chrono_literals;
+
+namespace {
+
+constexpr clio::run::u64 kRamTargetBytes = 256ULL * 1024 * 1024;
+constexpr unsigned kPort = 10623;
+const char *kTargetName = "getblob_priv_target";
+
+/** True when CLIO_GETBLOB_PRIV_MODE=separate: bring up a daemon in its own
+ *  process and attach as a pure client (exercises the client-staging path).
+ *  Otherwise the runtime is started inline (exercises the direct-write path). */
+bool SeparateMode() {
+  const char *m = std::getenv("CLIO_GETBLOB_PRIV_MODE");
+  return m != nullptr && std::string(m) == "separate";
+}
+
+/** Run `clio_run <args>` to completion, returning its exit code. */
+int RunCli(const std::vector<std::string> &args, int timeout_sec) {
+  std::vector<std::string> full;
+  full.push_back(CLIO_RUN_EXE);
+  full.insert(full.end(), args.begin(), args.end());
+  std::vector<char *> argv;
+  for (auto &a : full) argv.push_back(a.data());
+  argv.push_back(nullptr);
+  pid_t pid = fork();
+  if (pid < 0) return -1;
+  if (pid == 0) {
+    execv(argv[0], argv.data());
+    _exit(127);
+  }
+  auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(timeout_sec);
+  int status = 0;
+  while (true) {
+    pid_t r = waitpid(pid, &status, WNOHANG);
+    if (r == pid) return WIFEXITED(status) ? WEXITSTATUS(status) : -2;
+    if (std::chrono::steady_clock::now() >= deadline) {
+      kill(pid, SIGKILL);
+      waitpid(pid, &status, 0);
+      return -3;
+    }
+    std::this_thread::sleep_for(100ms);
+  }
+}
+
+clio::run::test::RuntimeServer *g_server = nullptr;
+
+/** Deterministic byte at logical position i of the test pattern. */
+char PatternByte(size_t i) { return static_cast<char>((i * 131 + 7) & 0xFF); }
+
+class Fixture {
+ public:
+  bool initialized_ = false;
+  bool separate_ = false;
+
+  Fixture() {
+    separate_ = SeparateMode();
+    if (separate_) {
+      initialized_ = InitSeparate();
+    } else {
+      initialized_ = InitInline();
+    }
+  }
+
+  /** Inline: this process IS the runtime. Register a RAM target by hand. */
+  bool InitInline() {
+    if (!clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, true)) {
+      return false;
+    }
+    std::this_thread::sleep_for(300ms);
+    if (!clio::cte::core::CLIO_CTE_CLIENT_INIT()) {
+      return false;
+    }
+    std::this_thread::sleep_for(200ms);
+
+    auto *cte = CLIO_CTE_CLIENT;
+    clio::run::PoolId bdev_pool_id(915, 0);
+    clio::run::bdev::Client bdev_client(bdev_pool_id);
+    auto create = bdev_client.AsyncCreate(clio::run::PoolQuery::Dynamic(),
+                                          kTargetName, bdev_pool_id,
+                                          clio::run::bdev::BdevType::kRam,
+                                          kRamTargetBytes);
+    create.Wait();
+    auto reg = cte->AsyncRegisterTarget(kTargetName,
+                                        clio::run::bdev::BdevType::kRam,
+                                        kRamTargetBytes,
+                                        clio::run::PoolQuery::Local(),
+                                        bdev_pool_id);
+    reg.Wait();
+    if (reg->GetReturnCode() != 0) return false;
+    // Best-effort: attach the SHM metadata cache so the zero-IPC path can run.
+    (void)cte->AttachShmCache();
+    return true;
+  }
+
+  /** Separate: compose a real daemon in its own process, attach as a client. */
+  bool InitSeparate() {
+    const std::string work = "/tmp/clio_getblob_priv_test";
+    std::filesystem::remove_all(work);
+    std::filesystem::create_directories(work);
+    const std::string yaml = work + "/compose.yaml";
+    {
+      std::ofstream f(yaml);
+      f << "compose:\n"
+           "  - mod_name: clio_cte_core\n"
+           "    pool_name: \"getblob_priv_cte\"\n"
+           "    pool_query: local\n"
+           "    pool_id: \"515.0\"\n"
+           "    storage:\n"
+           "      - path: "
+        << work << "/ram_dev\n"
+           "        bdev_type: ram\n"
+           "        capacity_limit: "
+        << (kRamTargetBytes / (1024 * 1024)) << "mb\n"
+           "    dpe:\n"
+           "      dpe_type: random\n";
+    }
+
+    setenv("CLIO_WAIT_SERVER", "15", 1);
+    setenv("CLIO_BIND_ADDR", "127.0.0.1", 1);
+
+    static clio::run::test::RuntimeServer server;
+    g_server = &server;
+    if (!server.Start(kPort) || !server.WaitForReady()) {
+      return false;
+    }
+    if (RunCli({"compose", "start", yaml}, 60) != 0) {
+      return false;
+    }
+    if (!clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, false)) {
+      return false;
+    }
+    if (!clio::cte::core::CLIO_CTE_CLIENT_INIT()) {
+      return false;
+    }
+    (void)CLIO_CTE_CLIENT->AttachShmCache();
+    return true;
+  }
+};
+
+Fixture *g_fixture = nullptr;
+
+/** Put `n` bytes of the deterministic pattern (starting at pattern index
+ *  `base`) at [off, off+n) of `blob`, through an ordinary SHM PutBlob. */
+void PutPattern(clio::cte::core::TagId tag_id, const std::string &blob,
+                clio::run::u64 off, size_t n, size_t base) {
+  auto *ipc = CLIO_IPC;
+  auto *cte = CLIO_CTE_CLIENT;
+  ctp::ipc::FullPtr<char> buf = ipc->AllocateBuffer(n);
+  REQUIRE(!buf.IsNull());
+  for (size_t i = 0; i < n; ++i) buf.ptr_[i] = PatternByte(base + i);
+  auto p = cte->AsyncPutBlob(tag_id, blob, off, n, ctp::ipc::ShmPtr<>(buf.shm_));
+  p.Wait();
+  REQUIRE(p->GetReturnCode() == 0);
+  ipc->FreeBuffer(buf);
+}
+
+}  // namespace
+
+// The heart of the issue: read into PRIVATE memory and get the right bytes,
+// under whichever runtime configuration the fixture chose.
+TEST_CASE("GetBlob into private memory returns correct bytes", "[cte][823]") {
+  REQUIRE(g_fixture != nullptr);
+  REQUIRE(g_fixture->initialized_);
+  auto *cte = CLIO_CTE_CLIENT;
+
+  clio::cte::core::Tag tag("getblob_priv_tag");
+  clio::cte::core::TagId tag_id = tag.GetTagId();
+
+  const std::string blob = "priv_blob";
+  const size_t kN = 64 * 1024;  // 64 KiB
+  PutPattern(tag_id, blob, 0, kN, 0);
+
+  // Full read into a genuinely private buffer (heap, not SHM).
+  std::vector<char> priv(kN, 0);
+  auto g = cte->AsyncGetBlob(tag_id, blob, 0, kN, /*flags=*/0, priv.data());
+  g.Wait();  // Empty (cache-hit) future Wait()s to true; otherwise task rc==0.
+  for (size_t i = 0; i < kN; ++i) {
+    REQUIRE(priv[i] == PatternByte(i));
+  }
+
+  // Offset read of a sub-range lands the right slice at the buffer start.
+  const size_t kOff = 4096, kLen = 8192;
+  std::vector<char> sub(kLen, 0);
+  auto g2 = cte->AsyncGetBlob(tag_id, blob, kOff, kLen, 0, sub.data());
+  g2.Wait();
+  for (size_t i = 0; i < kLen; ++i) {
+    REQUIRE(sub[i] == PatternByte(kOff + i));
+  }
+}
+
+// Repeated reads must not leak or hang: the client path allocates a staging
+// buffer per call and relies on TASK_DATA_OWNER to reclaim it. A leak here
+// exhausts the main SHM segment and later reads fail; a missed free would trip
+// the allocator's leak checker at shutdown.
+TEST_CASE("Private GetBlob is leak-free under repetition", "[cte][823]") {
+  REQUIRE(g_fixture != nullptr);
+  REQUIRE(g_fixture->initialized_);
+  auto *cte = CLIO_CTE_CLIENT;
+
+  clio::cte::core::Tag tag("getblob_priv_loop_tag");
+  clio::cte::core::TagId tag_id = tag.GetTagId();
+
+  const std::string blob = "loop_blob";
+  const size_t kN = 32 * 1024;
+  PutPattern(tag_id, blob, 0, kN, 11);
+
+  for (int iter = 0; iter < 256; ++iter) {
+    std::vector<char> priv(kN, 0);
+    auto g = cte->AsyncGetBlob(tag_id, blob, 0, kN, 0, priv.data());
+    g.Wait();
+    // Spot-check a few positions each iteration (full compare would dominate
+    // runtime); correctness of the whole buffer is covered by the case above.
+    REQUIRE(priv[0] == PatternByte(11));
+    REQUIRE(priv[kN / 2] == PatternByte(11 + kN / 2));
+    REQUIRE(priv[kN - 1] == PatternByte(11 + kN - 1));
+  }
+}
+
+// The zero-IPC shared-cache fast path, when the cache is attachable, must
+// deliver identical bytes (it copies straight out of the RAM bdev's segment
+// and returns an empty, already-satisfied future).
+TEST_CASE("Private GetBlob shared-cache fast path is correct", "[cte][823]") {
+  REQUIRE(g_fixture != nullptr);
+  REQUIRE(g_fixture->initialized_);
+  auto *cte = CLIO_CTE_CLIENT;
+  if (!cte->HasShmCache() && !cte->AttachShmCache()) {
+    // Cache unavailable in this configuration; the direct/staged paths are
+    // covered by the cases above. Nothing to assert here.
+    return;
+  }
+
+  clio::cte::core::Tag tag("getblob_priv_cache_tag");
+  clio::cte::core::TagId tag_id = tag.GetTagId();
+  const std::string blob = "cache_blob";
+  const size_t kN = 16 * 1024;
+  PutPattern(tag_id, blob, 0, kN, 99);
+
+  std::vector<char> priv(kN, 0);
+  auto g = cte->AsyncGetBlob(tag_id, blob, 0, kN, 0, priv.data());
+  g.Wait();
+  for (size_t i = 0; i < kN; ++i) {
+    REQUIRE(priv[i] == PatternByte(99 + i));
+  }
+}
+
+int main(int argc, char **argv) {
+  static Fixture fixture;
+  g_fixture = &fixture;
+  std::string filter = (argc > 1) ? argv[1] : "";
+  int rc = SimpleTest::run_all_tests(filter);
+  clio::run::CLIO_RUNTIME_FINALIZE();
+  return rc;
+}


### PR DESCRIPTION
## Summary
Adds `CoreClient::AsyncGetBlob(char*)` — reads a blob region straight into a caller-owned **private** buffer, instead of forcing the caller through the allocate-SHM → pass-`ShmPtr` → copy-out → free dance the existing `ShmPtr` overload requires. Resolves to one of three paths, fastest first:

- **Shared-cache hit** — copies the bytes straight out of the RAM bdev's shared segment with zero IPC and returns an already-satisfied (empty) `Future` (`Wait()` returns immediately).
- **Runtime (co-located) mode** — the daemon shares this address space, so the private pointer is wrapped as a null-allocator `ShmPtr` (`IpcManager::ToFullPtr` resolves such an offset **as** an absolute address) and the bdev read lands directly in the caller's buffer. No staging buffer, no copy, no `FullPtr` allocation.
- **Client mode** — the daemon cannot reach private memory, so the read is staged through a freshly allocated SHM buffer. `GetBlobTask` gains two host-only, **non-serialized** fields (`priv_dest_`/`priv_src_`) and a `PostWait()` override that copies the staged bytes into the caller's buffer once the read completes; `TASK_DATA_OWNER` frees the staging buffer when the task is destroyed.

Fixes #823.

## Correctness note
`TASK_DATA_OWNER` is set **only after** `Send` has serialized the task. `Task::SerializeIn` ships `task_flags_`, so setting it earlier would hand the flag to the daemon — whose task shares the very same physical SHM buffer on the local path — and it would free the client's buffer out from under us. The two new fields are absent from `SerializeIn`/`SerializeOut`, so the wire layout is unchanged.

## Test plan
`context-transfer-engine/test/unit/test_getblob_priv.cc`, run in **both** configurations the issue calls for, registered as two ctest entries:
- `cte_getblob_priv_inline` — co-located runtime → exercises the direct-write path.
- `cte_getblob_priv_separate` — forks a real `clio_run` daemon and attaches as a pure client → exercises the SHM-staging + `PostWait` path.

Cases: correctness of a full read into a `std::vector<char>`, offset sub-range reads, the shared-cache fast path, and a 256-iteration leak/repeat loop that proves `TASK_DATA_OWNER` reclaims the staging buffers (no SHM exhaustion, clean shutdown).

- [x] `cte_getblob_priv_inline` — 3/3 pass locally
- [x] `cte_getblob_priv_separate` — 3/3 pass locally
- [x] `test_vectored_blob_io` (same `GetBlobTask` struct) — 2/2, no regression
- [x] cpplint clean on all changed files

## Base
Stacked on `820-worker-task-batching` (open PR #821 → `dev`); this PR's diff is only the #823 changes. Rebase onto `dev` once #820 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)