### PR TITLE
bdev: incremental RAM-segment population + opt-in CLIO_PREFAULT pre-faulting

### DIFF
--- a/context-runtime/modules/bdev/include/clio_runtime/bdev/bdev_tasks.h
+++ b/context-runtime/modules/bdev/include/clio_runtime/bdev/bdev_tasks.h
@@ -171,6 +171,14 @@ struct CreateParams {
   // transports. YAML key: growth_unit (size string, e.g. "1GB").
   clio::run::u64 growth_unit_ = clio::run::u64(1) << 30;  // 1 GiB default
 
+  // Incremental population unit for the RAM bdev's sparse SHM mapping: when
+  // an allocation crosses the populated watermark, the next this-many bytes
+  // are bulk-faulted (SystemInfo::BulkFault) so data memcpys stop paying one
+  // demand fault per 4KB. 0 disables population (pure lazy faulting).
+  // Committed memory stays bounded by the allocation high-water mark plus
+  // one unit. YAML key: populate_unit (size string).
+  clio::run::u64 populate_unit_ = clio::run::u64(64) << 20;  // 64 MiB default
+
   // Required: chimod library name for module manager
   static constexpr const char *chimod_lib_name = "clio_bdev";
 
@@ -250,7 +258,7 @@ struct CreateParams {
   template <class Archive>
   void serialize(Archive &ar) {
     ar(bdev_type_, total_size_, io_depth_, alignment_, perf_metrics_,
-       persistence_level_, alloc_log_path_, growth_unit_);
+       persistence_level_, alloc_log_path_, growth_unit_, populate_unit_);
   }
 
   /**
@@ -301,6 +309,12 @@ struct CreateParams {
     if (config["growth_unit"]) {
       std::string growth_str = config["growth_unit"].as<std::string>();
       growth_unit_ = ctp::ConfigParse::ParseSize(growth_str);
+    }
+
+    // Load RAM-bdev incremental population unit (optional, default 64MB)
+    if (config["populate_unit"]) {
+      std::string populate_str = config["populate_unit"].as<std::string>();
+      populate_unit_ = ctp::ConfigParse::ParseSize(populate_str);
     }
 
     // Load performance metrics (optional)

--- a/context-runtime/modules/bdev/include/clio_runtime/bdev/transports/mem_bdev_transport.h
+++ b/context-runtime/modules/bdev/include/clio_runtime/bdev/transports/mem_bdev_transport.h
@@ -11,6 +11,7 @@
 // Must follow the runtime headers above: posix_shm_mmap.h needs the memory
 // backend base types they pull in.
 #include <clio_ctp/memory/backend/posix_shm_mmap.h>
+#include <atomic>
 #include <limits>
 #include <mutex>
 #include <string>
@@ -115,6 +116,20 @@ class MemBdevTransport : public BdevTransport {
   ShmRamHeader *shm_header_ = nullptr;
   bool shm_backed_ = false;
   std::string shm_name_;
+
+  // Incremental population of the sparse SHM mapping (SystemInfo::BulkFault).
+  // First-touch demand faulting made cold placement ~20x slower than warm on
+  // WSL2 (one #PF per 4KB of memcpy), so when an allocation crosses this
+  // watermark the NEXT populate-unit of pages is bulk-faulted in. The
+  // watermark advances by CAS — no lock — because population is ADVISORY: a
+  // thread that observes an advanced watermark before the winner's BulkFault
+  // finishes just demand-faults those pages exactly as before. Committed
+  // memory stays <= round_up(allocation high-water mark, unit): capacity that
+  // is never allocated is never touched.
+  clio::run::u64 populate_unit_ = 64ULL << 20;
+  std::atomic<clio::run::u64> populated_bytes_{0};
+  /** Bulk-fault [populated_bytes_, round_up(end, unit)) if end crosses it. */
+  void EnsurePopulated(clio::run::u64 end);
 
   // A lazily-allocated RAM page. A kPinned pool allocates page-locked host
   // memory through GpuApi (cudaMallocHost / hipHostMalloc / sycl::malloc_host)

--- a/context-runtime/modules/bdev/src/transports/mem_bdev_transport.cc
+++ b/context-runtime/modules/bdev/src/transports/mem_bdev_transport.cc
@@ -17,6 +17,7 @@ bool MemBdevTransport::Init(const CreateParams& params,
                             const std::string& /*pool_name*/, Runtime* runtime) {
   ram_capacity_ = (params.total_size_ == 0) ? DefaultRamCapacityBytes() : params.total_size_;
   bdev_type_ = params.bdev_type_;
+  populate_unit_ = params.populate_unit_;
   force_sync_gpu_ = (std::getenv("CLIO_BDEV_FORCE_SYNC") != nullptr);
 
   clio::run::WorkOrchestrator *work_orchestrator = CLIO_WORK_ORCHESTRATOR;
@@ -145,7 +146,48 @@ void MemBdevTransport::FreeRamPage(RamPage &page) {
 }
 
 bool MemBdevTransport::AllocateBlocks(size_t size, int worker_id, std::vector<Block>& blocks) {
-  return allocator_.AllocateBlocks(size, worker_id, blocks);
+  if (!allocator_.AllocateBlocks(size, worker_id, blocks)) {
+    return false;
+  }
+  // Bulk-fault any not-yet-populated pages these blocks cover, so the
+  // upcoming data memcpy does not take one demand fault per 4KB. Recycled and
+  // below-watermark blocks skip this with a single atomic load.
+  clio::run::u64 end = 0;
+  for (const Block &b : blocks) {
+    clio::run::u64 e = b.offset_ + b.size_;
+    if (e > end) end = e;
+  }
+  EnsurePopulated(end);
+  return true;
+}
+
+void MemBdevTransport::EnsurePopulated(clio::run::u64 end) {
+  if (!shm_backed_ || shm_base_ == nullptr || populate_unit_ == 0) {
+    return;
+  }
+  clio::run::u64 cur = populated_bytes_.load(std::memory_order_acquire);
+  while (end > cur) {
+    clio::run::u64 target =
+        ((end + populate_unit_ - 1) / populate_unit_) * populate_unit_;
+    if (target > shm_usable_) {
+      target = shm_usable_;
+    }
+    if (target <= cur) {
+      return;  // range already covered (or mapping exhausted)
+    }
+    // Claim [cur, target) by CAS, then populate it. Claiming FIRST is what
+    // makes this lock-free-safe: population is advisory, so a thread that
+    // sees the advanced watermark before our BulkFault completes simply
+    // demand-faults those pages as it always did. Losers re-read `cur` and
+    // either find their range covered or claim the next disjoint span, so
+    // concurrent claims never overlap and never double-populate.
+    if (populated_bytes_.compare_exchange_weak(cur, target,
+                                               std::memory_order_acq_rel,
+                                               std::memory_order_acquire)) {
+      ctp::SystemInfo::BulkFault(shm_base_ + cur, target - cur);
+      return;
+    }
+  }
 }
 
 void MemBdevTransport::FreeBlocks(int worker_id, const std::vector<Block>& blocks) {

--- a/context-runtime/modules/bdev/src/transports/mem_bdev_transport.cc
+++ b/context-runtime/modules/bdev/src/transports/mem_bdev_transport.cc
@@ -8,7 +8,9 @@
 #include <clio_runtime/worker.h>
 #include <clio_runtime/work_orchestrator.h>
 #include <clio_runtime/bdev/bdev_runtime.h>
+#include <clio_ctp/util/config_parse.h>
 #include <clio_ctp/util/gpu_api.h>
+#include <chrono>
 #include <cstdlib>
 
 namespace clio::run::bdev {
@@ -34,6 +36,43 @@ bool MemBdevTransport::Init(const CreateParams& params,
   // exactly as before on the private heap; only the client fast path is lost.
   if (bdev_type_ == BdevType::kRam && runtime != nullptr) {
     InitShmBacking(runtime->pool_id_);
+  }
+
+  // CLIO_PREFAULT: pre-fault the RAM segment at init instead of (or ahead of)
+  // the incremental allocation-time population. "0" means the WHOLE mapping;
+  // any other value is a size string (ConfigParse::ParseSize, e.g. "512MB",
+  // "4GB") pre-faulting that prefix, clamped to the mapping. Unset keeps the
+  // default: pages are populated one populate_unit at a time as allocations
+  // cross the watermark.
+  //
+  // This trades memory for cold-write latency EXPLICITLY: whatever is
+  // pre-faulted is committed RAM immediately, so "0" on a 16GB tier commits
+  // 16GB at compose. The populated watermark starts past the pre-faulted
+  // prefix, so incremental population resumes seamlessly beyond it.
+  if (shm_backed_ && shm_base_ != nullptr) {
+    const char *prefault = std::getenv("CLIO_PREFAULT");
+    if (prefault != nullptr && *prefault != '\0') {
+      clio::run::u64 want;
+      if (std::string(prefault) == "0") {
+        want = shm_usable_;
+      } else {
+        want = std::min<clio::run::u64>(
+            ctp::ConfigParse::ParseSize(prefault), shm_usable_);
+      }
+      if (want > 0) {
+        auto begin = std::chrono::steady_clock::now();
+        ctp::SystemInfo::BulkFault(shm_base_, static_cast<size_t>(want));
+        populated_bytes_.store(want, std::memory_order_release);
+        auto ms = std::chrono::duration<double, std::milli>(
+                      std::chrono::steady_clock::now() - begin)
+                      .count();
+        HLOG(kInfo,
+             "RAM bdev '{}': CLIO_PREFAULT={} pre-faulted {} of {} bytes in "
+             "{} ms",
+             shm_name_, prefault, want, shm_usable_,
+             static_cast<clio::run::u64>(ms));
+      }
+    }
   }
 
   return true;

--- a/context-transport-primitives/include/clio_ctp/introspect/system_info.h
+++ b/context-transport-primitives/include/clio_ctp/introspect/system_info.h
@@ -238,6 +238,31 @@ class SystemInfo {
 
   CTP_DLL static void UnmapMemory(void *ptr, size_t size);
 
+  /**
+   * Bulk-fault the pages of [addr, addr+size) for WRITING, so a subsequent
+   * memcpy into the range takes no per-4KB page-fault round trips (measured
+   * ~7.6us/fault under WSL2 — first-touch faulting turned 10.6 GB/s of RAM
+   * bdev placement into 0.5 GB/s).
+   *
+   * ADVISORY: correctness never depends on this call — untouched pages
+   * demand-fault exactly as before, so any failure path may simply return.
+   * Platform behavior:
+   *  - Linux:   madvise(MADV_POPULATE_WRITE) (kernel >= 5.14), which
+   *             populates in-kernel at a fraction of the per-#PF cost;
+   *             older kernels fall back to the write-touch loop.
+   *  - Windows: PrefetchVirtualMemory to bring the range resident in bulk.
+   *  - macOS:   write-touch loop (no populate API); still batches the
+   *             faults at a controlled point instead of inside the copy.
+   * The fallback write-touch loop performs a volatile read-modify-write of
+   * one byte per page, preserving existing contents.
+   *
+   * @param addr Start of the range (any alignment; internally page-aligned).
+   * @param size Bytes to populate.
+   * @return True if a bulk populate mechanism (or the touch loop) ran;
+   *         false only for a null/empty range.
+   */
+  CTP_DLL static bool BulkFault(void *addr, size_t size);
+
   CTP_DLL static void *AlignedAlloc(size_t alignment, size_t size);
 
   /** Free memory returned by AlignedAlloc. POSIX accepts plain free()

--- a/context-transport-primitives/src/system_info.cc
+++ b/context-transport-primitives/src/system_info.cc
@@ -37,6 +37,8 @@
 #include <clio_ctp/util/env_compat.h>
 #include "clio_ctp/introspect/system_info.h"
 
+#include <atomic>
+#include <cerrno>
 #include <climits>
 #ifdef __linux__
 #include <linux/limits.h>  // PATH_MAX on some Linux toolchains
@@ -755,6 +757,63 @@ void SystemInfo::UnmapMemory(void *ptr, size_t size) {
 #elif CTP_ENABLE_WINDOWS_SYSINFO
   VirtualFree(ptr, size, MEM_RELEASE);
 #endif
+}
+
+// Some build toolchains (older glibc headers) predate the kernel constant;
+// the kernel rejects it with EINVAL when unsupported, which the fallback
+// below handles, so defining it locally is safe.
+#if defined(__linux__) && !defined(MADV_POPULATE_WRITE)
+#define MADV_POPULATE_WRITE 23
+#endif
+
+bool SystemInfo::BulkFault(void *addr, size_t size) {
+  if (addr == nullptr || size == 0) {
+    return false;
+  }
+  // Page-align the range: madvise requires an aligned start, and the touch
+  // loop wants to land exactly once per page.
+  const size_t page = static_cast<size_t>(GetPageSize());
+  uintptr_t begin = reinterpret_cast<uintptr_t>(addr);
+  uintptr_t end = begin + size;
+  begin &= ~(static_cast<uintptr_t>(page) - 1);
+
+#if defined(__linux__)
+  // Cache the kernel's answer: one EINVAL/ENOSYS (pre-5.14) is permanent,
+  // so later calls skip straight to the touch loop.
+  static std::atomic<bool> populate_supported{true};
+  if (populate_supported.load(std::memory_order_relaxed)) {
+    if (madvise(reinterpret_cast<void *>(begin), end - begin,
+                MADV_POPULATE_WRITE) == 0) {
+      return true;
+    }
+    if (errno == EINVAL || errno == ENOSYS) {
+      populate_supported.store(false, std::memory_order_relaxed);
+    }
+    // Any other errno (e.g. ENOMEM under pressure): fall through and touch —
+    // partial population is fine, the remainder demand-faults.
+  }
+#elif defined(_WIN32)
+  // PrefetchVirtualMemory materializes the whole range into the working set
+  // in one call. Pages arrive resident; the later write's dirty-bit
+  // transition is a cheap soft fault, not a demand-zero fault.
+  WIN32_MEMORY_RANGE_ENTRY range;
+  range.VirtualAddress = reinterpret_cast<PVOID>(begin);
+  range.NumberOfBytes = static_cast<SIZE_T>(end - begin);
+  if (PrefetchVirtualMemory(GetCurrentProcess(), 1, &range, 0)) {
+    return true;
+  }
+  // Fall through to the touch loop (e.g. pre-Win8, or an unmapped subrange).
+#endif
+
+  // Universal fallback (and the macOS primary path): write-touch one byte
+  // per page. A volatile read-modify-write faults the page for writing while
+  // preserving its contents. Same per-page cost as demand faulting, but paid
+  // here, at a controlled point, instead of scattered through a bulk memcpy.
+  volatile char *p = reinterpret_cast<volatile char *>(begin);
+  for (uintptr_t off = 0; off < end - begin; off += page) {
+    p[off] = p[off];
+  }
+  return true;
 }
 
 void *SystemInfo::AlignedAlloc(size_t alignment, size_t size) {


### PR DESCRIPTION
Cherry-picked from `luke-lmcache` (the two self-contained bdev commits; the lmcache-specific integration stays on its branch).

## Why

Cold-put diagnosis on `clio_cte_bench`: 28MB cold placements ran **499 MB/s with 919,638 daemon minor faults** — exactly one per 4KB page written into the sparse memfd segment — while warm in-place overwrites of the same blobs ran **10.6 GB/s with ~1,900 faults**. First-touch demand faulting IS the cold-write cost (~7.6µs/page on WSL2); the placement pipeline itself is fine.

## What

1. **`SystemInfo::BulkFault(addr, size)`** — portable, *advisory* bulk page population: `madvise(MADV_POPULATE_WRITE)` on Linux ≥5.14 (capability cached on first EINVAL/ENOSYS), `PrefetchVirtualMemory` on Windows, contents-preserving volatile write-touch fallback elsewhere. Advisory by contract: untouched pages demand-fault exactly as before, so no correctness ever depends on it.
2. **Incremental population watermark** in `MemBdevTransport`: when `AllocateBlocks` crosses the populated-bytes watermark, the crossing thread CAS-claims the next `populate_unit` (default 64MB; YAML `populate_unit`, `CreateParams::populate_unit_`, 0 = off) and bulk-populates it. Lock-free and safe precisely because population is advisory. Committed memory stays ≤ round-up(allocation high-water mark, unit).
3. **`CLIO_PREFAULT` env** — explicit memory-for-latency trade at compose time: `0` pre-faults the whole mapping; any other value is a ConfigParse size string (e.g. `4GB`) pre-faulting that prefix (clamped), seeding the watermark so incremental population resumes beyond it. Unset = watermark-only (default behavior unchanged).

Measured on WSL2: `CLIO_PREFAULT=4GB` moved 28MB cold puts from **440 MB/s / 919,638 faults to 4,309 MB/s / ~2,100 faults**, with the 4GB pre-fault paid once at compose (~7.5s) instead of inside the data path.

## Local validation (CPU build, x86)

- `test_bdev_fragmentation` 1/1, `test_tiered_storage_dram_default` 5/5, `test_reorganize_blob` 6/6 — all green.
- `CLIO_PREFAULT=8MB` smoke: `RAM bdev ...: CLIO_PREFAULT=8MB pre-faulted 8388608 of 17760256 bytes in 8 ms` and the suite stays green.
- Cherry-picks applied cleanly on top of #860's lazy-file-bdev-growth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)