### PR TITLE
feat(#526): reproducible performance evaluation pipelines

### DIFF
--- a/jarvis_clio_core/jarvis_clio_core/clio_cte/pkg.py
+++ b/jarvis_clio_core/jarvis_clio_core/clio_cte/pkg.py
@@ -8,6 +8,7 @@ from jarvis_cd.core.pkg import Service
 from jarvis_cd.util import SizeType
 from jarvis_cd.shell.process import Rm, Mkdir
 from jarvis_cd.shell import PsshExecInfo, Exec
+from jarvis_cd.util.container_utils import container_kwargs
 import yaml
 import os
 import re
@@ -166,6 +167,13 @@ class ClioCte(Service):
             parent_dir = os.path.dirname(path)
             if not parent_dir:
                 continue
+            # NOTE: configure runs BEFORE the pipeline's container instance
+            # starts, so this Mkdir cannot be container-wrapped. It is fine
+            # for host-visible paths ($HOME, shared storage); a file device
+            # under /tmp (remapped in-container via tmp_bind_root) would need
+            # its dir created at start() time instead. The performance
+            # evaluation pipelines use ram:: tiers only, so this loop is a
+            # no-op there.
             Mkdir(parent_dir,
                   PsshExecInfo(env=self.mod_env, hostfile=self.hostfile)).run()
 
@@ -226,10 +234,9 @@ class ClioCte(Service):
         Exec(cmd, PsshExecInfo(
             env=self.mod_env,
             hostfile=self.hostfile,
-            container=getattr(self, '_container_engine', 'none'),
-            container_image=self.deploy_image_name(),
             private_dir=self.private_dir,
             bind_mounts=self.container_mounts,
+            **container_kwargs(self),
         )).run()
 
         self.log("CTE started successfully")
@@ -255,10 +262,15 @@ class ClioCte(Service):
             if path.startswith('ram::'):
                 continue
             try:
-                Rm(path, PsshExecInfo(hostfile=self.hostfile)).run()
+                # Wrapped: file devices may live under /tmp, which the
+                # container remaps via tmp_bind_root. Best-effort no-op if
+                # the instance is already down.
+                Rm(path, PsshExecInfo(hostfile=self.hostfile,
+                                      **container_kwargs(self))).run()
                 parent_dir = os.path.dirname(path)
                 if parent_dir:
-                    Rm(parent_dir, PsshExecInfo(hostfile=self.hostfile)).run()
+                    Rm(parent_dir, PsshExecInfo(hostfile=self.hostfile,
+                                                **container_kwargs(self))).run()
             except Exception as e:
                 self.log(f"Error cleaning {path}: {e}")
 

--- a/jarvis_clio_core/jarvis_clio_core/clio_cte_libfuse/pkg.py
+++ b/jarvis_clio_core/jarvis_clio_core/clio_cte_libfuse/pkg.py
@@ -1,12 +1,14 @@
 """
-IOWarp FUSE adapter — bare-metal only.
+IOWarp FUSE adapter.
 
 Mounts the CTE-backed virtual filesystem at a configured path by launching
 the `clio_cte_fuse` binary (built with CLIO_CTE_ENABLE_FUSE_ADAPTER=ON).
+Supports both bare-metal and container deployment modes.
 """
 from jarvis_cd.core.pkg import Service
 from jarvis_cd.shell import Exec, PsshExecInfo
-from jarvis_cd.shell.process import Mkdir, Kill
+from jarvis_cd.shell.process import Kill
+from jarvis_cd.util.container_utils import container_kwargs
 import time
 
 
@@ -61,22 +63,43 @@ class ClioCteLibfuse(Service):
         # of the binary; calling it here just makes start() idempotent.
         self.stop()
 
-        Mkdir(mp, PsshExecInfo(env=self.mod_env, hostfile=self.hostfile)).run()
+        # container_kwargs routes the mkdir into the run's apptainer instance
+        # (jarvis only wraps when exec_info.container is set). REQUIRED here:
+        # under tmp_bind_root the in-container /tmp is a different directory
+        # from the host /tmp, so the mountpoint must be created in-container.
+        Exec(f'mkdir -p {mp}',
+             PsshExecInfo(env=self.mod_env, hostfile=self.hostfile,
+                          **container_kwargs(self))).run()
 
         fuse_cmd = f'{self.binary} {mp} {extra}'.strip()
         self.log(f"Mounting IOWarp CTE FUSE at {mp}: {fuse_cmd}")
-        Exec(fuse_cmd, PsshExecInfo(
+        # Shell-background the daemon inside a synchronous wrapped Exec: the
+        # `nohup ... &` detaches it from the wrap's `bash -c` shell, and it
+        # parents into the apptainer instance, whose mount/shm namespaces it
+        # must share with the runtime and the fio that writes through the
+        # mount. Daemon output goes to a per-host log on the auto-mounted
+        # shared_dir (not /dev/null — a masked mount failure here previously
+        # surfaced only as downstream ENOSPC).
+        fuse_log = f'{self.shared_dir}/cte_fuse.$(hostname).log'
+        bg_cmd = f'nohup {fuse_cmd} </dev/null >{fuse_log} 2>&1 &'
+        Exec(bg_cmd, PsshExecInfo(
             env=self.mod_env, hostfile=self.hostfile,
-            exec_async=True)).run()
+            **container_kwargs(self))).run()
         time.sleep(self.config.get('sleep', 2))
 
     def stop(self):
         mp = self.config['mountpoint']
         self.log(f"Unmounting {mp}")
+        # Both teardown steps must run inside the instance: the FUSE mount
+        # exists only in the instance's mount namespace (host-side
+        # fusermount3 sees "not found in /etc/mtab"), and the wrapped Kill
+        # scopes pkill to this run's PID namespace.
         Exec(f'fusermount3 -u {mp}', PsshExecInfo(
-            env=self.mod_env, hostfile=self.hostfile)).run()
+            env=self.mod_env, hostfile=self.hostfile,
+            **container_kwargs(self))).run()
         Kill(self.binary, PsshExecInfo(
-            env=self.mod_env, hostfile=self.hostfile)).run()
+            env=self.mod_env, hostfile=self.hostfile,
+            **container_kwargs(self))).run()
 
     def clean(self):
         self.stop()

--- a/jarvis_clio_core/jarvis_clio_core/clio_runtime/pkg.py
+++ b/jarvis_clio_core/jarvis_clio_core/clio_runtime/pkg.py
@@ -7,6 +7,7 @@ and container deployment modes via deploy_mode configuration.
 from jarvis_cd.core.pkg import Service
 from jarvis_cd.shell import Exec, PsshExecInfo
 from jarvis_cd.shell.process import Kill, GdbServer
+from jarvis_cd.util.container_utils import container_kwargs
 from jarvis_cd.util import SizeType
 from jarvis_cd.util.logger import Color
 import os
@@ -318,6 +319,34 @@ class ClioRuntime(Service):
 
         self.log("Starting IOWarp runtime")
 
+        # Self-heal BEFORE launching a fresh runtime: kill any stale chimaera
+        # left alive by a prior combo, THEN reclaim its chi_* shm. Both are
+        # host-side (unwrapped) on purpose — apptainer shares the host /dev/shm
+        # and PID space, and the stale process we're hunting has, by definition,
+        # ESCAPED the prior combo's instance:// PID namespace, so the wrapped
+        # `Kill('chimaera')` in the previous stop() could not reach it.
+        #
+        # Why this matters (observed on single_node job 21563, combo 18): the
+        # sweep is sequential in ONE allocation, so combo N+1's runtime start
+        # inherits whatever combo N's teardown left behind. Every teardown logs
+        # `ERROR ... Server dead` — the runtime dies hard, not gracefully — so a
+        # wedged/re-parented chimaera CAN survive. If it does and we only rm the
+        # shm, the fresh runtime comes up alongside the survivor with an
+        # inconsistent pool registry; a client task then routes to the null pool
+        # (`worker.cc ... Container not found for pool_id=PoolId(0,0)`) and, with
+        # no IPC failover, HANGS forever (combo 18 stalled ~8 h to the wall
+        # clock). Killing first makes the old "no live chimaera here" assumption
+        # actually true. Idempotent: in the healthy case nothing matches, so this
+        # is a no-op that leaves startup state unchanged. The `[c]himaera` /
+        # `[c]lio_run` bracket keeps pkill from matching its own argv; `|| true`
+        # keeps a no-match (exit 1) from looking like a failure. Without the shm
+        # reclaim a single mid-startup death also snowballs into a /dev/shm
+        # ENOSPC cascade for every subsequent combo.
+        Exec("pkill -9 -f '[c]himaera' || true; "
+             "pkill -9 -f '[c]lio_run' || true; "
+             'rm -f /dev/shm/chi_*',
+             PsshExecInfo(hostfile=self.hostfile)).run()
+
         cmd = 'clio_run runtime start'
         # Jarvis runs default to a fresh session; a persistent deployment
         # (ephemeral=false) recomposes saved pools + replays the WAL instead.
@@ -328,10 +357,9 @@ class ClioRuntime(Service):
             env=self.env,
             hostfile=self.hostfile,
             exec_async=True,
