### PR TITLE
Escape the SHM response wait when the server dies mid-flight

### DIFF
--- a/context-runtime/include/clio_runtime/ipc/ipc_cpu2cpu_impl.h
+++ b/context-runtime/include/clio_runtime/ipc/ipc_cpu2cpu_impl.h
@@ -9,6 +9,7 @@
 #define CLIO_RUNTIME_INCLUDE_IPC_CPU2CPU_IMPL_H_
 
 #include "clio_runtime/ipc/ipc_cpu2cpu.h"
+#include "clio_runtime/ipc/ipc_cpu2cpu_zmq.h"
 
 #include <unordered_map>
 
@@ -157,6 +158,19 @@ bool IpcCpu2Cpu::RecvOut(IpcManager *ipc,
       if (start.GetUsecFromStart(now) >= static_cast<double>(max_sec) * 1e6) {
         return false;
       }
+    }
+    // Server-death escape (issue #851): unlike the ZMQ twin of this loop, the
+    // SHM wait used to have NO liveness check — a task in flight over SHM when
+    // the runtime died (reconnect test: AsyncStopRuntime, then submit) left
+    // the client parked here forever, since a dead server can never set
+    // FUTURE_COMPLETE. The 1s heartbeat flips server_alive_; hand the future
+    // to the ZMQ RecvOut, whose kClientShm-origin head implements the
+    // reconnect/failover + resend path.
+    if (!ipc->server_alive_.load(std::memory_order_acquire) &&
+        !ipc->reconnecting_.load()) {
+      HLOG(kWarning,
+           "Recv(SHM): server died mid-wait; handing off to reconnect path");
+      return IpcCpu2CpuZmq::RecvOut(ipc, future, max_sec);
     }
   }
 


### PR DESCRIPTION
## Summary
- `IpcCpu2Cpu::RecvOut`'s wait loop now re-checks `server_alive_` each pass (as its ZMQ twin always did) and hands the future to `IpcCpu2CpuZmq::RecvOut`, whose `kClientShm`-origin head implements the reconnect/failover + resend path.

## Motivation
Fixes #851 — the root cause of the Cluster Tests workflow being cancelled on 30/30 recent runs (~2.5 h each). A task in flight over SHM when the runtime dies could never complete, and the SHM wait loop had no liveness check and no deadline (default `Wait()`), so the client parked forever. The reconnect integration test hits this deterministically: `AsyncStopRuntime`, then submit — the `IpcManager::Recv` dispatch can win the race against the 1 s heartbeat and choose the SHM path, after which the death is never noticed.

Reproduced and validated against a live 4-node docker cluster (deps-cpu, DooD):
- **Before**: `clio_run_reconnect_tests '[reconnect]'` hangs ≥300 s at "Step 3: Creating pool on new host"; wedged client's main thread parked in `epoll_wait`; no reconnect log lines ever appear.
- **After**: the escape fires ("server died mid-wait; handing off to reconnect path"), `WaitForServerAndReconnect` fails over (`Trying 8/16: 172.26.0.13` → connected), post-failover task completes — suite passes 1/1.

## Test plan
- [x] Live 4-node reconnect suite passes (was: infinite hang)
- [ ] Cluster Tests workflow on this PR completes instead of being cancelled
- [ ] No regression in unit gates

## Breaking changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)