### PR TITLE
Integrate Clio into YCSB with a comparison harness vs Redis/RocksDB/DynamoDB

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -38,3 +38,10 @@ sudo service ssh start
 
 # Activate Python virtual environment
 echo "Python venv available at ${HOME_DIR}/venv (auto-activated in new shells)"
+
+# Provision YCSB + comparison stores into external/ (issue #862).
+# Best-effort: benchmark tooling must not block container creation.
+if [ -x /workspace/docker/provision-ycsb.sh ]; then
+    /workspace/docker/provision-ycsb.sh /workspace || \
+        echo "WARN: YCSB provisioning incomplete (re-run docker/provision-ycsb.sh)"
+fi

--- a/context-transfer-engine/benchmark/CMakeLists.txt
+++ b/context-transfer-engine/benchmark/CMakeLists.txt
@@ -81,3 +81,29 @@ endif()
 
 # NOTE: Compression benchmark (clio_cte_compress_bench) has been moved to
 # context-transfer-engine/compressor/test/
+
+# YCSB JNI binding (issue #862): thin shim behind site.ycsb.db.ClioClient.
+# Built only when JNI headers are present so plain builds don't grow a Java
+# dependency; the Java half lives in benchmark/ycsb/ClioClient.java and is
+# compiled with javac against the YCSB core jar at benchmark time.
+# find_path instead of find_package(JNI): FindJNI refuses headless JDKs
+# (no AWT), and a loadable JNI library needs only jni.h — the JVM resolves
+# its own symbols at System.loadLibrary time.
+find_path(CLIO_JNI_INCLUDE_DIR jni.h
+  HINTS $ENV{JAVA_HOME}/include /usr/lib/jvm/default-java/include)
+if(CLIO_JNI_INCLUDE_DIR)
+  message(STATUS "YCSB JNI binding enabled (jni.h at ${CLIO_JNI_INCLUDE_DIR})")
+  add_library(clio_ycsb_jni SHARED
+    ycsb/clio_ycsb_jni.cc
+  )
+  target_include_directories(clio_ycsb_jni PRIVATE
+    ${CLIO_JNI_INCLUDE_DIR} ${CLIO_JNI_INCLUDE_DIR}/linux)
+  target_link_libraries(clio_ycsb_jni
+    clio::cte::core_client
+    clio::run::cxx
+  )
+  target_compile_features(clio_ycsb_jni PRIVATE cxx_std_17)
+  install(TARGETS clio_ycsb_jni
+    LIBRARY DESTINATION bin
+  )
+endif()

