### PR TITLE
Expose private-memory GetBlob on Tag + Python (#823)

### DIFF
--- a/context-transfer-engine/core/include/clio_cte/core/core_client.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_client.h
@@ -1414,6 +1414,26 @@ class Tag {
                size_t data_size, size_t off = 0);
 
   /**
+   * Asynchronous private-memory GetBlob (issue #823): read a blob region
+   * straight into a caller-owned PRIVATE buffer (char*, e.g. heap/stack), with
+   * no manual shared-memory management. Delegates to
+   * CoreClient::AsyncGetBlob(char*) — see there for the three paths (shared
+   * cache / runtime-direct / client-staging).
+   *
+   * @param blob_name Name of the blob to retrieve
+   * @param data Output PRIVATE buffer (pre-allocated by caller, >= data_size)
+   * @param data_size Size of data to retrieve (must be > 0)
+   * @param off Offset within blob (default 0)
+   * @return Future over the read. On the shared-cache path the Future is EMPTY
+   *         (Wait() returns immediately; do not dereference it); otherwise the
+   *         task is readable after Wait() (GetReturnCode()==0 on success). The
+   *         buffer holds the bytes once Wait() returns.
+   */
+  clio::run::Future<GetBlobTask> AsyncGetBlob(const std::string &blob_name,
+                                              char *data, size_t data_size,
+                                              size_t off = 0);
+
+  /**
    * Get blob score
    * @param blob_name Name of the blob
    * @return Blob score (0.0-1.0)

--- a/context-transfer-engine/core/src/tag.cc
+++ b/context-transfer-engine/core/src/tag.cc
@@ -219,6 +219,25 @@ void Tag::GetBlob(const std::string &blob_name, char *data, size_t data_size, si
   ipc_manager->FreeBuffer(shm_fullptr);
 }
 
+clio::run::Future<GetBlobTask> Tag::AsyncGetBlob(const std::string &blob_name,
+                                                 char *data, size_t data_size,
+                                                 size_t off) {
+  // Validate input parameters
+  if (data_size == 0) {
+    throw std::invalid_argument("data_size must be specified for AsyncGetBlob");
+  }
+  if (data == nullptr) {
+    throw std::invalid_argument("data buffer must be pre-allocated by caller");
+  }
+
+  // issue #823: read straight into the caller's PRIVATE buffer. The client
+  // picks the fastest of shared-cache / runtime-direct / client-staging; the
+  // returned Future is empty on a cache hit and readable otherwise.
+  auto *cte_client = CLIO_CTE_CLIENT;
+  return cte_client->AsyncGetBlob(tag_id_, blob_name, off, data_size,
+                                  /*flags=*/0, data);
+}
+
 void Tag::GetBlob(const std::string &blob_name, ctp::ipc::ShmPtr<> data, size_t data_size, size_t off) {
   // Validate input parameters
   if (data_size == 0) {

--- a/context-transfer-engine/wrapper/python/core_bindings.cc
+++ b/context-transfer-engine/wrapper/python/core_bindings.cc
@@ -307,12 +307,25 @@ NB_MODULE(clio_cte_core_ext, m) {
              // binary, and nanobind decodes a returned std::string as UTF-8,
              // which raises UnicodeDecodeError on any non-text payload. This
              // also mirrors PutBlob, which already accepts nb::bytes.
+             //
+             // The std::string's buffer IS private memory, so this reads
+             // straight into it via the private-memory path (issue #823): no
+             // manual SHM allocate/copy/free, and a zero-IPC copy when the blob
+             // is in the shared cache.
              std::string result(data_size, '\0');
-             self.GetBlob(blob_name, result.data(), data_size, off);
+             auto fut =
+                 self.AsyncGetBlob(blob_name, result.data(), data_size, off);
+             fut.Wait();
+             // Empty (cache-hit) future -> already succeeded, do not deref.
+             // Non-empty (miss) future -> the task carries the return code.
+             if (fut.get() != nullptr && fut.get()->GetReturnCode() != 0) {
+               throw std::runtime_error("GetBlob operation failed");
+             }
              return nb::bytes(result.data(), result.size());
            },
            "blob_name"_a, "data_size"_a, "off"_a = 0,
-           "Get blob data. Automatically allocates shared memory and copies data. "
+           "Get blob data into a private buffer (issue #823): no manual shared "
+           "memory management, and a zero-IPC copy on a shared-cache hit. "
            "Args: blob_name (str), data_size (int), off (int, optional). "
            "Returns: bytes containing the raw blob data")
       .def("GetBlobScore", &clio::cte::core::Tag::GetBlobScore,


### PR DESCRIPTION
## Summary
Follow-up to #829 (which added `CoreClient::AsyncGetBlob(char*)` and merged into `820-worker-task-batching`). This exposes that private-memory read through the **Tag API** and **Python**:

- **Tag C++ API** — `Tag::AsyncGetBlob(blob_name, char* data, size, off)`, a Tag-level entry point that delegates to `CoreClient::AsyncGetBlob(char*)`. The caller's own heap/stack buffer is the destination: no manual SHM allocate/copy/free, and a zero-IPC copy when the blob is in the shared cache.
- **Python** — the `Tag.GetBlob` nanobind binding now reads through this path. The `bytes` buffer it fills (a `std::string`) is already private memory, so it reads straight into it. Error semantics are preserved: the miss-path task's return code is checked (an empty cache-hit future is success and is never dereferenced), and it still raises on error. Blocking + `bytes`-returning, so Python callers get the optimization transparently with no API change.

Part of #823.

## Test plan
- [x] `Tag::AsyncGetBlob` compiles in the CTE core libs; cpplint clean on all changed files.
- [x] The nanobind extension `clio_cte_core_ext` builds clean with the binding change.
- [x] Existing Python regression `test_cte_getblob_bytes.py` (16 KiB non-UTF-8 `PutBlob`/`GetBlob` round-trip) passes against an inline runtime — now exercising the private-memory path end to end through Python.

## Base
Stacked on `820-worker-task-batching` (same base as #829). This PR's diff is only the Tag + Python commit; rebase onto `dev` once #820/#821 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)