### PR TITLE
feat(bdev): grow the backing file lazily in growth-unit steps (#858)

### DIFF
--- a/context-runtime/modules/bdev/include/clio_runtime/bdev/bdev_client.h
+++ b/context-runtime/modules/bdev/include/clio_runtime/bdev/bdev_client.h
@@ -65,7 +65,8 @@ class Client : public clio::run::ContainerClient {
       BdevType bdev_type, clio::run::u64 total_size = 0,
       clio::run::u32 io_depth = 32, clio::run::u32 alignment = 4096,
       const PerfMetrics* perf_metrics = nullptr,
-      const std::string& alloc_log_path = "") {
+      const std::string& alloc_log_path = "",
+      clio::run::u64 growth_unit = clio::run::u64(1) << 30) {
     auto* ipc_manager = CLIO_CPU_IPC;
 
     // CreateTask should always use admin pool, never the client's pool_id_
@@ -86,7 +87,7 @@ class Client : public clio::run::ContainerClient {
         this,             // Client pointer for PostWait
         // CreateParams arguments (perf_metrics is optional, defaults used if nullptr):
         bdev_type, total_size, io_depth, safe_alignment, perf_metrics,
-        alloc_log_path);
+        alloc_log_path, growth_unit);
 
     // Submit to runtime
     return ipc_manager->Send(task);

--- a/context-runtime/modules/bdev/include/clio_runtime/bdev/bdev_tasks.h
+++ b/context-runtime/modules/bdev/include/clio_runtime/bdev/bdev_tasks.h
@@ -164,6 +164,13 @@ struct CreateParams {
   // disabled (no file created), preserving pre-WAL behavior.
   std::string alloc_log_path_;
 
+  // #858: file-backed devices grow the backing file lazily in units of this
+  // many bytes instead of truncating the full capacity at compose (on NTFS a
+  // plain SetEndOfFile claims the clusters eagerly, so the old full-capacity
+  // truncate reserved the whole tier up front). Ignored by RAM/GPU
+  // transports. YAML key: growth_unit (size string, e.g. "1GB").
+  clio::run::u64 growth_unit_ = clio::run::u64(1) << 30;  // 1 GiB default
+
   // Required: chimod library name for module manager
   static constexpr const char *chimod_lib_name = "clio_bdev";
 
@@ -206,12 +213,14 @@ struct CreateParams {
   // Constructor with optional performance metrics (as last parameter)
   CreateParams(BdevType bdev_type, clio::run::u64 total_size, clio::run::u32 io_depth,
                clio::run::u32 alignment, const PerfMetrics *perf_metrics = nullptr,
-               const std::string &alloc_log_path = "")
+               const std::string &alloc_log_path = "",
+               clio::run::u64 growth_unit = clio::run::u64(1) << 30)
       : bdev_type_(bdev_type),
         total_size_(total_size),
         io_depth_(io_depth),
         alignment_(alignment),
-        alloc_log_path_(alloc_log_path) {
+        alloc_log_path_(alloc_log_path),
+        growth_unit_(growth_unit) {
     // Set performance metrics (use provided metrics or defaults)
     if (perf_metrics != nullptr) {
       perf_metrics_ = *perf_metrics;
@@ -241,7 +250,7 @@ struct CreateParams {
   template <class Archive>
   void serialize(Archive &ar) {
     ar(bdev_type_, total_size_, io_depth_, alignment_, perf_metrics_,
-       persistence_level_, alloc_log_path_);
+       persistence_level_, alloc_log_path_, growth_unit_);
   }
 
   /**
@@ -286,6 +295,12 @@ struct CreateParams {
     // Load alignment (optional)
     if (config["alignment"]) {
       alignment_ = config["alignment"].as<clio::run::u32>();
+    }
+
+    // Load lazy-growth unit for file-backed devices (optional, default 1GB)
+    if (config["growth_unit"]) {
+      std::string growth_str = config["growth_unit"].as<std::string>();
+      growth_unit_ = ctp::ConfigParse::ParseSize(growth_str);
     }
 
     // Load performance metrics (optional)

--- a/context-runtime/modules/bdev/include/clio_runtime/bdev/transports/fs_bdev_transport.h
+++ b/context-runtime/modules/bdev/include/clio_runtime/bdev/transports/fs_bdev_transport.h
@@ -10,6 +10,9 @@
 #include <clio_runtime/bdev/transports/block_allocator.h>
 #include <clio_ctp/io/async_io_factory.h>
 
+#include <atomic>
+#include <mutex>
+
 namespace clio::run::bdev {
 
 /**
@@ -47,9 +50,23 @@ class FsBdevTransport : public BdevTransport {
   std::string file_path_;
   clio::run::u32 io_depth_;
 
+  // #858: lazy backing-file growth. The file is truncated to at most one
+  // growth unit at Init and extended in growth-unit steps as allocations
+  // cross the backed frontier — never the full capacity up front (on NTFS
+  // SetEndOfFile claims clusters eagerly, so the old full-capacity truncate
+  // physically reserved the whole tier at compose).
+  clio::run::u64 growth_unit_ = clio::run::u64(1) << 30;
+  std::atomic<clio::run::u64> file_backed_bytes_{0};
+  std::mutex grow_mu_;
+
   bool InitializeWorkerIOContexts();
   void CleanupWorkerIOContexts();
   WorkerIOContext* GetWorkerIOContext(size_t worker_id);
+
+  /** Extend the backing file so [0, end_offset) is inside it (growth-unit
+   *  granularity, capped at capacity). Returns false if the extension fails
+   *  (e.g. the disk is genuinely full). */
+  bool EnsureFileBacked(clio::run::u64 end_offset);
 };
 
 } // namespace clio::run::bdev

--- a/context-runtime/modules/bdev/src/transports/fs_bdev_transport.cc
+++ b/context-runtime/modules/bdev/src/transports/fs_bdev_transport.cc
@@ -78,26 +78,62 @@ bool FsBdevTransport::Init(const CreateParams& params,
     return false;
   }
 
-  clio::run::u64 file_size = 0;
   off_t current_size = setup_io->GetFileSize();
   if (current_size < 0) {
     HLOG(kError, "Failed to get file size for: {}", file_path_);
     setup_io->Close();
     return false;
   }
-  file_size = static_cast<clio::run::u64>(current_size);
+  clio::run::u64 existing = static_cast<clio::run::u64>(current_size);
 
-  if (params.total_size_ > 0 && params.total_size_ < file_size) {
+  // Device capacity (what the allocator hands out): the configured size when
+  // one is given, else the existing file's size, else a 1GB default.
+  //
+  // #858 semantic change: a configured capacity is no longer clamped to a
+  // smaller existing file. With lazy growth, "backing file smaller than
+  // capacity" is the NORMAL state after any restart (the file only ever grew
+  // as far as allocations reached), so the old min(existing, configured)
+  // clamp would silently shrink the device to its previously-touched prefix
+  // on every restart. The existing file is instead treated as the
+  // already-backed prefix, and growth resumes from there.
+  clio::run::u64 file_size;
+  if (params.total_size_ > 0) {
     file_size = params.total_size_;
+  } else if (existing > 0) {
+    file_size = existing;
+  } else {
+    file_size = 1ULL << 30;
   }
 
-  if (file_size == 0) {
-    file_size = (params.total_size_ > 0) ? params.total_size_ : (1ULL << 30);
-    if (!setup_io->Truncate(static_cast<size_t>(file_size))) {
+  // #858: growth granularity for the lazy backing-file extension
+  // (EnsureFileBacked). 0 disables stepping — each allocation extends the
+  // file exactly as far as it needs.
+  growth_unit_ = params.growth_unit_;
+
+  if (existing == 0) {
+    // Fresh (empty) backing file: truncate only the FIRST growth unit into
+    // existence. The rest of the file materializes in EnsureFileBacked as
+    // allocations cross the backed frontier. This keeps a 500GB
+    // capacity_limit from claiming 500GB at compose time on filesystems that
+    // allocate eagerly on a size set (NTFS SetEndOfFile; any FS without
+    // sparse files) and gives ENOSPC a chance to surface at allocation time
+    // instead of mid-write.
+    clio::run::u64 initial = file_size;
+    if (growth_unit_ > 0 && growth_unit_ < initial) {
+      initial = growth_unit_;
+    }
+    if (!setup_io->Truncate(static_cast<size_t>(initial))) {
       HLOG(kError, "Failed to truncate file");
       setup_io->Close();
       return false;
     }
+    file_backed_bytes_.store(initial, std::memory_order_relaxed);
+  } else {
+    // Existing file: its current extent is the already-backed prefix (capped
+    // at the device capacity — a larger file than the device just has spare
+    // tail the allocator will never address).
+    file_backed_bytes_.store(existing < file_size ? existing : file_size,
+                             std::memory_order_relaxed);
   }
 
   setup_io->Close();
@@ -118,7 +154,68 @@ void FsBdevTransport::Destroy() {
 }
 
 bool FsBdevTransport::AllocateBlocks(size_t size, int worker_id, std::vector<Block>& blocks) {
-  return allocator_.AllocateBlocks(size, worker_id, blocks);
+  if (!allocator_.AllocateBlocks(size, worker_id, blocks)) {
+    return false;
+  }
+  // #858: back every returned block with real file before the caller can
+  // touch it. Reads of allocated-but-unwritten blocks must land inside the
+  // file (and return zeros) exactly as they did when the whole capacity was
+  // truncated up front — a block past EOF would short-read instead.
+  clio::run::u64 end = 0;
+  for (const Block &b : blocks) {
+    clio::run::u64 e = b.offset_ + b.size_;
+    if (e > end) end = e;
+  }
+  if (!EnsureFileBacked(end)) {
+    // The disk cannot actually provide the space the allocator promised.
+    // Fail the allocation cleanly (the caller sees the same "no space"
+    // result as an exhausted allocator) instead of handing out blocks whose
+    // writes would EIO later.
+    allocator_.FreeBlocks(worker_id, blocks);
+    blocks.clear();
+    return false;
+  }
+  return true;
+}
+
+bool FsBdevTransport::EnsureFileBacked(clio::run::u64 end_offset) {
+  // Fast path: recycled or low blocks are already inside the backed prefix.
+  if (end_offset <= file_backed_bytes_.load(std::memory_order_acquire)) {
+    return true;
+  }
+  std::lock_guard<std::mutex> lock(grow_mu_);
+  clio::run::u64 backed = file_backed_bytes_.load(std::memory_order_relaxed);
+  if (end_offset <= backed) {
+    return true;  // another thread grew past us while we waited
+  }
+  // Grow in growth-unit steps (capped at capacity) so a bump-allocation
+  // stream costs one truncate per unit, not one per allocation.
+  clio::run::u64 target = end_offset;
+  if (growth_unit_ > 0) {
+    target = ((end_offset + growth_unit_ - 1) / growth_unit_) * growth_unit_;
+  }
+  clio::run::u64 capacity = allocator_.GetCapacity();
+  if (capacity > 0 && target > capacity) {
+    target = capacity;
+  }
+  auto io = OpenBackingFile(io_depth_, file_path_);
+  if (!io) {
+    HLOG(kError, "EnsureFileBacked: failed to open {} to grow it", file_path_);
+    return false;
+  }
+  bool ok = io->Truncate(static_cast<size_t>(target));
+  io->Close();
+  if (!ok) {
+    HLOG(kError,
+         "EnsureFileBacked: failed to grow {} from {} to {} bytes — treating "
+         "as out of space",
+         file_path_, backed, target);
+    return false;
+  }
+  HLOG(kDebug, "EnsureFileBacked: grew {} from {} to {} bytes", file_path_,
+       backed, target);
+  file_backed_bytes_.store(target, std::memory_order_release);
+  return true;
 }
 
 void FsBdevTransport::FreeBlocks(int worker_id, const std::vector<Block>& blocks) {

--- a/context-runtime/modules/bdev/test/test_bdev_chimod.cc
+++ b/context-runtime/modules/bdev/test/test_bdev_chimod.cc
@@ -432,6 +432,78 @@ TEST_CASE("bdev_block_allocation_4kb", "[bdev][allocate][4kb]") {
 }
 
 /**
+ * Regression for #858: the backing file of a file bdev must be allocated
+ * LAZILY, in growth-unit steps, instead of being truncated to the full
+ * capacity at create. (On NTFS a plain SetEndOfFile claims the clusters
+ * eagerly, so the old full-capacity truncate physically reserved the whole
+ * tier at compose time.)
+ */
+TEST_CASE("bdev_lazy_file_growth", "[bdev][file][growth]") {
+  BdevChimodFixture fixture;
+
+  if (fixture.getNumContainers() != 1) {
+    HLOG(kInfo, "bdev_lazy_file_growth: skipping (needs a local stat of the "
+                "backing file; num_containers != 1)");
+    return;
+  }
+
+  constexpr clio::run::u64 kCapacity = 64 * 1024 * 1024;   // 64MB device
+  constexpr clio::run::u64 kGrowthUnit = 8 * 1024 * 1024;  // 8MB steps
+
+  auto file_size_of = [](const std::string& path) -> clio::run::i64 {
+    struct stat st;
+    if (stat(path.c_str(), &st) != 0) return -1;
+    return static_cast<clio::run::i64>(st.st_size);
+  };
+
+  SECTION("Fresh file is backed one growth unit at a time") {
+    REQUIRE(g_initialized);
+    // Deliberately NO createTestFile: the lazy path is the fresh-file path.
+    clio::run::PoolId custom_pool_id(141, 0);
+    clio::run::bdev::Client client(custom_pool_id);
+    auto create_task = client.AsyncCreate(
+        clio::run::PoolQuery::Dynamic(), fixture.getTestFile(), custom_pool_id,
+        clio::run::bdev::BdevType::kFile, kCapacity, 32, 4096,
+        /*perf_metrics=*/nullptr, /*alloc_log_path=*/"", kGrowthUnit);
+    create_task.Wait();
+    REQUIRE(create_task->GetReturnCode() == 0);
+    client.pool_id_ = create_task->new_pool_id_;
+
+    // After create: exactly ONE growth unit on disk, not the full capacity.
+    REQUIRE(file_size_of(fixture.getTestFile()) ==
+            static_cast<clio::run::i64>(kGrowthUnit));
+
+    auto pool_query = clio::run::PoolQuery::DirectHash(0);
+
+    // An allocation inside the backed prefix must not grow the file.
+    auto alloc1 = client.AsyncAllocateBlocks(pool_query, 4 * 1024 * 1024);
+    alloc1.Wait();
+    REQUIRE(alloc1->return_code_ == 0);
+    REQUIRE(fixture.validateBlockAllocation(
+        std::vector<clio::run::bdev::Block>(alloc1->blocks_.begin(),
+                                            alloc1->blocks_.end()),
+        4 * 1024 * 1024));
+    REQUIRE(file_size_of(fixture.getTestFile()) ==
+            static_cast<clio::run::i64>(kGrowthUnit));
+
+    // Crossing the frontier grows the file by whole growth units.
+    auto alloc2 = client.AsyncAllocateBlocks(pool_query, 8 * 1024 * 1024);
+    alloc2.Wait();
+    REQUIRE(alloc2->return_code_ == 0);
+    REQUIRE(file_size_of(fixture.getTestFile()) ==
+            static_cast<clio::run::i64>(2 * kGrowthUnit));
+
+    // Growth is capped at the device capacity, never past it.
+    auto alloc3 = client.AsyncAllocateBlocks(pool_query, 46 * 1024 * 1024);
+    alloc3.Wait();
+    REQUIRE(alloc3->return_code_ == 0);
+    clio::run::i64 final_size = file_size_of(fixture.getTestFile());
+    REQUIRE(final_size > static_cast<clio::run::i64>(2 * kGrowthUnit));
+    REQUIRE(final_size <= static_cast<clio::run::i64>(kCapacity));
+  }
+}
+
+/**
  * Regression for #798: alloc/free accounting must be alignment-symmetric.
  *
  * StandardBlockAllocator charged the caller's raw request on allocate but


### PR DESCRIPTION
## Summary
- `FsBdevTransport` no longer truncates a fresh backing file to the full configured capacity at compose. It truncates at most **one growth unit** (default **1GB**; YAML `growth_unit`; `CreateParams::growth_unit_`) and extends the file in growth-unit steps from `AllocateBlocks` whenever an allocation crosses the backed frontier — before the caller can touch the blocks, so reads of allocated-but-unwritten blocks still land inside the file and return zeros, preserving the old invariant.
- If the extension fails (the disk genuinely can't provide the space the allocator promised), the allocation is rolled back and fails cleanly at placement time, instead of surfacing as a write EIO later.
- The allocator is a monotonic bump heap, so growth costs one truncate per unit; recycled blocks take a lock-free fast path.

## Motivation
Fixes #858. `Truncate` is a plain size-set on every I/O backend (`ftruncate`; `SetFilePointerEx`+`SetEndOfFile` in `IocpAsyncIO`) and nothing marks the file sparse — so on NTFS (and any filesystem without sparse files) a 500GB `capacity_limit` physically claimed 500GB of the volume at compose time. On Linux the file was sparse, but the full-size truncate gave no early ENOSPC signal either.

## Semantic change
A configured capacity is no longer clamped to a smaller existing file (`min(existing, configured)`). Under lazy growth, "backing file smaller than capacity" is the *normal* state after any restart — the old clamp would silently shrink the device to its previously-touched prefix on every restart. The existing file is now the already-backed prefix and growth resumes from there. Unconfigured devices (`total_size == 0`) keep the legacy capacity-from-file-size behavior, which is what every existing test that pre-creates its backing file uses.

## Test plan
- [x] New regression test `bdev_lazy_file_growth`: fresh 64MB device with an 8MB growth unit backs exactly 8MB after create; allocations inside the backed prefix don't grow the file; crossing the frontier grows in whole units; growth never exceeds capacity
- [x] `cr_all_bdev_tests`, `cr_all_safe_bdev_tests`, `cr_bdev_explicit_backend_{ipc,shm,tcp}`, `cr_bdev_force_net`, `cte_tiered_storage_all`, `cte_tiered_dram_default_all` pass
- [x] Full `^cte_` suite (75 tests) passes
- [ ] Windows CI green (the platform the eager allocation actually hurt)

## Follow-ups (out of scope)
- Plumb a per-storage-device `growth_unit` through the CTE `RegisterTarget` chain (the 1GB default applies everywhere today; the YAML knob works for directly-composed bdev pools).
- Optionally `FSCTL_SET_SPARSE` on Windows for fully lazy cluster allocation within the grown region.

## Breaking changes
None expected in practice; see the semantic change above (configured capacity now wins over a smaller existing file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)