### PR TITLE
Bound the inline route-retry by wall-clock deadline, not iteration count

### DIFF
--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -3873,11 +3873,18 @@ RouteResult IpcManager::RouteTask(Future<Task> &future, bool force_enqueue) {
         // timeouts, a retry storm filling the whole 300 s window). Fail them
         // immediately instead — the same harmless outcome as the historical
         // silent drop, but loud and with a completed future.
-        constexpr int kInlineRetryMs = 5000;
-        for (int i = 0;
-             !task_ptr->IsPeriodic() && i < kInlineRetryMs &&
-             (result == RouteResult::Retry || result == RouteResult::Dne);
-             ++i) {
+        //
+        // The budget is a wall-clock DEADLINE, not an iteration count (issue
+        // #849): sleep_for(1ms) rounds up to the platform timer granularity —
+        // ~15.6ms on Windows — so a 5000-iteration loop actually burned ~75s
+        // per unroutable task there, and ServerInit's handful of exhausted
+        // retries alone exceeded a 300s ctest window.
+        constexpr auto kInlineRetryBudget = std::chrono::seconds(5);
+        const auto deadline =
+            std::chrono::steady_clock::now() + kInlineRetryBudget;
+        while (!task_ptr->IsPeriodic() &&
+               (result == RouteResult::Retry || result == RouteResult::Dne) &&
+               std::chrono::steady_clock::now() < deadline) {
           std::this_thread::sleep_for(std::chrono::milliseconds(1));
           result = RouteLocal(future, force_enqueue);
         }
@@ -3895,7 +3902,9 @@ RouteResult IpcManager::RouteTask(Future<Task> &future, bool force_enqueue) {
           HLOG(kError,
                "RouteTask: inline retry exhausted ({} ms) on non-worker "
                "thread; failing task pool={} method={}",
-               kInlineRetryMs, task_ptr->pool_id_, task_ptr->method_);
+               std::chrono::duration_cast<std::chrono::milliseconds>(
+                   kInlineRetryBudget).count(),
+               task_ptr->pool_id_, task_ptr->method_);
           task_ptr->SetReturnCode(static_cast<u32>(-1));
           task_ptr->SetComplete();
         }
@@ -4034,7 +4043,13 @@ RouteResult IpcManager::RouteLocal(Future<Task> &future, bool force_enqueue) {
   ContainerHold exec_container = exec_dc.get();
 
   if (!exec_container) {
-    HLOG(kError, "RouteLocal: Container not found for pool={} container_id={} method={}",
+    // kDebug, not kError: this is the routine transient-miss result that the
+    // retry paths (worker retry queue, the non-worker inline retry loop) poll
+    // against — at kError a single exhausted 5s inline retry emits ~5000
+    // lines, and a green coverage run logs ~19k of these (issue #849). The
+    // callers in RouteTask log the kError summary on first failure and on
+    // retry exhaustion.
+    HLOG(kDebug, "RouteLocal: Container not found for pool={} container_id={} method={}",
          task_ptr->pool_id_, container_id, task_ptr->method_);
     return RouteResult::Dne;
   }


### PR DESCRIPTION
## Summary
- Replace the #822 inline retry's `for (i < 5000) sleep_for(1ms)` with a `steady_clock` deadline of 5 s — on Windows, `sleep_for(1ms)` rounds up to ~15.6 ms (timer granularity), so the count-based "5 s" budget actually burned **~75 s per unroutable task**.
- Downgrade `RouteLocal`'s per-attempt container-not-found log from kError to kDebug (the retry paths poll it: one exhausted retry emitted ~5001 lines; a green coverage run carries ~19k). `RouteTask` keeps its kError summary on first failure and on exhaustion.

## Motivation
Fixes #849. ServerInit submits ~5 structurally-unroutable admin tasks from *inside* the admin container's own Create — the retry can never succeed there, so each burns the full budget. On Windows that's 4–5 serialized ~75 s burns, overrunning the 300 s ctest window: a random test per run dies during init (observed as `cte_query_blob_multitag` on `icx (windows-2025-vs2026)`, run 30373841230, with exactly 5001 retry lines each for methods 14/21/19/28 and 3658 for method 31 at the kill). On Linux the same loops add ~25 s to every test's init — a major part of the unit-amd64 gate going from ~44 min to ~83 min.

Follow-up (out of scope here, noted in #849): skip the retry entirely when the unroutable pool is the one this thread is currently inside CreatePool for, recovering the remaining ~25 s/test on all platforms.

## Test plan
- [x] `cte_core_*` (15), `cte_query_tag_exact`, `cte_tag_construction/putblob`, force_net variants — 21/21 pass locally
- [x] Windows jobs stop losing a random test to a 300 s init stall — all four Windows jobs green on this PR in 22–28 min, including `icx (windows-2025-vs2026)` (22.6 min), the job that hit the 300 s kill on #844
- [ ] unit-amd64 gate wall-time drops back toward the 44–45 min baseline — this PR's run is still ~82 min, as expected: Linux `sleep_for(1ms)` is accurate so the deadline change is a no-op there; the Linux ~25 s/test recovery needs the deferred follow-up (skip retries for the pool this thread is inside CreatePool for)

## Breaking changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
