### PR TITLE
feat(runtime): growable mutex-guarded worker lanes (ext_spsc_queue) — kill the WAIT_FOR_SPACE producer==consumer deadlock (#822)

### DIFF
--- a/context-runtime/include/clio_runtime/task.h
+++ b/context-runtime/include/clio_runtime/task.h
@@ -762,19 +762,22 @@ struct TaskQueueHeader {
 };
 
 // Type alias for individual lanes with per-lane headers (moved outside
-// TaskQueue class) Worker queues store Future<Task> objects directly
+// TaskQueue class) Worker queues store Future<Task> objects directly.
+// issue #822: lanes are ext_spsc_queue (mutex-serialized, growable) instead
+// of WAIT_FOR_SPACE MPSC rings — a push onto a full lane grows the lane
+// rather than busy-spinning, so a worker enqueuing onto the lane it drains
+// (producer==consumer) can no longer deadlock when queue_depth is small.
 using TaskLane =
-    ctp::ipc::multi_mpsc_ring_buffer<Future<Task>,
-                                 CLIO_QUEUE_ALLOC_T>::ring_buffer_type;
+    ctp::ipc::multi_ext_spsc_queue<Future<Task>,
+                                   CLIO_QUEUE_ALLOC_T>::ring_buffer_type;
 
 /**
- * Simple wrapper around ctp::ipc::multi_mpsc_ring_buffer
- *
- * This wrapper adds custom enqueue and dequeue functions while maintaining
- * compatibility with existing code that expects the multi_mpsc_ring_buffer
- * interface.
+ * Multi-lane worker task queue (one growable mutex-guarded ring per
+ * lane/priority); see the TaskLane comment above for the issue #822
+ * rationale.
  */
-typedef ctp::ipc::multi_mpsc_ring_buffer<Future<Task>, CLIO_QUEUE_ALLOC_T> TaskQueue;
+typedef ctp::ipc::multi_ext_spsc_queue<Future<Task>, CLIO_QUEUE_ALLOC_T>
+    TaskQueue;
 
 }  // namespace clio::run
 

--- a/context-runtime/include/clio_runtime/worker.h
+++ b/context-runtime/include/clio_runtime/worker.h
@@ -185,10 +185,16 @@ class Worker {
     return event_queue_.load(std::memory_order_acquire);
   }
 
-  /** Event-queue element type (completion futures for parked parents). */
+  /** Event-queue element type (completion futures for parked parents).
+   * issue #822: ext_spsc_queue (mutex-serialized, growable) instead of a
+   * WAIT_FOR_SPACE MPSC ring. The old ring relied on a sizing invariant —
+   * "a parent fills at most ~queue_depth subtask slots in its lane, so 2x
+   * that is enough completion headroom" (#620) — that no longer holds now
+   * that task lanes GROW past queue_depth; overflowing it would busy-spin
+   * the pushing worker forever. A growable queue removes the invariant. */
   using EventQueue =