-            container=self._container_engine,
-            container_image=self.deploy_image_name(),
             private_dir=self.private_dir,
             bind_mounts=self.container_mounts,
+            **container_kwargs(self),
         )
         if self.config.get('do_dbg', False):
             GdbServer(cmd, self.config['dbg_port'], exec_info).run()
@@ -372,10 +400,27 @@ class ClioRuntime(Service):
 
         self.log("Stopping IOWarp runtime")
 
-        Exec('clio_run runtime stop',
-             PsshExecInfo(env=self.env, hostfile=self.hostfile)).run()
+        # BOUND the graceful stop, and run it INSIDE the instance
+        # (container_kwargs) — symmetric with start(). The earlier
+        # intermittent "shm_attach shm_open failed" during stop was the
+        # host-side stop client trying to attach shm owned by the
+        # in-instance runtime; wrapping puts the stop client in the same
+        # namespace. `timeout` still caps a wedged stop; Kill below is what
+        # actually frees the runtime. `-k 10` SIGKILLs if clio_run ignores
+        # the SIGTERM. Harmless on bare-metal (engine 'none' -> no wrap).
+        Exec('timeout -k 10 45 clio_run runtime stop',
+             PsshExecInfo(env=self.env, hostfile=self.hostfile,
+                          **container_kwargs(self))).run()
+        # Backstop force-kill under BOTH daemon names: 'chimaera' (pre-rebrand
+        # CLIO, e.g. an older prebuilt image) and 'clio_run' (post Chimaera->Clio
+        # rebrand). Kill of a name with no matches is benign, so the union is
+        # safe whichever CLIO vintage is deployed.
+        Kill('chimaera',
+             PsshExecInfo(env=self.env, hostfile=self.hostfile,
+                          **container_kwargs(self))).run()
         Kill('clio_run',
-             PsshExecInfo(env=self.env, hostfile=self.hostfile)).run()
+             PsshExecInfo(env=self.env, hostfile=self.hostfile,
+                          **container_kwargs(self))).run()
 
         port = self.config['port']
         host = self.hostfile.hosts[0] if self.hostfile.hosts else '127.0.0.1'
@@ -395,8 +440,15 @@ class ClioRuntime(Service):
 
     def kill(self):
         self.log("Forcibly killing IOWarp runtime")
+        # Both daemon names — pre-rebrand ('chimaera') and post ('clio_run');
+        # see stop() for rationale.
+        Kill('chimaera', PsshExecInfo(
+            hostfile=self.hostfile,
+            **container_kwargs(self)
+        )).run()
         Kill('clio_run', PsshExecInfo(
-            hostfile=self.hostfile
+            hostfile=self.hostfile,
+            **container_kwargs(self)
         )).run()
 
     def clean(self):
@@ -409,6 +461,16 @@ class ClioRuntime(Service):
         if os.path.exists(log_file):
             os.remove(log_file)
 
+        # HOST-SIDE (deliberately NOT wrapped): clean() runs *after* stop() has
+        # already torn the apptainer instance down, so a wrapped `apptainer exec
+        # instance://…` here would target a dead instance and silently no-op —
+        # leaking the runtime's shm across every sweep combo until /dev/shm
+        # (a 48 GiB tmpfs on Ares) fills and later combos die with ENOSPC
+        # ([Errno 28]). Apptainer shares the host /dev/shm by default (no
+        # --contain), so chimaera's shm_open segments physically live on the
+        # host /dev/shm; a bare host-side rm reaches the exact same files and
+        # reclaims them regardless of instance state. On distributed runs the
+        # hostfile fans this out host-side to every node's local /dev/shm.
         Exec('rm -f /dev/shm/chi_*', PsshExecInfo(
             hostfile=self.hostfile
         )).run()

