### PR TITLE
Remove the FixupAfterCopy dispatch layer (GPU path is POD-only)

### DIFF
--- a/context-runtime/include/clio_runtime/container.h
+++ b/context-runtime/include/clio_runtime/container.h
@@ -380,26 +380,6 @@ class Container {
                          clio::run::shared_ptr<Task> task_ptr) = 0;
 
   /**
-   * Fix up POD bytewise-copied tasks (clio::run::priv::string SSO data_
-   * pointers, etc.) before dispatching Run. Called by the GPU2CPU pop
-   * path when the kernel's task was in kDeviceMem and the worker had
-   * to D2H-copy the POD bytes into a host scratch buffer — at that
-   * point any embedded `data_` pointers still reference the original
-   * device buffer offsets and must be re-pointed at the scratch copy.
-   *
-   * Default no-op for chimods whose tasks are already trivially
-   * relocatable (no SSO strings, no SVO vectors). Each chimod that
-   * has SSO/SVO members should override and dispatch per method to
-   * the per-task `FixupAfterCopy()`.
-   */
-  virtual void FixupAfterCopy(u32 method,
-                              clio::run::shared_ptr<Task> &task_ptr) {
-    (void)method;
-    (void)task_ptr;
-  }
-
-
-  /**
    * Get remaining work count for this container - PURE VIRTUAL
    * Must be implemented by all derived container classes
    * @return Number of work units remaining in this container

--- a/context-runtime/include/clio_runtime/task.h
+++ b/context-runtime/include/clio_runtime/task.h
@@ -703,14 +703,6 @@ class Task {
   void AggregateIn(const ctp::ipc::FullPtr<Task>& member_task) {
     (void)member_task;
   }
-
-  /**
-   * Fix up internal pointers after a cudaMemcpy/memcpy (POD copy path).
-   * Override in tasks that contain priv::vector or other pointer-bearing
-   * fields to re-seat inline (SVO) pointers to the new host address.
-   * Default is a no-op for pure POD tasks.
-   */
-  CTP_CROSS_FUN void FixupAfterCopy() {}
 };
 
 }  // namespace clio::run