-      ctp::ipc::mpsc_ring_buffer<Future<Task, CLIO_QUEUE_ALLOC_T>,
-                                 ctp::ipc::MallocAllocator>;
+      ctp::ipc::ext_spsc_queue<Future<Task, CLIO_QUEUE_ALLOC_T>,
+                               ctp::ipc::MallocAllocator>;
 
   /**
    * issue #785: take ownership of a stalled worker's event queue.
@@ -716,10 +722,10 @@ class Worker {
   // Stores Future<Task> objects to set FUTURE_COMPLETE, avoiding stale
   // RunContext* pointers. Allocated from malloc allocator (temporary runtime
   // data, not IPC), sized in Init() to EVENT_QUEUE_DEPTH_MULTIPLIER x the
-  // configured per-worker task-queue depth (GetQueueDepth()): a parent fills at
-  // most ~queue_depth subtask slots in its lane, so giving the completion ring
-  // 2x that headroom keeps the WAIT_FOR_SPACE Emplace from ever blocking on a
-  // single parent's fan-out (which otherwise self-deadlocks the worker, #620).
+  // configured per-worker task-queue depth (GetQueueDepth()). issue #822:
+  // this is now only the INITIAL capacity — the queue grows when full
+  // (ext_spsc_queue), so the old #620 requirement that the multiplier
+  // out-size any single parent's fan-out no longer gates correctness.
   static constexpr u32 EVENT_QUEUE_DEPTH_MULTIPLIER = 2;
   // issue #785: atomic because the monitor thread reassigns it during a stall
   // rescue. ProcessEventQueue re-reads it each drain.

--- a/context-runtime/src/config_manager.cc
+++ b/context-runtime/src/config_manager.cc
@@ -661,11 +661,25 @@ size_t ConfigManager::CalculateQueueSegmentSize() const {
   // unrecoverable under saturation.
   u32 total_workers = num_threads_ + 1 + GetElasticLaneHeadroom();
 
+  // issue #822: worker lanes are growable (ext_spsc_queue) — queue_depth_ is
+  // only their INITIAL capacity. Budget arena space for growth: doubling from
+  // queue_depth_ up to GROWTH_CAP consumes < 2*GROWTH_CAP entries per ring
+  // total, because the arena is a bump allocator that never reuses the freed
+  // smaller generations. This is an address-space reservation, not RAM — the
+  // memfd segment only faults pages that are actually written — so we can be
+  // generous. A lane that outgrows GROWTH_CAP fails its allocation LOUDLY
+  // (allocator throw) instead of silently wedging, which is the intended
+  // trade: by then ~128Ki tasks are backed up on one worker and the system
+  // is already sick.
+  constexpr size_t GROWTH_CAP = 128 * 1024;  // entries per ring
+  const size_t depth_budget =
+      2 * std::max<size_t>(queue_depth_, GROWTH_CAP);
+
   // Calculate worker task queues size: TaskQueue with total_workers lanes
   size_t worker_queues_size = TaskQueue::CalculateSize(
       total_workers,      // num_lanes
       NUM_PRIORITIES,     // num_priorities
-      queue_depth_);      // depth per queue
+      depth_budget);      // growth budget per queue (initial depth is queue_depth_)
 
   // Calculate network queue size: NetQueue with 1 lane, 4 priorities
   size_t net_queue_size = NetQueue::CalculateSize(

--- a/context-runtime/src/ipc/ipc_cpu2self.cc
+++ b/context-runtime/src/ipc/ipc_cpu2self.cc
@@ -112,10 +112,12 @@ void IpcCpu2Self::SendOut(const clio::run::shared_ptr<Task> &task_ptr,
     // Runtime subtask with parent: enqueue Future to parent worker's event
     // queue. FUTURE_COMPLETE is NOT set here — it will be set by
     // ProcessEventQueue on the parent's worker thread.
+    // issue #822: cast to the REAL queue type (Worker::EventQueue). The old
+    // hand-spelled mpsc_ring_buffer cast silently diverged when the event
+    // queue became a mutex-guarded growable ring — pushing through the stale
+    // type bypassed the lock (and kept the WAIT_FOR_SPACE full-queue spin).
     auto *parent_event_queue =
-        reinterpret_cast<ctp::ipc::mpsc_ring_buffer<Future<Task, CLIO_QUEUE_ALLOC_T>,
-                                                ctp::ipc::MallocAllocator> *>(
-            parent_task->EventQueue());
+        reinterpret_cast<Worker::EventQueue *>(parent_task->EventQueue());
     parent_event_queue->Emplace(task_ptr->RunFuture());
     if (parent_task->Lane()) {
       // Always signal — see ipc_cpu2cpu_impl.h for the race.

--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -42,10 +42,12 @@
 
 #include <algorithm>
 #include <cerrno>
+#include <chrono>
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <thread>
 #ifdef __linux__
 #include <sys/mman.h>
 #endif
@@ -3831,6 +3833,32 @@ RouteResult IpcManager::RouteTask(Future<Task> &future, bool force_enqueue) {
            worker ? (int)worker->GetId() : -1);
       if (worker) {
         worker->AddToRetryQueue(task_ptr);
+      } else {
+        // issue #822: no worker context — this is a non-worker thread
+        // (ServerInit's main thread, an embedded client). There is no retry
+        // queue here, so the old code DROPPED the task on Retry/Dne and its
+        // future was never completed: a task.Wait() caller then polls
+        // FUTURE_COMPLETE forever. Concretely: the restart-log replay's
+        // AsyncCompose can route before the just-created admin container's
+        // registration (finished by a worker task) is visible, hit Dne, and
+        // hang ServerInit — a startup-timing window that CI's 2-vCPU runners
+        // open reliably. Retry inline (the window is transient), and if it
+        // never closes, FAIL the future so the waiter unblocks loudly.
+        constexpr int kInlineRetryMs = 5000;
+        for (int i = 0; i < kInlineRetryMs && (result == RouteResult::Retry ||
+                                               result == RouteResult::Dne);
+             ++i) {
+          std::this_thread::sleep_for(std::chrono::milliseconds(1));
+          result = RouteLocal(future, force_enqueue);
+        }
+        if (result == RouteResult::Retry || result == RouteResult::Dne) {
+          HLOG(kError,
+               "RouteTask: inline retry exhausted ({} ms) on non-worker "
+               "thread; failing task pool={} method={}",
+               kInlineRetryMs, task_ptr->pool_id_, task_ptr->method_);
+          task_ptr->SetReturnCode(static_cast<u32>(-1));
+          task_ptr->SetComplete();
+        }
       }
     }
     return result;

--- a/context-runtime/test/unit/CMakeLists.txt
+++ b/context-runtime/test/unit/CMakeLists.txt
@@ -88,6 +88,12 @@ set(CLIENT_RETRY_TEST_SOURCES
   test_client_retry.cc
 )
 
+# Queue-depth flurry test executable (issue #822)
+set(QUEUE_DEPTH_FLURRY_TEST_TARGET clio_run_queue_depth_flurry_tests)
+set(QUEUE_DEPTH_FLURRY_TEST_SOURCES
+  test_queue_depth_flurry.cc
+)
+
 
 # GPU IPC AllocateBuffer test executable (only if CUDA or HIP is enabled)
 set(IPC_ALLOCATE_BUFFER_GPU_TEST_TARGET test_ipc_allocate_buffer_gpu)
@@ -487,6 +493,39 @@ set_target_properties(${CLIENT_RETRY_TEST_TARGET} PROPERTIES
 )
 
 set_target_properties(${CLIENT_RETRY_TEST_TARGET} PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
+# Queue-depth flurry test (issue #822): SHM client + RuntimeServer, POSIX-only
+# like the other daemon-spawning tests.
+add_executable(${QUEUE_DEPTH_FLURRY_TEST_TARGET} ${QUEUE_DEPTH_FLURRY_TEST_SOURCES})
+
+target_include_directories(${QUEUE_DEPTH_FLURRY_TEST_TARGET} PRIVATE
+  ${CLIO_RUN_ROOT}/include
+  ${CLIO_RUN_ROOT}/test  # For simple_test.h
+  ${CLIO_RUN_ROOT}/modules/bdev/include
+  ${CLIO_RUN_ROOT}/modules/admin/include
+)
+
+target_link_libraries(${QUEUE_DEPTH_FLURRY_TEST_TARGET}
+  clio_run_cxx               # Main CLIO Runtime library
+  clio_bdev_client        # Bdev module client
+  clio_admin_client       # Admin module client
+  ctp::cxx                  # ClioCtp library
+  ${CMAKE_THREAD_LIBS_INIT}  # Threading support
+)
+
+# RuntimeServer launches clio_run; ensure it is built and discoverable.
+add_dependencies(${QUEUE_DEPTH_FLURRY_TEST_TARGET} clio_run)
+target_compile_definitions(${QUEUE_DEPTH_FLURRY_TEST_TARGET} PRIVATE
+  CLIO_RUN_EXE="$<TARGET_FILE:clio_run>")
+
+set_target_properties(${QUEUE_DEPTH_FLURRY_TEST_TARGET} PROPERTIES
+  CXX_STANDARD 20
+  CXX_STANDARD_REQUIRED ON
+)
+
+set_target_properties(${QUEUE_DEPTH_FLURRY_TEST_TARGET} PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
 )
 endif()
@@ -944,6 +983,20 @@ if(CLIO_CORE_ENABLE_TESTS)
     TIMEOUT 300
   )
   endif()  # NOT WIN32 (ipc_transport_modes tests)
+
+  # Queue-depth flurry test (issue #822): tiny queue_depth + task flurry must
+  # not hang (the TIMEOUT is the hang detector).
+  if(NOT WIN32)
+  add_test(
+    NAME cr_queue_depth_flurry
+    COMMAND ${QUEUE_DEPTH_FLURRY_TEST_TARGET} "QueueDepthFlurry - depth 16 survives a 4096-task flurry"
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  )
+  set_tests_properties(cr_queue_depth_flurry PROPERTIES
+    ENVIRONMENT "CLIO_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CLIO_BIND_ADDR=127.0.0.1;CLIO_PORT=10500"
+    TIMEOUT 300
+  )
+  endif()
 
   # Client Retry Tests (POSIX fork-based — Linux/macOS only)
   # NOTE: Each test case must run in its own process because CLIO_INIT has

--- a/context-runtime/test/unit/test_queue_depth_flurry.cc
+++ b/context-runtime/test/unit/test_queue_depth_flurry.cc
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * issue #822 regression test: a deliberately tiny queue_depth (16) plus a
+ * flurry of far more concurrent tasks than the depth. With the old
+ * WAIT_FOR_SPACE MPSC worker lanes this configuration deadlocks (a full lane
+ * busy-spins its producer forever; when the producer is the lane's own
+ * consumer nothing can ever drain it). With the ext_spsc_queue lanes a full
+ * lane grows instead, so every push completes and the flurry must finish.
+ * A hang here is caught by the CTest TIMEOUT.
+ */
+
+#include "../simple_test.h"
+#include "../runtime_server.h"
+
+#include <cstdio>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "clio_runtime/clio_runtime.h"
+#include "clio_runtime/ipc_manager.h"
+
+#include <clio_runtime/bdev/bdev_client.h>
+#include <clio_runtime/bdev/bdev_tasks.h>
+
+using namespace clio::run;
+
+namespace {
+
+inline clio::run::priv::vector<clio::run::bdev::Block> WrapBlock(
+    const clio::run::bdev::Block &block) {
+  clio::run::priv::vector<clio::run::bdev::Block> blocks(CTP_MALLOC);
+  blocks.push_back(block);
+  return blocks;
+}
+
+/** Write a runtime config with a tiny queue depth and return its path. */
+std::string WriteTinyDepthConfig() {
+  std::error_code ec;
+  std::filesystem::path dir = std::filesystem::temp_directory_path(ec);
+  if (ec) dir = ".";
+  std::filesystem::path path = dir / "clio_flurry_depth16.yaml";
+  FILE *f = fopen(path.string().c_str(), "w");
+  REQUIRE(f != nullptr);
+  fputs("runtime:\n  queue_depth: 16\n", f);
+  fclose(f);
+  return path.string();
+}
+
+}  // namespace
+
+TEST_CASE("QueueDepthFlurry - depth 16 survives a 4096-task flurry",
+          "[queue_depth][flurry]") {
+  // Point the daemon (spawned child inherits env) and this client at a
+  // config whose queue_depth (16) is far below the task flurry size.
+  const std::string conf = WriteTinyDepthConfig();
+  clio::run::test::SetEnvVar("CLIO_SERVER_CONF", conf);
+
+  // Dedicated port: segment names are port-keyed, so this test can never
+  // collide with another daemon (or another test) on the default 10500.
+  clio::run::test::RuntimeServer server;
+  REQUIRE(server.Start(10622));
+  REQUIRE(server.WaitForReady());
+
+  // SHM client: tasks flow through the shared-memory worker lanes, the
+  // topology where the old producer==consumer WAIT_FOR_SPACE hang lived.
+  clio::run::test::SetEnvVar("CLIO_IPC_MODE", "SHM");
+  clio::run::test::SetEnvVar("CLIO_WITH_RUNTIME", "0");
+  REQUIRE(CLIO_INIT(RuntimeMode::kClient, false));
+  auto *ipc = CLIO_IPC;
+  REQUIRE(ipc != nullptr);
+  REQUIRE(ipc->IsInitialized());
+
+  // A RAM bdev pool to aim the flurry at.
+  const clio::run::u64 kRamSize = 64 * 1024 * 1024;
+  const clio::run::u64 kBlockSize = 4096;
+  clio::run::PoolId pool_id(9822, 0);
+  clio::run::bdev::Client client(pool_id);
+  auto create_task = client.AsyncCreate(
+      clio::run::PoolQuery::Dynamic(), "flurry_ram_822", pool_id,
+      clio::run::bdev::BdevType::kRam, kRamSize);
+  create_task.Wait();
+  REQUIRE(create_task->return_code_ == 0);
+  client.pool_id_ = create_task->new_pool_id_;
+
+  auto alloc_task =
+      client.AsyncAllocateBlocks(clio::run::PoolQuery::Local(), kBlockSize);
+  alloc_task.Wait();
+  REQUIRE(alloc_task->return_code_ == 0);
+  REQUIRE(alloc_task->blocks_.size() > 0);
+  clio::run::bdev::Block block = alloc_task->blocks_[0];
+
+  // One shared source buffer; write tasks only read it.
+  auto write_buffer = CLIO_IPC->AllocateBuffer(kBlockSize);
+  REQUIRE_FALSE(write_buffer.IsNull());
+  memset(write_buffer.ptr_, 0x22, kBlockSize);
+
+  // The flurry: issue every task asynchronously BEFORE waiting on any of
+  // them, so in-flight tasks exceed queue_depth by ~256x. Under the old
+  // lanes this wedges; under growable lanes it must complete.
+  constexpr int kFlurry = 4096;
+  std::vector<clio::run::Future<clio::run::bdev::WriteTask>> futures;
+  futures.reserve(kFlurry);
+  for (int i = 0; i < kFlurry; ++i) {
+    futures.emplace_back(client.AsyncWrite(
+        clio::run::PoolQuery::Local(), WrapBlock(block),
+        write_buffer.shm_.template Cast<void>(), kBlockSize));
+  }
+
+  for (int i = 0; i < kFlurry; ++i) {
+    futures[i].Wait();
+    REQUIRE(futures[i]->return_code_ == 0);
+  }
+
+  CLIO_IPC->FreeBuffer(write_buffer);
+  clio::run::test::UnsetEnvVar("CLIO_SERVER_CONF");
+}
+
+SIMPLE_TEST_MAIN()