--- a/jarvis_clio_core/pipelines/ares/README.md
+++ b/jarvis_clio_core/pipelines/ares/README.md
@@ -1,0 +1,320 @@
+# Issue #526 perf-eval pipelines — Ares setup guide
+
+This directory holds the two Jarvis regression pipelines for Issue #526:
+
+- [single_node.yaml](single_node.yaml) — one node, a 4×6 (I/O size × thread
+  count) sweep over four storage stacks = **24 rows**.
+- [distributed.yaml](distributed.yaml) — four nodes, a 1→2→4 client-node scaling
+  sweep over three stacks = **3 rows**.
+
+Both run their real work inside a pre-built Apptainer container (the SIF). This
+guide takes you from a **fresh Ares account that has only Spack and a clio-core
+checkout** to a green `jarvis ppl submit`. No conda, and no assumptions beyond
+those two things.
+
+---
+
+## Quick reference — full sequence
+
+The whole setup, if you accept every default. Each step is explained in detail
+below; start there if anything fails or you need to deviate.
+
+```bash
+# 0. prerequisites: on Ares login node, spack on PATH, $CLIO_REPO and $JARVIS_CD set
+export CLIO_REPO="$HOME/clio-core"
+export JARVIS_CD="$HOME/jarvis-cd"
+
+# 1. spack recipes up to date
+spack repo update builtin
+
+# 2. apptainer (compute node preferred; ~suid mandatory)
+spack install apptainer@1.5.0~suid          # or: GOFLAGS=-buildvcs=false spack install --dirty apptainer@1.5.0~suid
+
+# 3. spack view on a shared FS — apptainer only, no deps (see step 3 for why)
+spack view -d false symlink -i "/mnt/common/$USER/perf-eval-view" apptainer
+
+# 4. jarvis venv
+python3 -m venv "$HOME/jarvis-venv"
+"$HOME/jarvis-venv/bin/pip" install -e "$JARVIS_CD"
+
+# 5. put both on PATH for the interactive steps below
+export PATH="/mnt/common/$USER/perf-eval-view/bin:$HOME/jarvis-venv/bin:$PATH"
+
+# 6. init jarvis + build the SIF + register the clio repo
+jarvis init
+bash "$JARVIS_CD/docker/build_perf_eval_image.sh"
+jarvis repo add "$CLIO_REPO/jarvis_clio_core"
+
+# 7. submit
+jarvis ppl submit "$CLIO_REPO/jarvis_clio_core/pipelines/ares/single_node.yaml"
+jarvis ppl submit "$CLIO_REPO/jarvis_clio_core/pipelines/ares/distributed.yaml"
+```
+
+---
+
+## The mental model (read this first)
+
+A submit succeeds when the login node can put **two host binaries** on `PATH`
+before the job starts, and the SIF is staged where Jarvis looks for it:
+
+1. **`apptainer`** — launches the per-node containers. Provided by a **Spack
+   view** on a shared filesystem (so every compute node sees the same binary).
+2. **`jarvis`** — the launcher itself; the generated sbatch script calls bare
+   `jarvis ppl run`. Provided by a **dedicated Python venv**
+   (`pip install -e <jarvis-cd>`).
+3. **The SIF** — `iowarp-perf-eval.sif`, staged under
+   `<jarvis shared_dir>/containers/` so the YAMLs resolve it by basename.
+
+The pipelines never `spack load` or `conda activate` — those install shell
+functions that misbehave under the `set -euo pipefail` job script. Everything is
+plain `PATH` prepends. The pre_cmds in each YAML re-apply the same `export PATH`
+inside the job, driven by three env vars you can override at submit time:
+
+| Env var | Default | What it points at |
+|---|---|---|
+| `PERF_EVAL_VIEW` | `/mnt/common/$USER/perf-eval-view` | Spack view dir holding `apptainer` (step 3) |
+| `JARVIS_VENV` | `$HOME/jarvis-venv` | The jarvis venv (step 4) |
+| `CLIO_REPO` | `$HOME/clio-core` | This clio-core checkout (used for `jarvis repo add`) |
+
+If you accept every default below, you never set any of these. Override them
+**before** `jarvis ppl submit` (they are read when the job runs, not when it is
+queued).
+
+---
+
+## Prerequisites
+
+- You are on an **Ares login node**.
+- **Spack is installed and on `PATH`** (`spack --version` works — i.e. you have
+  sourced `share/spack/setup-env.sh`). Spack on Ares is a *per-user* install, so
+  its package recipes can be out of date — step 1 fixes that.
+- **clio-core is checked out** (this repo). Its path is your `CLIO_REPO`
+  (default `$HOME/clio-core`).
+- **jarvis-cd is checked out at `dev`** — it carries the container deploy,
+  `container_fakeroot`, `run_timeout`, the Slurm `scheduler:` block, and the SIF
+  build script these pipelines depend on. Call its path `$JARVIS_CD` below.
+- **Docker is available** on the machine where you build the SIF (step 6). The
+  SIF build is a `docker build` followed by an `apptainer build
+  docker-daemon://…`.
+
+> **Shared-filesystem requirement.** The Spack install tree, the view, the venv,
+> and the SIF must all live on a filesystem the compute nodes can see. On Ares
+> both `$HOME` (NFS) and `/mnt/common` qualify. The defaults put the view under
+> `/mnt/common/$USER` and everything else under `$HOME`. If your Spack install
+> root is on node-local disk, move it (or the view symlinks will dangle on the
+> compute nodes).
+
+---
+
+## Step 1 — Bring Spack's package recipes up to date
+
+The `--buildvcs` failure that older notes warn about is a **version bug in
+apptainer ≤ 1.4.4**, not an Ares bug. It is gone in **apptainer 1.5.0** (added
+upstream 2026-06-19). A stale per-user Spack packages checkout is the usual
+reason `1.5.0` is missing:
+
+```bash
+spack repo update builtin
+spack versions --safe apptainer | head    # expect 1.5.0 at the top
+```
+
+If `spack repo update` reports *"cannot rebase: you have unstaged changes,"* your
+builtin checkout has local edits. Find that checkout's path with `spack repo
+list`, `git stash` inside it, and re-run the update. `1.5.0` needs
+**`go@1.25.7:`**; if that will not resolve on your Spack, use a fallback version —
+see step 2.
+
+---
+
+## Step 2 — Build `apptainer` with Spack
+
+**`~suid` is mandatory.** The builtin recipe defaults to `+suid`, which builds a
+setuid `starter-suid` that must be root-owned — unbuildable unprivileged and
+fatal to the rootless `--fakeroot` path these pipelines use. Always pass `~suid`.
+
+On a **compute node** (recommended — a clean `/tmp` stage tree never trips the Go
+VCS check):
+
+```bash
+srun -p debug -N1 -n1 --pty bash        # grab an interactive compute node
+spack install apptainer@1.5.0~suid
+exit
+```
+
+If you must build on the **login node**, force the VCS stamp off (this works at
+1.5.0 because the Go build flag is no longer clobbered by apptainer's makefile):
+
+```bash
+GOFLAGS=-buildvcs=false spack install --dirty apptainer@1.5.0~suid
+```
+
+**Version fallbacks** (if `go@1.25.7` will not resolve): `spack install
+apptainer@1.4.4~suid` (needs `go@1.23.6`) or `@1.3.6~suid` (needs `go@1.20`).
+Use the same version in the view command in step 3.
+
+---
+
+## Step 3 — Build the Spack view (the `apptainer` on `PATH`)
+
+Materialize `apptainer` into a view under `/mnt/common` so every node sees it.
+**Link only apptainer itself — no dependencies (`-d false`):**
+
+```bash
+rm -rf "/mnt/common/$USER/perf-eval-view"      # if re-running; symlinks only, uninstalls nothing
+spack view -d false symlink -i "/mnt/common/$USER/perf-eval-view" apptainer
+```
+
+**Why no dependencies.** The view exists for one purpose: put the `apptainer`
+binary on `PATH`. Apptainer does not find its helpers through `PATH` — the spack
+recipe symlinks the FUSE helpers (`squashfuse`, `fuse-overlayfs`, `gocryptfs`,
+`e2fsprogs`) into its own `libexec/apptainer/bin`, and bakes an absolute
+`mksquashfs` path into `apptainer.conf`. So a dependency-free view is fully
+functional, and it removes two whole classes of failure:
+
+- **Dependency version conflicts can't happen.** Linking the closure pulls in
+  build-time artifacts like `compiler-wrapper`; if any two installed specs
+  disagree on its version, the view refuses to build (see
+  [Troubleshooting](#troubleshooting)). Nothing to conflict when nothing is
+  linked.
+- **`shadow` can't shadow the system tools.** `shadow` is a run-dependency (via
+  `+libsubid`) shipping its own `newuidmap`/`newgidmap`. Because the view is
+  PATH-**prepended**, its user-owned, non-setuid copies would beat the system's
+  setuid-root `/usr/bin/newuidmap`, and `--fakeroot` would die with *"newuidmap
+  must be owned by the root user."* Spack cannot make a setuid binary
+  unprivileged, so the system copies are the ones you want — and with `-d false`
+  they are never at risk.
+
+Verify:
+
+```bash
+export PATH="/mnt/common/$USER/perf-eval-view/bin:$PATH"
+command -v apptainer                     # -> the view path
+command -v newuidmap                      # -> /usr/bin/newuidmap (NOT the view)
+```
+
+> **Alternative — a full runtime closure in the view.** If you want apptainer's
+> dependencies on `PATH` too, link them but exclude the two problem packages:
+> `spack view -e shadow -e compiler-wrapper symlink -i "/mnt/common/$USER/perf-eval-view" apptainer`
+> (`-e` takes a regex and may be repeated). Both forms are verified working on
+> Ares; `-d false` is documented as the default because it is immune to
+> dependency drift on any machine.
+
+---
+
+## Step 4 — Create the jarvis venv (the `jarvis` on `PATH`)
+
+A dedicated venv keeps jarvis off conda and makes the launcher environment
+reproducible:
+
+```bash
+python3 -m venv "$HOME/jarvis-venv"
+"$HOME/jarvis-venv/bin/pip" install -e "$JARVIS_CD"
+export PATH="$HOME/jarvis-venv/bin:$PATH"
+command -v jarvis                         # -> $HOME/jarvis-venv/bin/jarvis
+```
+
+`pip install -e` pulls jarvis's Python deps; any gap surfaces here (cheap),
+before you ever queue a job.
+
+---
+
+## Step 5 — Initialize Jarvis
+
+This writes `~/.ppi-jarvis/*.yaml`, which defines `shared_dir` — where the SIF
+build stages the image and where the pipelines look for it:
+
+```bash
+jarvis init                               # accepts defaults; shared_dir = ~/.ppi-jarvis/shared
+```
+
+`~/.ppi-jarvis/shared` is on NFS home, so it is node-visible and fine. To put it
+on `/mnt/common` instead:
+`jarvis init ~/.ppi-jarvis/config ~/.ppi-jarvis/private /mnt/common/$USER/jarvis-shared`.
+
+---
+
+## Step 6 — Build the SIF
+
+With `apptainer` (view) and `jarvis` (venv) both on `PATH` from the steps above,
+build the image. This does a `docker build` then converts it to a SIF and stages
+it at `<shared_dir>/containers/iowarp-perf-eval.sif`:
+
+```bash
+bash "$JARVIS_CD/docker/build_perf_eval_image.sh"
+```
+
+- It reads `shared_dir` from `~/.ppi-jarvis/*.yaml`, so step 5 must be done
+  first.
+- It bakes in clio-core at `CLIO_REF` (default `dev`) — the resolved commit SHA
+  is echoed; record it, that is exactly what is inside the SIF.
+- Re-run it daily so the sweep tracks the latest IOWarp. Useful overrides:
+  `CLIO_REF=<branch|sha>`, `IOWARP_SPEC="iowarp@dev +fuse"`, `SKIP_DOCKER_BUILD=1`
+  (reuse an existing local docker image).
+
+---
+
+## Step 7 — Register the clio-core package repo
+
+The pipelines' pre_cmds run `jarvis repo add "$CLIO_REPO/jarvis_clio_core"`
+idempotently, but doing it once now confirms the clio packages
+(`clio_runtime`, `clio_cte`, `clio_cte_libfuse`) import cleanly:
+
+```bash
+jarvis repo add "$CLIO_REPO/jarvis_clio_core"
+jarvis repo list                          # jarvis_clio_core should appear
+```
+
+---
+
+## Step 8 — Submit
+
+Hostfiles are **generated automatically** by the scheduler from
+`$SLURM_JOB_NODELIST` at job start — you do **not** create
+`~/.jarvis-perf-eval/*_hostfile.txt` by hand.
+
+```bash
+jarvis ppl submit "$CLIO_REPO/jarvis_clio_core/pipelines/ares/single_node.yaml"
+# then, when that is green:
+jarvis ppl submit "$CLIO_REPO/jarvis_clio_core/pipelines/ares/distributed.yaml"
+```
+
+`single_node.yaml` requests 1 node on `debug`; `distributed.yaml` requests 4. If
+you accepted every default in steps 3–5, submit with no extra env. Otherwise
+export your overrides first, e.g.:
+
+```bash
+PERF_EVAL_VIEW=/some/view JARVIS_VENV=$HOME/jarvis-venv CLIO_REPO=$HOME/src/clio-core \
+  jarvis ppl submit "$CLIO_REPO/jarvis_clio_core/pipelines/ares/single_node.yaml"
+```
+
+---
+
+## Verifying a run
+
+1. In the `.out` log, the toolchain echo must point at **your view and venv**:
+   ```
+   toolchain: apptainer=/mnt/common/<you>/perf-eval-view/bin/apptainer jarvis=/home/<you>/jarvis-venv/bin/jarvis
+   ```
+   A miniconda path here means the migrated toolchain did **not** take effect.
+2. The post_cmd prints `ALL 24 GREEN` (single_node) / `ALL 3 GREEN`
+   (distributed).
+3. **Check the numbers, not just the color.** Open the results CSV
+   (`$HOME/single_node_results/results.csv` or `$HOME/distributed_results/results.csv`)
+   and confirm the throughput columns are populated — a green row with a blank
+   `*_max_mibs` column is a failure. Sane single-node reference: `nfs_ior` 4k read
+   scales roughly 380 → 5000+ MiB/s across 1 → 32 ranks.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `apptainer@1.5.0` is an unknown version | Stale Spack packages repo — **step 1** (`spack repo update builtin`). |
+| `error obtaining VCS status: exit status 128` during build | Building on the login node. Build on a compute node, or use `GOFLAGS=-buildvcs=false spack install --dirty …` (**step 2**). |
+| `go@1.25.7` won't concretize | Use a fallback: `apptainer@1.4.4~suid` or `@1.3.6~suid`, and the same version in the step-3 view command. |
+| `spack view`: *Package conflict detected: (Linked) X@1.0 … (Specified) X@1.1*, or *Package merge blocked by file: …/.spack/compiler-wrapper/spec.json* | Two specs in apptainer's dependency closure disagree on a package version (typically `compiler-wrapper`, after some deps were built at different times). `-i`/`--ignore-conflicts` does **not** fix it — that only suppresses file collisions between unrelated packages. Use the step-3 command as written (`-d false`), which links no dependencies and cannot hit this. If you need the closure linked, exclude the offenders: `-e shadow -e compiler-wrapper`. Delete the view first (`rm -rf "/mnt/common/$USER/perf-eval-view"`) — it is only symlinks, so this uninstalls nothing. |
+| `--fakeroot`: *newuidmap must be owned by the root user* | `shadow` leaked into the view and its non-setuid `newuidmap` is shadowing `/usr/bin/newuidmap`. Cannot happen with the step-3 command (`-d false` links no deps); if you used the full-closure alternative, rebuild it with `-e shadow`. |
+| `--fakeroot`: *Target N is owned by a different user … gid mismatch* | Slurm gave the job the project GID. The pipelines already re-exec under `exec sg "$USER"` in pre_cmd #1; for a **hand-run** smoke, wrap it yourself: `sg "$USER" -c 'apptainer instance start --fakeroot <SIF> t'`. |
+| `ERROR: SIF missing: …/iowarp-perf-eval.sif` | The SIF was never staged — run **step 6** (`build_perf_eval_image.sh`). |
+| `ERROR: apptainer/jarvis not on PATH` in the job log | Your `PERF_EVAL_VIEW` / `JARVIS_VENV` override does not match where you built them, or the view/venv is on node-local disk. Fix the override or move them onto a shared FS. |

--- a/jarvis_clio_core/pipelines/ares/distributed.yaml
+++ b/jarvis_clio_core/pipelines/ares/distributed.yaml
@@ -1,0 +1,312 @@
+# =============================================================================
+# Issue #526 — multi-node performance evaluation sweep (containerized).
+# =============================================================================
+#
+# Sweeps the ior client node count 1 -> 2 -> 4 at a fixed I/O working point
+# (xfer 1m, ppn 4, block 256m => 1 GiB written per node per phase) across three
+# storage stacks, recording every run into one results.csv for day-over-day
+# tracking.
+#
+#   1. NFS + ior           -> ior against the cluster's shared NFS home
+#   2. CTE + libfuse + ior -> ior through the per-node CTE FUSE mounts
+#   3. juicefs + ior       -> ior through per-node JuiceFS mounts, sharing one
+#                             namespace via redis metadata on the head node
+#
+# Services stay up on all four nodes throughout; only the ior client fan
+# varies, so no service churn is charged to a row. Each node runs its packages
+# inside its own apptainer instance; ior's mpiexec runs inside the head
+# instance and spawns remote ranks over the peer instances' sshd on port 2222.
+#
+# The CTE pool is registered on every node before any FUSE mount, under the
+# default pool_name clio_cte_core (== the C++ kCtePoolName), so the FUSE
+# client's AsyncCreate composes locally instead of racing cross-node.
+# pool_query: local keeps each node's I/O node-local and the scaling symmetric.
+#
+# Usage:
+#   bash <jarvis-cd>/docker/build_perf_eval_image.sh   # stage the SIF
+#   jarvis ppl submit <abs path>/distributed.yaml
+#
+#   Needs jarvis-cd @ dev for container_fakeroot, run_timeout, builtin.ior's
+#   container path + num_nodes, builtin.juicefs meta_use_head, and
+#   jarvis_cd.util.container_utils. Env overrides read by pre_cmds at job
+#   runtime: PERF_EVAL_VIEW, JARVIS_VENV, CLIO_REPO — see single_node.yaml.
+#
+# Output:
+#   ${HOME}/distributed_results/results.csv — 3 rows, one per node count.
+#   Columns: {nfs_ior,cte_ior,jfs_ior}.write_max_mibs / .read_max_mibs /
+#   .runtime.
+
+scheduler:
+  name: slurm
+  job_name: perf_eval_distributed
+  nodes: 4
+  ntasks_per_node: 1
+  cpus_per_task: 32
+  partition: debug
+  time: "04:00:00"
+  output: ${HOME}/distributed-%j.out
+  error: ${HOME}/distributed-%j.err
+  # Uncomment to steer clear of nodes with a broken fakeroot uidmap; the
+  # preflight below re-detects per job and prints an updated list.
+  # exclude: "ares-comp-15,ares-comp-17"
+  # MUST stay literally identical to config.hostfile below.
+  hostfile: "${HOME}/.jarvis-perf-eval/distributed_hostfile.txt"
+  pre_cmds:
+    # 1) fakeroot GID fix on the head node (see single_node.yaml).
+    - 'if [ "$(id -gn)" != "$USER" ] && getent group "$USER" >/dev/null 2>&1; then echo "re-exec under group $USER for apptainer --fakeroot"; exec sg "$USER" -c "exec bash \"$0\""; fi'
+    # 2) Host launcher toolchain: spack-built apptainer (via a spack view under
+    #    /mnt/common, seen on every node) + the jarvis venv, prepended to PATH.
+    #    Pure `export` -- no `spack load` / `conda activate` under `set -euo
+    #    pipefail`. Override PERF_EVAL_VIEW / JARVIS_VENV before submitting.
+    - 'export PATH="${PERF_EVAL_VIEW:-/mnt/common/$USER/perf-eval-view}/bin:${JARVIS_VENV:-$HOME/jarvis-venv}/bin:$PATH"'
+    - 'command -v apptainer >/dev/null 2>&1 || { echo "ERROR: apptainer not on PATH (view: ${PERF_EVAL_VIEW:-/mnt/common/$USER/perf-eval-view})" >&2; exit 1; }'
+    - 'command -v jarvis    >/dev/null 2>&1 || { echo "ERROR: jarvis not on PATH (venv: ${JARVIS_VENV:-$HOME/jarvis-venv})" >&2; exit 1; }'
+    - 'echo "toolchain: apptainer=$(command -v apptainer) jarvis=$(command -v jarvis)"'
+    # 3) SIF gate ($SIF is reused by the preflight below — one bash process)
+    - 'JSD=$(grep -hE "^[[:space:]]*shared_dir:" "$HOME"/.ppi-jarvis/*.yaml 2>/dev/null | head -1 | sed -E "s/^[[:space:]]*shared_dir:[[:space:]]*//" | tr -d "\"" || true)'
+    - 'SIF="$JSD/containers/iowarp-perf-eval.sif"; [ -n "$JSD" ] && [ -f "$SIF" ] || { echo "ERROR: SIF missing: $SIF — build via jarvis-cd docker/build_perf_eval_image.sh" >&2; exit 1; }'
+    # 4) per-node stale-state reap (all 4 nodes; head included). Warn-only —
+    #    a node that fails prep is caught by the fakeroot preflight below.
+    #    CRITICAL: this inline string is argv of srun AND each node's bash;
+    #    the pkill patterns are BRACKETED so they never match it.
+    - |-
+      srun --kill-on-bad-exit=0 --ntasks-per-node=1 bash -c '
+        command -v apptainer >/dev/null 2>&1 || { echo "WARNING: $(hostname): apptainer not on PATH"; exit 0; }
+        timeout 30 apptainer instance stop --all >/dev/null 2>&1 || true
+        pkill -9 -f "[c]himaera" 2>/dev/null || true
+        pkill -9 -f "[c]lio_run" 2>/dev/null || true
+        { command -v fuser >/dev/null 2>&1 && fuser -k 9413/tcp; } >/dev/null 2>&1 || true
+        rm -f /dev/shm/chi_* 2>/dev/null || true
+        find /tmp -maxdepth 1 \( -name "distributed_run*" -o -name "distributed" \) -mmin +10 -exec rm -rf {} + 2>/dev/null || true
+        rm -rf /tmp/iowarp_chi* 2>/dev/null || true
+        echo "prep done: $(hostname)"
+      ' || echo "WARNING: per-node prep rc=$? — continuing"
+    # 5) fakeroot preflight: a real throwaway --fakeroot instance per node
+    #    over ssh (same hop jarvis uses). Broken-uidmap nodes fail here in
+    #    seconds; the job aborts with a ready resubmit hint.
+    - |-
+      BAD=""
+      for h in $(scontrol show hostnames "$SLURM_JOB_NODELIST"); do
+        if env -u LD_LIBRARY_PATH ssh -n -o BatchMode=yes "$h" \
+            "PATH=\"${PERF_EVAL_VIEW:-/mnt/common/$USER/perf-eval-view}/bin:\$PATH\" apptainer instance start --fakeroot $SIF pf_$$ >/dev/null 2>&1 && apptainer instance stop pf_$$ >/dev/null 2>&1"; then
+          echo "fakeroot OK: $h"
+        else
+          echo "fakeroot FAILED: $h"
+          BAD="${BAD:+$BAD,}$h"
+        fi
+      done
+      if [ -n "$BAD" ]; then
+        echo "ERROR: fakeroot preflight failed on: $BAD" >&2
+        echo "Resubmit excluding them: set exclude: \"$BAD\" in the scheduler block, or: sbatch --exclude=$BAD <pipeline shared_dir>/submit.slurm" >&2
+        exit 1
+      fi
+    # 6) experiment dirs + repo registration + clean-slate results
+    - 'mkdir -p "$HOME/perf_eval_scratch/distributed/nfs" "$HOME/perf_eval_scratch/distributed/jfs_data" "$HOME/cte_libfuse_perf_eval" "$HOME/distributed_results"'
+    - 'jarvis repo add "${CLIO_REPO:-$HOME/clio-core}/jarvis_clio_core" 2>/dev/null || true'
+    - 'rm -f "$HOME/distributed_results/results.csv"'
+  post_cmds:
+    - 'RES="$HOME/distributed_results/results.csv"; n=$(grep -c success "$RES" 2>/dev/null || true); n=${n:-0}; echo "successful rows: $n / 3"; [ "$n" -ge 3 ] && echo "ALL 3 GREEN" || echo "INCOMPLETE — inspect $RES and the .err log"'
+
+config:
+  name: distributed
+
+  # MUST stay literally identical to scheduler.hostfile above.
+  hostfile: "${HOME}/.jarvis-perf-eval/distributed_hostfile.txt"
+
+  # The OUTER jarvis Pssh between nodes brings up the per-node containers, and
+  # this string ALSO becomes mpiexec's --mca plm_rsh_agent: the ssh that spawns
+  # prted INSIDE the remote node's instance sshd on -p 2222 (jarvis appends the
+  # port via plm_rsh_args). env -u LD_LIBRARY_PATH strips a managed env's
+  # LD_LIBRARY_PATH so /usr/bin/ssh doesn't abort on an OpenSSL mismatch.
+  # StrictHostKeyChecking=no + UserKnownHostsFile=/dev/null are REQUIRED for the
+  # -p 2222 hop: the remote instance's sshd presents a host key never seen for
+  # that host:port, so a strict client aborts with "Host key verification
+  # failed" and PRTE loses the remote daemon (the SIF's ssh_config drop-in did
+  # not take effect on Ares). They also cover the outer host->host hop
+  # harmlessly (those keys are already trusted).
+  ssh_cmd: "env -u LD_LIBRARY_PATH ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+
+  # Fabric tuning prefix for the in-instance mpiexec. MUST begin with the
+  # literal "mpiexec " — jarvis string-matches it to inject the container wrap
+  # and the rsh plm. btl_tcp_if_include pins the MPI data plane to the 40 GbE
+  # NIC; oob/prte_if_include keep the spawn graph on the 1 GbE management NIC;
+  # prte_tmpdir_base keeps the PRTE session dir on node-local in-container
+  # /tmp rather than NFS or a small host /tmp.
+  mpi_cmd: 'mpiexec --mca btl_tcp_if_include enp47s0np0 --mca oob_tcp_if_include eno1 --prtemca prte_if_include eno1 --prtemca prte_tmpdir_base /tmp/iowarp_prte_tmp'
+
+  # ---- Containerized deployment (Ares dev jarvis — APPTAINER) -----------
+  # Pre-staged SIF referenced by BASENAME -> <shared_dir>/containers/
+  # iowarp-perf-eval.sif. It lives on the shared FS, so one SIF serves every
+  # allocated node. See single_node.yaml for the rationale behind
+  # container_fakeroot, tmp_bind_root, and the shared-scratch container_binds.
+  base_deploy_mode: container
+  container_engine: apptainer
+  container_image: "iowarp-perf-eval"
+  container_fakeroot: true
+  # In-container /tmp -> node-local disk (chimaera IPC socket/memfd + juicefs
+  # cache + PRTE session dir must not live on the NFS overlay).
+  tmp_bind_root: "/tmp"
+  # Overlay upper on node-local /tmp (a shared-NFS overlay upper is a
+  # multi-node corruption hazard; jarvis errors without a node-local root).
+  container_overlay_root: "/tmp"
+  # Shared-FS scratch bound at instance start on EVERY node (see
+  # single_node.yaml). Critical here: it puts the JuiceFS object store on real
+  # shared NFS at an IDENTICAL host path on all nodes, so under meta_use_head
+  # the distributed filesystem is genuinely shared (an unbound $HOME data_dir
+  # would be per-node overlay — not shared). Same for the nfs_ior baseline.
+  container_binds:
+    - ${HOME}/perf_eval_scratch:${HOME}/perf_eval_scratch
+  env:
+    CLIO_MEMFD_DIR: "/tmp/iowarp_chimaera"
+
+  pkgs:
+    # ---- Services (started in order; stopped in reverse) -----------------
+    # Redis metadata engine for JuiceFS (head-node container). single_instance:
+    # a 4-node fan-out would push redis into CLUSTER mode (shared nodes.conf
+    # collision + DB0-only, breaking meta_url .../1). builtin.redis's config
+    # binds 0.0.0.0 with protected-mode off, so the OTHER nodes' mounts can
+    # reach this head-node server (see juicefs meta_use_head below).
+    - pkg_type: builtin.redis
+      pkg_name: redis
+      port: 6379
+      single_instance: true
+      sleep: 4
+
+    # clio_run runtime on EVERY allocated node's container (Pssh-launched
+    # across the hostfile). shm client transport within each node.
+    # swim_enabled: false avoids mid-IOR SWIM "node confirmed dead" cascades.
+    - pkg_type: jarvis_clio_core.clio_runtime
+      pkg_name: runtime
+      num_threads: 4
+      port: 9413
+      ipc_mode: "shm"
+      log_level: "info"
+      sleep: 4
+      swim_enabled: false
+
+    # CTE pool on every node, single local RAM tier (neighborhood: 1 = each
+    # node serves its own data; pool_query: local => node-local I/O =>
+    # symmetric scaling). Registers the default pool clio_cte_core on ALL
+    # nodes BEFORE any FUSE mount — the multi-node AsyncCreate-race mitigation
+    # (see header). 16 GiB tier vs 1 GiB/node peak ior set = 16x headroom.
+    - pkg_type: jarvis_clio_core.clio_cte
+      pkg_name: cte_core
+      devices:
+        - ["ram::cte_ram_tier1", "16GB", 1.0]
+      dpe_type: "max_bw"
+      neighborhood: 1
+      pool_query: "local"
+      default_target_timeout_ms: 30000
+      poll_period_ms: 5000
+
+    # CTE libfuse mount on EVERY node. The mountpoint sits under $HOME so each
+    # node's FUSE mount shadows the NFS dir locally — one `out:` path below is
+    # therefore a CTE-backed target on every node.
+    - pkg_type: jarvis_clio_core.clio_cte_libfuse
+      pkg_name: cte_fuse
+      mountpoint: ${HOME}/cte_libfuse_perf_eval
+      log_level: "info"
+      extra_fuse_args: "-f"
+      sleep: 2
+
+    # JuiceFS: format + FUSE mount on EVERY node, so it scales with the sweep.
+    # meta_use_head rewrites the meta host to hostfile[0] at start(), where
+    # the single_instance redis lives — all nodes share ONE filesystem
+    # namespace (head-node meta + shared-NFS object store on the bound
+    # perf_eval_scratch, identical path on every node), mounted locally on each
+    # node's /tmp. If this misbehaves, set single_instance: true here and on
+    # jfs_ior for a head-pinned baseline.
+    - pkg_type: builtin.juicefs
+      pkg_name: juicefs
+      meta_use_head: true
+      meta_url: "redis://127.0.0.1:6379/1"
+      storage: file
+      data_dir: ${HOME}/perf_eval_scratch/distributed/jfs_data
+      mountpoint: /tmp/jfs_mnt
+      cache_dir: /tmp/juicefs_cache
+      name: jfsbench
+      format_fresh: true
+      mount_wait: 20
+
+    # ---- Benchmark drivers (Applications; run sequentially) --------------
+    # builtin.ior, with the num_nodes subset knob. Shared keys:
+    # api posix, write+read, fpp (per-node mounts make shared-file impossible
+    # for the CTE/jfs stacks), block 256m x ppn 4 = 1 GiB per node per phase,
+    # stonewall 120 runtime cap. log: is left UNSET so builtin.ior defaults it
+    # to each package's own host-bound shared_dir/ior.log (auto-distinct); an
+    # explicit ${HOME} log lands in the fakeroot overlay and loses every stat.
+    # num_nodes/nprocs are swept below (nprocs = num_nodes x ppn, zipped
+    # explicitly).
+    # 1) NFS: ior against shared NFS via the bound perf_eval_scratch (identical host
+    #    path on every node), scaling with node count. If NFS scaling
+    #    misbehaves, set single_instance: true here and drop this package's
+    #    num_nodes/nprocs vars for a head-pinned single-client baseline.
+    - pkg_type: builtin.ior
+      pkg_name: nfs_ior
+      api: posix
+      write: true
+      read: true
+      fpp: true
+      xfer: "1m"
+      block: "256m"
+      ppn: 4
+      nprocs: 4
+      num_nodes: 1
+      stonewall: 120
+      out: ${HOME}/perf_eval_scratch/distributed/nfs/ior_nfs.bin
+
+    # 2) CTE + libfuse: ior through each node's local CTE FUSE mount.
+    - pkg_type: builtin.ior
+      pkg_name: cte_ior
+      api: posix
+      write: true
+      read: true
+      fpp: true
+      xfer: "1m"
+      block: "256m"
+      ppn: 4
+      nprocs: 4
+      num_nodes: 1
+      stonewall: 120
+      out: ${HOME}/cte_libfuse_perf_eval/ior_cte.bin
+
+    # 3) juicefs: ior through each node's local JuiceFS mount (one shared
+    #    filesystem namespace; fpp keeps per-rank files distinct).
+    - pkg_type: builtin.ior
+      pkg_name: jfs_ior
+      api: posix
+      write: true
+      read: true
+      fpp: true
+      xfer: "1m"
+      block: "256m"
+      ppn: 4
+      nprocs: 4
+      num_nodes: 1
+      stonewall: 120
+      out: /tmp/jfs_mnt/ior_jfs.bin
+
+# Node-count sweep within the single 4-node allocation: jarvis subsets the
+# hostfile to the FIRST num_nodes hosts for each ior; nprocs is zipped
+# explicitly as num_nodes x ppn (ppn fixed at 4). Services stay up on all 4
+# nodes at every point.
+vars:
+  nfs_ior.num_nodes: [1, 2, 4]
+  cte_ior.num_nodes: [1, 2, 4]
+  jfs_ior.num_nodes: [1, 2, 4]
+  nfs_ior.nprocs:    [4, 8, 16]
+  cte_ior.nprocs:    [4, 8, 16]
+  jfs_ior.nprocs:    [4, 8, 16]
+
+loop:
+  # One axis, 3 values => 3 rows.
+  - [nfs_ior.num_nodes, cte_ior.num_nodes, jfs_ior.num_nodes,
+     nfs_ior.nprocs, cte_ior.nprocs, jfs_ior.nprocs]
+
+# Per-combination wall-clock backstop: with stonewall capping each ior phase
+# at 120 s, a healthy row stays far under 1800; expiry records the row failed
+# and the sweep continues instead of losing the whole allocation.
+run_timeout: 1800
+
+repeat: 1
+output: "${HOME}/distributed_results"