--- a/context-runtime/modules/bdev/include/clio_runtime/bdev/bdev_tasks.h
+++ b/context-runtime/modules/bdev/include/clio_runtime/bdev/bdev_tasks.h
@@ -354,11 +354,6 @@ struct AllocateBlocksTask : public clio::run::Task {
       : clio::run::Task(task_node, pool_id, pool_query, Method::kAllocateBlocks), size_(size), blocks_(CLIO_PRIV_ALLOC) {
   }
 
-  /** Fix up priv::vector SVO pointer after cudaMemcpy D→H */
-  CTP_CROSS_FUN void FixupAfterCopy() {
-    blocks_.FixupSvoPtr();
-  }
-
   /** Serialize IN and INOUT parameters */
   template <typename Archive>
   CTP_CROSS_FUN void SerializeIn(Archive &ar) {
@@ -445,11 +440,6 @@ struct FreeBlocksTask : public clio::run::Task {
     // No additional output parameters
   }
 
-  /** Fix up SVO pointer after POD copy (e.g., CPU→GPU memcpy) */
-  CTP_CROSS_FUN void FixupAfterCopy() {
-    blocks_.FixupSvoPtr();
-  }
-
   /**
    * Copy from another FreeBlocksTask (assumes this task is already constructed)
    * @param other Pointer to the source task to copy from
@@ -522,11 +512,6 @@ struct WriteTask : public clio::run::Task {
   CTP_CROSS_FUN void SerializeOut(Archive &ar) {
     Task::SerializeOut(ar);
     ar(bytes_written_, io_error_);
-  }
-
-  /** Fix up priv::vector SVO pointer after cudaMemcpy D→H */
-  CTP_CROSS_FUN void FixupAfterCopy() {
-    blocks_.FixupSvoPtr();
   }
 
   /** AggregateOut */
@@ -607,11 +592,6 @@ struct ReadTask : public clio::run::Task {
     ar(length_, bytes_read_, io_error_);
     // Use BULK_XFER to actually transfer the read data back
     ar.bulk(data_, length_, BULK_XFER);
-  }
-
-  /** Fix up priv::vector SVO pointer after cudaMemcpy D→H */
-  CTP_CROSS_FUN void FixupAfterCopy() {
-    blocks_.FixupSvoPtr();
   }
 
   /** AggregateOut */

--- a/context-runtime/src/ipc/ipc_gpu2cpu.cc
+++ b/context-runtime/src/ipc/ipc_gpu2cpu.cc
@@ -139,13 +139,9 @@ bool IpcGpu2Cpu::RecvIn(IpcManager *ipc, GpuTaskLane *gpu_lane, Worker *worker) 
     return true;
   }
 
-  // Fix up SSO/SVO `data_` pointers in the host-resident task copy if we
-  // D2H-copied it. The chimod's container override dispatches by method id to
-  // the per-task FixupAfterCopy(). Skip when the task never moved (kPinnedHost /
-  // kManagedUvm path).
-  if (task_on_device) {
-    container->FixupAfterCopy(method_id, future.GetTaskPtr());
-  }
+  // No post-copy fixup: tasks that cross this boundary must be bitwise
+  // relocatable (fully-POD, e.g. the Pod*Blob tasks) — the D2H copy above is
+  // already a correct host-side task.
 
   // Allocate the task's RunContext (and resolve its container) now that it is
   // deserialized, so RouteTask / the worker have an active RunContext.

--- a/context-transfer-engine/core/include/clio_cte/core/core_runtime.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_runtime.h
@@ -87,14 +87,6 @@ public:
   ~Runtime() override;
 
   /**
-   * Fix up POD task members (clio::run::priv::string SSO data_ pointers,
-   * etc.) after a GPU2CPU D2H POD memcpy. Dispatched by the GPU pop
-   * path on the worker before Run.
-   */
-  void FixupAfterCopy(clio::run::u32 method,
-                      clio::run::shared_ptr<clio::run::Task>& task_ptr) override;
-
-  /**
    * Create the container (Method::kCreate)
    * This method both creates and initializes the container
    * Returns TaskResume for coroutine-based async operations

--- a/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
@@ -382,11 +382,6 @@ struct RegisterTargetTask : public clio::run::Task {
     Task::SerializeOut(ar);
   }
 
-  /** Fix up priv::string SSO pointer after cudaMemcpy D→H */
-  CTP_CROSS_FUN void FixupAfterCopy() {
-    target_name_.FixupSsoPointer();
-  }
-
   /**
    * Copy from another RegisterTargetTask
    * Used when creating replicas for remote execution
@@ -1273,11 +1268,6 @@ struct GetOrCreateTagTask : public clio::run::Task {
     ar(tag_id_);
   }
 
-  /** Fix up priv::string SSO pointer after cudaMemcpy for CPU→GPU */
-  CTP_CROSS_FUN void FixupAfterCopy() {
-    tag_name_.FixupSsoPointer();
-  }
-
   /**
    * Copy from another GetOrCreateTagTask
    */
@@ -1519,12 +1509,6 @@ struct PutBlobTask : public clio::run::Task {
     // CLIO_FORCE_NET (issue #500).
     ar(blob_name_, context_);
     ar.PopPod();
-  }
-
-  /** Fix up priv::string SSO pointer after cudaMemcpy D→H */
-  CTP_CROSS_FUN void FixupAfterCopy() {
-    blob_name_.FixupSsoPointer();
-    segments_.FixupSvoPtr();
   }
 
   /**
@@ -1780,12 +1764,6 @@ struct GetBlobTask : public clio::run::Task {
     }
   }
 
-  /** Fix up priv::string SSO pointer after cudaMemcpy D→H */
-  CTP_CROSS_FUN void FixupAfterCopy() {
-    blob_name_.FixupSsoPointer();
-    segments_.FixupSvoPtr();
-  }
-
   /**
    * Copy from another GetBlobTask
    */
@@ -1968,8 +1946,8 @@ struct EvictTask : public clio::run::Task {
 // These mirror PutBlob/GetBlob/ReorganizeBlob but carry the blob name in an
 // inline clio::run::priv::fixed_string<32> (no allocator, no SSO) instead of a
 // priv::string. Every field is therefore POD and the whole task is
-// bitwise-relocatable: a cudaMemcpy D<->H of the task is correct with ZERO
-// FixupAfterCopy (none is defined). Blob names are capped at 31 chars + NUL.
+// bitwise-relocatable: a cudaMemcpy D<->H of the task is correct with zero
+// post-copy fixup. Blob names are capped at 31 chars + NUL.
 // They share the runtime handler logic with the non-POD tasks via the
 // Runtime::*Impl<TaskT> member templates (same field names; both name types
 // expose .str()).
@@ -2081,8 +2059,6 @@ struct PodPutBlobTask : public clio::run::Task {
     // blob_data_ must NOT be echoed).
     ar(blob_name_, context_);
   }
-
-  // No FixupAfterCopy — fixed_string is position-independent.
 
   void Copy(const ctp::ipc::FullPtr<PodPutBlobTask> &other) {
     Task::Copy(other.template Cast<Task>());
@@ -2203,8 +2179,6 @@ struct PodGetBlobTask : public clio::run::Task {
       ar.bulk(blob_data_, size_, BULK_XFER);
     }
   }
-
-  // No FixupAfterCopy — fixed_string is position-independent.
 
   void Copy(const ctp::ipc::FullPtr<PodGetBlobTask> &other) {
     Task::Copy(other.template Cast<Task>());

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -294,27 +294,6 @@ clio::run::u64 Runtime::ParseCapacityToBytes(const std::string &capacity_str) {
   return static_cast<clio::run::u64>(value * multiplier);
 }
 
-void Runtime::FixupAfterCopy(clio::run::u32 method,
-                              clio::run::shared_ptr<clio::run::Task> &task_ptr) {
-  switch (method) {
-    case Method::kRegisterTarget:
-      task_ptr.template Cast<RegisterTargetTask>().get()->FixupAfterCopy();
-      break;
-    case Method::kGetOrCreateTag:
-      task_ptr.template Cast<GetOrCreateTagTask<CreateParams>>()
-          .get()->FixupAfterCopy();
-      break;
-    case Method::kPutBlob:
-      task_ptr.template Cast<PutBlobTask>().get()->FixupAfterCopy();
-      break;
-    case Method::kGetBlob:
-      task_ptr.template Cast<GetBlobTask>().get()->FixupAfterCopy();
-      break;
-    default:
-      break;
-  }
-}
-
 namespace {
 
 /**

--- a/context-transfer-engine/test/unit/gpu/test_cte_devmem_putget.cc
+++ b/context-transfer-engine/test/unit/gpu/test_cte_devmem_putget.cc
@@ -21,8 +21,8 @@
  *   1. Kernel mutates the device-side POD (writes pattern to blob_data,
  *      then calls Send) and waits on the device-side gpu::FutureShm.
  *   2. CPU GPU worker pops the task, D2H-copies the POD into a host
- *      scratch slot, calls Container::FixupAfterCopy to relocate the
- *      clio::run::priv::string SSO data_ pointer, runs the chimod handler,
+ *      scratch slot and runs the chimod handler directly — the Pod*Blob
+ *      tasks are bitwise-relocatable, so no post-copy fixup step exists —
  *      then H2D-copies the (mutated) POD back to the original device
  *      address and flips FUTURE_COMPLETE on the device fshm via
  *      cudaMemcpy.
@@ -30,7 +30,7 @@
  *      device memory, and proceeds to GetBlob.
  *
  * The two-task round-trip gives us end-to-end coverage of:
- *   - Device→host POD copy + SSO fixup on the inbound path.
+ *   - Device→host POD copy consumed with zero fixup on the inbound path.
  *   - DeviceAwareMemcpy on the bdev side reading kDeviceMem blob_data.
  *   - Host→device POD writeback so the kernel sees output fields.
  *   - cudaMemcpy of the FUTURE_COMPLETE flag word as the device-fshm

--- a/context-transport-primitives/include/clio_ctp/data_structures/priv/fixed_string.h
+++ b/context-transport-primitives/include/clio_ctp/data_structures/priv/fixed_string.h
@@ -32,8 +32,9 @@ namespace ctp::priv {
  * members of its own, so it is **bitwise-relocatable**: no heap, no SSO, no
  * self-referential pointer, and an identical layout on host and device. A raw
  * memcpy/cudaMemcpy of a struct embedding a fixed_string is correct with ZERO
- * post-copy fixup — which is exactly why GPU tasks can carry it without the
- * priv::string FixupSsoPointer dance. The copy/move/dtor are defaulted so the
+ * post-copy fixup — which is exactly why GPU tasks can carry it while a
+ * priv::string (whose SSO caches a self-pointer) cannot cross a bytewise
+ * copy. The copy/move/dtor are defaulted so the
  * type remains trivially copyable (the converting constructors below do not
  * affect that).
  *

--- a/context-transport-primitives/include/clio_ctp/data_structures/priv/string.h
+++ b/context-transport-primitives/include/clio_ctp/data_structures/priv/string.h
@@ -607,17 +607,6 @@ class basic_string {
   }
 
   /**
-   * Fix up the data_ pointer after a bulk memcpy.
-   * After memcpy, data_ still points to the source object's buffer.
-   * This repoints it to this object's own SSO buffer.
-   * Only valid when UsingSso() is true.
-   */
-  CTP_INLINE_CROSS_FUN
-  void FixupSsoPointer() {
-    data_ = storage_.buffer_;
-  }
-
-  /**
    * Initialize this string by copying SSO data from another string.
    * No allocator needed — copies the inline buffer directly.
    * Only valid when the source is using SSO (size <= SSOSize).

--- a/context-transport-primitives/include/clio_ctp/data_structures/priv/vector.h
+++ b/context-transport-primitives/include/clio_ctp/data_structures/priv/vector.h
@@ -676,16 +676,6 @@ class vector {
 
  public:
   /**
-   * Re-seat data_.ptr_ to this object's inline SVO buffer after a memcpy.
-   * Call after cudaMemcpy/memcpy when the vector was using SVO (size <= SVO_SIZE).
-   * Preserves size_ and the data already in svo_[].
-   */
-  CTP_INLINE_CROSS_FUN
-  void FixupSvoPtr() {
-    data_.ptr_ = svo_data();
-  }
-
-  /**
    * Default constructor (no allocator).
    * Creates an empty vector with SVO buffer available.
    */


### PR DESCRIPTION
## Summary
- Delete the entire post-copy fixup layer for GPU-boundary task copies: the `ipc_gpu2cpu.cc` call site, the virtual `Container::FixupAfterCopy`, the base `Task::FixupAfterCopy` no-op, `cte::Runtime::FixupAfterCopy` method dispatch, all 8 per-task overrides (4 bdev, 4 CTE core), and the `priv::vector::FixupSvoPtr` / `priv::string::FixupSsoPointer` container hooks.
- Net −138/+11 lines; the GPU2CPU boundary now has a single invariant instead of per-type cooperation: any task that crosses it must be bitwise-relocatable (fully POD, e.g. the `Pod*Blob` family).

## Motivation
Closes #556. The fixup machinery existed because `priv::string`/`priv::vector` cache absolute pointers into their own inline (SSO/SVO) storage, which dangle after a raw `cudaMemcpy`/`memcpy`. The issue proposed making those containers position-independent — but the Pod task work (fixed_string names, POD-only fields, host/device-stable `Task` layout) made GPU-crossing tasks relocatable by construction, so the whole dispatch layer is dead code and can simply be removed.

## Test plan
- [x] CTE core suite passes locally (CPU build): `ctest -R cte_core_` → 18/18 passed
- [x] bdev paths pass: `cr_all_safe_bdev_tests`, `cte_bdev_fragmentation`, `cte_functional_all` all passed
- [ ] GPU CI: `test_cte_devmem_putget` (Pod task D2H/H2D round-trip, now with zero fixup step) — needs the CUDA runner
- [x] No new compiler warnings in the touched targets

## Breaking changes
Chimods can no longer rely on a post-copy fixup hook: a task submitted from GPU device memory must be bitwise-relocatable (no `priv::string`/`priv::vector` members). All in-tree GPU-crossing tasks (the `Pod*Blob` family) already satisfy this. Doc follow-up: `docs/docs/sdk/context-runtime/6.gpu_clients.md` (separate docs repo) still describes the `FixupAfterCopy` escape hatch and should be updated to state the POD requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)