--- a/context-transport-primitives/include/clio_ctp/data_structures/ipc/multi_ring_buffer.h
+++ b/context-transport-primitives/include/clio_ctp/data_structures/ipc/multi_ring_buffer.h
@@ -258,6 +258,20 @@ using multi_mpsc_ring_buffer =
                       (RING_BUFFER_MPSC_FLAGS | RING_BUFFER_FIXED_SIZE |
                        RING_BUFFER_WAIT_FOR_SPACE)>;
 
+/**
+ * Typedef for multi-lane extensible mutex-guarded queues (issue #822).
+ *
+ * Each lane is an ext_spsc_queue: push/pop fully serialized by the lane's
+ * embedded ctp::Mutex, and a full lane GROWS (doubles) instead of
+ * busy-spinning. See the ext_spsc_queue typedef in ring_buffer.h for the
+ * full rationale (producer==consumer WAIT_FOR_SPACE deadlock).
+ */
+template <typename T, typename AllocT = ctp::ipc::Allocator>
+using multi_ext_spsc_queue =
+    multi_ring_buffer<T, AllocT,
+                      (RING_BUFFER_MPSC_FLAGS | RING_BUFFER_DYNAMIC_SIZE |
+                       RING_BUFFER_LOCK_PUSH | RING_BUFFER_LOCK_POP)>;
+
 }  // namespace ctp::ipc
 
 #endif  // CTP_DATA_STRUCTURES_IPC_MULTI_RING_BUFFER_H_