--- a/jarvis_clio_core/pipelines/ares/single_node.yaml
+++ b/jarvis_clio_core/pipelines/ares/single_node.yaml
@@ -1,0 +1,304 @@
+# =============================================================================
+# Issue #526 — single-node performance evaluation sweep (containerized).
+# =============================================================================
+#
+# Benchmarks four storage stacks back-to-back over one shared
+# (I/O size x thread count) grid and records every run into a single
+# results.csv, so a daily run can be diffed against yesterday's to catch
+# performance regressions.
+#
+#   1. NFS + ior               -> ior against the cluster's NFS home
+#   2. CTE + libfuse + ior     -> ior through the CTE FUSE mount
+#   3. redis + redis-benchmark -> SET/GET against a node-local redis
+#   4. juicefs + ior           -> ior through the JuiceFS FUSE mount
+#
+#   Grid: I/O size {4k, 64k, 128k, 1m} x thread count {1,2,4,8,16,32}
+#         = 24 combinations. "threads" means MPI ranks (nprocs = ppn) for the
+#         ior drivers, and -c clients / --threads for redis-benchmark.
+#
+# Every package runs inside one long-running apptainer instance on the node, so
+# the CTE and JuiceFS FUSE mounts are visible to ior in the same mount
+# namespace.
+#
+# Usage:
+#   # Stage the SIF; re-run daily so the sweep tracks the latest IOWarp.
+#   bash <jarvis-cd>/docker/build_perf_eval_image.sh
+#   jarvis ppl submit <abs path>/single_node.yaml
+#
+#   Needs jarvis-cd @ dev for container_fakeroot, run_timeout, builtin.ior's
+#   container path, builtin.juicefs, and jarvis_cd.util.container_utils (which
+#   the clio_* packages import). pre_cmds expand when the JOB runs, so export
+#   any overrides before submitting: PERF_EVAL_VIEW (spack view with apptainer,
+#   default /mnt/common/$USER/perf-eval-view), JARVIS_VENV (jarvis venv, default
+#   $HOME/jarvis-venv), CLIO_REPO (this checkout, default $HOME/clio-core).
+#
+# Output:
+#   ${HOME}/single_node_results/results.csv — 24 rows. Per-driver columns:
+#   <ior pkg>.write_max_mibs / .read_max_mibs / .runtime, and
+#   redis_bench.set_rps / .get_rps / .set_p50_ms / .get_p99_ms / .runtime
+#   (redis-benchmark's raw CSV lands in the pipeline shared_dir).
+
+scheduler:
+  name: slurm
+  job_name: perf_eval_single_node
+  nodes: 1
+  ntasks_per_node: 1
+  # cpus_per_task must stay large: Ares Slurm uses proctrack/cgroup with
+  # ConstrainCores, and a 1-core cgroup starves clio_run's dedicated workers
+  # alongside FUSE + ior ranks.
+  cpus_per_task: 32
+  partition: debug
+  time: "12:00:00"
+  output: ${HOME}/single_node-%j.out
+  error: ${HOME}/single_node-%j.err
+  # Uncomment to steer clear of nodes with a broken fakeroot uidmap.
+  # exclude: "ares-comp-15,ares-comp-17"
+  # MUST stay literally identical to config.hostfile below.
+  hostfile: "${HOME}/.jarvis-perf-eval/single_node_hostfile.txt"
+  pre_cmds:
+    # 1) fakeroot GID fix: Slurm hands the job the project primary GID;
+    #    rootless --fakeroot validates the GID map against group == $USER.
+    #    Guarded self-re-exec of this job script under the personal group.
+    - 'if [ "$(id -gn)" != "$USER" ] && getent group "$USER" >/dev/null 2>&1; then echo "re-exec under group $USER for apptainer --fakeroot"; exec sg "$USER" -c "exec bash \"$0\""; fi'
+    # 2) The one place the host launcher toolchain is brought up: spack-built
+    #    apptainer (via a spack view under /mnt/common, seen on every node) plus
+    #    the jarvis venv, prepended to PATH. Pure `export` -- no `spack load` /
+    #    `conda activate` (shell functions that misbehave under `set -euo
+    #    pipefail`). Override PERF_EVAL_VIEW / JARVIS_VENV before submitting.
+    - 'export PATH="${PERF_EVAL_VIEW:-/mnt/common/$USER/perf-eval-view}/bin:${JARVIS_VENV:-$HOME/jarvis-venv}/bin:$PATH"'
+    - 'command -v apptainer >/dev/null 2>&1 || { echo "ERROR: apptainer not on PATH (view: ${PERF_EVAL_VIEW:-/mnt/common/$USER/perf-eval-view})" >&2; exit 1; }'
+    - 'command -v jarvis    >/dev/null 2>&1 || { echo "ERROR: jarvis not on PATH (venv: ${JARVIS_VENV:-$HOME/jarvis-venv})" >&2; exit 1; }'
+    - 'echo "toolchain: apptainer=$(command -v apptainer) jarvis=$(command -v jarvis)"'
+    # 3) SIF gate: fail fast if the image was never staged.
+    #    pre_cmds are verbatim shell, so resolve jarvis's shared_dir here.
+    - 'JSD=$(grep -hE "^[[:space:]]*shared_dir:" "$HOME"/.ppi-jarvis/*.yaml 2>/dev/null | head -1 | sed -E "s/^[[:space:]]*shared_dir:[[:space:]]*//" | tr -d "\"" || true)'
+    - 'SIF="$JSD/containers/iowarp-perf-eval.sif"; [ -n "$JSD" ] && [ -f "$SIF" ] || { echo "ERROR: SIF missing: $SIF — build via jarvis-cd docker/build_perf_eval_image.sh" >&2; exit 1; }'
+    # 4) stale-state cleanup: ghost daemons/instances from a crashed prior
+    #    run wedge this one (port 9413, /dev/shm segments, leftover per-run
+    #    /tmp). pkill patterns are BRACKETED so they never match this
+    #    script's own argv.
+    - 'timeout 30 apptainer instance stop --all >/dev/null 2>&1 || true'
+    - 'pkill -9 -f "[c]himaera" 2>/dev/null || true'
+    - 'pkill -9 -f "[c]lio_run" 2>/dev/null || true'
+    - '{ command -v fuser >/dev/null 2>&1 && fuser -k 9413/tcp; } >/dev/null 2>&1 || true'
+    - 'rm -f /dev/shm/chi_* 2>/dev/null || true'
+    - 'find /tmp -maxdepth 1 \( -name "single_node_run*" -o -name "single_node" \) -mmin +10 -exec rm -rf {} + 2>/dev/null || true'
+    - 'rm -rf /tmp/iowarp_chi* 2>/dev/null || true'
+    # 5) experiment dirs + repo registration + clean-slate results (the
+    #    sweep runner resumes over an existing results.csv and would skip
+    #    previously-failed rows)
+    - 'mkdir -p "$HOME/perf_eval_scratch/single_node/nfs" "$HOME/perf_eval_scratch/single_node/jfs_data" "$HOME/single_node_results"'
+    - 'jarvis repo add "${CLIO_REPO:-$HOME/clio-core}/jarvis_clio_core" 2>/dev/null || true'
+    - 'rm -f "$HOME/single_node_results/results.csv"'
+  post_cmds:
+    - 'RES="$HOME/single_node_results/results.csv"; n=$(grep -c success "$RES" 2>/dev/null || true); n=${n:-0}; echo "successful rows: $n / 24"; [ "$n" -ge 24 ] && echo "ALL 24 GREEN" || echo "INCOMPLETE — inspect $RES and the .err log"'
+
+config:
+  name: single_node
+
+  # MUST stay literally identical to scheduler.hostfile above.
+  hostfile: "${HOME}/.jarvis-perf-eval/single_node_hostfile.txt"
+
+  # ---- Containerized deployment (Ares dev jarvis — APPTAINER) -----------
+  base_deploy_mode: container
+  container_engine: apptainer
+  # Pre-staged SIF referenced by BASENAME, not a path: jarvis resolves it to
+  #   <jarvis shared_dir>/containers/iowarp-perf-eval.sif
+  # container_uri is UNSET, so jarvis trusts this SIF and performs no
+  # pull/build. Not env-expanded — keep it a bare basename.
+  container_image: "iowarp-perf-eval"
+  # The CTE and JuiceFS FUSE mounts need CAP_SYS_ADMIN *effective* inside the
+  # container. Under a non-setuid apptainer only --fakeroot supplies it
+  # (--add-caps SYS_ADMIN is a no-op rootless, and fusermount then fails to
+  # open /dev/fuse). With fakeroot, container_caps and a /dev/fuse bind are
+  # both unnecessary.
+  container_fakeroot: true
+  # Redirect in-container /tmp to NODE-LOCAL disk. Default jarvis backs
+  # apptainer /tmp with an NFS overlay, which breaks chimaera's IPC unix
+  # sockets and would put the JuiceFS cache on NFS. tmp_bind_root makes jarvis
+  # bind <root>/single_node/tmp -> /tmp from local disk instead.
+  tmp_bind_root: "/tmp"
+  # Bind a shared-FS scratch dir into the instance. Applied at `apptainer
+  # instance start` (the same mechanism as tmp_bind_root), so unlike a
+  # per-exec --bind it takes effect. Required because inside a --fakeroot
+  # instance $HOME is the overlay, not a host bind: without this, nfs_ior's
+  # out and juicefs's data_dir would land on ephemeral node-local storage
+  # instead of real NFS. Jarvis does not create bind sources — the pre_cmd
+  # mkdir above must run first or instance start fails.
+  container_binds:
+    - ${HOME}/perf_eval_scratch:${HOME}/perf_eval_scratch
+
+  env:
+    # In-container memfd dir for chimaera (container /tmp is private + writable).
+    CLIO_MEMFD_DIR: "/tmp/iowarp_chimaera"
+
+  pkgs:
+    # ---- Services (started in order; stopped in reverse) -----------------
+    # Redis: metadata engine for JuiceFS (DB 1) AND server for redis-benchmark
+    # (DB 0). One server covers both; no persistence keeps it a fair in-memory
+    # peer of the CTE RAM tier.
+    - pkg_type: builtin.redis
+      pkg_name: redis
+      port: 6379
+      sleep: 4
+
+    # clio_run runtime daemon (shm IPC for single-node). swim_enabled: false
+    # avoids mid-IOR SWIM "node confirmed dead" cascades.
+    - pkg_type: jarvis_clio_core.clio_runtime
+      pkg_name: runtime
+      num_threads: 4
+      port: 9413
+      ipc_mode: "shm"
+      log_level: "info"
+      sleep: 4
+      swim_enabled: false
+
+    # CTE pool, single RAM tier. 24 GiB = 12x the 2 GiB peak ior write set
+    # (32 ranks x 64 MiB block). pool_name stays at its default
+    # clio_cte_core == the C++ kCtePoolName constant — required so the FUSE
+    # client's AsyncCreate composes against the same pool (see the pool_name
+    # menu text for the cross-node race this avoids).
+    - pkg_type: jarvis_clio_core.clio_cte
+      pkg_name: cte_core
+      devices:
+        - ["ram::cte_ram_tier1", "24GB", 1.0]
+      dpe_type: "max_bw"
+      neighborhood: 1
+      pool_query: "local"
+      default_target_timeout_ms: 30000
+      poll_period_ms: 5000
+
+    # CTE libfuse mount (in-container): the "+ libfuse" path the ior driver
+    # below writes through (POSIX -> FUSE -> CTE).
+    - pkg_type: jarvis_clio_core.clio_cte_libfuse
+      pkg_name: cte_fuse
+      # FUSE mountpoint on NODE-LOCAL /tmp (writable via tmp_bind_root), NOT
+      # /mnt: the image's /mnt is read-only SquashFS.
+      mountpoint: /tmp/cte_mnt
+      log_level: "info"
+      extra_fuse_args: "-f"
+      sleep: 2
+
+    # JuiceFS: format (storage=file) + FUSE mount. Object store on the bound
+    # shared-FS scratch (real NFS, bypasses the overlay); mount + cache on
+    # in-container node-local /tmp (a distributed-FS cache stays node-local).
+    - pkg_type: builtin.juicefs
+      pkg_name: juicefs
+      meta_url: "redis://127.0.0.1:6379/1"
+      storage: file
+      data_dir: ${HOME}/perf_eval_scratch/single_node/jfs_data
+      mountpoint: /tmp/jfs_mnt
+      cache_dir: /tmp/juicefs_cache
+      name: jfsbench
+      format_fresh: true
+      mount_wait: 20
+
+    # ---- Benchmark drivers (Applications; run sequentially) --------------
+    # builtin.ior. Shared keys: api posix, write+read,
+    # fpp (file-per-process — REQUIRED through per-node FUSE mounts), fixed
+    # block 64m per rank (data-bounded runtime; the xfer sweep below is the
+    # I/O-size axis), stonewall 120 (ior -D: phase runtime cap). log: is left
+    # UNSET on purpose — builtin.ior then defaults it to each package's own
+    # shared_dir/ior.log, which is host-bound and auto-distinct per package.
+    # An explicit ${HOME}/..._results/*.log silently lost every stat: inside
+    # the --fakeroot instance $HOME is the overlay (not a host bind) and the
+    # log parent dir does not exist there, so ior's `tee <log>` failed and the
+    # host-side stat parser found nothing.
+    # 1) NFS: ior against real NFS via the bound perf_eval_scratch (an unbound $HOME
+    #    path would hit the fakeroot overlay, not NFS — see container_binds).
+    - pkg_type: builtin.ior
+      pkg_name: nfs_ior
+      api: posix
+      write: true
+      read: true
+      fpp: true
+      xfer: "4k"
+      block: "64m"
+      nprocs: 1
+      ppn: 1
+      stonewall: 120
+      out: ${HOME}/perf_eval_scratch/single_node/nfs/ior_nfs.bin
+
+    # 2) CTE + libfuse: ior through the CTE FUSE mount.
+    - pkg_type: builtin.ior
+      pkg_name: cte_ior
+      api: posix
+      write: true
+      read: true
+      fpp: true
+      xfer: "4k"
+      block: "64m"
+      nprocs: 1
+      ppn: 1
+      stonewall: 120
+      out: /tmp/cte_mnt/ior_cte.bin
+
+    # 3) redis: builtin.redis-benchmark (SET/GET -> -t set,get; --csv stats).
+    #    The "threads" axis drives clients (-c) AND nthreads (--threads),
+    #    zipped equal: a row means N connections driven by N I/O threads.
+    #    count (-n) is zipped with req_size so total data stays ~1 GiB
+    #    (count = 1 GiB / req_size), keeping the working set axis-independent.
+    - pkg_type: builtin.redis-benchmark
+      pkg_name: redis_bench
+      port: 6379
+      write: true
+      read: true
+      req_size: 4096
+      count: 262144
+      clients: 1
+      nthreads: 1
+
+    # 4) juicefs: ior through the JuiceFS FUSE mount.
+    - pkg_type: builtin.ior
+      pkg_name: jfs_ior
+      api: posix
+      write: true
+      read: true
+      fpp: true
+      xfer: "4k"
+      block: "64m"
+      nprocs: 1
+      ppn: 1
+      stonewall: 120
+      out: /tmp/jfs_mnt/ior_jfs.bin
+
+vars:
+  # I/O size, applied to all four drivers at once (zipped, length 4). 1m = the
+  # issue's 1024 KB point. redis req_size is in BYTES; count is the matching
+  # ~1 GiB request budget (1 GiB / req_size), so 4k<->262144, 64k<->16384,
+  # 128k<->8192, 1m<->1024 stay paired.
+  nfs_ior.xfer:        ["4k",   "64k",  "128k", "1m"]
+  cte_ior.xfer:        ["4k",   "64k",  "128k", "1m"]
+  jfs_ior.xfer:        ["4k",   "64k",  "128k", "1m"]
+  redis_bench.req_size: [4096,  65536,  131072, 1048576]
+  redis_bench.count:    [262144, 16384, 8192,   1024]
+
+  # Thread count, applied to all four drivers at once (zipped, length 6).
+  # ior: nprocs AND ppn (single node => equal). redis-benchmark: clients (-c)
+  # AND nthreads (--threads), zipped equal.
+  nfs_ior.nprocs:      [1, 2, 4, 8, 16, 32]
+  nfs_ior.ppn:         [1, 2, 4, 8, 16, 32]
+  cte_ior.nprocs:      [1, 2, 4, 8, 16, 32]
+  cte_ior.ppn:         [1, 2, 4, 8, 16, 32]
+  jfs_ior.nprocs:      [1, 2, 4, 8, 16, 32]
+  jfs_ior.ppn:         [1, 2, 4, 8, 16, 32]
+  redis_bench.clients: [1, 2, 4, 8, 16, 32]
+  redis_bench.nthreads: [1, 2, 4, 8, 16, 32]
+
+loop:
+  # Outer group: I/O size (+ redis request budget), 4 values.
+  - [nfs_ior.xfer, cte_ior.xfer, jfs_ior.xfer,
+     redis_bench.req_size, redis_bench.count]
+  # Inner group: thread count, 6 values  =>  4 x 6 = 24 combinations.
+  - [nfs_ior.nprocs, nfs_ior.ppn, cte_ior.nprocs, cte_ior.ppn,
+     jfs_ior.nprocs, jfs_ior.ppn, redis_bench.clients, redis_bench.nthreads]
+
+# Per-combination wall-clock backstop (requires jarvis-cd @ dev; older
+# versions silently ignore this key). With stonewall capping each ior
+# phase at 120 s, a healthy combo stays well under 1200; expiry records the
+# row failed and the sweep continues — one wedged package can no longer lose
+# the other 23 rows of the shared allocation.
+run_timeout: 1200
+
+repeat: 1                       # bump to 3 for variance (~3x wall-clock)
+output: "${HOME}/single_node_results"


