### PR TITLE
Follow-up to #833: RAM-sized metadata segment default + private-put test suite

### DIFF
--- a/context-runtime/include/clio_runtime/config_manager.h
+++ b/context-runtime/include/clio_runtime/config_manager.h
@@ -436,10 +436,13 @@ class ConfigManager : public ctp::BaseConfig {
   size_t main_segment_size_ = 0;
   size_t client_data_segment_size_ = ctp::Unit<size_t>::Megabytes(256);
   // issue #783: metadata segment. Deliberately huge and never pre-faulted --
-  // shm_open + ftruncate + mmap is lazily populated, so the 8 GB reservation
-  // costs only the pages actually touched. NOTE: on a host whose /dev/shm is
-  // smaller than the live set, touching past the tmpfs limit raises SIGBUS,
-  // not ENOMEM. See CalculateMetadataSegmentSize().
+  // shm_open + ftruncate + mmap is lazily populated, so the reservation
+  // (default: the machine's RAM capacity, so metadata scales with the host)
+  // costs only the pages actually touched. Creation-time safety clamps live in
+  // ipc_manager.cc (half the cgroup-aware budget on Linux; 1 GB file cap
+  // elsewhere). NOTE: on a host whose /dev/shm is smaller than the live set,
+  // touching past the tmpfs limit raises SIGBUS, not ENOMEM. See
+  // CalculateMetadataSegmentSize().
   // 0 means "auto-calculate" — CalculateMetadataSegmentSize() supplies the
   // default. Initialising this to a non-zero size would make the explicit
   // override branch there permanently true and the documented sentinel a lie;

--- a/context-runtime/src/config_manager.cc
+++ b/context-runtime/src/config_manager.cc
@@ -640,12 +640,21 @@ size_t ConfigManager::CalculateMetadataSegmentSize() const {
     return metadata_segment_size_;
   }
 
-  // Default 8 GB. This is an address-space reservation, not an allocation: the
-  // segment is never pre-faulted, so only pages the runtime actually writes
-  // consume RAM. Sized generously because the CTE metadata cache (issue #783)
-  // holds one entry per live tag and blob, and growing the segment later would
-  // invalidate every client's mapping.
-  return ctp::Unit<size_t>::Gigabytes(8);
+  // Default: the machine's RAM capacity. This is an address-space RESERVATION,
+  // not an allocation: the segment is sparse and never pre-faulted, so only
+  // pages the runtime actually writes consume memory. Sizing the reservation
+  // like RAM means metadata capacity scales with the machine instead of hitting
+  // an arbitrary fixed ceiling (the old 8 GB default), and growing the segment
+  // later is impossible without invalidating every client's mapping — so
+  // reserve big up front. Safety is enforced downstream at creation time
+  // (ipc_manager.cc): on Linux the request is clamped to half the
+  // cgroup-aware process memory budget (containers!), and on non-Linux — where
+  // the segment is a real file, not memfd — it is capped at 1 GB.
+  size_t ram = ctp::SystemInfo::GetRamCapacity();
+  if (ram == 0) {
+    return ctp::Unit<size_t>::Gigabytes(8);  // introspection failed; old default
+  }
+  return ram;
 }
 
 size_t ConfigManager::CalculateQueueSegmentSize() const {

--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -944,8 +944,8 @@ bool IpcManager::ServerInitShm() {
     // issue #783: runtime-wide metadata segment (pid.3). Backs the CTE
     // shared-memory metadata cache. Deliberately NON-FATAL: if it cannot be
     // created the runtime still starts and every client simply falls back to
-    // the RPC path. That matters because the reservation is huge (8 GB by
-    // default) and a host with a small /dev/shm can legitimately refuse it --
+    // the RPC path. That matters because the reservation is huge (the host's
+    // RAM capacity by default) and a constrained host can legitimately refuse it --
     // losing an optimization is acceptable, failing to boot is not.
     metadata_allocator_id_ = ctp::ipc::AllocatorId::Get(pid, 3);
     std::string metadata_segment_name =

--- a/context-transfer-engine/core/include/clio_cte/core/core_client.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_client.h
@@ -625,8 +625,9 @@ class Client : public clio::run::ContainerClient {
    * client-visible pin/lease against reorganization; left as a follow-up.
    *
    * @return A Future over the put; readable after Wait() (GetReturnCode()==0 on
-   *         success). An empty Future is returned only if SHM staging could not
-   *         be allocated in client mode.
+   *         success). An empty Future (Wait() returns immediately, get() is
+   *         null) is returned for a degenerate request (size==0 or null
+   *         source) or when SHM staging could not be allocated in client mode.
    */
   clio::run::Future<PutBlobTask> AsyncPutBlob(
       const TagId &tag_id, const std::string &blob_name,
@@ -636,12 +637,16 @@ class Client : public clio::run::ContainerClient {
       const clio::run::PoolQuery &pool_query = clio::run::PoolQuery::Dynamic()) {
     auto *ipc_manager = CLIO_CPU_IPC;
 
-    // A zero-length put carries no payload; route it through the ShmPtr overload
-    // with a null buffer so the two modes below never see size 0.
+    // Degenerate requests (no payload / no source) are rejected CLIENT-SIDE
+    // with an empty Future — same contract as the staging-allocation failure
+    // below: Wait() succeeds immediately, get() is null, and nothing reaches
+    // the runtime. The earlier version routed these through the ShmPtr
+    // overload with a null buffer, which the co-located handler rejects
+    // cleanly — but in CLIENT mode Send's serialization bulk-exposes `size`
+    // bytes from the null pointer and segfaults (cte_putblob_priv_separate,
+    // "rejects degenerate requests").
     if (size == 0 || priv_data == nullptr) {
-      return AsyncPutBlob(tag_id, blob_name.c_str(), offset, size,
-                          ctp::ipc::ShmPtr<>::GetNull(), score, context, flags,
-                          pool_query);
+      return clio::run::Future<PutBlobTask>();
     }
 
     if (CLIO_RUNTIME_MANAGER->IsRuntime()) {

--- a/context-transfer-engine/test/unit/CMakeLists.txt
+++ b/context-transfer-engine/test/unit/CMakeLists.txt
@@ -1410,6 +1410,53 @@ set_tests_properties(cte_getblob_priv_separate PROPERTIES
     RESOURCE_LOCK "clio_runtime_port"
     TIMEOUT 180
     LABELS "unit;core;cte;msan_skip")
+
+# Write-side mirror (issue #830): private-memory AsyncPutBlob. Same two
+# configurations as the getblob_priv pair above — inline (co-located runtime,
+# zero-copy FromRaw write) and separate (pure client, TASK_DATA_OWNER staging).
+add_executable(test_putblob_priv
+    test_putblob_priv.cc
+)
+
+target_include_directories(test_putblob_priv PRIVATE
+    ${CMAKE_SOURCE_DIR}/context-runtime/test
+)
+
+target_compile_definitions(test_putblob_priv PRIVATE
+    CLIO_RUN_EXE="$<TARGET_FILE:clio_run>")
+
+target_link_libraries(test_putblob_priv
+    clio_cte_core_client
+    clio_cte_core_runtime
+    clio::run::admin_client
+    clio::run::bdev_client
+    ctp::cxx
+    ${CMAKE_THREAD_LIBS_INIT}
+)
+
+add_dependencies(test_putblob_priv
+    clio_run
+    clio_cte_core_runtime
+    clio_bdev_runtime
+    clio_admin_runtime)
+
+add_test(NAME cte_putblob_priv_inline
+    COMMAND test_putblob_priv
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set_tests_properties(cte_putblob_priv_inline PROPERTIES
+    ENVIRONMENT "${_getblob_priv_env}"
+    RESOURCE_LOCK "clio_runtime_port"
+    TIMEOUT 120
+    LABELS "unit;core;cte;msan_skip")
+
+add_test(NAME cte_putblob_priv_separate
+    COMMAND test_putblob_priv
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set_tests_properties(cte_putblob_priv_separate PROPERTIES
+    ENVIRONMENT "${_getblob_priv_env};CLIO_PUTBLOB_PRIV_MODE=separate"
+    RESOURCE_LOCK "clio_runtime_port"
+    TIMEOUT 180
+    LABELS "unit;core;cte;msan_skip")
 endif()  # UNIX
 
 add_executable(test_cte_gpu_metadata_cache

--- a/context-transfer-engine/test/unit/test_putblob_priv.cc
+++ b/context-transfer-engine/test/unit/test_putblob_priv.cc
@@ -1,0 +1,382 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved. BSD 3-Clause license.
+ */
+
+/**
+ * Private-memory AsyncPutBlob (issue #830).
+ *
+ * CoreClient::AsyncPutBlob(const char*) writes a blob region straight from a
+ * caller-owned PRIVATE buffer instead of making the caller hand-manage an SHM
+ * buffer. It is the write-side mirror of the private-memory AsyncGetBlob
+ * (issue #823), and like that path it resolves differently per configuration,
+ * so this test runs in BOTH:
+ *
+ *   - Runtime started INLINE (co-located): the daemon shares this address
+ *     space, so the private pointer is wrapped as a null-allocator ShmPtr and
+ *     the write reads directly out of the caller's buffer — no staging copy.
+ *     `CLIO_PUTBLOB_PRIV_MODE` unset / "inline".
+ *   - Runtime started SEPARATE (its own process): a pure client cannot expose
+ *     private memory, so the payload is staged through an SHM buffer copied in
+ *     before Send, and the task is marked TASK_DATA_OWNER so ~PutBlobTask
+ *     reclaims the staging buffer. `CLIO_PUTBLOB_PRIV_MODE=separate`.
+ *
+ * Read-back verification deliberately uses the ordinary SHM GetBlob, so a bug
+ * in the private-memory READ path cannot mask a bug in the write path.
+ *
+ * The buffers handed to the API here are genuine private memory
+ * (std::vector<char> / stack), never SHM — that is the whole point of the API.
+ */
+
+#include <fcntl.h>
+#include <signal.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "clio_cte/core/core_client.h"
+#include "clio_runtime/bdev/bdev_client.h"
+#include "clio_runtime/clio_runtime.h"
+#include "runtime_server.h"
+#include "simple_test.h"
+
+using namespace std::chrono_literals;
+
+namespace {
+
+constexpr clio::run::u64 kRamTargetBytes = 256ULL * 1024 * 1024;
+constexpr unsigned kPort = 10624;
+const char *kTargetName = "putblob_priv_target";
+
+/** True when CLIO_PUTBLOB_PRIV_MODE=separate: bring up a daemon in its own
+ *  process and attach as a pure client (exercises the SHM staging path).
+ *  Otherwise the runtime is started inline (exercises the direct path). */
+bool SeparateMode() {
+  const char *m = std::getenv("CLIO_PUTBLOB_PRIV_MODE");
+  return m != nullptr && std::string(m) == "separate";
+}
+
+/** Run `clio_run <args>` to completion, returning its exit code. */
+int RunCli(const std::vector<std::string> &args, int timeout_sec) {
+  std::vector<std::string> full;
+  full.push_back(CLIO_RUN_EXE);
+  full.insert(full.end(), args.begin(), args.end());
+  std::vector<char *> argv;
+  for (auto &a : full) argv.push_back(a.data());
+  argv.push_back(nullptr);
+  pid_t pid = fork();
+  if (pid < 0) return -1;
+  if (pid == 0) {
+    execv(argv[0], argv.data());
+    _exit(127);
+  }
+  auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(timeout_sec);
+  int status = 0;
+  while (true) {
+    pid_t r = waitpid(pid, &status, WNOHANG);
+    if (r == pid) return WIFEXITED(status) ? WEXITSTATUS(status) : -2;
+    if (std::chrono::steady_clock::now() >= deadline) {
+      kill(pid, SIGKILL);
+      waitpid(pid, &status, 0);
+      return -3;
+    }
+    std::this_thread::sleep_for(100ms);
+  }
+}
+
+clio::run::test::RuntimeServer *g_server = nullptr;
+
+/** Deterministic byte at logical position i of the test pattern. */
+char PatternByte(size_t i) { return static_cast<char>((i * 131 + 7) & 0xFF); }
+
+class Fixture {
+ public:
+  bool initialized_ = false;
+  bool separate_ = false;
+
+  Fixture() {
+    separate_ = SeparateMode();
+    if (separate_) {
+      initialized_ = InitSeparate();
+    } else {
+      initialized_ = InitInline();
+    }
+  }
+
+  /** Inline: this process IS the runtime. Register a RAM target by hand. */
+  bool InitInline() {
+    if (!clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, true)) {
+      return false;
+    }
+    std::this_thread::sleep_for(300ms);
+    if (!clio::cte::core::CLIO_CTE_CLIENT_INIT()) {
+      return false;
+    }
+    std::this_thread::sleep_for(200ms);
+
+    auto *cte = CLIO_CTE_CLIENT;
+    clio::run::PoolId bdev_pool_id(916, 0);
+    clio::run::bdev::Client bdev_client(bdev_pool_id);
+    auto create = bdev_client.AsyncCreate(clio::run::PoolQuery::Dynamic(),
+                                          kTargetName, bdev_pool_id,
+                                          clio::run::bdev::BdevType::kRam,
+                                          kRamTargetBytes);
+    create.Wait();
+    auto reg = cte->AsyncRegisterTarget(kTargetName,
+                                        clio::run::bdev::BdevType::kRam,
+                                        kRamTargetBytes,
+                                        clio::run::PoolQuery::Local(),
+                                        bdev_pool_id);
+    reg.Wait();
+    if (reg->GetReturnCode() != 0) return false;
+    // Best-effort: attach the SHM metadata cache so the zero-IPC read-back
+    // path can run where available.
+    (void)cte->AttachShmCache();
+    return true;
+  }
+
+  /** Separate: compose a real daemon in its own process, attach as a client. */
+  bool InitSeparate() {
+    const std::string work = "/tmp/clio_putblob_priv_test";
+    std::filesystem::remove_all(work);
+    std::filesystem::create_directories(work);
+    const std::string yaml = work + "/compose.yaml";
+    {
+      std::ofstream f(yaml);
+      f << "compose:\n"
+           "  - mod_name: clio_cte_core\n"
+           "    pool_name: \"putblob_priv_cte\"\n"
+           "    pool_query: local\n"
+           "    pool_id: \"516.0\"\n"
+           "    storage:\n"
+           "      - path: "
+        << work << "/ram_dev\n"
+           "        bdev_type: ram\n"
+           "        capacity_limit: "
+        << (kRamTargetBytes / (1024 * 1024)) << "mb\n"
+           "    dpe:\n"
+           "      dpe_type: random\n";
+    }
+
+    setenv("CLIO_WAIT_SERVER", "15", 1);
+    setenv("CLIO_BIND_ADDR", "127.0.0.1", 1);
+
+    static clio::run::test::RuntimeServer server;
+    g_server = &server;
+    if (!server.Start(kPort) || !server.WaitForReady()) {
+      return false;
+    }
+    if (RunCli({"compose", "start", yaml}, 60) != 0) {
+      return false;
+    }
+    if (!clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, false)) {
+      return false;
+    }
+    if (!clio::cte::core::CLIO_CTE_CLIENT_INIT()) {
+      return false;
+    }
+    (void)CLIO_CTE_CLIENT->AttachShmCache();
+    return true;
+  }
+};
+
+Fixture *g_fixture = nullptr;
+
+/** Read [off, off+n) of `blob` through an ordinary SHM GetBlob, so the
+ *  verification path is independent of the private-memory READ path. */
+std::vector<char> GetViaShm(clio::cte::core::TagId tag_id,
+                            const std::string &blob, clio::run::u64 off,
+                            size_t n) {
+  auto *ipc = CLIO_IPC;
+  auto *cte = CLIO_CTE_CLIENT;
+  ctp::ipc::FullPtr<char> buf = ipc->AllocateBuffer(n);
+  REQUIRE(!buf.IsNull());
+  std::memset(buf.ptr_, 0, n);
+  auto g = cte->AsyncGetBlob(tag_id, blob, off, n, /*flags=*/0,
+                             ctp::ipc::ShmPtr<>(buf.shm_));
+  g.Wait();
+  REQUIRE(g->GetReturnCode() == 0);
+  std::vector<char> out(buf.ptr_, buf.ptr_ + n);
+  ipc->FreeBuffer(buf);
+  return out;
+}
+
+/** Get-or-create a tag and return its id. Deliberately uses the client API
+ *  rather than the clio::cte::core::Tag wrapper, which is on its way out
+ *  (issue #826). */
+clio::cte::core::TagId ResolveTag(const std::string &name) {
+  auto t = CLIO_CTE_CLIENT->AsyncGetOrCreateTag(name);
+  t.Wait();
+  REQUIRE(t->GetReturnCode() == 0);
+  return t->tag_id_;
+}
+
+/** A private (heap) buffer holding `n` bytes of the pattern from `base`. */
+std::vector<char> PrivatePattern(size_t n, size_t base) {
+  std::vector<char> v(n);
+  for (size_t i = 0; i < n; ++i) v[i] = PatternByte(base + i);
+  return v;
+}
+
+}  // namespace
+
+// The heart of the issue: write FROM private memory and have the right bytes
+// land in the blob, under whichever runtime configuration the fixture chose.
+TEST_CASE("PutBlob from private memory stores correct bytes", "[cte][830]") {
+  REQUIRE(g_fixture != nullptr);
+  REQUIRE(g_fixture->initialized_);
+  auto *cte = CLIO_CTE_CLIENT;
+
+  clio::cte::core::TagId tag_id = ResolveTag("putblob_priv_tag");
+
+  const std::string blob = "priv_blob";
+  const size_t kN = 64 * 1024;  // 64 KiB
+
+  // Full write from a genuinely private buffer (heap, not SHM).
+  std::vector<char> priv = PrivatePattern(kN, 0);
+  auto p = cte->AsyncPutBlob(tag_id, blob, /*offset=*/0, kN, priv.data());
+  p.Wait();
+  REQUIRE(p->GetReturnCode() == 0);
+
+  std::vector<char> got = GetViaShm(tag_id, blob, 0, kN);
+  for (size_t i = 0; i < kN; ++i) {
+    REQUIRE(got[i] == PatternByte(i));
+  }
+}
+
+// An offset write must land at the right place and leave its neighbours alone —
+// the in-place-overwrite shape the issue cares about for repeated writes.
+TEST_CASE("Private PutBlob at an offset overwrites only its range",
+          "[cte][830]") {
+  REQUIRE(g_fixture != nullptr);
+  REQUIRE(g_fixture->initialized_);
+  auto *cte = CLIO_CTE_CLIENT;
+
+  clio::cte::core::TagId tag_id = ResolveTag("putblob_priv_offset_tag");
+
+  const std::string blob = "offset_blob";
+  const size_t kN = 32 * 1024;
+  std::vector<char> base = PrivatePattern(kN, 0);
+  auto p0 = cte->AsyncPutBlob(tag_id, blob, 0, kN, base.data());
+  p0.Wait();
+  REQUIRE(p0->GetReturnCode() == 0);
+
+  // Overwrite a middle slice with a different pattern (base 500).
+  const size_t kOff = 4096, kLen = 8192;
+  std::vector<char> patch = PrivatePattern(kLen, 500);
+  auto p1 = cte->AsyncPutBlob(tag_id, blob, kOff, kLen, patch.data());
+  p1.Wait();
+  REQUIRE(p1->GetReturnCode() == 0);
+
+  std::vector<char> got = GetViaShm(tag_id, blob, 0, kN);
+  for (size_t i = 0; i < kN; ++i) {
+    const char want = (i >= kOff && i < kOff + kLen)
+                          ? PatternByte(500 + (i - kOff))
+                          : PatternByte(i);
+    REQUIRE(got[i] == want);
+  }
+}
+
+// Once the Future completes the caller owns its buffer again: in client mode
+// the payload was copied into SHM before Send, and in runtime mode the daemon
+// read straight from this buffer but is done by the time Wait() returns.
+// Mutating it afterwards must not disturb what was stored.
+TEST_CASE("Private PutBlob buffer is reusable after Wait", "[cte][830]") {
+  REQUIRE(g_fixture != nullptr);
+  REQUIRE(g_fixture->initialized_);
+  auto *cte = CLIO_CTE_CLIENT;
+
+  clio::cte::core::TagId tag_id = ResolveTag("putblob_priv_reuse_tag");
+
+  const std::string blob = "reuse_blob";
+  const size_t kN = 16 * 1024;
+  std::vector<char> priv = PrivatePattern(kN, 77);
+  auto p = cte->AsyncPutBlob(tag_id, blob, 0, kN, priv.data());
+  p.Wait();
+  REQUIRE(p->GetReturnCode() == 0);
+
+  // Scribble over the caller's buffer, then confirm the blob is unchanged.
+  std::memset(priv.data(), 0xAB, kN);
+  std::vector<char> got = GetViaShm(tag_id, blob, 0, kN);
+  for (size_t i = 0; i < kN; ++i) {
+    REQUIRE(got[i] == PatternByte(77 + i));
+  }
+}
+
+// Repeated writes must not leak or hang: the client path allocates a staging
+// buffer per call and relies on TASK_DATA_OWNER to reclaim it. A leak here
+// exhausts the main SHM segment and later writes fail; a missed free would trip
+// the allocator's leak checker at shutdown. This is also the repeated-write
+// workload issue #830 wants to optimize, so it must stay correct.
+TEST_CASE("Private PutBlob is leak-free under repetition", "[cte][830]") {
+  REQUIRE(g_fixture != nullptr);
+  REQUIRE(g_fixture->initialized_);
+  auto *cte = CLIO_CTE_CLIENT;
+
+  clio::cte::core::TagId tag_id = ResolveTag("putblob_priv_loop_tag");
+
+  const std::string blob = "loop_blob";
+  const size_t kN = 32 * 1024;
+
+  for (int iter = 0; iter < 256; ++iter) {
+    // Vary the pattern per iteration so a stale-buffer bug cannot pass by
+    // coincidence: the read-back must see THIS iteration's bytes.
+    const size_t base = static_cast<size_t>(iter) * 7 + 3;
+    std::vector<char> priv = PrivatePattern(kN, base);
+    auto p = cte->AsyncPutBlob(tag_id, blob, 0, kN, priv.data());
+    p.Wait();
+    REQUIRE(p->GetReturnCode() == 0);
+  }
+
+  // Spot-check the final iteration's bytes survived (a full compare every
+  // iteration would dominate runtime).
+  const size_t last_base = static_cast<size_t>(255) * 7 + 3;
+  std::vector<char> got = GetViaShm(tag_id, blob, 0, kN);
+  REQUIRE(got[0] == PatternByte(last_base));
+  REQUIRE(got[kN / 2] == PatternByte(last_base + kN / 2));
+  REQUIRE(got[kN - 1] == PatternByte(last_base + kN - 1));
+}
+
+// A degenerate request returns an EMPTY future rather than submitting a task.
+// Wait() must return immediately instead of hanging, and — the part that
+// matters — no blob may be created as a side effect.
+TEST_CASE("Private PutBlob rejects degenerate requests", "[cte][830]") {
+  REQUIRE(g_fixture != nullptr);
+  REQUIRE(g_fixture->initialized_);
+  auto *cte = CLIO_CTE_CLIENT;
+
+  clio::cte::core::TagId tag_id = ResolveTag("putblob_priv_degenerate_tag");
+
+  std::vector<char> priv = PrivatePattern(1024, 5);
+  auto p_null = cte->AsyncPutBlob(tag_id, "null_blob", 0, 1024, nullptr);
+  p_null.Wait();
+  auto p_zero = cte->AsyncPutBlob(tag_id, "zero_blob", 0, 0, priv.data());
+  p_zero.Wait();
+
+  // Neither name may exist: a rejected request must not reach the runtime.
+  auto listed = cte->AsyncGetContainedBlobs(tag_id);
+  listed.Wait();
+  REQUIRE(listed->GetReturnCode() == 0);
+  for (const std::string &name : listed->blob_names_) {
+    REQUIRE(name != "null_blob");
+    REQUIRE(name != "zero_blob");
+  }
+}
+
+int main(int argc, char **argv) {
+  static Fixture fixture;
+  g_fixture = &fixture;
+  std::string filter = (argc > 1) ? argv[1] : "";
+  int rc = SimpleTest::run_all_tests(filter);
+  clio::run::CLIO_RUNTIME_FINALIZE();
+  return rc;
+}

--- a/context-transfer-engine/test/unit/test_putblob_priv.cc
+++ b/context-transfer-engine/test/unit/test_putblob_priv.cc
@@ -113,16 +113,14 @@ class Fixture {
   }
 
   /** Inline: this process IS the runtime. Register a RAM target by hand. */
-  bool InitInline() {
-    if (!clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, true)) {
-      return false;
-    }
-    std::this_thread::sleep_for(300ms);
-    if (!clio::cte::core::CLIO_CTE_CLIENT_INIT()) {
-      return false;
-    }
-    std::this_thread::sleep_for(200ms);
-
+  /** Register a RAM target into the pool CLIO_CTE_CLIENT actually talks to
+   *  (the default clio_cte_core pool). Shared by the inline and separate
+   *  fixtures so both place the target where the client's PutBlobs look for
+   *  it — same fix as test_getblob_priv: the compose in separate mode
+   *  registers its storage into the COMPOSED pool (516.0) while the client
+   *  talks to the default pool (512.0), so without this the setup put fails
+   *  with rc 11 ("no targets") on the deps-cpu/Boost CI configs. */
+  static bool RegisterRamTarget() {
     auto *cte = CLIO_CTE_CLIENT;
     clio::run::PoolId bdev_pool_id(916, 0);
     clio::run::bdev::Client bdev_client(bdev_pool_id);
@@ -137,10 +135,23 @@ class Fixture {
                                         clio::run::PoolQuery::Local(),
                                         bdev_pool_id);
     reg.Wait();
-    if (reg->GetReturnCode() != 0) return false;
+    return reg->GetReturnCode() == 0;
+  }
+
+  bool InitInline() {
+    if (!clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, true)) {
+      return false;
+    }
+    std::this_thread::sleep_for(300ms);
+    if (!clio::cte::core::CLIO_CTE_CLIENT_INIT()) {
+      return false;
+    }
+    std::this_thread::sleep_for(200ms);
+
+    if (!RegisterRamTarget()) return false;
     // Best-effort: attach the SHM metadata cache so the zero-IPC read-back
     // path can run where available.
-    (void)cte->AttachShmCache();
+    (void)CLIO_CTE_CLIENT->AttachShmCache();
     return true;
   }
 
@@ -182,6 +193,13 @@ class Fixture {
       return false;
     }
     if (!clio::cte::core::CLIO_CTE_CLIENT_INIT()) {
+      return false;
+    }
+    // Register the RAM target into the pool this client actually uses — the
+    // daemon services the bdev create + RegisterTarget exactly as inline mode
+    // does. Without this the composed pool holds the only target and every
+    // put from the client's default pool fails rc 11 (see RegisterRamTarget).
+    if (!RegisterRamTarget()) {
       return false;
     }
     (void)CLIO_CTE_CLIENT->AttachShmCache();


### PR DESCRIPTION
Two commits pushed to the #833 branch minutes after it merged (same stranding as the #821→#833 handoff):

1. **Metadata segment defaults to system RAM capacity** — the #783 metadata reservation was a fixed 8 GB ceiling; it now defaults to `SystemInfo::GetRamCapacity()` (sparse, never pre-faulted, so the request itself costs nothing) and scales with the host. `metadata_segment_size` config override unchanged; both creation-time safety layers kept (Linux: clamp to half the cgroup-aware budget — verified live: 11.7 GB request → 5.98 GB clamp; non-Linux: 1 GB file-backed cap). Config suite 10/10.

2. **Wire in the orphaned #830 private-put test suite** (`test_putblob_priv.cc`, write-side mirror of `test_getblob_priv`, 5 cases, inline + separate configurations) — and fix the real bug it immediately caught: a private `AsyncPutBlob` with a null source (or size 0) segfaulted in CLIENT mode (Send serialization bulk-exposed `size` bytes from the null pointer). Degenerate requests are now rejected client-side with an empty Future, never reaching the runtime. All four priv suites pass; the separate putblob run drops from a 97 s crash to 4.8 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)