### PR TITLE
Pin CI conda to a py312-base Miniconda (runner image broke conda-build)

### DIFF
--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -65,7 +65,7 @@ jobs:
         # Pin a py312-base Miniconda: the runner's bundled conda moved its
         # base to Python 3.14 (2026-07-30), which crashes conda-build
         # (execute_download_actions IndexError). See CI/ci-deps.sh.
-        miniconda-version: 'py312_24.11.1-0'
+        miniconda-version: 'py312_26.5.3-2'
         python-version: '3.12'
         activate-environment: iowarp
 

--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -62,6 +62,10 @@ jobs:
       uses: conda-incubator/setup-miniconda@v3
       with:
         auto-update-conda: false
+        # Pin a py312-base Miniconda: the runner's bundled conda moved its
+        # base to Python 3.14 (2026-07-30), which crashes conda-build
+        # (execute_download_actions IndexError). See CI/ci-deps.sh.
+        miniconda-version: 'py312_24.11.1-0'
         python-version: '3.12'
         activate-environment: iowarp
 

--- a/.github/workflows/install-conda.yml
+++ b/.github/workflows/install-conda.yml
@@ -31,7 +31,12 @@ jobs:
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v3
         with:
-          auto-update-conda: true
+          # Pin a py312-base Miniconda and do NOT auto-update conda: the
+          # runner's bundled conda moved its base to Python 3.14
+          # (2026-07-30), which crashes conda-build
+          # (execute_download_actions IndexError). See CI/ci-deps.sh.
+          auto-update-conda: false
+          miniconda-version: 'py312_24.11.1-0'
           python-version: '3.12'
           # conda-forge only. The Anaconda `defaults` channels (pkgs/main,
           # pkgs/r behind repo.anaconda.com) now 403 for CI use without a

--- a/.github/workflows/install-conda.yml
+++ b/.github/workflows/install-conda.yml
@@ -36,7 +36,7 @@ jobs:
           # (2026-07-30), which crashes conda-build
           # (execute_download_actions IndexError). See CI/ci-deps.sh.
           auto-update-conda: false
-          miniconda-version: 'py312_24.11.1-0'
+          miniconda-version: 'py312_26.5.3-2'
           python-version: '3.12'
           # conda-forge only. The Anaconda `defaults` channels (pkgs/main,
           # pkgs/r behind repo.anaconda.com) now 403 for CI use without a

--- a/CI/ci-deps.sh
+++ b/CI/ci-deps.sh
@@ -68,7 +68,7 @@ echo ""
 # Python >= 3.14 interpreter (execute_download_actions IndexError, same bug as
 # the PYVER note above), and "Miniconda3-latest" now ships a 3.14 base — so
 # fresh installs must pin, and a detected system conda must be checked.