### PR DESCRIPTION
## Body

Closes #526.

### What this is

Two reproducible performance-evaluation sweeps for Ares, plus the container-mode
behavior in the CLIO jarvis packages they drive, plus a setup walkthrough that
takes a user from "Spack and clio-core installed" to a green run with no other
assumptions.

| Pipeline | Sweep | Rows |
|---|---|---|
| `single_node.yaml` | 4 I/O sizes × 6 thread counts over NFS, CTE+libfuse, redis, JuiceFS | 24 |
| `distributed.yaml` | 1 → 2 → 4 client-node scaling over NFS, CTE+libfuse, JuiceFS | 3 |

Both run on the native jarvis Slurm scheduler, inside an Apptainer container,
and are **validated green on Ares — 24/24 and 3/3** with non-blank throughput
columns (a green row with an empty throughput cell is a failure, not a pass).

### Files

- `jarvis_clio_core/pipelines/ares/single_node.yaml`
- `jarvis_clio_core/pipelines/ares/distributed.yaml`
- `jarvis_clio_core/pipelines/ares/README.md`
- `jarvis_clio_core/jarvis_clio_core/clio_runtime/pkg.py`
- `jarvis_clio_core/jarvis_clio_core/clio_cte/pkg.py`
- `jarvis_clio_core/jarvis_clio_core/clio_cte_libfuse/pkg.py`

