### PR TITLE
Build the coverage gate at Info log level, not Debug

### DIFF
--- a/CI/calculate_coverage.sh
+++ b/CI/calculate_coverage.sh
@@ -210,6 +210,12 @@ if [ "$DO_BUILD" = true ]; then
     # CLIO_CTE_ENABLE_COMPRESS=ON default leaked through and broke the
     # pkg_check_modules(liblz4 REQUIRED) call when lz4 wasn't in the
     # conda env.
+    # Info log level, not the debug preset's Debug (issue #845): Debug compiles
+    # every DEBUG HLOG into the hot path — one format+write syscall per task
+    # pop — which makes tests slow-not-stuck on the 2-vCPU coverage runners
+    # (cte_bdev_fragmentation alone emitted ~3.8M lines inside its 300 s ctest
+    # window). Same lever as e93def6d for the adapters gate; costs coverage of
+    # HLOG(kDebug) lines only.
     cmake --preset=debug \
         -DCLIO_CORE_ENABLE_COVERAGE=ON \
         -DCLIO_CORE_ENABLE_CONDA=ON \
@@ -217,6 +223,7 @@ if [ "$DO_BUILD" = true ]; then
         -DCLIO_CTE_ENABLE_ADIOS2_ADAPTER=OFF \
         -DCLIO_CTE_ENABLE_COMPRESS=OFF \
         -DCLIO_CORE_ENABLE_GRAY_SCOTT=OFF \
+        -DCLIO_CTP_LOG_LEVEL=1 \
         ${PHASE_CMAKE_ARGS}
 
     print_info "Building project..."


### PR DESCRIPTION
## Summary
- Add `-DCLIO_CTP_LOG_LEVEL=1` (Info) to the coverage configure in `CI/calculate_coverage.sh`, overriding the debug preset's `0` (Debug).

## Motivation
Fixes #845. Debug level compiles every DEBUG `HLOG` into the hot path — a format+write syscall per task pop. On the 2-vCPU coverage runners this makes tests slow-not-stuck (`cte_bdev_fragmentation` emitted ~3.8M log lines while provably progressing through its 300 s ctest window, run 30323741257) and, combined with the #841 startup wedge (fix: #844), pushed `build-test (unit amd64)` past its 2 h limit. Identical lever to e93def6d, which fixed the same disease on the linux adapters gate.

## Test plan
- [x] `bash -n` passes
- [ ] This PR's own `build-test (unit *)` jobs build at Info and ctest wall-time drops

## Breaking changes
None. Coverage of `HLOG(kDebug)` lines is no longer measured — accepted tradeoff (same as adapters gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)