### PR TITLE
fix(runtime): exactly-once origin completion + strict event-resume guard (#856)

### DIFF
--- a/context-runtime/include/clio_runtime/ipc/ipc_run2run.h
+++ b/context-runtime/include/clio_runtime/ipc/ipc_run2run.h
@@ -288,9 +288,23 @@ class IpcManagerRun2Run {
   /**
    * Finalize an origin task once all its replicas have been aggregated:
    * delete replica tasks, remove from send_map_, and call EndTask.
+   * Exactly-once: internally claims the origin via ClaimOrigin() and returns
+   * without side effects if another completion path already claimed it.
    */
   void RecvOutCompleteOriginTask(size_t net_key,
                                   clio::run::shared_ptr<clio::run::Task> origin_task);
+
+  /**
+   * Atomically claim the right to complete an origin (issue #856). Erases the
+   * origin from send_map_ (and progress_map_) under send_map_mutex_ and
+   * returns true iff this caller performed the erase. Every path that can
+   * complete an origin — replica-count completion, the #628 Gone verdict, the
+   * dead-node timeout scan — must claim first, so an origin is EndTask'd
+   * exactly once. A double EndTask writes completion state into a task whose
+   * RunContext the first completion already freed (heap corruption that
+   * crashed the leader-election recovery leader).
+   */
+  bool ClaimOrigin(size_t net_key);
 
   // ---------------------------------------------------------------------------
   // Retry helpers

--- a/context-runtime/src/ipc/ipc_run2run.cc
+++ b/context-runtime/src/ipc/ipc_run2run.cc
@@ -222,7 +222,19 @@ void IpcManagerRun2Run::SendIn(clio::run::shared_ptr<clio::run::Task> origin_tas
         HLOG(kWarning,
              "[SendIn] Task {} target node {} is dead, net_timeout=0 -> skip",
              origin_task->task_id_, target_node_id);
-        origin_task->CompletedReplicas()++;
+        // Issue #856: if this skip is the LAST replica to be accounted (every
+        // other replica already responded), nobody else will ever observe
+        // completed == size — the origin would never complete and its awaiting
+        // client/fiber parks forever (the 15-minute leader-election step
+        // timeout). Check for completion here like every other counting path.
+        // Reaching size mid-loop is only possible when every replica has
+        // already contributed, so no later iteration touches Subtasks() after
+        // RecvOutCompleteOriginTask clears it.
+        clio::run::u32 completed =
+            origin_task->CompletedReplicas().fetch_add(1) + 1;
+        if (completed == origin_task->Subtasks().size()) {
+          RecvOutCompleteOriginTask(send_map_key, origin_task);
+        }
         continue;
       }
       HLOG(kWarning,
@@ -606,10 +618,29 @@ int IpcManagerRun2Run::RecvOutAggregate(
   return 0;
 }
 
+bool IpcManagerRun2Run::ClaimOrigin(size_t net_key) {
+  std::lock_guard<std::mutex> lk(send_map_mutex_);
+  bool present = (send_map_.find(net_key) != nullptr);
+  if (present) {
+    send_map_.erase(net_key);
+  }
+  progress_map_.erase(net_key);  // #628: drop task-progress tracking
+  return present;
+}
+
 void IpcManagerRun2Run::RecvOutCompleteOriginTask(
     size_t net_key,
     clio::run::shared_ptr<clio::run::Task> origin_task) {
   auto *ipc_manager = CLIO_IPC;
+
+  // Exactly-once (issue #856): completion is legal only for the path that
+  // erases the origin from send_map_. If the dead-node timeout scan (or any
+  // other completer) got here first, this origin is already finalized —
+  // touching it again would EndTask a task whose first completion freed its
+  // RunContext.
+  if (!ClaimOrigin(net_key)) {
+    return;
+  }
 
   clio::run::DynamicContainer container =
       CLIO_POOL_MANAGER->GetStaticContainer(origin_task->pool_id_);
@@ -623,12 +654,6 @@ void IpcManagerRun2Run::RecvOutCompleteOriginTask(
   // Clearing the vector drops the last shared_ptr owner of each replica subtask,
   // freeing them via RAII (replaces the former per-subtask DelTask).
   origin_task->Subtasks().clear();
-
-  {
-    std::lock_guard<std::mutex> lk(send_map_mutex_);
-    send_map_.erase(net_key);
-    progress_map_.erase(net_key);  // #628: drop task-progress tracking
-  }
 
   auto *worker = CLIO_CUR_WORKER;
   if (worker == nullptr) {
@@ -996,29 +1021,13 @@ void IpcManagerRun2Run::ScanSendMapTimeouts() {
          "[ScanSendMapTimeouts] Task {} timed out waiting for dead node",
          origin_task->task_id_);
     origin_task->SetReturnCode(kRun2RunNetworkTimeoutRC);
-    // Fix B (#628): this runs on the net worker's periodic tick, where
-    // CLIO_CUR_WORKER can be null. Fall back to the net-recv worker rather than
-    // dereferencing null (mirrors RecvOutCompleteOriginTask).
-    auto *worker = CLIO_CUR_WORKER;
-    if (worker == nullptr) {
-      auto *scheduler = CLIO_IPC->GetScheduler();
-      worker = scheduler ? scheduler->GetNetRecvWorker() : nullptr;
-    }
-    if (worker != nullptr) {
-      worker->EndTask(origin_task, true);
-    } else {
-      HLOG(kError,
-           "[ScanSendMapTimeouts] No worker available to complete task {}",
-           origin_task->task_id_);
-    }
-  }
-
-  if (!to_complete.empty()) {
-    std::lock_guard<std::mutex> lk(send_map_mutex_);
-    for (auto &entry : to_complete) {
-      send_map_.erase(entry.first);
-      progress_map_.erase(entry.first);  // #628: drop task-progress tracking
-    }
+    // Exactly-once (issue #856): funnel through RecvOutCompleteOriginTask,
+    // whose ClaimOrigin() erases the send_map_ entry BEFORE completing. The
+    // old order (EndTask first, erase in a second pass) left a window where a
+    // late replica response found the origin still in send_map_, aggregated
+    // into the completed task, and completed it a second time — the double
+    // EndTask heap corruption behind the leader-election crashes.
+    RecvOutCompleteOriginTask(entry.first, origin_task);
   }
 }
 
@@ -1027,6 +1036,12 @@ void IpcManagerRun2Run::ScanSendMapTimeouts() {
 // =============================================================================
 
 void IpcManagerRun2Run::FlushStaleStateForNode(clio::run::u64 node_id) {
+  // Origins whose flushed retry was the last unaccounted replica; completed
+  // OUTSIDE retry_queues_mutex_ (EndTask is heavyweight and must not run
+  // under the retry lock).
+  std::vector<std::pair<size_t, clio::run::shared_ptr<clio::run::Task>>>
+      to_complete;
+  {
   std::lock_guard<std::mutex> _rqlk(retry_queues_mutex_);
 
   for (auto it = send_in_retry_.begin(); it != send_in_retry_.end();) {
@@ -1044,7 +1059,13 @@ void IpcManagerRun2Run::FlushStaleStateForNode(clio::run::u64 node_id) {
       }
     }
     if (!origin.IsNull()) {
-      origin->CompletedReplicas()++;
+      // Issue #856: same last-replica rule as the SendIn dead-skip — if this
+      // flush accounts the final replica, the origin must complete here or it
+      // never will.
+      clio::run::u32 completed = origin->CompletedReplicas().fetch_add(1) + 1;
+      if (completed == origin->Subtasks().size()) {
+        to_complete.emplace_back(net_key, origin);
+      }
     }
     HLOG(kInfo,
          "[FlushStale] Discarding SendIn retry for restarted node {}",
@@ -1061,6 +1082,11 @@ void IpcManagerRun2Run::FlushStaleStateForNode(clio::run::u64 node_id) {
          "[FlushStale] Discarding SendOut retry for restarted node {}",
          node_id);
     it = send_out_retry_.erase(it);
+  }
+  }  // release retry_queues_mutex_ before completing origins
+
+  for (auto &entry : to_complete) {
+    RecvOutCompleteOriginTask(entry.first, entry.second);
   }
 }
 

--- a/context-runtime/src/worker.cc
+++ b/context-runtime/src/worker.cc
@@ -1658,8 +1658,20 @@ void Worker::ProcessEventQueue() {
     // Skipping is safe: FUTURE_COMPLETE was already set above, so when the
     // parent's own await reaches this future it completes without suspending,
     // and the future the parent IS waiting on delivers its own event.
+    //
+    // The match must be EXACT — including when awaited is null (issue #856).
+    // Null means the parent is not suspended on any future right now: it is
+    // either running or cooperatively yielded (a periodic task, e.g.
+    // HeartbeatProbe, parked in the periodic queue between cycles). Resuming
+    // it here executes the fiber while it is still queued, so the periodic
+    // pop later resumes the same fiber a second time — two executions share
+    // one fiber stack and its frame locals are freed twice (the recovery
+    // leader's free(): invalid pointer abort in TriggerRecovery during
+    // leader-election). Both await paths record the awaited future before
+    // suspending, and a future with a null FutureShm matches null == null,
+    // so exact equality cannot strand a legitimate waiter.
     const void* awaited = parent->AwaitedFshm();
-    if (awaited != nullptr && awaited != future.GetFutureShm().ptr_) {
+    if (awaited != future.GetFutureShm().ptr_) {
       continue;
     }
     parent->SetAwaitedFshm(nullptr);


### PR DESCRIPTION
Two confirmed leader-election-recovery bugs from the #856 crash hunt. **Draft** because the primary #856 crash (fiber-frame/heap corruption in TriggerRecovery during the recovery broadcast await) is NOT yet fixed by these — they are necessary hygiene either way, and the second one fixes the 15-minute leader-elect wedge variant.

**1. Exactly-once origin completion (`ClaimOrigin`)**
An origin task with replicas on a dead node could be completed by three independent paths: the replica-count path, the #628 Gone-verdict path, and `ScanSendMapTimeouts` — and the timeout scan called `EndTask` **before** erasing `send_map_`, leaving a window where a late replica response aggregated into the finalized origin and completed it a second time (double `EndTask` → writes into a freed RunContext). `send_map_` erasure is now the single linearization point; every completer claims first.

Also: the `SendIn` dead-node skip and `FlushStaleStateForNode` incremented `CompletedReplicas` without checking for completion — if theirs was the final count the origin never completed and the awaiting client parked forever (the leader-elect 15-minute step timeout).

**2. Strict event-resume guard**
`ProcessEventQueue` resumed a parent when its awaited-future slot was **null** (not awaiting anything). For a periodic task cooperatively parked in the periodic queue, a straggler completion event resumed the fiber while it was still queued — the periodic pop then resumed the same fiber a second time.

**Validation**: 4-node leader-elect harness — Phase 1 (leader kill → failover → resent create) passes with these + diagnostics; `cte_reorganize_force_net` & friends unaffected. The remaining #856 corruption reproduces with and without these fixes and is documented on the issue with the full evidence trail (7 instrumented runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)