### The launcher toolchain

The pipelines need two binaries on `PATH` on the login/compute node before a run
starts — `apptainer` (starts the containers) and `jarvis` (the generated sbatch
script calls bare `jarvis ppl run`).

Both come from a plain `export PATH` prepending a **Spack view** (upstream
builtin `apptainer@1.5.0~suid`, symlinked under `/mnt/common` so every node sees
it) and a **jarvis venv**. Plain `export` rather than `spack load`, which is a
shell function and misbehaves under `set -euo pipefail`.

Three env vars, all defaulted for a stock Ares setup and overridable before
submitting:

| Var | Default |
|---|---|
| `PERF_EVAL_VIEW` | `/mnt/common/$USER/perf-eval-view` |
| `JARVIS_VENV` | `$HOME/jarvis-venv` |
| `CLIO_REPO` | `$HOME/clio-core` |

The toolchain block hard-fails with a named path if either binary is missing and
echoes both resolved paths — that echo is the entire diagnosis when this breaks
on a cluster.

### Package changes

All three follow one rule: jarvis wraps a command into the run's container only
when the `ExecInfo` carries a container engine. It is never injected
automatically, so each `ExecInfo` must be threaded explicitly. These use the
shared `container_kwargs()` helper from the companion jarvis-cd PR, which is a
no-op in bare-metal mode — so **bare-metal behavior is unchanged**.