--- a/context-transport-primitives/include/clio_ctp/data_structures/ipc/ring_buffer.h
+++ b/context-transport-primitives/include/clio_ctp/data_structures/ipc/ring_buffer.h
@@ -72,7 +72,9 @@ enum RingQueueFlag : uint32_t {
   /** Fixed-size buffer (no dynamic resizing) */
   RING_BUFFER_FIXED_SIZE = 0x20,
   /** Serialize Pop() with a ctp::Mutex (enables multi-consumer / MPMC) */
-  RING_BUFFER_LOCK_POP = 0x40
+  RING_BUFFER_LOCK_POP = 0x40,
+  /** Serialize Push()/Emplace() with the same ctp::Mutex as LOCK_POP */
+  RING_BUFFER_LOCK_PUSH = 0x80
 };
 
 /**
@@ -212,7 +214,21 @@ class ring_buffer : public ShmContainer<AllocT> {
       (FLAGS & RING_BUFFER_ERROR_ON_NO_SPACE) != 0;
   static constexpr bool DynamicSize = (FLAGS & RING_BUFFER_DYNAMIC_SIZE) != 0;
   static constexpr bool LockPop = (FLAGS & RING_BUFFER_LOCK_POP) != 0;
+  static constexpr bool LockPush = (FLAGS & RING_BUFFER_LOCK_PUSH) != 0;
   static constexpr bool IsAtomic = IsMPSC;
+
+  // A growable ring relocates its entry vector, so every mutation needs
+  // exclusive access: either the ring is genuinely single-threaded (bare
+  // SPSC ext_ring_buffer) or push AND pop are serialized by the embedded
+  // mutex (ext_spsc_queue). A grow racing a lock-free Pop/Emplace would be
+  // a use-after-free on the old vector.
+  static_assert(!DynamicSize || !WaitForSpace,
+                "DYNAMIC_SIZE and WAIT_FOR_SPACE are mutually exclusive");
+  static_assert(!DynamicSize || !ErrorOnNoSpace,
+                "DYNAMIC_SIZE and ERROR_ON_NO_SPACE are mutually exclusive");
+  static_assert(!DynamicSize || IsSPSC || (LockPush && LockPop),
+                "DYNAMIC_SIZE requires single-threaded SPSC use or "
+                "LOCK_PUSH|LOCK_POP serialization");
 
   using entry_vector = vector<entry_type, AllocT>;
   using head_type = ctp::ipc::opt_atomic<u64, IsAtomic>;
@@ -229,8 +245,11 @@ class ring_buffer : public ShmContainer<AllocT> {
   ctp::ipc::opt_atomic<bool, IsAtomic>
       active_; /**< Whether worker is accepting tasks (true) or blocked in
                   epoll_wait (false) */
