### PR TITLE
test(runtime): retry detached daemon spawn on fresh ports (#848 de-flake)

### DIFF
--- a/context-runtime/test/unit/test_daemon_detached_spawn.cc
+++ b/context-runtime/test/unit/test_daemon_detached_spawn.cc
@@ -54,24 +54,37 @@ TEST_CASE("DaemonDetachedSpawn - transport initializes without a console (#721)"
   constexpr unsigned kPort = 10615;
   const std::string log_path =
       (fs::temp_directory_path() / "clio_detached_spawn.log").string();
-  ::remove(log_path.c_str());
   test::SetEnvVar("CLIO_TEST_SERVER_LOG", log_path);
   test::SetEnvVar("CTP_LOG_LEVEL", "info");
-  test::SetEnvVar("CLIO_PORT", std::to_string(kPort));
 
   // Spawn the daemon with NO controlling console (the #721 failure mode).
+  //
+  // Issue #848 (most frequent cluster member): on the Windows runners the
+  // daemon sometimes dies ~200ms into startup — its captured log ends
+  // abruptly mid-init with no error, the signature of colliding with a
+  // lingering prior daemon's port / named shared-memory segments rather
+  // than anything #721-related. Retry the spawn on a FRESH port (fresh
+  // port-keyed segment names) before declaring failure; the #721 assertion
+  // below is unaffected by which attempt produced the daemon.
   test::RuntimeServer server;
-  REQUIRE(server.Start(kPort, "127.0.0.1", /*ephemeral=*/true, /*detached=*/true));
-  const bool ready = server.WaitForReady();
-  if (!ready) {
-    // Intermittent windows-only failure mode (issue #848): the daemon dies
-    // during startup and WaitForReady returns fast via its IsRunning check.
-    // A bare REQUIRE leaves nothing to diagnose in CI, so dump the daemon's
-    // captured output and liveness before failing.
-    std::printf(
-        "[detached-spawn] daemon not ready (IsRunning=%d); daemon log "
-        "follows:\n----\n%s\n----\n",
-        static_cast<int>(server.IsRunning()), ReadWholeFile(log_path).c_str());
+  bool ready = false;
+  unsigned port = kPort;
+  for (int attempt = 0; attempt < 3 && !ready; ++attempt, port += 7) {
+    ::remove(log_path.c_str());
+    test::SetEnvVar("CLIO_PORT", std::to_string(port));
+    if (!server.Start(port, "127.0.0.1", /*ephemeral=*/true,
+                      /*detached=*/true)) {
+      continue;
+    }
+    ready = server.WaitForReady();
+    if (!ready) {
+      std::printf(
+          "[detached-spawn] attempt %d on port %u: daemon not ready "
+          "(IsRunning=%d); daemon log follows:\n----\n%s\n----\n",
+          attempt, port, static_cast<int>(server.IsRunning()),
+          ReadWholeFile(log_path).c_str());
+      server.Stop();
+    }
   }
   REQUIRE(ready);
 


### PR DESCRIPTION
De-flakes the most frequent #848 cluster member. `cr_detached_spawn`'s recurring Windows failure (fast-fail ~0.2s, 219/220 pass) shows the daemon dying ~200ms into startup with its log ending abruptly mid-init and no error — the signature of colliding with a lingering prior daemon's fixed port (10615) and port-keyed SHM segment names, not the #721 no-console transport bug this test exists to catch.

The test now retries the spawn up to 3 times, each on a fresh port (=> fresh segment names), dumping per-attempt diagnostics on failure; the #721 assertions (ROUTER reachable, no WSASTARTUP failure in the log) run unchanged against whichever attempt produced a healthy daemon.

Occurrences logged on #848: PR #871 icx, dev post-#844/#850 (x2), PR #844 icx, fix-routetask branch, luke-lmcache (today, twice including one combined with a linker file-lock transient).

🤖 Generated with [Claude Code](https://claude.com/claude-code)