**`clio_cte_libfuse`** — was documented bare-metal-only, now supports both modes.
The substantive fixes:

- The mountpoint `mkdir` must run **in-container**: under `tmp_bind_root` the
  in-container `/tmp` is a different directory from the host `/tmp`.
- The FUSE daemon is shell-backgrounded (`nohup … &`) inside a *synchronous*
  wrapped Exec, so it detaches from the wrap's shell and parents into the
  apptainer instance — it must share mount and shm namespaces with the runtime
  and with the fio writing through the mount.
- Daemon output goes to a per-host log on `shared_dir`, **not `/dev/null`**: a
  masked mount failure here previously surfaced only as a confusing downstream
  `ENOSPC`.
- Teardown (`fusermount3 -u`, then the kill) runs in-container too — the mount
  exists only in the instance's mount namespace, so host-side `fusermount3`
  reports `not found in /etc/mtab`, and the wrapped kill correctly scopes to the
  run's PID namespace.

**`clio_runtime`** — self-heal before launching a fresh runtime: kill any stale
`chimaera` left by the previous combo, *then* reclaim its `chi_*` shm. These two
steps are deliberately **host-side and unwrapped**: apptainer shares the host
`/dev/shm` and PID space, and by definition a surviving process has escaped the
prior combo's PID namespace, so the previous `stop()`'s wrapped kill could not
reach it. This is not hypothetical — observed on single_node job 21563, combo 18.
The sweep runs sequentially in one allocation, and every teardown logs
`Server dead` (the runtime exits hard, not gracefully), so a wedged process can
survive; clearing only the shm would bring the new runtime up alongside the
survivor.