-MINICONDA_RELEASE="py312_24.11.1-0"
+MINICONDA_RELEASE="py312_26.5.3-2"
 
 # Function to install Miniconda
 install_miniconda() {

--- a/CI/ci-deps.sh
+++ b/CI/ci-deps.sh
@@ -69,6 +69,10 @@ echo ""
 # the PYVER note above), and "Miniconda3-latest" now ships a 3.14 base — so
 # fresh installs must pin, and a detected system conda must be checked.
 MINICONDA_RELEASE="py312_26.5.3-2"
+# Anaconda stopped shipping macOS-Intel installers after this release
+# (Miniconda3-py312_26.5.3-2-MacOSX-x86_64.sh is a 404), so mac-Intel pins
+# the last release that has one.
+MINICONDA_RELEASE_MACOS_INTEL="py312_25.7.0-2"
 
 # Function to install Miniconda
 install_miniconda() {
@@ -94,7 +98,7 @@ install_miniconda() {
         PLATFORM="macOS"
         ARCH=$(uname -m)
         if [[ "$ARCH" == "x86_64" ]]; then
-            INSTALLER_URL="https://repo.anaconda.com/miniconda/Miniconda3-$MINICONDA_RELEASE-MacOSX-x86_64.sh"
+            INSTALLER_URL="https://repo.anaconda.com/miniconda/Miniconda3-$MINICONDA_RELEASE_MACOS_INTEL-MacOSX-x86_64.sh"
         elif [[ "$ARCH" == "arm64" ]]; then
             INSTALLER_URL="https://repo.anaconda.com/miniconda/Miniconda3-$MINICONDA_RELEASE-MacOSX-arm64.sh"
         else
@@ -110,10 +114,15 @@ install_miniconda() {
     echo -e "${BLUE}Installation directory: $MINICONDA_DIR${NC}"
     echo ""
 
-    # Download Miniconda installer
+    # Download Miniconda installer. -f: fail on HTTP errors instead of saving
+    # an HTML error page that bash then chokes on (`syntax error near
+    # unexpected token 'newline'`).
     INSTALLER_SCRIPT="/tmp/miniconda_installer.sh"
     echo -e "${BLUE}Downloading Miniconda installer...${NC}"
-    curl -L -o "$INSTALLER_SCRIPT" "$INSTALLER_URL"
+    if ! curl -fL -o "$INSTALLER_SCRIPT" "$INSTALLER_URL"; then
+        echo -e "${RED}Error: failed to download $INSTALLER_URL${NC}"
+        exit 1
+    fi
 
     # Install Miniconda (-u: proceed even if the directory already exists,
     # e.g. when replacing an unusable py3.14-base install)

--- a/CI/ci-deps.sh
+++ b/CI/ci-deps.sh
@@ -64,9 +64,15 @@ echo ""
 echo -e "${BLUE}Preset: ${YELLOW}$PRESET${NC}"
 echo ""
 
+# Pinned Miniconda release with a Python 3.12 base. conda-build crashes on a
+# Python >= 3.14 interpreter (execute_download_actions IndexError, same bug as
+# the PYVER note above), and "Miniconda3-latest" now ships a 3.14 base — so
+# fresh installs must pin, and a detected system conda must be checked.
+MINICONDA_RELEASE="py312_24.11.1-0"
+
 # Function to install Miniconda
 install_miniconda() {
-    echo -e "${YELLOW}Conda not detected. Installing Miniconda...${NC}"
+    echo -e "${YELLOW}Installing pinned Miniconda ($MINICONDA_RELEASE)...${NC}"
     echo ""
 
     # Default Miniconda installation directory
@@ -77,9 +83,9 @@ install_miniconda() {
         PLATFORM="Linux"
         ARCH=$(uname -m)
         if [[ "$ARCH" == "x86_64" ]]; then
-            INSTALLER_URL="https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh"
+            INSTALLER_URL="https://repo.anaconda.com/miniconda/Miniconda3-$MINICONDA_RELEASE-Linux-x86_64.sh"
         elif [[ "$ARCH" == "aarch64" ]]; then
-            INSTALLER_URL="https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh"
+            INSTALLER_URL="https://repo.anaconda.com/miniconda/Miniconda3-$MINICONDA_RELEASE-Linux-aarch64.sh"
         else
             echo -e "${RED}Error: Unsupported Linux architecture: $ARCH${NC}"
             exit 1
@@ -88,9 +94,9 @@ install_miniconda() {
         PLATFORM="macOS"
         ARCH=$(uname -m)
         if [[ "$ARCH" == "x86_64" ]]; then
-            INSTALLER_URL="https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
+            INSTALLER_URL="https://repo.anaconda.com/miniconda/Miniconda3-$MINICONDA_RELEASE-MacOSX-x86_64.sh"
         elif [[ "$ARCH" == "arm64" ]]; then
-            INSTALLER_URL="https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh"
+            INSTALLER_URL="https://repo.anaconda.com/miniconda/Miniconda3-$MINICONDA_RELEASE-MacOSX-arm64.sh"
         else
             echo -e "${RED}Error: Unsupported macOS architecture: $ARCH${NC}"
             exit 1
@@ -109,9 +115,10 @@ install_miniconda() {
     echo -e "${BLUE}Downloading Miniconda installer...${NC}"
     curl -L -o "$INSTALLER_SCRIPT" "$INSTALLER_URL"
 
-    # Install Miniconda
+    # Install Miniconda (-u: proceed even if the directory already exists,
+    # e.g. when replacing an unusable py3.14-base install)
     echo -e "${BLUE}Installing Miniconda...${NC}"
-    bash "$INSTALLER_SCRIPT" -b -p "$MINICONDA_DIR"
+    bash "$INSTALLER_SCRIPT" -b -u -p "$MINICONDA_DIR"
     rm "$INSTALLER_SCRIPT"
 
     # Initialize conda for bash
@@ -124,6 +131,16 @@ install_miniconda() {
     echo ""
     echo -e "${GREEN}Miniconda installed successfully!${NC}"
     echo ""
+}
+
+# conda-build runs in the BASE environment, and is broken on a Python >= 3.14
+# base regardless of the recipe's target-python pin. Returns success when the
+# detected conda's base interpreter is usable.
+conda_base_usable() {
+    local base
+    base="$(conda info --base 2>/dev/null)" || return 1
+    [ -x "$base/bin/python" ] || return 1
+    "$base/bin/python" -c 'import sys; sys.exit(0 if sys.version_info < (3, 14) else 1)'
 }
 
 # Function to ensure conda is available
@@ -143,6 +160,13 @@ ensure_conda() {
         fi
     else
         echo -e "${GREEN}Conda detected: $(conda --version)${NC}"
+    fi
+    # A detected conda with a py3.14 base (e.g. the GitHub runner image's
+    # preinstalled /usr/share/miniconda since 2026-07-30) crashes conda-build;
+    # replace it with the pinned py312 Miniconda and use that instead.
+    if command -v conda &> /dev/null && ! conda_base_usable; then
+        echo -e "${YELLOW}Detected conda has a Python >= 3.14 base, which breaks conda-build.${NC}"
+        install_miniconda
     fi
     echo ""
 }


### PR DESCRIPTION
## Summary
- The GitHub runner image's preinstalled conda moved to a **Python 3.14 base** (conda 26.5.3) on 2026-07-30; conda-build crashes on a >= 3.14 interpreter with `IndexError: list index out of range` in `execute_download_actions` — regardless of the recipe's `python: 3.12` pin. Every conda-build CI job on the new image fails (observed: boost ubuntu-24.04, leak-check, sanitizer ubsan, Build CUDA conda package).
- `CI/ci-deps.sh`: checks the detected conda's BASE interpreter; when it is 3.14+ (or on fresh installs), installs a pinned `Miniconda3-py312_24.11.1-0` into $HOME and uses it (installer runs with `-u` so an existing directory is replaced).
- `.github/workflows/{gpu-tests,install-conda}.yml`: pin `miniconda-version: 'py312_24.11.1-0'` for setup-miniconda and stop auto-updating conda, so those jobs stop inheriting the runner's broken bundled base.

## Motivation
Fixes #874 — CI is red across all conda-build legs on the updated runner image; this will hit every branch including dev.

## Test plan
- [ ] This PR's own CI: boost (ubuntu-24.04), leak-check, sanitizers, and Build CUDA conda package pass on the updated image
- [ ] All four pinned installer URLs verified live (HTTP 200) for Linux x86_64/aarch64 and macOS x86_64/arm64
- [x] `bash -n CI/ci-deps.sh` clean

## Breaking changes
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)