--- a/context-transfer-engine/benchmark/CMakeLists.txt
+++ b/context-transfer-engine/benchmark/CMakeLists.txt
@@ -97,7 +97,12 @@ if(CLIO_JNI_INCLUDE_DIR)
     ycsb/clio_ycsb_jni.cc
   )
   target_include_directories(clio_ycsb_jni PRIVATE
-    ${CLIO_JNI_INCLUDE_DIR} ${CLIO_JNI_INCLUDE_DIR}/linux)
+    ${CLIO_JNI_INCLUDE_DIR}
+    # jni.h includes the per-platform jni_md.h from a subdirectory; listing
+    # all three is harmless (nonexistent include dirs are ignored).
+    ${CLIO_JNI_INCLUDE_DIR}/linux
+    ${CLIO_JNI_INCLUDE_DIR}/darwin
+    ${CLIO_JNI_INCLUDE_DIR}/win32)
   target_link_libraries(clio_ycsb_jni
     clio::cte::core_client
     clio::run::cxx

--- a/context-transfer-engine/benchmark/ycsb/.gitignore
+++ b/context-transfer-engine/benchmark/ycsb/.gitignore
@@ -1,0 +1,1 @@
+results/

--- a/context-transfer-engine/benchmark/ycsb/ClioClient.java
+++ b/context-transfer-engine/benchmark/ycsb/ClioClient.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ * BSD 3-Clause License. See LICENSE file.
+ */
+
+package site.ycsb.db;
+
+import site.ycsb.ByteArrayByteIterator;
+import site.ycsb.ByteIterator;
+import site.ycsb.DB;
+import site.ycsb.DBException;
+import site.ycsb.Status;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.Vector;
+
+/**
+ * YCSB binding for the Clio Context Transfer Engine (issue #862).
+ *
+ * One CTE tag ("ycsb") holds all records; the YCSB key is the blob name and
+ * the record's field map is serialized into the blob payload (field count,
+ * then UTF field name + length-prefixed bytes per field). The native side
+ * (libclio_ycsb_jni.so) is a thin JNI shim over the CTE SHM client; the Clio
+ * runtime daemon must be running before the workload starts.
+ *
+ * scan() and delete() return NOT_IMPLEMENTED: the CTE client exposes no
+ * ordered scan or blob destroy today, which confines runs to the core
+ * workloads A, B, C and F (none of which scan or delete).
+ */
+public class ClioClient extends DB {
+
+  private static native int nativeInit();
+  private static native int nativePut(String key, byte[] value);
+  private static native byte[] nativeGet(String key);
+
+  static {
+    System.loadLibrary("clio_ycsb_jni");
+  }
+
+  @Override
+  public void init() throws DBException {
+    int rc = nativeInit();
+    if (rc != 0) {
+      throw new DBException("Clio native init failed rc=" + rc
+          + " (is the clio_run daemon running?)");
+    }
+  }
+
+  private static byte[] serialize(Map<String, ByteIterator> values)
+      throws IOException {
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    DataOutputStream out = new DataOutputStream(bos);
+    out.writeInt(values.size());
+    for (Map.Entry<String, ByteIterator> e : values.entrySet()) {
+      out.writeUTF(e.getKey());
+      byte[] v = e.getValue().toArray();
+      out.writeInt(v.length);
+      out.write(v);
+    }
+    out.flush();
+    return bos.toByteArray();
+  }
+
+  private static void deserialize(byte[] data, Set<String> fields,
+      Map<String, ByteIterator> result) throws IOException {
+    DataInputStream in = new DataInputStream(new ByteArrayInputStream(data));
+    int n = in.readInt();
+    for (int i = 0; i < n; i++) {
+      String field = in.readUTF();
+      int len = in.readInt();
+      byte[] v = new byte[len];
+      in.readFully(v);
+      if (fields == null || fields.contains(field)) {
+        result.put(field, new ByteArrayByteIterator(v));
+      }
+    }
+  }
+
+  private String blobName(String table, String key) {
+    return table + "/" + key;
+  }
+
+  @Override
+  public Status read(String table, String key, Set<String> fields,
+      Map<String, ByteIterator> result) {
+    byte[] data = nativeGet(blobName(table, key));
+    if (data == null) {
+      return Status.NOT_FOUND;
+    }
+    try {
+      deserialize(data, fields, result);
+    } catch (IOException e) {
+      return Status.ERROR;
+    }
+    return Status.OK;
+  }
+
+  @Override
+  public Status insert(String table, String key,
+      Map<String, ByteIterator> values) {
+    try {
+      int rc = nativePut(blobName(table, key), serialize(values));
+      return rc == 0 ? Status.OK : Status.ERROR;
+    } catch (IOException e) {
+      return Status.ERROR;
+    }
+  }
+
+  @Override
+  public Status update(String table, String key,
+      Map<String, ByteIterator> values) {
+    // Read-modify-write so partial-field updates (workloads A/B/F) preserve
+    // the untouched fields, matching what the redis/rocksdb bindings do.
+    byte[] existing = nativeGet(blobName(table, key));
+    Map<String, ByteIterator> merged = new HashMap<>();
+    if (existing != null) {
+      try {
+        deserialize(existing, null, merged);
+      } catch (IOException e) {
+        return Status.ERROR;
+      }
+    }
+    merged.putAll(values);
+    return insert(table, key, merged);
+  }
+
+  @Override
+  public Status delete(String table, String key) {
+    return Status.NOT_IMPLEMENTED;
+  }
+
+  @Override
+  public Status scan(String table, String startkey, int recordcount,
+      Set<String> fields, Vector<HashMap<String, ByteIterator>> result) {
+    return Status.NOT_IMPLEMENTED;
+  }
+}

--- a/context-transfer-engine/benchmark/ycsb/README.md
+++ b/context-transfer-engine/benchmark/ycsb/README.md
@@ -1,0 +1,93 @@
+# YCSB benchmark integration (issue #862)
+
+Benchmarks the CTE blob store with [YCSB](https://github.com/brianfrankcooper/YCSB)
+and compares it against Redis, RocksDB, and DynamoDB (Local) on the core
+workloads A (50/50 read/update), B (95/5), C (read-only), and F
+(read-modify-write). Workloads D/E are excluded: the Clio binding has no
+ordered scan (`scan()`/`delete()` return `NOT_IMPLEMENTED`).
+
+## Pieces
+
+| File | Role |
+|------|------|
+| `ClioClient.java` | YCSB `DB` adapter (`site.ycsb.db.ClioClient`); serializes the YCSB field map into one blob per key under tag `ycsb`, blob name `<table>/<key>` |
+| `clio_ycsb_jni.cc` | JNI shim over the CTE SHM client (`libclio_ycsb_jni`, built by CMake when a JDK is present) |
+| `run_comparison.sh` | Driver: load+run each workload against each DB with identical parameters, per-DB service lifecycle included |
+| `ddb_create_table.py` | Creates YCSB's `usertable` on DynamoDB Local (boto3) |
+
+## Provisioning (done by the devcontainer)
+
+- `external/YCSB` — source clone (reference / future maven builds)
+- `external/ycsb-dist/` — extracted 0.17.0 release binding tarballs
+  (`redis`, `rocksdb`, `dynamodb`), `dynamodb-local/DynamoDBLocal.jar`,
+  and `clio-binding/classes` (the compiled `ClioClient`)
+- `redis-server`, a JDK (for `javac` + `jni.h`), python3 `boto3`
+
+Manual setup, if needed:
+
+```bash
+DIST=external/ycsb-dist && mkdir -p $DIST && cd $DIST
+for b in redis rocksdb dynamodb; do
+  curl -sfLO https://github.com/brianfrankcooper/YCSB/releases/download/0.17.0/ycsb-$b-binding-0.17.0.tar.gz
+  tar xzf ycsb-$b-binding-0.17.0.tar.gz
+done
+curl -sfL -o ddb.tar.gz https://d1ni2b6xgvw0s0.cloudfront.net/dynamodb_local_latest.tar.gz
+mkdir -p dynamodb-local && tar xzf ddb.tar.gz -C dynamodb-local
+mkdir -p clio-binding/classes
+javac -cp ycsb-redis-binding-0.17.0/lib/core-0.17.0.jar \
+      -d clio-binding/classes \
+      ../../context-transfer-engine/benchmark/ycsb/ClioClient.java
+```
+
+## Building the shim
+
+`libclio_ycsb_jni.so` builds with the normal tree whenever CMake's
+`find_package(JNI)` succeeds (install `openjdk-21-jdk-headless`):
+
+```bash
+cmake --build build-cpu --target clio_ycsb_jni
+```
+
+## Running
+
+```bash
+cd context-transfer-engine/benchmark/ycsb
+BUILD_DIR=../../../build-cpu ./run_comparison.sh            # all four DBs
+./run_comparison.sh clio redis                              # subset
+RECORDS=1000000 OPS=1000000 THREADS=8 ./run_comparison.sh   # bigger run
+```
+
+Each DB × workload gets a fresh load phase; the run-phase `[OVERALL]
+Throughput` lines are summarized at the end and full YCSB outputs land in
+`results/`. The Clio leg starts/stops its own `clio_run` daemon (default
+config: SHM client, RAM bdev); Redis and DynamoDB Local are started/stopped
+per workload; RocksDB is embedded (fresh temp dir per workload).
+
+## Reference numbers
+
+First run on the WSL2 dev container (100k records / 100k ops / 4 threads /
+~1.1KB records; run-phase `[OVERALL] Throughput` in ops/sec — single-node
+noisy-box numbers, magnitudes not gospel):
+
+| Workload | clio (SHM) | redis | rocksdb (embedded) | dynamodb-local |
+|----------|-----------:|------:|-------------------:|---------------:|
+| A (50/50 read/update) | 6,952 | 21,650 | 49,140 | 1,664 |
+| B (95/5)              | 42,553 | 16,787 | 64,809 | 1,867 |
+| C (read-only)         | 34,566–55,866 | 21,044 | 62,383 | 1,915 |
+| F (read-modify-write) | 7,637 | 14,762 | 27,824 | 1,335 |
+
+Reading: Clio's SHM read path beats Redis ~2x on the read-heavy workloads;
+update-heavy A/F pay double because the binding's `update` is a client-side
+full-record read + full-record rewrite (see Caveats) where redis writes a
+single hash field. Embedded RocksDB (no IPC at all) leads everywhere;
+DynamoDB Local's HTTP path trails by ~10-30x. Obvious next lever: a partial
+PutBlob-at-offset or server-side field merge for updates.
+
+## Caveats
+
+- DynamoDB Local is not the DynamoDB service: numbers characterize the
+  binding + local engine, not AWS-hosted performance.
+- The Clio binding's `update` is a client-side read-modify-write (like the
+  stock rocksdb binding); redis uses hash-field updates natively.
+- One tag holds all records; blob metadata scale-out across tags is not
+  exercised.

--- a/context-transfer-engine/benchmark/ycsb/clio_ycsb_jni.cc
+++ b/context-transfer-engine/benchmark/ycsb/clio_ycsb_jni.cc
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ * BSD 3-Clause License. See LICENSE file.
+ */
+
+/**
+ * JNI shim backing the YCSB Clio binding (site.ycsb.db.ClioClient, issue
+ * #862). Maps the YCSB key/value model onto the CTE blob store: one tag
+ * ("ycsb") holds every record, the YCSB key is the blob name, and the
+ * serialized field map (built Java-side) is the blob payload.
+ *
+ * The runtime daemon must already be running (clio_run runtime start); this
+ * shim connects as a SHM client. Init is process-wide and idempotent — YCSB
+ * constructs one DB adapter per client thread, and every adapter's init()
+ * funnels through the same std::once.
+ */
+
+#include <jni.h>
+#include <signal.h>
+
+#include <cstring>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include <clio_runtime/clio_runtime.h>
+#include <clio_cte/core/core_client.h>
+
+namespace {
+
+clio::cte::core::Tag *g_tag = nullptr;
+std::once_flag g_init_once;
+int g_init_rc = -100;  // set by the once-body; <0 means init failed
+
+void InitOnce() {
+  // The Clio SHM transport wakes waiters with tgkill(SIGUSR1); clio-aware
+  // threads block the signal and consume it via signalfd, but JVM threads
+  // keep the default mask, and SIGUSR1's default action TERMINATES the
+  // process if a wake ever lands on one of them. A no-op handler makes such
+  // strays harmless without disturbing signalfd delivery on blocked threads.
+  struct sigaction sa;
+  memset(&sa, 0, sizeof(sa));
+  sa.sa_handler = [](int) {};
+  sigemptyset(&sa.sa_mask);
+  sigaction(SIGUSR1, &sa, nullptr);
+
+  // default_with_runtime=false: connect to the externally-started clio_run
+  // daemon (true would embed a runtime in the JVM and fight the daemon for
+  // port 9413).
+  if (!clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, false)) {
+    g_init_rc = -1;
+    return;
+  }
+  if (!clio::cte::core::CLIO_CTE_CLIENT_INIT()) {
+    g_init_rc = -2;
+    return;
+  }
+  auto *cte_client = CLIO_CTE_CLIENT;
+  if (cte_client == nullptr) {
+    g_init_rc = -3;
+    return;
+  }
+  cte_client->Init(clio::cte::core::kCtePoolId);
+  clio::cte::core::CreateParams params;
+  auto create_task = cte_client->AsyncCreate(
+      clio::run::PoolQuery::Dynamic(), clio::cte::core::kCtePoolName,
+      clio::cte::core::kCtePoolId, params);
+  create_task.Wait();
+  if (create_task->GetReturnCode() != 0) {
+    g_init_rc = -4;
+    return;
+  }
+  g_tag = new clio::cte::core::Tag("ycsb");
+  g_init_rc = 0;
+}
+
+}  // namespace
+
+extern "C" {
+
+JNIEXPORT jint JNICALL Java_site_ycsb_db_ClioClient_nativeInit(JNIEnv *,
+                                                               jclass) {
+  std::call_once(g_init_once, InitOnce);
+  return static_cast<jint>(g_init_rc);
+}
+
+JNIEXPORT jint JNICALL Java_site_ycsb_db_ClioClient_nativePut(
+    JNIEnv *env, jclass, jstring key, jbyteArray value) {
+  if (g_tag == nullptr) return -1;
+  const char *key_chars = env->GetStringUTFChars(key, nullptr);
+  if (key_chars == nullptr) return -2;
+  jsize len = env->GetArrayLength(value);
+  jbyte *bytes = env->GetByteArrayElements(value, nullptr);
+  if (bytes == nullptr) {
+    env->ReleaseStringUTFChars(key, key_chars);
+    return -3;
+  }
+  int rc = 0;
+  try {
+    g_tag->PutBlob(key_chars, reinterpret_cast<const char *>(bytes),
+                   static_cast<size_t>(len));
+  } catch (const std::exception &) {
+    // Tag::PutBlob throws on a failed put (e.g. daemon死/capacity); an
+    // exception escaping a JNI boundary terminates the JVM, so convert to a
+    // status the Java adapter can surface as Status.ERROR.
+    rc = -10;
+  }
+  env->ReleaseByteArrayElements(value, bytes, JNI_ABORT);
+  env->ReleaseStringUTFChars(key, key_chars);
+  return rc;
+}
+
+JNIEXPORT jbyteArray JNICALL Java_site_ycsb_db_ClioClient_nativeGet(
+    JNIEnv *env, jclass, jstring key) {
+  if (g_tag == nullptr) return nullptr;
+  const char *key_chars = env->GetStringUTFChars(key, nullptr);
+  if (key_chars == nullptr) return nullptr;
+  std::string key_str(key_chars);
+  env->ReleaseStringUTFChars(key, key_chars);
+
+  clio::run::u64 size = 0;
+  std::vector<char> buf;
+  try {
+    size = g_tag->GetBlobSize(key_str);
+    if (size == 0) return nullptr;  // absent key
+    buf.resize(size);
+    g_tag->GetBlob(key_str, buf.data(), size, 0);
+  } catch (const std::exception &) {
+    return nullptr;  // surfaced as Status.NOT_FOUND/ERROR by the adapter
+  }
+
+  jbyteArray out = env->NewByteArray(static_cast<jsize>(size));
+  if (out == nullptr) return nullptr;
+  env->SetByteArrayRegion(out, 0, static_cast<jsize>(size),
+                          reinterpret_cast<const jbyte *>(buf.data()));
+  return out;
+}
+
+}  // extern "C"

