### PR TITLE
fix(runtime): 30s non-worker inline-retry deadline for admin-pool tasks (#883)

### DIFF
--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -3880,8 +3880,20 @@ RouteResult IpcManager::RouteTask(Future<Task> &future, bool force_enqueue) {
         // per unroutable task there, and ServerInit's handful of exhausted
         // retries alone exceeded a 300s ctest window.
         constexpr auto kInlineRetryBudget = std::chrono::seconds(5);
+        // Admin-pool tasks get a longer leash (issue #883): the admin
+        // container is GUARANTEED to register (ServerInit creates it), but on
+        // loaded CI runners (Windows icx Debug, 2 vCPU) its worker-side
+        // registration has been observed to outlast 5 s, terminally failing
+        // embedded ClientInit -- and the whole test -- for a wedge that
+        // clears moments later (3 distinct tests on 2026-07-31, all rerun
+        // green). Waiting longer here cannot reintroduce the #849
+        // recovery-test time burn: those exhausted retries target non-admin
+        // pools and keep the 5 s deadline.
+        const auto inline_retry_budget = (task_ptr->pool_id_ == kAdminPoolId)
+                                             ? std::chrono::seconds(30)
+                                             : kInlineRetryBudget;
         const auto deadline =
-            std::chrono::steady_clock::now() + kInlineRetryBudget;
+            std::chrono::steady_clock::now() + inline_retry_budget;
         while (!task_ptr->IsPeriodic() &&
                (result == RouteResult::Retry || result == RouteResult::Dne) &&
                std::chrono::steady_clock::now() < deadline) {
@@ -3903,7 +3915,7 @@ RouteResult IpcManager::RouteTask(Future<Task> &future, bool force_enqueue) {
                "RouteTask: inline retry exhausted ({} ms) on non-worker "
                "thread; failing task pool={} method={}",
                std::chrono::duration_cast<std::chrono::milliseconds>(
-                   kInlineRetryBudget).count(),
+                   inline_retry_budget).count(),
                task_ptr->pool_id_, task_ptr->method_);
           task_ptr->SetReturnCode(static_cast<u32>(-1));
           task_ptr->SetComplete();


### PR DESCRIPTION
Fixes #883 — the recurring Windows icx startup wedge (three different tests on 2026-07-31: `fuse_cte_list_subdirs`, `cte_existing_pool_all`, `cte_query_tag_matchall`; all rerun-green).

Non-worker-thread route retries keep their 5 s wall-clock deadline (#849) — except tasks targeting `kAdminPoolId`, which now get 30 s. Rationale: the admin container is guaranteed to register (ServerInit creates it), so an admin-pool Dne is always the transient init window, never the structurally-unroutable class; terminally failing embedded ClientInit at 5 s converts a slow runner into a red test. The #849 follow-up concern (recovery-test retries burning wall clock) targets non-admin pools and is unaffected.

One-line behavioral diff; periodic tasks still fail immediately (self-blocking class), parking remains reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)