### PR TITLE
Rewrite the round-robin CDP GPU test on CDP2

### DIFF
--- a/context-transport-primitives/test/unit/gpu/CMakeLists.txt
+++ b/context-transport-primitives/test/unit/gpu/CMakeLists.txt
@@ -86,31 +86,31 @@ if(CLIO_CORE_ENABLE_CUDA)
   )
   add_test(NAME test_thread_alloc_gpu COMMAND test_thread_alloc_gpu)
 
-  # RoundRobinAllocator CDP test. This is CDP1-only — it launches child kernels
-  # and calls cudaDeviceSynchronize() from device code, and forces CDP1 via
-  # CUDA_FORCE_CDP1_IF_SUPPORTED. CUDA 13 removed CDP1 entirely (CCCL hard-errors
-  # on CUDA_FORCE_CDP1_IF_SUPPORTED, and device-side cudaDeviceSynchronize is
-  # gone), so only build it on CUDA < 13. A CUDA 13+ build would need a CDP2
-  # rewrite (CDP2 has no device-side synchronize).
+  # RoundRobinAllocator CDP test. The test source picks its CDP flavor from the
+  # toolkit: CDP2 (fire-and-forget children joined by a tail launch) when the
+  # headers expose cudaStreamFireAndForget, else the CDP1 device-side
+  # cudaDeviceSynchronize. So do NOT define CUDA_FORCE_CDP1_IF_SUPPORTED on
+  # CUDA >= 12 — it both hides the CDP2 stream macros and fails to bring back
+  # device-side cudaDeviceSynchronize, which CUDA 12 does not declare at all for
+  # sm_90+ (see issue #828). On CUDA < 12 only CDP1 exists; silence its
+  # 11.6-onwards deprecation warning.
   find_package(CUDAToolkit QUIET)
-  if(CUDAToolkit_VERSION VERSION_LESS 13)
-    add_cuda_executable(test_round_robin_alloc_gpu TRUE test_round_robin_alloc_gpu.cc
-      INCLUDE_DIRS ${CLIO_CTP_GPU_INCLUDE_DIRS}
-      DEFS CUDA_FORCE_CDP1_IF_SUPPORTED __CDPRT_SUPPRESS_SYNC_DEPRECATION_WARNING)
-    target_link_libraries(test_round_robin_alloc_gpu
-      ctp::cuda_cxx
-      Catch2::Catch2WithMain
-    )
-    target_compile_options(test_round_robin_alloc_gpu PRIVATE
-      $<$<COMPILE_LANGUAGE:CUDA>:--extended-lambda -rdc=true>)
-    add_test(NAME test_round_robin_alloc_gpu COMMAND test_round_robin_alloc_gpu)
-    set_tests_properties(test_round_robin_alloc_gpu PROPERTIES
-      TIMEOUT 60 LABELS "gpu;allocator")
-  else()
-    message(STATUS
-      "Skipping test_round_robin_alloc_gpu: CDP1 was removed in CUDA >= 13 "
-      "(needs a CDP2 rewrite — no device-side cudaDeviceSynchronize)")
+  set(CLIO_RR_CDP_DEFS "")
+  if(CUDAToolkit_VERSION VERSION_LESS 12)
+    set(CLIO_RR_CDP_DEFS __CDPRT_SUPPRESS_SYNC_DEPRECATION_WARNING)
   endif()
+  add_cuda_executable(test_round_robin_alloc_gpu TRUE test_round_robin_alloc_gpu.cc
+    INCLUDE_DIRS ${CLIO_CTP_GPU_INCLUDE_DIRS}
+    DEFS ${CLIO_RR_CDP_DEFS})
+  target_link_libraries(test_round_robin_alloc_gpu
+    ctp::cuda_cxx
+    Catch2::Catch2WithMain
+  )
+  target_compile_options(test_round_robin_alloc_gpu PRIVATE
+    $<$<COMPILE_LANGUAGE:CUDA>:--extended-lambda -rdc=true>)
+  add_test(NAME test_round_robin_alloc_gpu COMMAND test_round_robin_alloc_gpu)
+  set_tests_properties(test_round_robin_alloc_gpu PROPERTIES
+    TIMEOUT 60 LABELS "gpu;allocator")
 
   add_subdirectory(runtime)
 

