### PR TITLE
fix(ipc): non-worker-thread route failures were silently dropped — startup wedge behind the unit-amd64 CI timeouts

### DIFF
--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -3829,8 +3829,28 @@ RouteResult IpcManager::RouteTask(Future<Task> &future, bool force_enqueue) {
       HLOG(kError, "RouteTask: RouteLocal returned {} for pool={} method={}, worker={}",
            (int)result, task_ptr->pool_id_, task_ptr->method_,
            worker ? (int)worker->GetId() : -1);
+      if (!worker) {
+        // Routed from a NON-worker thread (the runtime main thread during
+        // ServerInit/compose, via IpcCpu2Self::SendIn). This used to be a
+        // silent DROP: the transient Dne/Retry (e.g. the admin pool's static
+        // container not yet resolvable while compose submits GetOrCreatePool)
+        // lost the task forever, the submitter waited on a future nobody
+        // completes, and the runtime wedged at startup with provably idle
+        // workers — the CI unit-gate 300 s timeouts on cte_tag_construction /
+        // cte_query_* et al. Park it on a published worker's retry queue
+        // instead; every worker polls its retry queue each loop iteration and
+        // sleeps at most max_sleep, so the re-route needs no explicit wake.
+        worker = CLIO_WORK_ORCHESTRATOR->GetWorker(0);
+      }
       if (worker) {
         worker->AddToRetryQueue(task_ptr);
+      } else {
+        // No worker published yet (pre-SpawnWorkerThreads). Nothing can ever
+        // retry this task; make the loss loud instead of a silent hang.
+        HLOG(kFatal,
+             "RouteTask: dropping unroutable task (pool={} method={}) — no "
+             "worker exists to retry it",
+             task_ptr->pool_id_, task_ptr->method_);
       }
     }
     return result;


### PR DESCRIPTION
## Symptom

`build-test (unit amd64)` fails at the 2 h job limit ([run 30323741257](https://github.com/iowarp/clio-core/actions/runs/30323741257/job/90164732419)): **14 tests time out** (cte_tag_construction, cte_tag_large, cte_query_* ×4, cr_streaming_* ×2, cr_ipc_internals, cte_core_workflow, cte_runtime_coverage_all, cte_parallel_overlap_stress, cte_bdev_fragmentation, cte_evict), burning ~80 min, and ctest never reaches the tail of the suite. All 14 pass locally in seconds. The gate has not been green since the #833 batch landed (every run since was cancelled or timed out).

## Diagnosis (from the CI log)

The hung tests share one signature — the daemon wedges **at startup**, mid-compose:

```
ServerInit  Compose: Creating pool ram::chi_default_bdev (module: clio_bdev, ...)
RouteLocal  Container not found for pool=PoolId(1,0) container_id=4294967295 method=10
RouteTask   RouteLocal returned 4 for pool=PoolId(1,0) method=10, worker=-1
```

…followed by 300 s of nothing but the scheduler's idle heartbeat, with **cumulative exec-time bins all zero** — the workers never executed a single task while the test's client waited forever.

`worker=-1` is the tell: compose submits `GetOrCreatePool` from the runtime **main thread** (`IpcCpu2Self::SendIn` → `RouteTask(force_enqueue=true)`). When the route hits a transient `Dne` (the admin pool's static container isn't resolvable yet — a startup race that 2-vCPU coverage-instrumented runners lose far more often than dev boxes), the handler did:

```cpp
if (worker) { worker->AddToRetryQueue(task_ptr); }   // CLIO_CUR_WORKER == null here
```

No `else`. The task is silently dropped, nobody ever completes its future, and ServerInit hangs — same defect class as the #785 periodic-task drop ("this used to return silently, DROPPING the periodic task").

In passing runs the same transient shows up on other methods (14/21/19/28/31 during admin-pool create) but those are periodic tasks whose next period papers over the loss. `GetOrCreatePool` gets no second chance.

## Fix

When the routing thread is not a worker, park the task on a **published** worker's retry queue (`CLIO_WORK_ORCHESTRATOR->GetWorker(0)`, bounded by `num_workers_published_`) instead of dropping it. Workers poll `ProcessRetryQueue()` every loop iteration and never sleep past `max_sleep` (50 ms), so no explicit wake is needed; the retry clears routed state and re-resolves, which converges once the container is registered. If no worker exists at all (pre-`SpawnWorkerThreads`), log at **Fatal** so the loss is loud instead of a silent hang.

## Not addressed here (deliberately)

The gate also runs the whole suite at `CLIO_CTP_LOG_LEVEL=0` (the `debug` preset), and the #820/#833 batch added per-task-pop DEBUG logging — `cte_bdev_fragmentation` emitted 3.8M log lines while *demonstrably progressing* through its 300 s window (slow-not-stuck, the ci-adapters e93def6d disease). If the gate is still tight after this fix, building the coverage phases at Info is the follow-up lever; kept out of this PR to keep the correctness fix isolated.

## Testing

- Local (Release, x86): full `test_tag_operations` battery, `test_query`, `test_vectored_blob_io` (4), `test_core_functionality` SHM-cache suite (5), `test_cte_shm_metadata_cache` (9) — all green with the fix.
- The startup race itself is timing-dependent (never reproduced in 8 pinned-2-CPU local runs); the CI gate on this PR is the real regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
