### PR TITLE
CTE: authoritative blob-transform bit — SHM fast path refuses rewritten bytes (#818)

### DIFF
--- a/context-runtime/test/unit/test_autogen_coverage.cc
+++ b/context-runtime/test/unit/test_autogen_coverage.cc
@@ -12302,6 +12302,12 @@ TEST_CASE("Autogen - CTE Context struct GlobalSerialize", "[autogen][cte][contex
     ctx.persistence_target_ = 1;
     ctx.min_persistence_level_ = 2;
     ctx.preallocate_ = 4096;
+    // issue #818: the transform bit is serialized UNCONDITIONALLY, outside the
+    // compression guard below -- a safety flag that vanishes with a compile
+    // flag is worse than no flag, and a conditionally-present member changes
+    // Context's wire layout between TUs built with different flags.
+    ctx.transform_flags_ = clio::cte::core::kBlobTransformed |
+                           clio::cte::core::kBlobTransformCompressed;
 #ifdef CLIO_CTE_ENABLE_COMPRESSION
     ctx.dynamic_compress_ = 2;
     ctx.compress_lib_ = 3;
@@ -12330,6 +12336,9 @@ TEST_CASE("Autogen - CTE Context struct GlobalSerialize", "[autogen][cte][contex
     REQUIRE(loaded.persistence_target_ == 1);
     REQUIRE(loaded.min_persistence_level_ == 2);
     REQUIRE(loaded.preallocate_ == 4096);
+    REQUIRE(loaded.transform_flags_ ==
+            (clio::cte::core::kBlobTransformed |
+             clio::cte::core::kBlobTransformCompressed));
 #ifdef CLIO_CTE_ENABLE_COMPRESSION
     REQUIRE(loaded.dynamic_compress_ == 2);
     REQUIRE(loaded.compress_lib_ == 3);

--- a/context-transfer-engine/compressor/src/compressor_runtime.cc
+++ b/context-transfer-engine/compressor/src/compressor_runtime.cc
@@ -770,6 +770,13 @@ clio::run::TaskResume Runtime::Compress(clio::run::shared_ptr<CompressTask> &tas
       std::memcpy(compressed_shm.ptr_ + header_size, compressed_buffer.data(),
                   compressed_size);
 
+      // Tell the runtime these bytes are no longer the caller's bytes, so it
+      // can mark the blob authoritatively (issue #818). This is the ONLY place
+      // that knows it for certain -- compress_lib_ is set on the not-beneficial
+      // path below too, where the stored bytes are raw.
+      context.transform_flags_ |= clio::cte::core::kBlobTransformed |
+                                  clio::cte::core::kBlobTransformCompressed;
+
       // Call PutBlob with header + compressed data
       ctp::ipc::ShmPtr<> compressed_shm_ptr =
           compressed_shm.shm_.template Cast<void>();
@@ -802,13 +809,20 @@ clio::run::TaskResume Runtime::Compress(clio::run::shared_ptr<CompressTask> &tas
       // Compression failed or didn't reduce size - store original data
       HLOG(kDebug, "Compression not beneficial, storing original data");
 
+      // Mark uncompressed BEFORE the put, not after. The bytes below are the
+      // caller's original bytes, so the blob must not be recorded as carrying
+      // the codec we merely attempted -- this used to be zeroed only after
+      // PutBlob had already copied compress_lib_ onto the BlobInfo, which is
+      // half of why compress_lib_ cannot be trusted as a transform signal
+      // (issue #818). transform_flags_ is deliberately left unset here.
+      context.compress_lib_ = 0;
+
       auto put_task = core_client_->AsyncPutBlob(
           task->tag_id_, task->blob_name_.str(), task->offset_, task->size_,
           task->blob_data_, task->score_, context, task->flags_,
           clio::run::PoolQuery::Local());
       put_task.Wait();
 
-      context.compress_lib_ = 0;  // Mark as uncompressed
       task->context_ = put_task->context_;
       task->return_code_ = put_task->return_code_;
     }

--- a/context-transfer-engine/core/include/clio_cte/core/blob_transform.h
+++ b/context-transfer-engine/core/include/clio_cte/core/blob_transform.h
@@ -1,0 +1,72 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Distributed under BSD 3-Clause license.                                   *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Illinois Institute of Technology.                        *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of Clio. The full Clio copyright notice, including      *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the top directory.                *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef CLIO_CTE_CORE_BLOB_TRANSFORM_H_
+#define CLIO_CTE_CORE_BLOB_TRANSFORM_H_
+
+#include "clio_runtime/types.h"
+
+namespace clio::cte::core {
+
+/**
+ * How a blob's STORED bytes relate to the LOGICAL bytes the caller put
+ * (issue #818).
+ *
+ * AUTHORITATIVE. This is the single source of truth for "are the bytes on the
+ * device still the caller's bytes?" -- deliberately NOT derived from
+ * compress_lib_, which answers a different question (which codec was
+ * *requested*) and is wrong in both directions:
+ *
+ *  - False positive: the compressor chimod used to call PutBlob with
+ *    compress_lib_ still set when compression turned out not to be beneficial,
+ *    zeroing it only afterwards. The blob was then recorded as compressed while
+ *    holding raw bytes.
+ *  - False negative: core only records compress_lib_ under
+ *    `#if CTP_ENABLE_COMPRESS` (OFF by default), yet the metadata log persists
+ *    it unconditionally -- so a restart can restore a genuinely compressed blob
+ *    into a runtime that never populates the field.
+ *
+ * Compression is only the first transform; encryption and any future
+ * byte-rewriting layer must set this too. Consumers must therefore ask
+ * `BlobInfo::IsTransformed()` / `ShmBlobRecord::IsTransformed()`, never
+ * `compress_lib_ != 0`.
+ *
+ * COMPILED UNCONDITIONALLY, on purpose. Putting the flag word behind
+ * `#if CTP_ENABLE_COMPRESS` would reintroduce exactly the failure it exists to
+ * prevent (a build with compression off silently reporting "not transformed"),
+ * and would make the enclosing types change size with a compile flag -- the
+ * Context/PutBlobTask ABI-skew hazard.
+ *
+ * FORWARD COMPATIBILITY: a reader that does not recognise a bit must still
+ * treat the blob as transformed, which is why the IsTransformed() predicates
+ * test the whole word against zero rather than one known bit. An unknown future
+ * transform then fails safe (refuse the direct-read fast path) instead of being
+ * handed back as raw bytes.
+ *
+ * This lives in its own header, rather than in core_tasks.h beside BlobInfo, so
+ * that the deliberately lightweight shared-memory cache header can name these
+ * bits without pulling in the full task/config include graph.
+ */
+enum BlobTransformFlags : clio::run::u32 {
+  kBlobTransformNone = 0,
+  /** Generic "these bytes are not the caller's bytes". ALWAYS set alongside
+   *  whichever specific bit(s) apply, so a reader that understands none of the
+   *  specific kinds still gets a correct yes/no answer. */
+  kBlobTransformed = 1u << 0,
+  /** Stored as CompressionHeader + codec output. */
+  kBlobTransformCompressed = 1u << 1,
+  /** Stored as ciphertext (reserved; no producer sets this yet). */
+  kBlobTransformEncrypted = 1u << 2,
+};
+
+}  // namespace clio::cte::core
+
+#endif  // CLIO_CTE_CORE_BLOB_TRANSFORM_H_

--- a/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
@@ -42,6 +42,7 @@
 #include <clio_runtime/clio_runtime.h>
 #include <clio_cte/core/autogen/core_methods.h>
 #include <clio_cte/core/core_config.h>
+#include <clio_cte/core/blob_transform.h>
 // Include admin tasks for GetOrCreatePoolTask
 #include <clio_runtime/admin/admin_tasks.h>
 // Include bdev tasks for BdevType enum
@@ -827,8 +828,19 @@ struct BlobInfo {
   // the WAL/metadata log, so it resets on restart (organizers must treat a
   // zero count as "cold or freshly restored", which decays gracefully).
   clio::run::u64 access_count_;
-  int compress_lib_;     // Compression library ID used for this blob (0 = no
-                         // compression)
+  // Authoritative record of whether the stored bytes have been rewritten by
+  // some transform (compression, encryption, ...). See BlobTransformFlags.
+  // STICKY: once set it is never cleared by a later put. A partial overwrite of
+  // a compressed blob with raw bytes leaves a blob that is neither wholly raw
+  // nor wholly transformed, and the only safe reading of that is "transformed"
+  // -- over-refusing the direct-read fast path costs a round-trip, whereas
+  // under-refusing hands back codec bytes as if they were data. Cleared only
+  // when the blob itself is destroyed.
+  clio::run::u32 transform_flags_;
+  int compress_lib_;     // Compression library ID *requested* for this blob
+                         // (0 = none). Provenance/telemetry only -- NOT a
+                         // reliable answer to "is this blob compressed?";
+                         // ask IsTransformed(). See BlobTransformFlags.
   int compress_preset_;  // Compression preset used (1=FAST, 2=BALANCED, 3=BEST)
   clio::run::u64
       trace_key_;  // Unique trace ID for linking to trace logs (0 = not traced)
@@ -894,6 +906,7 @@ struct BlobInfo {
         last_modified_(0),
         last_read_(0),
         access_count_(0),
+        transform_flags_(kBlobTransformNone),
         compress_lib_(0),
         compress_preset_(2),
         trace_key_(0),
@@ -911,6 +924,7 @@ struct BlobInfo {
         last_modified_(0),
         last_read_(0),
         access_count_(0),
+        transform_flags_(kBlobTransformNone),
         compress_lib_(0),
         compress_preset_(2),
         trace_key_(0),
@@ -929,6 +943,7 @@ struct BlobInfo {
         last_modified_(GetCurrentTimeNs()),
         last_read_(GetCurrentTimeNs()),
         access_count_(0),
+        transform_flags_(kBlobTransformNone),
         compress_lib_(0),
         compress_preset_(2),
         trace_key_(0),
@@ -947,6 +962,7 @@ struct BlobInfo {
         last_modified_(other.last_modified_),
         last_read_(other.last_read_),
         access_count_(other.access_count_),
+        transform_flags_(other.transform_flags_),
         compress_lib_(other.compress_lib_),
         compress_preset_(other.compress_preset_),
         trace_key_(other.trace_key_),
@@ -965,6 +981,7 @@ struct BlobInfo {
       last_modified_ = other.last_modified_;
       last_read_ = other.last_read_;
       access_count_ = other.access_count_;
+      transform_flags_ = other.transform_flags_;
       compress_lib_ = other.compress_lib_;
       compress_preset_ = other.compress_preset_;
       trace_key_ = other.trace_key_;
@@ -973,6 +990,30 @@ struct BlobInfo {
       placement_gen_ = other.placement_gen_;
     }
     return *this;
+  }
+
+  /**
+   * THE question to ask before handing a blob's stored bytes to a caller as if
+   * they were data: true means they must be run back through the inverse
+   * transform first (or the request refused).
+   *
+   * Tests the whole word, not one bit, so a transform introduced by a newer
+   * writer than this reader still answers "yes".
+   */
+  CTP_CROSS_FUN bool IsTransformed() const {
+    return transform_flags_ != kBlobTransformNone;
+  }
+
+  /**
+   * Record that the bytes being stored are transformed. Called by whoever
+   * actually rewrote them (e.g. the compressor chimod), never inferred.
+   *
+   * `kind` is the descriptive bit(s); kBlobTransformed is added automatically
+   * so a caller cannot set a kind without also setting the authoritative bit.
+   * Accumulates -- see the stickiness note on transform_flags_.
+   */
+  CTP_CROSS_FUN void MarkTransformed(clio::run::u32 kind) {
+    transform_flags_ |= kBlobTransformed | kind;
   }
 
   // Authoritative O(blocks) sum; the source of truth for total_size_cache_.
@@ -1081,6 +1122,22 @@ struct Context {
   bool emulate_;                    // IN: skip real I/O, model the time
   clio::run::u64 emulated_time_ns_;  // OUT: modeled duration of the skipped I/O
 
+  // IN (PutBlob): set by a caller that has ALREADY rewritten the bytes it is
+  // handing over (compressor chimod today, encryption later), so the runtime
+  // can mark the blob authoritatively. See BlobTransformFlags.
+  // OUT (GetBlob): the blob's recorded transform state, so a Get caller --
+  // scalar, POD, or vectored -- can detect that the returned bytes are stored
+  // form, not the producer's original bytes (GetBlob does not undo
+  // transforms).
+  //
+  // Deliberately OUTSIDE the #if below: a field whose presence depends on a
+  // compile flag changes Context's (and therefore PutBlobTask's) layout between
+  // translation units built with different flags, which is a live ABI-skew
+  // hazard in this tree -- some targets hardcode CTP_ENABLE_COMPRESS=1 while
+  // the option itself defaults OFF. The safety bit must never be the thing that
+  // goes missing.
+  clio::run::u32 transform_flags_;
+
 #if CTP_ENABLE_COMPRESS
   int dynamic_compress_;  // 0 - skip, 1 - static, 2 - dynamic
   int compress_lib_;      // The compression library to apply (0-10)
@@ -1112,7 +1169,8 @@ struct Context {
         min_persistence_level_(0),
         preallocate_(0),
         emulate_(false),
-        emulated_time_ns_(0)
+        emulated_time_ns_(0),
+        transform_flags_(kBlobTransformNone)
 #if CTP_ENABLE_COMPRESS
         ,
         dynamic_compress_(0),
@@ -1138,7 +1196,7 @@ struct Context {
   template <class Archive>
   CTP_CROSS_FUN void serialize(Archive &ar) {
     ar.range(persistence_target_, min_persistence_level_, preallocate_,
-             emulate_, emulated_time_ns_);
+             emulate_, emulated_time_ns_, transform_flags_);
 #if CTP_ENABLE_COMPRESS
     ar.range(dynamic_compress_, compress_lib_, compress_preset_, target_psnr_,
              psnr_chance_, max_performance_, consumer_node_, data_type_,

--- a/context-transfer-engine/core/include/clio_cte/core/shm_metadata_cache.h
+++ b/context-transfer-engine/core/include/clio_cte/core/shm_metadata_cache.h
@@ -37,6 +37,7 @@
 #include <clio_ctp/data_structures/ipc/string.h>
 #include <clio_ctp/data_structures/ipc/unordered_map.h>
 
+#include "clio_cte/core/blob_transform.h"
 #include "clio_runtime/clio_runtime.h"
 #include "clio_runtime/types.h"
 
@@ -94,6 +95,10 @@ enum ShmBlobFlags : clio::run::u32 {
    *  a PREFIX of it. Reads bounded by CoveredBytes() are still served; reads
    *  past the prefix must fall back to RPC. */
   kShmBlobTruncated = 1u << 1,
+  /** The stored bytes are transformed (compressed/encrypted/...), so copying
+   *  them out verbatim would hand the caller codec bytes. Mirrors
+   *  BlobInfo::IsTransformed(); see transform_flags_ below. */
+  kShmBlobTransformed = 1u << 2,
 };
 
 /**
@@ -120,7 +125,18 @@ struct ShmBlobRecord {
   float score_;
   clio::run::u32 flags_;
   clio::run::u32 num_blocks_;
-  clio::run::u32 reserved_;
+  /**
+   * Verbatim mirror of BlobInfo::transform_flags_ (issue #818) -- the
+   * authoritative "these are not the caller's bytes" word, carried so a client
+   * can tell WHY the fast path was refused and, later, undo the transform
+   * itself. Occupies the slot formerly named `reserved_`, so the record's size
+   * and layout are unchanged.
+   *
+   * Note total_size_ is the STORED size. For a transformed blob that is the
+   * post-transform byte count, which is not the blob's logical length -- one
+   * more reason a transformed record must never serve a direct read.
+   */
+  clio::run::u32 transform_flags_;
   ShmBlockDesc blocks_[kMaxInlineBlocks];
 
   ShmBlobRecord()
@@ -131,7 +147,12 @@ struct ShmBlobRecord {
         score_(0.0f),
         flags_(0),
         num_blocks_(0),
-        reserved_(0) {}
+        transform_flags_(0) {}
+
+  /** True if this blob's stored bytes have been rewritten by some transform. */
+  bool IsTransformed() const {
+    return transform_flags_ != 0 || (flags_ & kShmBlobTransformed) != 0;
+  }
 
   /**
    * True if the payload may be read directly out of shared memory.
@@ -141,9 +162,18 @@ struct ShmBlobRecord {
    * exactly; refusing the whole blob threw away complete information about the
    * part it did have. Callers must bound the read by CoveredBytes(), not by
    * total_size_ -- that is what keeps a truncated record safe.
+   *
+   * A TRANSFORMED record never qualifies (issue #818): its stored bytes are a
+   * codec's output, so copying them out would succeed and return the wrong
+   * thing. The transform check is deliberately redundant with the runtime
+   * clearing kShmBlobDirectReadable when it builds the record: this is the
+   * "default must be refuse" discipline the cache is built on, so a future
+   * writer that forgets to clear the flag still cannot cause a client to hand
+   * codec bytes back as data.
    */
   bool IsDirectReadable() const {
-    return (flags_ & kShmBlobDirectReadable) != 0 && num_blocks_ > 0;
+    return (flags_ & kShmBlobDirectReadable) != 0 && !IsTransformed() &&
+           num_blocks_ > 0;
   }
 
   /**

--- a/context-transfer-engine/core/include/clio_cte/core/transaction_log.h
+++ b/context-transfer-engine/core/include/clio_cte/core/transaction_log.h
@@ -53,6 +53,21 @@ enum class TxnType : uint8_t {
   kDelBlob = 3,
   kCreateTag = 4,
   kDelTag = 5,
+  /**
+   * Blob's stored bytes were transformed (issue #818).
+   *
+   * A separate record rather than a field on kCreateNewBlob for two reasons.
+   * The transform is only known at the END of a put, after the bytes have been
+   * written, whereas kCreateNewBlob is logged when the blob is first created.
+   * And replay must be able to re-apply the mark on top of a blob that
+   * kCreateNewBlob has just reinserted with default (untransformed) state --
+   * see ReplayTransactionLogs.
+   *
+   * Appending a type is safe for an older runtime: its replay chain ignores
+   * types it does not recognise, which leaves it exactly where it was before
+   * this record existed.
+   */
+  kSetBlobTransform = 6,
 };
 
 /** A single block entry within TxnExtendBlob */
@@ -85,6 +100,14 @@ struct TxnClearBlob {
   clio::run::u32 tag_major_;
   clio::run::u32 tag_minor_;
   std::string blob_name_;
+};
+
+/** Payload: mark a blob's stored bytes as transformed (issue #818) */
+struct TxnSetBlobTransform {
+  clio::run::u32 tag_major_;
+  clio::run::u32 tag_minor_;
+  std::string blob_name_;
+  clio::run::u32 transform_flags_;
 };
 
 /** Payload: delete a blob */
@@ -171,6 +194,15 @@ class TransactionLog {
     WriteU32(buffer_, txn.tag_major_);
     WriteU32(buffer_, txn.tag_minor_);
     WriteString(buffer_, txn.blob_name_);
+    WriteRecord(type, buffer_);
+  }
+
+  void Log(TxnType type, const TxnSetBlobTransform &txn) {
+    buffer_.clear();
+    WriteU32(buffer_, txn.tag_major_);
+    WriteU32(buffer_, txn.tag_minor_);
+    WriteString(buffer_, txn.blob_name_);
+    WriteU32(buffer_, txn.transform_flags_);
     WriteRecord(type, buffer_);
   }
 
@@ -284,6 +316,17 @@ class TransactionLog {
       txn.new_blocks_[i].target_offset_ = ReadU64(data, off);
       txn.new_blocks_[i].size_ = ReadU64(data, off);
     }
+    return txn;
+  }
+
+  static TxnSetBlobTransform DeserializeSetBlobTransform(
+      const std::vector<char> &data) {
+    TxnSetBlobTransform txn;
+    size_t off = 0;
+    txn.tag_major_ = ReadU32(data, off);
+    txn.tag_minor_ = ReadU32(data, off);
+    txn.blob_name_ = ReadString(data, off);
+    txn.transform_flags_ = ReadU32(data, off);
     return txn;
   }
 

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -387,6 +387,13 @@ bool Runtime::BuildShmBlobRecord(const BlobInfo &info, ShmBlobRecord *out) {
   // Carries the block-layout generation to the client, which compares it
   // before and after copying a payload (issue #817).
   out->placement_gen_ = info.placement_gen_;
+  // Carry the authoritative transform state across verbatim (issue #818),
+  // plus the flag-word mirror so a client that only looks at flags_ refuses
+  // too.
+  out->transform_flags_ = info.transform_flags_;
+  if (info.IsTransformed()) {
+    out->flags_ |= kShmBlobTransformed;
+  }
 
   size_t n = info.blocks_.size();
   if (n > kMaxInlineBlocks) {
@@ -406,7 +413,12 @@ bool Runtime::BuildShmBlobRecord(const BlobInfo &info, ShmBlobRecord *out) {
   // by the first block that fails to qualify -- the default must be "refuse",
   // so an unknown target can never be mistaken for a readable one. Blocks past
   // the cached prefix are not inspected and are never read from.
-  bool all_direct = (n > 0);
+  //
+  // A transformed blob is excluded up front regardless of placement: its bytes
+  // are a codec's output, so copying them out would succeed and return the
+  // wrong thing (issue #818). The client falls back to RPC, which is the only
+  // path that knows how to undo the transform.
+  bool all_direct = (n > 0) && !info.IsTransformed();
 
   for (size_t i = 0; i < n; ++i) {
     const BlobBlock &b = info.blocks_[i];
@@ -1779,9 +1791,36 @@ clio::run::TaskResume Runtime::PutBlobImpl(clio::run::shared_ptr<TaskT> &task) {
       }
     }
 
-#if CTP_ENABLE_COMPRESS
-    // Update compression metadata
+    // Record whether the bytes we just stored are still the caller's bytes
+    // (issue #818). The producer that rewrote them tells us; we never infer it
+    // from compress_lib_, which reports the codec *requested* and is wrong in
+    // both directions. Unconditionally compiled so a build with compression
+    // off cannot silently claim an untransformed blob.
     Context &context = task->context_;
+    if (context.transform_flags_ != kBlobTransformNone) {
+      const clio::run::u32 before = blob_info_ptr->transform_flags_;
+      blob_info_ptr->MarkTransformed(context.transform_flags_);
+      if (blob_info_ptr->transform_flags_ != before &&
+          !blob_txn_logs_.empty()) {
+        // Persist the mark. Without this the bit is only in the metadata log,
+        // which is written on flush -- so a crash between the put and the next
+        // flush would replay this blob from the transaction log alone and
+        // resurrect it as untransformed, i.e. direct-readable codec bytes.
+        // Logged only on an actual transition, so a stream of puts to an
+        // already-marked blob costs nothing.
+        clio::run::u32 wid = CLIO_CUR_WORKER->GetWorkerStats().worker_id_;
+        TxnSetBlobTransform txn;
+        txn.tag_major_ = tag_id.major_;
+        txn.tag_minor_ = tag_id.minor_;
+        txn.blob_name_ = blob_name;
+        txn.transform_flags_ = blob_info_ptr->transform_flags_;
+        blob_txn_logs_[wid % blob_txn_logs_.size()]->Log(
+            TxnType::kSetBlobTransform, txn);
+      }
+    }
+
+#if CTP_ENABLE_COMPRESS
+    // Update compression metadata (provenance/telemetry; see BlobInfo).
     blob_info_ptr->compress_lib_ = context.compress_lib_;
     blob_info_ptr->compress_preset_ = context.compress_preset_;
     blob_info_ptr->trace_key_ = context.trace_key_;
@@ -1975,6 +2014,12 @@ clio::run::TaskResume Runtime::GetBlobImpl(clio::run::shared_ptr<TaskT> &task) {
       task->return_code_ = 1;
       CLIO_CO_RETURN;
     }
+
+    // OUT: report the blob's transform state so every Get caller -- scalar,
+    // POD, and vectored all route through this Impl -- can detect that the
+    // bytes it is about to receive are not the producer's bytes (issue #818;
+    // GetBlob returns STORED bytes and does not undo transforms).
+    task->context_.transform_flags_ = blob_info_ptr->transform_flags_;
 
     // Use the pre-provided data pointer from the task
     ctp::ipc::ShmPtr<> blob_data_ptr = task->blob_data_;
@@ -3652,14 +3697,20 @@ clio::run::TaskResume Runtime::FlushMetadata(clio::run::shared_ptr<FlushMetadata
       task->entries_flushed_++;
     });
 
-    // Write BlobInfo entries (entry_type 1)
+    // Write BlobInfo entries (entry_type 2; see below)
     tag_blob_name_to_info_.for_each([&](const std::string &key,
                                         const std::shared_ptr<BlobInfo> &blob_info_sp) { const BlobInfo &blob_info = *blob_info_sp; (void)blob_info;
-      uint8_t entry_type = 1;
+      // Entry type 2 == blob record carrying transform_flags_ (issue #818).
+      // A NEW type rather than an extra field on type 1, because this log has
+      // no version header: an old reader given an appended field would parse it
+      // as block data and silently reconstruct garbage placement, whereas an
+      // unknown entry type stops the restore loudly.
+      uint8_t entry_type = 2;
       uint32_t key_len = static_cast<uint32_t>(key.size());
       uint32_t blob_name_len =
           static_cast<uint32_t>(blob_info.blob_name_.size());
       float score = blob_info.score_;
+      uint32_t transform_flags = blob_info.transform_flags_;
       int32_t compress_lib = blob_info.compress_lib_;
       int32_t compress_preset = blob_info.compress_preset_;
       clio::run::u64 trace_key = blob_info.trace_key_;
@@ -3673,6 +3724,8 @@ clio::run::TaskResume Runtime::FlushMetadata(clio::run::shared_ptr<FlushMetadata
                 sizeof(blob_name_len));
       ofs.write(blob_info.blob_name_.data(), blob_name_len);
       ofs.write(reinterpret_cast<const char *>(&score), sizeof(score));
+      ofs.write(reinterpret_cast<const char *>(&transform_flags),
+                sizeof(transform_flags));
       ofs.write(reinterpret_cast<const char *>(&compress_lib),
                 sizeof(compress_lib));
       ofs.write(reinterpret_cast<const char *>(&compress_preset),
@@ -3992,8 +4045,11 @@ void Runtime::RestoreMetadataFromLog() {
       }
       tags_restored++;
 
-    } else if (entry_type == 1) {
-      // BlobInfo entry
+    } else if (entry_type == 1 || entry_type == 2) {
+      // BlobInfo entry. Type 1 is the pre-#818 layout with no transform_flags_;
+      // type 2 carries it. Both are accepted so an existing metadata log still
+      // restores after an upgrade.
+      const bool has_transform_flags = (entry_type == 2);
       uint32_t key_len;
       ifs.read(reinterpret_cast<char *>(&key_len), sizeof(key_len));
       std::string composite_key(key_len, '\0');
@@ -4006,6 +4062,11 @@ void Runtime::RestoreMetadataFromLog() {
 
       float score;
       ifs.read(reinterpret_cast<char *>(&score), sizeof(score));
+      uint32_t transform_flags = 0;
+      if (has_transform_flags) {
+        ifs.read(reinterpret_cast<char *>(&transform_flags),
+                 sizeof(transform_flags));
+      }
       int32_t compress_lib;
       ifs.read(reinterpret_cast<char *>(&compress_lib), sizeof(compress_lib));
       int32_t compress_preset;
@@ -4024,6 +4085,16 @@ void Runtime::RestoreMetadataFromLog() {
       blob_info.compress_lib_ = compress_lib;
       blob_info.compress_preset_ = compress_preset;
       blob_info.trace_key_ = trace_key;
+      if (has_transform_flags) {
+        blob_info.transform_flags_ = transform_flags;
+      } else if (compress_lib != 0) {
+        // Legacy entry: the authoritative bit did not exist when this log was
+        // written, so compress_lib_ is the only evidence available. Treat it as
+        // "transformed" -- it over-reports (it is also set when compression was
+        // attempted but not applied), and over-reporting only costs the direct-
+        // read fast path, whereas under-reporting hands back codec bytes.
+        blob_info.MarkTransformed(kBlobTransformCompressed);
+      }
 
       // Read per-block data
       for (uint32_t i = 0; i < num_blocks; i++) {
@@ -4159,6 +4230,20 @@ void Runtime::ReplayTransactionLogs() {
         BlobInfo blob_info;
         blob_info.blob_name_ = txn.blob_name_;
         blob_info.score_ = txn.score_;
+        // Carry over any transform mark already restored for this key (issue
+        // #818). The WAL is only truncated once it exceeds a size threshold,
+        // so a kCreateNewBlob record can outlive the metadata flush that
+        // recorded the blob's transform state -- and this insert_or_assign
+        // would otherwise reset that state to "untransformed", i.e. fail open
+        // into direct reads of codec bytes. A later kSetBlobTransform record,
+        // when present, ORs in on top of this.
+        {
+          std::shared_ptr<BlobInfo> existing =
+              tag_blob_name_to_info_.get(composite_key);
+          if (existing) {
+            blob_info.transform_flags_ = existing->transform_flags_;
+          }
+        }
         tag_blob_name_to_info_.insert_or_assign(composite_key, std::make_shared<BlobInfo>(blob_info));
         MirrorBlobToShm(composite_key, blob_info);
         blobs_replayed++;
@@ -4209,6 +4294,24 @@ void Runtime::ReplayTransactionLogs() {
           blob_info_ptr->total_size_cache_ = 0;  // blocks_ cleared
         }
         blobs_replayed++;
+
+      } else if (type == TxnType::kSetBlobTransform) {
+        // issue #818. Replayed AFTER kCreateNewBlob for the same blob (records
+        // are applied in log order, and the mark is always logged later in the
+        // put than the create), so this reinstates the bit on top of the
+        // default-constructed BlobInfo that kCreateNewBlob inserts.
+        auto txn = TransactionLog::DeserializeSetBlobTransform(payload);
+        TagId tag_id{txn.tag_major_, txn.tag_minor_};
+        std::string composite_key = std::to_string(tag_id.major_) + "." +
+                                    std::to_string(tag_id.minor_) + "." +
+                                    txn.blob_name_;
+        std::shared_ptr<BlobInfo> blob_info_ptr =
+            tag_blob_name_to_info_.get(composite_key);
+        if (blob_info_ptr) {
+          blob_info_ptr->transform_flags_ |= txn.transform_flags_;
+          MirrorBlobToShm(composite_key, *blob_info_ptr);
+          blobs_replayed++;
+        }
 
       } else if (type == TxnType::kDelBlob) {
         auto txn = TransactionLog::DeserializeDelBlob(payload);

--- a/context-transfer-engine/test/unit/test_core_functionality.cc
+++ b/context-transfer-engine/test/unit/test_core_functionality.cc
@@ -2904,6 +2904,157 @@ TEST_CASE("CTE SHM cache direct payload read",
 }
 
 /**
+ * issue #818: a transformed blob must never be served from the direct-read
+ * fast path.
+ *
+ * The producer of the bytes declares the transform through
+ * Context::transform_flags_. This test drives that field directly rather than
+ * going through the compressor chimod, for two reasons: the chimod is only
+ * built when CLIO_CTE_ENABLE_COMPRESS is ON (it defaults OFF), and the property
+ * under test is precisely that the guard does NOT depend on compression being
+ * compiled in. A compressed blob is one instance of the rule; the rule is the
+ * bit.
+ */
+TEST_CASE("CTE SHM cache refuses direct reads of transformed blobs",
+          "[cte][core][shm_cache][transform][noleak]") {
+  auto *fixture = ctp::Singleton<CTECoreFunctionalTestFixture>::GetInstance();
+  clio::run::PoolQuery pool_query = clio::run::PoolQuery::Dynamic();
+  clio::cte::core::CreateParams params;
+
+  // ISOLATED pool whose ONLY target is kRam, exactly as the payload test does.
+  // This is load-bearing, not boilerplate: on the shared fixture pool the DPE
+  // places blobs on a file target, which is not direct-readable for reasons
+  // that have nothing to do with transforms -- so every "the fast path
+  // refuses" assertion below would pass for the wrong reason and the test
+  // would prove nothing.
+  clio::run::PoolId xform_pool(7802, 0);
+  clio::cte::core::Client client(xform_pool);
+  {
+    auto t = client.AsyncCreate(pool_query, "cte_shm_transform_pool",
+                                xform_pool, params);
+    t.Wait();
+    client.AttachShmCache(*t);
+  }
+  {
+    auto t = client.AsyncRegisterTarget(
+        "ram_transform_target", clio::run::bdev::BdevType::kRam,
+        64ULL * 1024 * 1024, clio::run::PoolQuery::Local(),
+        clio::run::PoolId(672, 0));
+    t.Wait();
+    REQUIRE(t->GetReturnCode() == 0);
+  }
+
+  if (!client.HasShmCache()) {
+    HLOG(kWarning,
+         "[#818] SHM metadata cache unavailable -- transform-guard assertions "
+         "SKIPPED (this test proves nothing on this host)");
+    return;
+  }
+
+  clio::cte::core::TagId tag_id;
+  {
+    auto t = client.AsyncGetOrCreateTag("shm_transform_tag");
+    t.Wait();
+    tag_id = t->tag_id_;
+  }
+  REQUIRE(!tag_id.IsNull());
+
+  const clio::run::u64 blob_size = 4096;
+  auto test_data = fixture->CreateTestData(blob_size, 'X');
+
+  // Put the SAME bytes twice: once declared raw, once declared transformed.
+  // The only difference between the two blobs is the bit, so any difference in
+  // how the cache treats them is attributable to it and nothing else.
+  auto put_blob = [&](const std::string &name, clio::run::u32 transform) {
+    auto fp = CLIO_IPC->AllocateBuffer(blob_size);
+    REQUIRE(!fp.IsNull());
+    REQUIRE(fixture->CopyToSharedMemory(fp, test_data));
+    clio::cte::core::Context ctx;
+    ctx.transform_flags_ = transform;
+    auto put = client.AsyncPutBlob(tag_id, name, 0, blob_size,
+                                   fp.shm_.template Cast<void>(), 0.9f, ctx, 0);
+    REQUIRE(!put.IsNull());
+    REQUIRE(fixture->WaitForTaskCompletion(put, 10000));
+    REQUIRE(put->return_code_ == 0);
+    CLIO_IPC->FreeBuffer(fp);
+  };
+
+  put_blob("raw_blob", clio::cte::core::kBlobTransformNone);
+  put_blob("transformed_blob", clio::cte::core::kBlobTransformed |
+                                   clio::cte::core::kBlobTransformCompressed);
+
+  clio::cte::core::ShmBlobRecord raw_rec, xform_rec;
+  REQUIRE(client.TryGetBlobRecordShm(tag_id, "raw_blob", &raw_rec));
+  REQUIRE(client.TryGetBlobRecordShm(tag_id, "transformed_blob", &xform_rec));
+
+  // CONTROL. Without this the refusal assertions below are vacuous: they would
+  // also hold if nothing here were direct-readable in the first place. The raw
+  // blob proves the fast path IS available for these bytes on this tier, so
+  // the transformed blob's refusal is attributable to the bit alone.
+  if (!raw_rec.IsDirectReadable()) {
+    HLOG(kWarning,
+         "[#818] raw control blob is not direct-readable -- refusal "
+         "assertions would be vacuous, SKIPPING");
+    return;
+  }
+  {
+    std::vector<char> control(blob_size, 0);
+    REQUIRE(client.TryReadBlobShm(tag_id, "raw_blob", control.data(),
+                                  blob_size));
+    REQUIRE(std::memcmp(control.data(), test_data.data(), blob_size) == 0);
+  }
+
+  SECTION("The transform state reaches the cache record") {
+    REQUIRE_FALSE(raw_rec.IsTransformed());
+    REQUIRE(xform_rec.IsTransformed());
+    REQUIRE((xform_rec.transform_flags_ &
+             clio::cte::core::kBlobTransformCompressed) != 0);
+  }
+
+  SECTION("A transformed record is never direct-readable") {
+    REQUIRE_FALSE(xform_rec.IsDirectReadable());
+    // ...and the runtime cleared the flag rather than relying solely on the
+    // client-side check, so an older client refuses too.
+    REQUIRE((xform_rec.flags_ &
+             clio::cte::core::kShmBlobDirectReadable) == 0);
+  }
+
+  SECTION("The payload fast path refuses") {
+    std::vector<char> got(blob_size, 0);
+    REQUIRE_FALSE(client.TryReadBlobShm(tag_id, "transformed_blob", got.data(),
+                                        blob_size));
+  }
+
+  SECTION("Refusing costs correctness nothing: RPC still returns the bytes") {
+    // The guard must degrade to the slow path, never to an error or to
+    // "no such blob".
+    auto rd = CLIO_IPC->AllocateBuffer(blob_size);
+    REQUIRE(!rd.IsNull());
+    auto g = client.AsyncGetBlob(tag_id, "transformed_blob", 0, blob_size, 0,
+                                 rd.shm_.template Cast<void>());
+    g.Wait();
+    REQUIRE(g->return_code_ == 0);
+    REQUIRE(std::memcmp(test_data.data(), rd.ptr_, blob_size) == 0);
+    // The get also REPORTS the transform state back through its context
+    // (OUT), so a caller can detect it received stored-form bytes.
+    REQUIRE((g->context_.transform_flags_ &
+             clio::cte::core::kBlobTransformed) != 0);
+    CLIO_IPC->FreeBuffer(rd);
+  }
+
+  SECTION("The bit is sticky across an overwrite with undeclared bytes") {
+    // A later put that does not declare a transform must not clear the mark:
+    // the blob may now be a mix of codec output and raw bytes, and the only
+    // safe reading of that is still "transformed".
+    put_blob("transformed_blob", clio::cte::core::kBlobTransformNone);
+    clio::cte::core::ShmBlobRecord after;
+    REQUIRE(client.TryGetBlobRecordShm(tag_id, "transformed_blob", &after));
+    REQUIRE(after.IsTransformed());
+    REQUIRE_FALSE(after.IsDirectReadable());
+  }
+}
+
+/**
  * issue #783: WRITE-THEN-READ cycle latency.
  *
  * The earlier benchmarks timed reads in steady state, with no interleaved

--- a/context-transfer-engine/test/unit/test_cte_shm_metadata_cache.cc
+++ b/context-transfer-engine/test/unit/test_cte_shm_metadata_cache.cc
@@ -210,6 +210,74 @@ TEST_CASE("ShmCache: truncated blob is readable only over its prefix",
   REQUIRE_FALSE(empty.IsDirectReadable());
 }
 
+TEST_CASE("ShmCache: transformed blob is not direct-readable", "[shm_cache]") {
+  // issue #818. A compressed/encrypted blob stores codec output, so copying
+  // its bytes out of shared memory would SUCCEED and return the wrong thing.
+  // Placement alone (node-local + kRam) must not be enough to qualify.
+  SECTION("descriptive transform bits refuse") {
+    ShmBlobRecord rec;
+    rec.num_blocks_ = 1;
+    rec.flags_ = kShmBlobDirectReadable;
+    rec.transform_flags_ = kBlobTransformed | kBlobTransformCompressed;
+    REQUIRE(rec.IsTransformed());
+    REQUIRE_FALSE(rec.IsDirectReadable());
+  }
+
+  SECTION("an unknown future transform still refuses") {
+    // The guard tests the whole word, not one known bit, so a transform
+    // introduced by a writer newer than this reader fails safe.
+    ShmBlobRecord rec;
+    rec.num_blocks_ = 1;
+    rec.flags_ = kShmBlobDirectReadable;
+    rec.transform_flags_ = 1u << 20;
+    REQUIRE(rec.IsTransformed());
+    REQUIRE_FALSE(rec.IsDirectReadable());
+  }
+
+  SECTION("the record flag alone refuses even if the word is empty") {
+    // Defence in depth: the runtime clears kShmBlobDirectReadable when it
+    // builds a transformed record, but the client must not depend on that.
+    ShmBlobRecord rec;
+    rec.num_blocks_ = 1;
+    rec.flags_ = kShmBlobDirectReadable | kShmBlobTransformed;
+    REQUIRE(rec.IsTransformed());
+    REQUIRE_FALSE(rec.IsDirectReadable());
+  }
+
+  SECTION("an untransformed blob is unaffected") {
+    ShmBlobRecord rec;
+    rec.num_blocks_ = 1;
+    rec.flags_ = kShmBlobDirectReadable;
+    REQUIRE_FALSE(rec.IsTransformed());
+    REQUIRE(rec.IsDirectReadable());
+  }
+}
+
+TEST_CASE("ShmCache: transform state survives the map round-trip",
+          "[shm_cache]") {
+  // The record is copied through the seqlock as raw bytes; prove the transform
+  // word rides along rather than being dropped like the old reserved_ slot.
+  Fixture f;
+  REQUIRE(f.Create());
+
+  ShmBlobRecord rec;
+  rec.total_size_ = 1024;
+  rec.num_blocks_ = 1;
+  rec.flags_ = kShmBlobTransformed;  // direct-readable deliberately NOT set
+  rec.transform_flags_ = kBlobTransformed | kBlobTransformCompressed;
+  rec.blocks_[0].size_ = 1024;
+  REQUIRE(PutBlob(f, "1.0.zblob", rec));
+
+  ShmBlobRecord out;
+  REQUIRE(f.root->blob_key_to_info_.TryGetBytes("1.0.zblob", 9, &out));
+  REQUIRE(out.transform_flags_ ==
+          (kBlobTransformed | kBlobTransformCompressed));
+  REQUIRE(out.IsTransformed());
+  REQUIRE_FALSE(out.IsDirectReadable());
+
+  f.Destroy();
+}
+
 TEST_CASE("ShmCache: tag maps round-trip", "[shm_cache]") {
   Fixture f;
   REQUIRE(f.Create());

--- a/context-transfer-engine/test/unit/test_cte_transaction_log.cc
+++ b/context-transfer-engine/test/unit/test_cte_transaction_log.cc
@@ -177,6 +177,38 @@ TEST_CASE("TransactionLog - ClearBlob DelBlob roundtrip", "[cte][txnlog]") {
   TxnRemove(path);
 }
 
+TEST_CASE("TransactionLog - SetBlobTransform roundtrip", "[cte][txnlog]") {
+  // issue #818: the record that persists a blob's transform mark between the
+  // put that set it and the next metadata flush.
+  std::string path = TxnTempFile("txn_set_transform");
+  TxnRemove(path);
+
+  TransactionLog log;
+  log.Open(path, 4096);
+
+  TxnSetBlobTransform txn;
+  txn.tag_major_ = 21;
+  txn.tag_minor_ = 22;
+  txn.blob_name_ = "compressed_blob";
+  txn.transform_flags_ = 0x3;  // kBlobTransformed | kBlobTransformCompressed
+  log.Log(TxnType::kSetBlobTransform, txn);
+  log.Sync();
+
+  auto entries = log.Load();
+  REQUIRE(entries.size() == 1);
+  REQUIRE(entries[0].first == TxnType::kSetBlobTransform);
+
+  TxnSetBlobTransform out =
+      TransactionLog::DeserializeSetBlobTransform(entries[0].second);
+  REQUIRE(out.tag_major_ == 21);
+  REQUIRE(out.tag_minor_ == 22);
+  REQUIRE(out.blob_name_ == "compressed_blob");
+  REQUIRE(out.transform_flags_ == 0x3);
+
+  log.Close();
+  TxnRemove(path);
+}
+
 TEST_CASE("TransactionLog - CreateTag DelTag roundtrip", "[cte][txnlog]") {
   std::string path = TxnTempFile("txn_tags");
   TxnRemove(path);

--- a/context-transfer-engine/test/unit/test_vectored_blob_io.cc
+++ b/context-transfer-engine/test/unit/test_vectored_blob_io.cc
@@ -361,6 +361,92 @@ TEST_CASE("Vectored I/O rejects malformed segments", "[cte][vectored][820]") {
   std::printf("[#820] vectored I/O rejects zero-size and null segments\n");
 }
 
+TEST_CASE("Vectored put/get honor the blob-transform bit",
+          "[cte][vectored][818]") {
+  // issue #818. The vectored APIs share PutBlobTask/GetBlobTask with the
+  // scalar path, so the transform declaration must flow through them
+  // identically: a vectored put that declares Context::transform_flags_ marks
+  // the blob, the SHM cache record refuses direct reads, and a vectored get
+  // still returns the stored bytes through the RPC fallback.
+  REQUIRE(g_fixture != nullptr);
+  REQUIRE(g_fixture->initialized_);
+  auto *ipc = CLIO_IPC;
+  auto *cte = CLIO_CTE_CLIENT;
+
+  clio::cte::core::Tag tag("vectored_transform_tag");
+  clio::cte::core::TagId tag_id = tag.GetTagId();
+
+  const size_t kSeg = 4096;
+  const int kN = 4;
+
+  auto put_vectored = [&](const std::string &blob, clio::run::u32 transform) {
+    std::vector<ctp::ipc::FullPtr<char>> bufs;
+    std::vector<clio::cte::core::BlobSegment> segs;
+    for (int i = 0; i < kN; ++i) {
+      auto b = FillBuf(kSeg, static_cast<char>('a' + i));
+      bufs.push_back(b);
+      segs.push_back(clio::cte::core::BlobSegment(
+          static_cast<clio::run::u64>(i) * kSeg, kSeg,
+          ctp::ipc::ShmPtr<>(b.shm_)));
+    }
+    clio::cte::core::Context ctx;
+    ctx.transform_flags_ = transform;
+    auto pv = cte->AsyncPutBlobVectored(tag_id, blob, segs, /*score=*/-1.0f,
+                                        ctx);
+    pv.Wait();
+    REQUIRE(pv->GetReturnCode() == 0);
+    for (auto &b : bufs) ipc->FreeBuffer(b);
+  };
+
+  put_vectored("vt_raw", clio::cte::core::kBlobTransformNone);
+  put_vectored("vt_transformed", clio::cte::core::kBlobTransformed |
+                                     clio::cte::core::kBlobTransformCompressed);
+
+  // The mark reaches the cache record, and only for the declared blob.
+  if (cte->HasShmCache()) {
+    clio::cte::core::ShmBlobRecord raw_rec, xf_rec;
+    REQUIRE(cte->TryGetBlobRecordShm(tag_id, "vt_raw", &raw_rec));
+    REQUIRE(cte->TryGetBlobRecordShm(tag_id, "vt_transformed", &xf_rec));
+    REQUIRE_FALSE(raw_rec.IsTransformed());
+    REQUIRE(xf_rec.IsTransformed());
+    REQUIRE_FALSE(xf_rec.IsDirectReadable());
+    REQUIRE((xf_rec.flags_ & clio::cte::core::kShmBlobDirectReadable) == 0);
+    // CONTROL: the raw blob on the same tier IS direct-readable, so the
+    // refusal above is attributable to the bit and not to placement.
+    REQUIRE(raw_rec.IsDirectReadable());
+  } else {
+    std::printf("[#818] SHM cache unavailable; record assertions skipped\n");
+  }
+
+  // A vectored get of the transformed blob must still return the stored
+  // bytes -- the guard degrades to the RPC path, never to an error.
+  {
+    std::vector<ctp::ipc::FullPtr<char>> bufs;
+    std::vector<clio::cte::core::BlobSegment> segs;
+    for (int i = 0; i < kN; ++i) {
+      auto b = FillBuf(kSeg, 0);
+      bufs.push_back(b);
+      segs.push_back(clio::cte::core::BlobSegment(
+          static_cast<clio::run::u64>(i) * kSeg, kSeg,
+          ctp::ipc::ShmPtr<>(b.shm_)));
+    }
+    auto gv = cte->AsyncGetBlobVectored(tag_id, "vt_transformed", segs);
+    gv.Wait();
+    REQUIRE(gv->GetReturnCode() == 0);
+    // ...and the get REPORTS the transform state back through its context, so
+    // the caller can detect the bytes are stored form, not the original.
+    REQUIRE((gv->context_.transform_flags_ &
+             clio::cte::core::kBlobTransformed) != 0);
+    for (int i = 0; i < kN; ++i) {
+      std::vector<char> want(kSeg, static_cast<char>('a' + i));
+      REQUIRE(std::memcmp(bufs[static_cast<size_t>(i)].ptr_, want.data(),
+                          kSeg) == 0);
+      ipc->FreeBuffer(bufs[static_cast<size_t>(i)]);
+    }
+  }
+  std::printf("[#818] vectored put/get honor the transform bit\n");
+}
+
 int main(int argc, char **argv) {
   g_fixture = new Fixture();
   std::string filter = (argc > 1) ? argv[1] : "";

--- a/project_blob_transform_bit.md
+++ b/project_blob_transform_bit.md
@@ -1,0 +1,148 @@
+# Authoritative blob-transform bit (issue #818)
+
+## Problem
+
+The #783 shared-memory metadata cache lets a client copy a blob's payload straight out of
+the RAM bdev segment, bypassing the runtime entirely. That fast path's whole safety argument
+is *"it can only be faster or equivalent, never wrong"* — it decides whether a payload is
+directly readable purely from placement (`every block is node-local and kRam`).
+
+Placement is not the only thing that determines whether the stored bytes are the caller's
+bytes. A compressed blob stores `CompressionHeader + codec output`; a future encrypted blob
+would store ciphertext. Copying those out verbatim succeeds and returns the wrong thing, with
+a success return code and no error anywhere.
+
+Today this is latent rather than live, because core `GetBlob` does not decompress either — so
+the RPC path is equally wrong and the two agree. The moment core learns transparent
+decompression, the fast path silently diverges.
+
+## Decision: one authoritative bit, not a compression lookup
+
+The issue proposed carrying `compress_lib_`/`compress_preset_` into the cache record and
+keying the guard off compression. **We do not key the guard off compression.** The
+authoritative signal is a dedicated flag word, `BlobInfo::transform_flags_`, asked via
+`BlobInfo::IsTransformed()`. Compression provenance is still carried, but only as
+provenance.
+
+Three reasons, in order of weight:
+
+### 1. Compression is not the only transform
+
+Encryption is the obvious next one, and it has exactly the same shape: stored bytes ≠ logical
+bytes, offsets into them are meaningless, and length is not preserved. A guard spelled
+`compress_lib_ != 0` would have to be found and widened by whoever adds it — i.e. the guard
+fails open for every transform nobody thought of yet. `IsTransformed()` tests the whole word
+against zero, so a bit set by a newer writer than the reader still answers "yes"; unknown
+transforms fail *safe*.
+
+### 2. `compress_lib_` is wrong in both directions today
+
+It answers "which codec was *requested*", not "what is on the device".
+
+**False positive.** `compressor_runtime.cc`, the not-beneficial branch: compression is
+attempted, does not shrink the data, and the original bytes are stored — but `AsyncPutBlob`
+was called with `context.compress_lib_` still set, and it was only zeroed *afterwards*. The
+runtime therefore recorded a codec on a blob holding raw bytes. (This PR also reorders that
+assignment, so the provenance field stops lying too.)
+
+**False negative.** Core records `compress_lib_` under `#if CTP_ENABLE_COMPRESS`, and
+`CLIO_CTE_ENABLE_COMPRESS` defaults **OFF** — while the metadata log persists the field
+unconditionally. A restart can therefore restore a genuinely compressed blob into a runtime
+that never populates the field, i.e. a blob that reads as "not compressed" while holding
+codec output. That is precisely the silent-wrong-data case the guard exists to prevent.
+
+A guard derived from a field that is wrong in both directions is not a guard.
+
+### 3. The bit must not be able to vanish with a compile flag
+
+`transform_flags_` is compiled **unconditionally**, on both `BlobInfo` and `Context` —
+deliberately outside the `#if CTP_ENABLE_COMPRESS` blocks that surround the neighbouring
+compression fields.
+
+Beyond the false-negative above, a field whose *presence* depends on a compile flag changes
+the size of `Context`, and therefore of `PutBlobTask`, between translation units built with
+different flags. That is a live hazard in this tree: `CLIO_CTE_ENABLE_COMPRESS` defaults OFF
+while several targets hardcode `CTP_ENABLE_COMPRESS=1`, and this exact skew has already been
+diagnosed once as a client/runtime `PutBlobTask` size mismatch. A safety bit is the last
+thing that should be able to go missing.
+
+## Design
+
+**Producer-declared, never inferred.** Whoever rewrites the bytes sets the bit. The compressor
+chimod sets `context.transform_flags_ |= kBlobTransformed | kBlobTransformCompressed` on the
+branch that actually stores compressed bytes, and leaves it clear on the branch that stores
+the original. `PutBlobImpl` copies it onto the `BlobInfo`. Core never guesses.
+
+**Sticky.** Once set, a later put does not clear it. A partial overwrite of a compressed blob
+with raw bytes leaves a blob that is neither wholly raw nor wholly transformed; the only safe
+reading of that is "transformed". Over-refusing costs a round-trip, under-refusing returns
+codec bytes as data. Cleared only when the blob is destroyed.
+
+**Refuse at both ends.** `BuildShmBlobRecord` declines to set `kShmBlobDirectReadable` for a
+transformed blob, *and* `ShmBlobRecord::IsDirectReadable()` independently rejects a record
+whose transform state is non-zero. The redundancy is the cache's existing "default must be
+refuse" discipline: a future writer that forgets to clear the flag still cannot cause a
+client to hand back codec bytes.
+
+**Record layout is unchanged.** `ShmBlobRecord::transform_flags_` occupies the slot formerly
+named `reserved_`, so the record's size and alignment are identical and `kLayoutVersion` does
+**not** need bumping. Bumping it would have been worse than useless here: it would force
+every pre-existing client to detach and lose the fast path for *all* blobs, when the actual
+protection — `kShmBlobDirectReadable` being clear — is a flag those clients already honour.
+
+## Persistence
+
+There are **two** independent persistence paths, and the bit has to survive both. Missing
+either one means a restart resurrects a transformed blob as untransformed — which is the
+fail-open direction, so this is not optional.
+
+### Metadata log (`FlushMetadata` / `RestoreMetadataFromLog`)
+
+No magic or version header; a bare stream of entries discriminated by a leading `entry_type`
+byte. Appending a field to the existing blob entry (type 1) would be misparsed by an older
+reader as block data, silently reconstructing garbage placement.
+
+So transform-carrying blob entries are written as a **new entry type 2**. The reader accepts
+both: type 2 reads the field; type 1 is legacy and derives the bit conservatively from
+`compress_lib_ != 0`. That derivation over-reports (it inherits the false positive above),
+which is the safe direction — it costs the fast path, not correctness. An older runtime given
+a new log hits the existing unknown-entry-type branch, which warns and stops the restore
+rather than misparsing it.
+
+### Transaction log (`ReplayTransactionLogs`)
+
+This log records *placement only* — `kCreateNewBlob` (name + score) and `kExtendBlob`
+(blocks). It has never carried compression state, which was harmless while nothing depended
+on it and is not harmless now. Two concrete holes, both closed here:
+
+1. **A put not yet flushed loses its mark.** A crash between the put and the next metadata
+   flush replays the blob from the transaction log alone. Fixed with a new
+   **`kSetBlobTransform` (type 6)** record, logged on the put that first sets the bit — only
+   on an actual transition, so repeated puts to an already-marked blob cost nothing.
+2. **A stale `kCreateNewBlob` clobbers a restored mark.** Replay runs *after*
+   `RestoreMetadataFromLog`, and `kCreateNewBlob` does an `insert_or_assign` of a fresh
+   `BlobInfo`. Because the WAL is truncated only once it exceeds a size threshold — not on
+   every flush — such a record can outlive the flush that persisted the blob's transform
+   state, resetting it to zero. Replay of `kCreateNewBlob` now carries over the transform
+   word of any blob already present under that key.
+
+Appending a transaction type is safe for an older runtime: its replay chain is an if/else-if
+with no trailing `else`, so unrecognised types are ignored, leaving it exactly where it was
+before the record existed.
+
+## Deliberately not changed
+
+`Tag::GetBlobSize`'s fast path still answers from `ShmBlobRecord::total_size_`, which is the
+**stored** size — for a transformed blob, the post-transform byte count. It is left alone
+because the RPC path returns the same number today, so refusing would cost a round-trip
+without changing a single answer. The stored-vs-logical distinction is now documented on the
+field itself, so whoever teaches `GetBlob` to decompress transparently has the note in front
+of them: at that point `GetBlobSize` must return the logical size, and its fast path must
+start consulting `IsTransformed()` too.
+
+Client-side decompression from shared memory — direction (B) in the issue, and the actually
+valuable follow-up, since it would skip the round-trip *and* move decompress CPU off the
+runtime worker — is out of scope here. It needs codec linkage in the client library, a
+decompressed-page cache with an invalidation story, and header-length validation against the
+record. This change is the correctness guard that has to land first, so nothing starts
+depending on direct reads of transformed data in the meantime.


### PR DESCRIPTION
Closes #818.

## What

The #783 shared-memory metadata cache decides whether a blob's payload is directly readable purely from **placement** (every block node-local + kRam). Placement is not the only thing that determines whether the stored bytes are the caller's bytes: a compressed blob stores `CompressionHeader + codec output`, a future encrypted blob would store ciphertext. Copying those out verbatim succeeds and returns the wrong thing.

This lands direction **(A)** from the issue — mark and refuse; no client-side decompression — with one deliberate deviation: the guard is keyed off a new **authoritative transform bit**, not off compression provenance.

## Design

- **`BlobInfo::transform_flags_` / `Context::transform_flags_` / `ShmBlobRecord::transform_flags_`** (`blob_transform.h`): producer-declared, never inferred. The compressor chimod sets `kBlobTransformed | kBlobTransformCompressed` on the branch that actually stores codec output, and no longer records a codec on the not-beneficial branch (it used to zero `compress_lib_` only *after* the put).
- **Not derived from `compress_lib_`**, which is wrong in both directions: false positive on the compressor's not-beneficial path, false negative because core records it under `#if CTP_ENABLE_COMPRESS` (default OFF) while the WAL persists it unconditionally.
- **Compiled unconditionally**, outside the `#if CTP_ENABLE_COMPRESS` blocks — a safety bit must not vanish with a compile flag, and conditionally-present `Context` members change `PutBlobTask`'s layout between TUs (an ABI skew already diagnosed once in this tree).
- **Sticky**: a later put never clears it; a partial overwrite of a compressed blob is neither wholly raw nor wholly transformed, and the only safe reading is "transformed".
- **Refuse at both ends**: `BuildShmBlobRecord` excludes transformed blobs from `kShmBlobDirectReadable`, and `ShmBlobRecord::IsDirectReadable()` independently rejects any record whose transform state is non-zero — including **unknown future bits**, which fail safe. Record layout is unchanged (`transform_flags_` occupies the old `reserved_` slot), so no `kLayoutVersion` bump and existing clients keep the fast path for raw blobs.

## Put/Get detection — scalar, POD, and vectored

- All Put variants route through the shared `PutBlobImpl`; all Get variants through `GetBlobImpl` — the vectored APIs share `PutBlobTask`/`GetBlobTask`, so the declaration flows through every entry point.
- **GetBlob now reports** the blob's transform word back through its INOUT `Context`, so any Get caller can detect that the returned bytes are stored form (`GetBlob` returns stored bytes and does not undo transforms).
- Every client SHM fast path (scalar native get, vectored all-hit, private-memory scatter) funnels through `TryReadBlobShm` → `IsDirectReadable()`, so a transformed blob degrades to RPC — never to an error, never to codec bytes.

## Persistence (both logs, both directions)

- **Metadata log**: transform-carrying blob entries are a new entry **type 2** (no version header ⇒ appending a field to type 1 would be misparsed as block data). Type 1 is still read; legacy entries derive the bit conservatively from `compress_lib_ != 0` — over-reports, which only costs the fast path.
- **Transaction log**: new **`kSetBlobTransform` (type 6)** record, logged only on an actual bit transition, so a crash between the put and the next metadata flush cannot resurrect a transformed blob as raw. `kCreateNewBlob` replay carries over the transform word of any blob already restored under that key (the WAL is truncated by size, not per flush, so a stale create could otherwise clobber the restored mark). Older runtimes ignore unknown txn types.

## Deliberately unchanged

`Tag::GetBlobSize` still answers with the **stored** size — same as the RPC path today; the stored-vs-logical distinction is documented on the record. Client-side decompression (direction B) is out of scope; this is the correctness guard that has to land first.

## Tests (all green locally, CPU build)

- `test_cte_shm_metadata_cache` (9): refusal matrix incl. **unknown-future-bit fail-safe** and record round-trip.
- `test_core_functionality` "refuses direct reads of transformed blobs": raw-blob control (fast path *is* available), record state, runtime + client-side refusal, RPC fallback returns identical bytes + reports the transform via Context, sticky-across-overwrite. **Negative-verified**: temporarily dropping the `BuildShmBlobRecord` mirror makes this suite fail.
- `test_vectored_blob_io` (4): new vectored put/get transform case + existing #820 suite.
- `test_cte_transaction_log` (10): new `kSetBlobTransform` roundtrip.
- Autogen `Context` serialize coverage incl. `transform_flags_` outside the compression guard.
- Compressor chimod compiled clean with `CLIO_CTE_ENABLE_COMPRESS=ON` (`build-compress`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