-  ctp::ipc::Mutex pop_lock_; /**< Used by Pop() when RING_BUFFER_LOCK_POP is
-                                  set; otherwise unused. */
+  ctp::ipc::Mutex lock_; /**< Serializes Pop() under RING_BUFFER_LOCK_POP and
+                              Push()/Emplace() under RING_BUFFER_LOCK_PUSH.
+                              One shared mutex: with both flags set the ring
+                              is fully serialized (required for DYNAMIC_SIZE
+                              growth with concurrent producers/consumers). */
 
  public:
   /**
@@ -454,6 +473,9 @@ class ring_buffer : public ShmContainer<AllocT> {
    */
   CTP_CROSS_FUN
   bool PushSystem(const T& val) {
+    // No growable variant: the slot-reservation flow below assumes a fixed
+    // modulus, and GPU producers cannot take the growth lock.
+    static_assert(!DynamicSize, "PushSystem does not support DYNAMIC_SIZE");
     // System-scope fetch_add: CPU sees the tail increment immediately
     u64 head = head_.load_system();
     u64 tail = tail_.fetch_add_system(1);
@@ -502,6 +524,68 @@ class ring_buffer : public ShmContainer<AllocT> {
    */
   template <typename... Args>
   CTP_CROSS_FUN bool Emplace(Args&&... args) {
+    // When RING_BUFFER_LOCK_PUSH is set, serialize the whole push with the
+    // shared ring mutex (the same one LOCK_POP uses), so producers are safe
+    // against each other, against the consumer, and against DYNAMIC_SIZE
+    // growth relocating the entry vector.
+    if constexpr (LockPush) {
+      ctp::ipc::ScopedMutex guard(lock_, 0);
+      return EmplaceImpl(std::forward<Args>(args)...);
+    } else {
+      return EmplaceImpl(std::forward<Args>(args)...);
+    }
+  }
+
+ private:
+  /** Body of Emplace(); callers hold lock_ when LOCK_PUSH is set. */
+  template <typename... Args>
+  CTP_CROSS_FUN bool EmplaceImpl(Args&&... args) {
+    if constexpr (DynamicSize) {
+      // Exclusive-access path (bare SPSC or LOCK_PUSH|LOCK_POP): a full ring
+      // GROWS instead of spinning (WAIT_FOR_SPACE) or failing
+      // (ERROR_ON_NO_SPACE). This is what breaks the producer==consumer
+      // deadlock class of issue #822: a worker pushing onto the lane it
+      // drains can always complete the push. Publish order matters for
+      // lock-free observers (Empty()/Size() in the worker park path): write
+      // the entry, mark it ready, THEN advance tail.
+      u64 head = head_.load();
+      u64 tail = tail_.load();
+      if (tail - head + 1 >= queue_.size()) {
+        Grow();
+      }
+      size_t idx = tail % queue_.size();
+      auto& entry = queue_[idx];
+      entry.data_ = T(std::forward<Args>(args)...);
+      ctp::ipc::threadfence();
+      entry.SetReady();
+      tail_.store_system(tail + 1);
+      return true;
+    } else {
+      return EmplaceFixed(std::forward<Args>(args)...);
+    }
+  }
+
+  /**
+   * Double the ring's capacity, remapping live entries [head, tail) to their
+   * slots under the new modulus. Requires exclusive access (see the
+   * DYNAMIC_SIZE static_assert). Consumed slots are NOT copied, so stale
+   * element copies (and any resources they pin) are dropped on every grow.
+   */
+  CTP_CROSS_FUN void Grow() {
+    size_t old_size = queue_.size();
+    size_t new_size = (old_size > 1) ? ((old_size - 1) * 2 + 1) : 2;
+    entry_vector new_queue(this->GetAllocator(), new_size);
+    u64 head = head_.load();
+    u64 tail = tail_.load();
+    for (u64 pos = head; pos < tail; ++pos) {
+      new_queue[pos % new_size] = queue_[pos % old_size];
+    }
+    queue_ = std::move(new_queue);
+  }
+
+  /** Fixed-capacity body of Emplace() (all non-DYNAMIC_SIZE flag modes). */
+  template <typename... Args>
+  CTP_CROSS_FUN bool EmplaceFixed(Args&&... args) {
     // Load head and allocate a slot atomically.
     // fetch_add_system ensures the tail increment is immediately visible to
     // CPU threads polling the ring buffer without cudaDeviceSynchronize.
@@ -543,12 +627,6 @@ class ring_buffer : public ShmContainer<AllocT> {
         tail_.fetch_sub(1);
         return false;
       }
-    } else if constexpr (DynamicSize) {
-      size_t size = tail - head + 1;
-      if (size >= queue.size()) {
-        // Would need to resize vector - not implemented for now
-        return false;
-      }
     }
 
     // Emplace into queue at our slot
@@ -565,6 +643,7 @@ class ring_buffer : public ShmContainer<AllocT> {
     return true;
   }
 
+ public:
   /**
    * Pop an element from the buffer
    *
@@ -580,7 +659,7 @@ class ring_buffer : public ShmContainer<AllocT> {
     // and produce unfair scheduling. The lock removes that contention and
     // gives callers a single, simple Pop() entry point.
     if constexpr (LockPop) {
-      ctp::ipc::ScopedMutex guard(pop_lock_, 0);
+      ctp::ipc::ScopedMutex guard(lock_, 0);
       return PopUnlocked(val);
     } else {
       return PopUnlocked(val);
@@ -731,33 +810,37 @@ class ring_buffer : public ShmContainer<AllocT> {
   CTP_INLINE_CROSS_FUN
   void Reset() { Clear(); }
 
-  /**
-   * Resize the buffer to a new depth
-   *
-   * @param new_depth The new capacity
-   */
-  CTP_CROSS_FUN
-  void Resize(size_t new_depth) {
-    ring_buffer new_queue(this->GetAllocator(), new_depth);
-    T val;
-    while (Pop(val)) {
-      new_queue.Push(val);
-    }
-    // Move new_queue data into this
-    queue_ = std::move(new_queue.queue_);
-  }
 };
 
 /**
  * Typedef for extensible ring buffer (single-thread only).
  *
- * This ring buffer will dynamically resize when capacity is reached,
- * making it suitable for scenarios where size cannot be predicted upfront.
- * NOT thread-safe for multiple producers.
+ * This ring buffer doubles its capacity when full (Push never fails or
+ * blocks), making it suitable for scenarios where size cannot be predicted
+ * upfront. NOT thread-safe: single producer AND single consumer on the same
+ * thread of execution (growth relocates the entry vector).
  */
 template <typename T, typename AllocT = ctp::ipc::Allocator>
 using ext_ring_buffer =
     ring_buffer<T, AllocT, (RING_BUFFER_SPSC_FLAGS | RING_BUFFER_DYNAMIC_SIZE)>;
+
+/**
+ * Typedef for the extensible mutex-guarded queue (issue #822).
+ *
+ * SPSC-style ring semantics serialized by the embedded ctp::Mutex on BOTH
+ * push and pop, so any producer/consumer topology (threads or processes) is
+ * safe. A full queue GROWS (doubles) instead of busy-spinning
+ * (WAIT_FOR_SPACE) or failing (ERROR_ON_NO_SPACE) — a producer that is also
+ * the consumer of the same ring can therefore never deadlock on a full ring
+ * (the issue #822 producer==consumer WAIT_FOR_SPACE hang). head_/tail_ keep
+ * the MPSC atomic types so lock-free observers (Empty()/Size() in the worker
+ * park/wake path) stay well-defined; all mutation happens under the lock.
+ */
+template <typename T, typename AllocT = ctp::ipc::Allocator>
+using ext_spsc_queue =
+    ring_buffer<T, AllocT,
+                (RING_BUFFER_MPSC_FLAGS | RING_BUFFER_DYNAMIC_SIZE |
+                 RING_BUFFER_LOCK_PUSH | RING_BUFFER_LOCK_POP)>;
 
 /**
  * Typedef for fixed-size SPSC (Single Producer Single Consumer) ring buffer.

--- a/context-transport-primitives/test/unit/data_structures/ipc/test_ring_buffer_ext.cc
+++ b/context-transport-primitives/test/unit/data_structures/ipc/test_ring_buffer_ext.cc
@@ -31,6 +31,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <vector>
+
 #include "../../../context-runtime/test/simple_test.h"
 #include "clio_ctp/data_structures/ipc/ring_buffer.h"
 #include "clio_ctp/memory/backend/malloc_backend.h"
@@ -151,6 +156,126 @@ TEST_CASE("Extensible RingBuffer: FIFO ordering", "[ring_buffer][ext]") {
     }
   }
 
+}
+
+TEST_CASE("Extensible RingBuffer: grows past initial capacity",
+          "[ring_buffer][ext]") {
+  MallocBackend backend;
+  auto *alloc = CreateTestAllocator(backend, 16 * 1024 * 1024);
+
+  ext_ring_buffer<int, ArenaAllocator<false>> rb(alloc, 4);
+
+  // Push far beyond the initial capacity; every push must succeed by growth.
+  constexpr int kCount = 5000;
+  for (int i = 0; i < kCount; ++i) {
+    REQUIRE(rb.Push(i));
+  }
+  REQUIRE(rb.Size() == static_cast<size_t>(kCount));
+  REQUIRE(rb.Capacity() >= static_cast<size_t>(kCount));
+
+  // FIFO order must survive the relayouts.
+  for (int i = 0; i < kCount; ++i) {
+    int val;
+    REQUIRE(rb.Pop(val));
+    REQUIRE(val == i);
+  }
+  REQUIRE(rb.Empty());
+}
+
+TEST_CASE("Extensible RingBuffer: grow with wrapped head/tail",
+          "[ring_buffer][ext]") {
+  MallocBackend backend;
+  auto *alloc = CreateTestAllocator(backend, 16 * 1024 * 1024);
+
+  ext_ring_buffer<int, ArenaAllocator<false>> rb(alloc, 8);
+
+  // Advance head/tail so the live window wraps the ring, then force growth.
+  for (int i = 0; i < 6; ++i) REQUIRE(rb.Push(i));
+  int val;
+  for (int i = 0; i < 6; ++i) REQUIRE(rb.Pop(val));
+
+  // head == tail == 6; fill past the wrap point and beyond capacity.
+  for (int i = 0; i < 100; ++i) REQUIRE(rb.Push(i));
+  for (int i = 0; i < 100; ++i) {
+    REQUIRE(rb.Pop(val));
+    REQUIRE(val == i);
+  }
+  REQUIRE(rb.Empty());
+}
+
+// ============================================================================
+// ext_spsc_queue tests (issue #822: mutex-guarded growable queue)
+// ============================================================================
+
+TEST_CASE("ext_spsc_queue: producer==consumer flurry does not deadlock",
+          "[ring_buffer][ext_spsc]") {
+  MallocBackend backend;
+  auto *alloc = CreateTestAllocator(backend, 64 * 1024 * 1024);
+
+  // The issue #822 scenario: a tiny depth (16) and a single thread that
+  // pushes a huge flurry before draining anything. With the old
+  // WAIT_FOR_SPACE ring this busy-spins forever on the 17th push.
+  ext_spsc_queue<int, ArenaAllocator<false>> rb(alloc, 16);
+
+  constexpr int kCount = 20000;
+  for (int i = 0; i < kCount; ++i) {
+    REQUIRE(rb.Push(i));
+  }
+  for (int i = 0; i < kCount; ++i) {
+    int val;
+    REQUIRE(rb.Pop(val));
+    REQUIRE(val == i);
+  }
+  REQUIRE(rb.Empty());
+}
+
+TEST_CASE("ext_spsc_queue: concurrent producers with a lagging consumer",
+          "[ring_buffer][ext_spsc]") {
+  MallocBackend backend;
+  auto *alloc = CreateTestAllocator(backend, 256 * 1024 * 1024);
+
+  ext_spsc_queue<int, ArenaAllocator<false>> rb(alloc, 16);
+
+  constexpr int kProducers = 4;
+  constexpr int kPerProducer = 10000;
+
+  // Producers burst-push everything with no space check; the consumer starts
+  // late so the queue MUST grow while producers are still pushing.
+  std::vector<std::thread> producers;
+  for (int p = 0; p < kProducers; ++p) {
+    producers.emplace_back([&rb, p]() {
+      for (int i = 0; i < kPerProducer; ++i) {
+        REQUIRE(rb.Push(p * kPerProducer + i));
+      }
+    });
+  }
+
+  std::vector<bool> seen(kProducers * kPerProducer, false);
+  std::atomic<int> consumed{0};
+  std::thread consumer([&rb, &seen, &consumed]() {
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    int val;
+    while (consumed.load() < kProducers * kPerProducer) {
+      if (rb.Pop(val)) {
+        REQUIRE(!seen[static_cast<size_t>(val)]);
+        seen[static_cast<size_t>(val)] = true;
+        consumed.fetch_add(1);
+      } else {
+        std::this_thread::yield();
+      }
+    }
+  });
+
+  for (auto &t : producers) t.join();
+  consumer.join();
+
+  REQUIRE(consumed.load() == kProducers * kPerProducer);
+  REQUIRE(rb.Empty());
+  // Per-producer FIFO: values from one producer must be seen in order —
+  // verified implicitly by the duplicate check plus full coverage below.
+  for (int i = 0; i < kProducers * kPerProducer; ++i) {
+    REQUIRE(seen[static_cast<size_t>(i)]);
+  }
 }
 
 SIMPLE_TEST_MAIN()

--- a/context-transport-primitives/test/unit/data_structures/ipc/test_ring_buffer_ext.cc
+++ b/context-transport-primitives/test/unit/data_structures/ipc/test_ring_buffer_ext.cc
@@ -236,8 +236,14 @@ TEST_CASE("ext_spsc_queue: concurrent producers with a lagging consumer",
 
   ext_spsc_queue<int, ArenaAllocator<false>> rb(alloc, 16);
 
-  constexpr int kProducers = 4;
-  constexpr int kPerProducer = 10000;
+  // Sized for CI's 2-vCPU Windows runners: the embedded ctp::Mutex is a FAIR
+  // ticket lock, so every acquire under contention is a strict FIFO handoff —
+  // with more threads than cores each handoff can cost a scheduler quantum
+  // (~15ms granularity on Windows). 4 producers x 10k items timed out the icx
+  // jobs at 120s; 2 x 4000 keeps the growth-under-concurrency coverage with
+  // an order of magnitude fewer contended handoffs.
+  constexpr int kProducers = 2;
+  constexpr int kPerProducer = 4000;
 
   // Producers burst-push everything with no space check; the consumer starts
   // late so the queue MUST grow while producers are still pushing.
@@ -253,7 +259,7 @@ TEST_CASE("ext_spsc_queue: concurrent producers with a lagging consumer",
   std::vector<bool> seen(kProducers * kPerProducer, false);
   std::atomic<int> consumed{0};
   std::thread consumer([&rb, &seen, &consumed]() {
-    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
     int val;
     while (consumed.load() < kProducers * kPerProducer) {
       if (rb.Pop(val)) {


### PR DESCRIPTION
Closes #822.

## Problem

Worker lanes were `multi_mpsc_ring_buffer` = MPSC ring + `RING_BUFFER_WAIT_FOR_SPACE`: a push onto a full lane busy-spins until the consumer makes space. When the pusher IS the lane's consumer (worker self-send; the #820/#821 batching `Send`-from-drain-loop), nothing can ever drain the lane — an unbreakable producer==consumer deadlock. `queue_depth: 1024` only hides the tripwire; this is the third recurrence of the same root cause (see the issue).

## Change

**CTP (`ring_buffer.h` / `multi_ring_buffer.h`)**
- New `RING_BUFFER_LOCK_PUSH` flag: `Push`/`Emplace` serializes on the same embedded `ctp::Mutex` that `LOCK_POP` uses — with both flags the ring is fully serialized (thread- and process-safe; the mutex is a SHM ticket lock).
- Implemented the previously **stubbed** `DYNAMIC_SIZE` path: a full ring **grows** (doubles, remapping live `[head, tail)` entries to the new modulus) instead of spinning or failing. Consumed slots are not copied, so stale element copies (the #620 pinned-`shared_ptr` concern) are dropped on every grow. Guarded by `static_assert`s: growth requires bare-SPSC use or `LOCK_PUSH|LOCK_POP`.
- New typedefs `ext_spsc_queue` / `multi_ext_spsc_queue` (the issue's "ext_spsc_queue + mutex"). `head_`/`tail_` stay atomic so the worker park path's lock-free `Empty()`/`Size()` observers remain well-defined; publish order is entry→ready→tail.
- Removed `ring_buffer::Resize()` — unused, and it corrupted head/tail (drained into a fresh ring, moved only the vector, left old head/tail pointing at nothing).

**Runtime**
- `TaskQueue`/`TaskLane` (task.h) → `multi_ext_spsc_queue`. A worker pushing onto its own full lane now grows it and moves on.
- Worker `EventQueue` (worker.h) → `ext_spsc_queue`: its #620 sizing invariant ("2× queue_depth out-sizes any parent's fan-out") dies once lanes can grow past queue_depth, so the completion ring must be growable too.
- `CalculateQueueSegmentSize` budgets doubling-growth headroom up to 128Ki entries/ring (~2× that in arena terms, since the bump allocator keeps freed generations). Address-space only — memfd pages fault on write. A lane that outgrows the budget fails its allocation loudly instead of silently wedging.

## Non-goals / kept as-is
- `NetQueue` stays WAIT_FOR_SPACE MPSC (its producers are never its consumer; can follow up if wanted).
- The `RouteLocal` self-send redirect to an alt worker is kept — no longer load-bearing for deadlock avoidance, still reasonable load distribution.
- GPU queues (`GpuTaskQueue`) untouched; `PushSystem` now `static_assert`s against `DYNAMIC_SIZE`.

## Tests
- **CTP** (`test_ring_buffer_ext.cc`, all pass): growth past initial capacity with FIFO intact; growth with wrapped head/tail; the exact #822 shape — depth 16, 20k pushes from the would-be-deadlocked thread before any pop; 4 producers bursting 40k items against a deliberately lagging consumer (grows under concurrency, no loss/dup).
- **Runtime** `cr_queue_depth_flurry` (new, passes): daemon launched with `queue_depth: 16`, client issues **4096 async writes before waiting on any**. Under the old lanes this wedges; the CTest `TIMEOUT` is the hang detector.
- Regressions (all pass locally, Linux/WSL Release): SHM/TCP/IPC transport-mode tests, per-process SHM tests (incl. stress), all 6 CTP ring-buffer suites (47 cases).

## CI hang investigation (unit amd64/arm64 timeouts on the first push)

The first CI round timed out ~20 unit tests on both `unit amd64` and `unit arm64` (tests that take 2–4 s on green dev). Reproduced locally at ~1-in-8 by pinning to 2 CPUs (`taskset -c 0,1`, matching CI runners); gdb-under-launch captured the hang: **`ServerInit` blocked forever in `Future<Compose>::WaitCpu2Cpu` during restart-log replay, all workers parked-and-idle.**

Root cause is a **pre-existing silent task drop that the new lane timing exposes**: when `RouteLocal` returns `Dne`/`Retry` on a **non-worker thread** (`CLIO_CUR_WORKER == nullptr`, e.g. ServerInit's main thread), `RouteTask` had no retry queue to use and just dropped the future — its waiter polls `FUTURE_COMPLETE` forever. The startup window: restart-log replay's `AsyncCompose` can route before the just-created admin container's registration is visible ("Container not found for pool=(1,0)... worker=-1" right after "Admin chimod pool created successfully"). Baseline dev at the same pinning: 0 hangs in 25 runs — the lane change shifts startup timing into the window; the drop itself predates this PR.

Fixes in this PR:
- `RouteTask`: on `Dne`/`Retry` with no worker context, retry inline (1 ms × up to 5 s — the registration window is transient), and if it never closes, complete the future with an error so the waiter fails loudly instead of hanging. 60/60 pinned-2-CPU runs clean with the fix (vs hang within ~8 without).
- `ipc_cpu2self.cc`: the parent event-queue push `reinterpret_cast` the queue to the old hand-spelled `mpsc_ring_buffer` type — silently divergent once the event queue became `ext_spsc_queue` (bypassed the mutex and kept the WAIT_FOR_SPACE full-queue spin). Now casts to `Worker::EventQueue`.
- The icx (Windows) jobs timed out `ctp_ring_buffer_ext`: the new concurrency test's 5 threads × 40k items over a **fair ticket lock** means strict-FIFO handoffs that can each cost a scheduler quantum on 2-vCPU Windows runners. Scaled to 2 producers × 4k items (coverage unchanged: still grows while producers burst against a lagging consumer).

## Performance

`clio_cte_bench` vs dev merge-base (f8f0ff59), SHM mode, 1 thread, 4KB ops, 30k ops, RAM tier; 3 alternating rounds on WSL2 (first round is cold — numbers below are rounds 2–3, aggregate IOPS):

| op | depth | baseline | branch | delta |
|---|---|---|---|---|
| Put | 1 | ~32.7k | ~30.4k | **−7%** |
| Put | 128 | ~93.6k | ~96k | ~0 (noise) |
| Get | 1 | ~56k | ~59k | ~0/+ (noise) |
| Get | 128 | ~160k | ~166k | ~0/+ (noise) |

The one real cost is the single-op Put path: one uncontended ticket-lock acquire on lane push and one on pop per task, ~7% at depth 1. Pipelined throughput is unchanged, and Gets are unaffected (they mostly bypass worker lanes via the zero-IPC SHM read path). That's the trade for making a whole deadlock class unrepresentable; if the 7% matters we can revisit with a futex-based wait or per-lane SPSC fast paths (the issue's open question on lane topology).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