--- a/context-transfer-engine/benchmark/ycsb/ddb_create_table.py
+++ b/context-transfer-engine/benchmark/ycsb/ddb_create_table.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Create the YCSB 'usertable' on DynamoDB Local (issue #862).
+
+DynamoDB Local accepts any credentials but the table must exist before the
+YCSB dynamodb binding can load into it. boto3 is provisioned by the
+devcontainer; primary key name matches the binding's dynamodb.primaryKey.
+"""
+import sys
+
+import boto3
+
+port = sys.argv[1] if len(sys.argv) > 1 else "8000"
+ddb = boto3.client(
+    "dynamodb",
+    endpoint_url=f"http://127.0.0.1:{port}",
+    region_name="us-east-1",
+    aws_access_key_id="fake",
+    aws_secret_access_key="fake",
+)
+existing = ddb.list_tables()["TableNames"]
+if "usertable" in existing:
+    print("usertable already exists")
+    sys.exit(0)
+ddb.create_table(
+    TableName="usertable",
+    KeySchema=[{"AttributeName": "firstname", "KeyType": "HASH"}],
+    AttributeDefinitions=[{"AttributeName": "firstname", "AttributeType": "S"}],
+    BillingMode="PAY_PER_REQUEST",
+)
+ddb.get_waiter("table_exists").wait(TableName="usertable")
+print("usertable created")

--- a/context-transfer-engine/benchmark/ycsb/run_comparison.sh
+++ b/context-transfer-engine/benchmark/ycsb/run_comparison.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+# YCSB comparison driver (issue #862): clio vs redis vs rocksdb vs
+# dynamodb-local on the core workloads that need no scan/delete (A, B, C, F).
+#
+# Prerequisites (the devcontainer provisions all of these):
+#   - external/ycsb-dist/ with the 0.17.0 redis/rocksdb/dynamodb binding
+#     tarballs extracted and clio-binding/classes compiled (see README.md)
+#   - external/ycsb-dist/dynamodb-local/DynamoDBLocal.jar
+#   - redis-server on PATH; a JDK (javac/java)
+#   - build directory with clio_run + libclio_ycsb_jni.so (BUILD_DIR below)
+#
+# Usage: ./run_comparison.sh [dbs...]   (default: clio redis rocksdb dynamodb)
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+DIST="$REPO_ROOT/external/ycsb-dist"
+BUILD_DIR="${BUILD_DIR:-$REPO_ROOT/build-cpu}"
+OUT_DIR="${OUT_DIR:-$SCRIPT_DIR/results}"
+mkdir -p "$OUT_DIR"
+
+RECORDS="${RECORDS:-100000}"
+OPS="${OPS:-100000}"
+THREADS="${THREADS:-4}"
+WORKLOADS="${WORKLOADS:-a b c f}"
+REDIS_PORT="${REDIS_PORT:-6399}"
+DDB_PORT="${DDB_PORT:-8000}"
+
+WL_DIR="$DIST/ycsb-redis-binding-0.17.0/workloads"
+CORE_JAR="$DIST/ycsb-redis-binding-0.17.0/lib/core-0.17.0.jar"
+HDR_JAR="$DIST/ycsb-redis-binding-0.17.0/lib/HdrHistogram-2.1.4.jar"
+HTRACE_JAR="$DIST/ycsb-redis-binding-0.17.0/lib/htrace-core4-4.1.0-incubating.jar"
+BASE_CP="$CORE_JAR:$HDR_JAR:$HTRACE_JAR"
+
+COMMON_PROPS=(-p "recordcount=$RECORDS" -p "operationcount=$OPS" -threads "$THREADS")
+
+run_phase() {  # $1=db-label $2=load|run $3=workload-letter $4=classpath $5...=extra props
+  local label="$1" phase="$2" wl="$3" cp="$4"; shift 4
+  local out="$OUT_DIR/${label}_workload${wl}_${phase}.txt"
+  local mode="-t"; [ "$phase" = "load" ] && mode="-load"
+  java -cp "$cp" ${CLIO_JAVA_OPTS:-} site.ycsb.Client $mode \
+    -db "$DB_CLASS" -P "$WL_DIR/workload$wl" "${COMMON_PROPS[@]}" "$@" \
+    > "$out" 2>&1
+  local tput
+  tput=$(grep -m1 "\[OVERALL\], Throughput" "$out" | awk -F', ' '{printf "%.0f", $3}')
+  echo "  $label workload$wl $phase: ${tput:-FAILED} ops/sec  ($out)"
+}
+
+bench_db() {  # $1=db-label; per-db classpath/class/props set below
+  local label="$1"
+  echo "=== $label ==="
+  for wl in $WORKLOADS; do
+    # workloads share the loaded dataset only within a db+workload pair; each
+    # workload gets a fresh load so RMW/update mixes start from clean state.
+    setup_db "$label" "$wl"
+    run_phase "$label" load "$wl" "$CP" "${PROPS[@]}"
+    run_phase "$label" run  "$wl" "$CP" "${PROPS[@]}"
+    teardown_db "$label"
+  done
+}
+
+setup_db() {
+  local label="$1" wl="$2"
+  case "$label" in
+    clio)
+      DB_CLASS=site.ycsb.db.ClioClient
+      CP="$BASE_CP:$DIST/clio-binding/classes"
+      PROPS=()
+      export CLIO_JAVA_OPTS="-Djava.library.path=$BUILD_DIR/bin"
+      pkill -9 -x clio_run 2>/dev/null; sleep 1
+      # The runtime binds 9413 without SO_REUSEADDR, so a fresh daemon can
+      # lose to the previous one's TIME_WAIT; retry until it actually listens.
+      local attempt ok=0
+      for attempt in 1 2 3 4 5; do
+        rm -rf /tmp/clio_$(whoami)/* 2>/dev/null
+        LD_LIBRARY_PATH="$BUILD_DIR/bin" "$BUILD_DIR/bin/clio_run" runtime start \
+          >> "$OUT_DIR/clio_daemon_${wl}.log" 2>&1 &
+        CLIO_PID=$!
+        sleep 3
+        if kill -0 "$CLIO_PID" 2>/dev/null && \
+           ss -ltn 2>/dev/null | grep -q ':9413 '; then
+          ok=1; break
+        fi
+        kill -9 "$CLIO_PID" 2>/dev/null; sleep 5
+      done
+      [ "$ok" = 1 ] || echo "  WARNING: clio daemon failed to start (workload $wl)"
+      ;;
+    redis)
+      DB_CLASS=site.ycsb.db.RedisClient
+      CP="$BASE_CP:$(ls "$DIST"/ycsb-redis-binding-0.17.0/lib/*.jar | tr '\n' ':')"
+      PROPS=(-p "redis.host=127.0.0.1" -p "redis.port=$REDIS_PORT")
+      redis-server --port "$REDIS_PORT" --daemonize yes --save '' --appendonly no
+      sleep 1
+      ;;
+    rocksdb)
+      DB_CLASS=site.ycsb.db.rocksdb.RocksDBClient
+      CP="$BASE_CP:$(ls "$DIST"/ycsb-rocksdb-binding-0.17.0/lib/*.jar | tr '\n' ':')"
+      ROCKS_DIR=$(mktemp -d /tmp/ycsb-rocksdb.XXXXXX)
+      PROPS=(-p "rocksdb.dir=$ROCKS_DIR")
+      ;;
+    dynamodb)
+      DB_CLASS=site.ycsb.db.DynamoDBClient
+      CP="$BASE_CP:$(ls "$DIST"/ycsb-dynamodb-binding-0.17.0/lib/*.jar | tr '\n' ':')"
+      PROPS=(-p "dynamodb.endpoint=http://127.0.0.1:$DDB_PORT"
+             -p "dynamodb.primaryKey=firstname"
+             -p "dynamodb.awsCredentialsFile=$OUT_DIR/ddb_creds.properties"
+             -p "table=usertable")
+      printf 'accessKey=fake\nsecretKey=fake\n' > "$OUT_DIR/ddb_creds.properties"
+      (cd "$DIST/dynamodb-local" && java -jar DynamoDBLocal.jar -inMemory \
+        -port "$DDB_PORT" > "$OUT_DIR/ddb_${wl}.log" 2>&1 &)
+      sleep 4
+      python3 "$SCRIPT_DIR/ddb_create_table.py" "$DDB_PORT"
+      ;;
+  esac
+}
+
+teardown_db() {
+  case "$1" in
+    clio)
+      kill "$CLIO_PID" 2>/dev/null; pkill -9 -x clio_run 2>/dev/null
+      rm -rf /tmp/clio_$(whoami)/* 2>/dev/null; sleep 1 ;;
+    redis)
+      redis-cli -p "$REDIS_PORT" shutdown nosave 2>/dev/null; sleep 1 ;;
+    rocksdb)
+      rm -rf "$ROCKS_DIR" ;;
+    dynamodb)
+      pkill -f DynamoDBLocal.jar 2>/dev/null; sleep 1 ;;
+  esac
+}
+
+DBS=("$@")
+if [ ${#DBS[@]} -eq 0 ]; then
+  DBS=(clio redis rocksdb dynamodb)
+fi
+for db in "${DBS[@]}"; do
+  case "$db" in
+    clio|redis|rocksdb|dynamodb) bench_db "$db" ;;
+    *) echo "unknown db '$db' (expected clio|redis|rocksdb|dynamodb)"; exit 2 ;;
+  esac
+done
+
+echo
+echo "=== Summary (run-phase throughput, ops/sec) ==="
+for f in "$OUT_DIR"/*_run.txt; do
+  b=$(basename "$f" _run.txt)
+  t=$(grep -m1 "\[OVERALL\], Throughput" "$f" | awk -F', ' '{printf "%.0f", $3}')
+  echo "$b: ${t:-FAILED}"
+done

--- a/docker/deps-cpu.Dockerfile
+++ b/docker/deps-cpu.Dockerfile
@@ -54,12 +54,15 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # System libraries and services
+# openjdk: YCSB (issue #862) needs java to run the harness + DynamoDB Local,
+# and the JDK's javac/jni.h to build the Clio binding (headless: no AWT).
 RUN apt-get update && apt-get install -y \
     libelf-dev \
     libaio-dev \
     liburing-dev \
     redis-server \
     redis-tools \
+    openjdk-21-jdk-headless \
     && rm -rf /var/lib/apt/lists/*
 
 # MPI

--- a/docker/provision-ycsb.sh
+++ b/docker/provision-ycsb.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Provision YCSB + comparison stores into external/ (issue #862).
+# Idempotent: safe to re-run; each artifact is skipped if already present.
+# Called from .devcontainer/post-create.sh; can also be run manually:
+#   ./docker/provision-ycsb.sh [repo-root]
+set -uo pipefail
+
+REPO_ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+EXT="$REPO_ROOT/external"
+DIST="$EXT/ycsb-dist"
+YCSB_VER=0.17.0
+mkdir -p "$DIST"
+
+# Source clone (reference + future maven builds of the full harness)
+if [ ! -d "$EXT/YCSB/.git" ]; then
+  git clone --depth 1 https://github.com/brianfrankcooper/YCSB.git "$EXT/YCSB" \
+    || echo "WARN: YCSB clone failed (offline?); release tarballs may still work"
+fi
+
+# Prebuilt binding tarballs: runnable without maven
+for b in redis rocksdb dynamodb; do
+  if [ ! -d "$DIST/ycsb-$b-binding-$YCSB_VER" ]; then
+    curl -sfL -o "$DIST/ycsb-$b-binding-$YCSB_VER.tar.gz" \
+      "https://github.com/brianfrankcooper/YCSB/releases/download/$YCSB_VER/ycsb-$b-binding-$YCSB_VER.tar.gz" \
+      && tar xzf "$DIST/ycsb-$b-binding-$YCSB_VER.tar.gz" -C "$DIST" \
+      || echo "WARN: fetch of ycsb-$b-binding failed"
+  fi
+done
+
+# DynamoDB Local
+if [ ! -f "$DIST/dynamodb-local/DynamoDBLocal.jar" ]; then
+  mkdir -p "$DIST/dynamodb-local"
+  curl -sfL -o "$DIST/dynamodb_local_latest.tar.gz" \
+    "https://d1ni2b6xgvw0s0.cloudfront.net/dynamodb_local_latest.tar.gz" \
+    && tar xzf "$DIST/dynamodb_local_latest.tar.gz" -C "$DIST/dynamodb-local" \
+    || echo "WARN: DynamoDB Local fetch failed"
+fi
+
+# boto3 for the usertable-creation helper (venv-local, no sudo needed)
+python3 -c 'import boto3' 2>/dev/null || pip install -q boto3 || true
+
+# Compile the Clio YCSB adapter when a JDK and the core jar are available
+CORE_JAR="$DIST/ycsb-redis-binding-$YCSB_VER/lib/core-$YCSB_VER.jar"
+SRC="$REPO_ROOT/context-transfer-engine/benchmark/ycsb/ClioClient.java"
+if command -v javac >/dev/null && [ -f "$CORE_JAR" ] && [ -f "$SRC" ]; then
+  mkdir -p "$DIST/clio-binding/classes"
+  javac -cp "$CORE_JAR" -d "$DIST/clio-binding/classes" "$SRC" \
+    || echo "WARN: ClioClient.java compile failed"
+fi
+
+echo "YCSB provisioning complete under $DIST"

--- a/external/.gitignore
+++ b/external/.gitignore
@@ -1,0 +1,2 @@
+/YCSB/
+/ycsb-dist/


### PR DESCRIPTION
## Summary
- **YCSB binding for Clio**: `site.ycsb.db.ClioClient` (one blob per key under a single CTE tag, field map serialized Java-side) over a JNI shim (`libclio_ycsb_jni`) on the CTE SHM client. Two JVM hazards handled: the SHM transport's `tgkill(SIGUSR1)` wake kills default-mask JVM threads (no-op handler installed), and `Tag::PutBlob`'s throw would cross the JNI boundary and abort the JVM (converted to status codes). CMake builds the shim whenever `jni.h` is found (`find_path`, since `FindJNI` rejects headless JDKs).
- **Comparison harness**: `run_comparison.sh` runs workloads A/B/C/F (binding has no scan/delete yet) against clio / redis / rocksdb / DynamoDB Local with identical parameters and per-DB service lifecycle (including a retrying clio daemon start — the runtime's 9413 bind loses to TIME_WAIT between back-to-back runs).
- **Provisioning**: `docker/provision-ycsb.sh` (idempotent: YCSB source clone into `external/`, 0.17.0 release binding tarballs, DynamoDB Local, boto3, adapter compile) hooked into `.devcontainer/post-create.sh`; `deps-cpu` gains `openjdk-21-jdk-headless` (deps-nvidia inherits). Everything was installed and validated in the live dev container first.

## First numbers (100k records / 100k ops / 4 threads / ~1.1KB records, run-phase ops/sec, WSL2 noisy-box)

| Workload | clio (SHM) | redis | rocksdb (embedded) | dynamodb-local |
|----------|-----------:|------:|-------------------:|---------------:|
| A (50/50 r/u) | 6,952 | 21,650 | 49,140 | 1,664 |
| B (95/5) | 42,553 | 16,787 | 64,809 | 1,867 |
| C (read-only) | 34,566–55,866 | 21,044 | 62,383 | 1,915 |
| F (RMW) | 7,637 | 14,762 | 27,824 | 1,335 |

Clio's SHM read path beats Redis ~2x on read-heavy workloads; update-heavy A/F pay double for the binding's client-side full-record read-modify-write (redis updates a single hash field). Obvious follow-up lever: partial PutBlob-at-offset or server-side field merge for updates; scan support would unlock D/E.

## Motivation
Closes #862.

## Test plan
- [x] Binding smoke: 1k-record load + 5k reads, 5000/5000 `Return=OK`
- [x] Full A/B/C/F comparison ran to completion for all four stores
- [x] `provision-ycsb.sh` idempotency verified (second run all-skips)
- [ ] CI (the JNI target is skipped where no JDK is present; deps-image rebuild picks up the JDK)

## Breaking changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)