**`clio_cte`** — container-routed start and cleanup. `configure` runs *before*
the instance exists, so its `Mkdir` stays host-side; that is correct for
host-visible paths, and the note in the code records the constraint for anyone
who later adds a `/tmp` file device. The perf-eval pipelines use `ram::` tiers,
so that path is a no-op for them.

### README

`pipelines/ares/README.md` — an 8-step walkthrough assuming only Spack and a
current clio-core: build the Spack view, create the jarvis venv, build the SIF,
configure jarvis, submit, and read the results. Plus a quick-reference command
block at the top, a "mental model" section, and 13 troubleshooting rows keyed to
actual error text, each of which was hit and resolved during validation.

Two findings worth surfacing, both from validating the README live on Ares:

- **`~suid` is mandatory.** Spack's builtin apptainer defaults to `+suid`, which
  builds a setuid `starter-suid` that cannot be installed unprivileged and
  breaks `--fakeroot`.
- **The view links no dependencies** (`spack view -d false symlink …`).
  Apptainer never resolves its helpers through `PATH` — the recipe symlinks the
  FUSE helpers into its own `libexec/apptainer/bin` and bakes an absolute
  `mksquashfs` path into `apptainer.conf` — so the dependency links were
  incidental surface area. Dropping them eliminates two failure classes
  structurally rather than patching them: the `compiler-wrapper` version
  conflict in apptainer's closure (which `-i/--ignore-conflicts` does *not*
  fix — it only covers file-level collisions between unrelated packages), and
  the `shadow`/`newuidmap must be owned by the root user` trap. The
  full-closure form (`-e shadow -e compiler-wrapper`) is documented as a
  verified-working alternative, but it is a denylist that needs maintaining as
  the closure drifts; `-d false` is an allowlist of one.

### Reviewer notes

- **Merge order:** the companion jarvis-cd PR should land first — these packages
  import `jarvis_cd.util.container_utils`, and the pipelines need the Apptainer
  deploy mode, `run_timeout`, and the `#SBATCH` variable expansion from it.
- Scope is intentionally the pipelines and their packages. Container/SIF
  internals were already Spack-based and are untouched.