--- a/context-transport-primitives/test/unit/gpu/test_round_robin_alloc_gpu.cc
+++ b/context-transport-primitives/test/unit/gpu/test_round_robin_alloc_gpu.cc
@@ -39,6 +39,14 @@
  *   2. Parent launches N CDP child kernels concurrently
  *   3. Each child claims a partition, allocates, writes, reads, frees
  *   4. Verify no corruption across concurrent child kernels
+ *
+ * CDP flavor: CUDA 12 removed the device-side cudaDeviceSynchronize() that CDP1
+ * used to join child grids (it is not even declared for __CUDA_ARCH__ >= 900,
+ * so forcing CDP1 cannot bring it back on Hopper). The parent therefore uses
+ * CDP2: children go to the fire-and-forget stream and the completion work is
+ * tail-launched, which the runtime schedules only after the parent grid and all
+ * of its fire-and-forget children have finished. Pre-CDP2 toolkits (CUDA < 12,
+ * where cudaStreamFireAndForget is not defined) keep the old CDP1 path.
  */
 
 #include <catch2/catch_all.hpp>
@@ -147,11 +155,32 @@ __global__ void RrChildKernel(
 // Parent kernel: init allocator, launch N CDP children, wait
 // ============================================================================
 
+#if defined(cudaStreamFireAndForget)
+#define CTP_TEST_CDP2 1
+#endif
+
+#ifdef CTP_TEST_CDP2
+/**
+ * Completion kernel, tail-launched by the parent. A tail launch runs only once
+ * the parent grid AND every one of its fire-and-forget children have completed,
+ * so this is the CDP2 replacement for the parent's old cudaDeviceSynchronize().
+ *
+ * @param num_children Number of children that were launched (for the log line)
+ * @param done Completion flag (pinned host memory)
+ */
+__global__ void RrDoneKernel(int num_children, int *done) {
+  if (threadIdx.x != 0) return;
+  printf("[PARENT] All %d children completed\n", num_children);
+  *done = 1;
+  __threadfence_system();
+}
+#endif
+
 /**
  * Parent persistent kernel that:
  *   1. Initializes the RoundRobinAllocator
  *   2. Launches num_children CDP child kernels (fire-and-forget)
- *   3. Uses cudaDeviceSynchronize to wait for all children
+ *   3. Joins them — tail launch under CDP2, cudaDeviceSynchronize under CDP1
  *   4. Writes completion flag
  *
  * @param alloc_base Device memory for the allocator
@@ -187,6 +216,16 @@ __global__ void RrParentKernel(
   printf("[PARENT] RoundRobinAllocator initialized: %d partitions, %zu bytes\n",
          num_partitions, alloc_capacity);
 
+#ifdef CTP_TEST_CDP2
+  // Launch CDP child kernels (fire-and-forget)
+  for (int i = 0; i < num_children; ++i) {
+    RrChildKernel<<<1, 32, 0, cudaStreamFireAndForget>>>(
+        alloc, alloc_size, results, i);
+  }
+
+  // Join: the tail launch is deferred until every child above has completed.
+  RrDoneKernel<<<1, 1, 0, cudaStreamTailLaunch>>>(num_children, done);
+#else
   // Launch CDP child kernels (fire-and-forget)
   for (int i = 0; i < num_children; ++i) {
     RrChildKernel<<<1, 32>>>(alloc, alloc_size, results, i);
@@ -198,6 +237,7 @@ __global__ void RrParentKernel(
   printf("[PARENT] All %d children completed\n", num_children);
   *done = 1;
   __threadfence_system();
+#endif
 }
 
 // ============================================================================
@@ -213,6 +253,10 @@ TEST_CASE("RoundRobinAllocator - CDP concurrent alloc/free", "[gpu][allocator]")
   // Set CDP limits
   cudaDeviceSetLimit(cudaLimitDevRuntimePendingLaunchCount, 256);
   cudaDeviceSetLimit(cudaLimitStackSize, 16384);
+  // CDP2 does not use the pending-launch-count limit and rejects it with
+  // cudaErrorUnsupportedLimit. That is harmless here, but it would otherwise be
+  // picked up by the cudaGetLastError() check on the kernel launch below.
+  cudaGetLastError();
 
   // Allocate device memory for the allocator
   char *d_alloc = ctp::GpuApi::Malloc<char>(kAllocatorCapacity);
@@ -235,7 +279,8 @@ TEST_CASE("RoundRobinAllocator - CDP concurrent alloc/free", "[gpu][allocator]")
   cudaError_t launch_err = cudaGetLastError();
   REQUIRE(launch_err == cudaSuccess);
 
-  // Wait for parent to complete (includes all children via cudaDeviceSynchronize)
+  // Wait for the parent to complete. A grid is not complete until all of its
+  // descendants are, so this covers the children and the tail launch too.
   ctp::GpuApi::Synchronize(stream);
   ctp::GpuApi::DestroyStream(stream);
 
@@ -269,6 +314,10 @@ TEST_CASE("RoundRobinAllocator - CDP many children stress", "[gpu][allocator][st
 
   cudaDeviceSetLimit(cudaLimitDevRuntimePendingLaunchCount, 256);
   cudaDeviceSetLimit(cudaLimitStackSize, 16384);
+  // CDP2 does not use the pending-launch-count limit and rejects it with
+  // cudaErrorUnsupportedLimit. That is harmless here, but it would otherwise be
+  // picked up by the cudaGetLastError() check on the kernel launch below.
+  cudaGetLastError();
 
   char *d_alloc = ctp::GpuApi::Malloc<char>(kAllocatorCapacity);
   REQUIRE(d_alloc != nullptr);


### PR DESCRIPTION
## Summary
- Rewrite `test_round_robin_alloc_gpu` on CDP2: children launch into `cudaStreamFireAndForget`, and a new `RrDoneKernel` launched on `cudaStreamTailLaunch` does the completion work. A tail launch runs only after the parent grid and all of its fire-and-forget children complete — exactly the join the removed device-side `cudaDeviceSynchronize()` provided.
- Keep the CDP1 body under `#else` for pre-CDP2 toolkits, selected on whether the headers define `cudaStreamFireAndForget`.
- Stop defining `CUDA_FORCE_CDP1_IF_SUPPORTED`, and retire the `CUDA >= 13` skip — CDP2 builds on both 12 and 13.

## Motivation
Fixes #828.

CUDA 12 removed the device-side `cudaDeviceSynchronize()` that CDP1 used to join child grids. The CMakeLists already passed `CUDA_FORCE_CDP1_IF_SUPPORTED`, but that cannot help on Hopper — `cuda_device_runtime_api.h` declares the device-side entry point only under `(__CUDA_ARCH__ < 900) && defined(CUDA_FORCE_CDP1_IF_SUPPORTED)`:

```c
#if (__CUDA_ARCH__ < 900) && (defined(CUDA_FORCE_CDP1_IF_SUPPORTED) || ...)
// cudaDeviceSynchronize is removed on sm_90+
extern __device__ ... cudaDeviceSynchronize(void);
#endif
```

So on `sm_90` the call bound to the `__host__` overload:

```
test_round_robin_alloc_gpu.cc(196): error: calling a __host__ function
  ("cudaDeviceSynchronize") from a __global__ function("RrParentKernel")
```

That same macro also suppresses `__CUDA_INTERNAL_USE_CDP2`, which hides the CDP2 stream macros — so it was actively blocking the only fix that keeps the test running on Hopper. This is option 1 from the issue; options 2 and 3 would either drop the CDP coverage this test exists to provide or skip it entirely on every modern toolkit.

One incidental fix: CDP2 does not use `cudaLimitDevRuntimePendingLaunchCount` and rejects it with `cudaErrorUnsupportedLimit`. That sticky error would otherwise be picked up by the `REQUIRE(cudaGetLastError() == cudaSuccess)` on the parent launch, so it is cleared first.

## Test plan
Verified on TACC Vista (GH200, `sm_90`, CUDA 12.5) via a full CDash Release+CUDA build:

- [x] Pre-fix reproduction: standalone `nvcc -arch=sm_90` on the old file produces the issue's two errors at line 196; the patched file compiles clean.
- [x] `test_round_robin_alloc_gpu` passes (0.24 s).
- [x] All existing tests pass: **100% tests passed, 0 failed out of 338**.
- [x] No new compiler warnings; **0 compiler errors** for the full build (previously 1 — the error that cascaded into ~214 "Not Run" tests without `MAKEFLAGS=-k`).
- [x] No new files, so no header changes needed.

Note on test strength: because the host also synchronizes the parent's stream (and a grid is not complete until all its descendants are), the passing children prove the allocator behavior but not tail-launch *ordering* on their own. The `REQUIRE(*h_done == 1)` does prove the tail-launched kernel ran; strict ordering rests on the documented CDP2 guarantee.

## Breaking changes
None. Test-only change. CUDA < 12 builds keep the CDP1 path; CUDA 13 builds gain the test back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
