### PR TITLE
fix(hdf5): correctness pass on the CLIO VFD and VOL connectors

### DIFF
--- a/.github/workflows/ci-vfd.yml
+++ b/.github/workflows/ci-vfd.yml
@@ -89,10 +89,15 @@ jobs:
                 -DCLIO_CORE_ENABLE_GRAY_SCOTT=OFF \
                 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
                 -DCLIO_CTP_LOG_LEVEL=1
-              # Targeted build: just the VFD test target pulls in the driver +
-              # the runtime libs it depends on (add_dependencies), not the whole
+              # Targeted build: the VFD test targets pull in the driver + the
+              # runtime libs they depend on (add_dependencies), not the whole
               # adapter/test matrix.
-              cmake --build build-vfd --target clio_cte_vfd_unit_tests -j"$(nproc)"
+              #
+              # Both test binaries must be named here. ctest below selects by
+              # name (-R vfd), so any target left out is still selected and then
+              # reported as "Not Run" 
+              cmake --build build-vfd -j"$(nproc)" \
+                --target clio_cte_vfd_unit_tests clio_cte_vfd_no_runtime_tests
               # ABI gate: the VFD MUST link the same libhdf5 the tools use.
               echo "== VFD libhdf5 linkage =="
               ldd build-vfd/bin/libclio_vfd.so | grep -i hdf5

--- a/benchmarks/hdf5-ingest/vol_c_cache_identity_test.c
+++ b/benchmarks/hdf5-ingest/vol_c_cache_identity_test.c
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved. BSD 3-Clause license.
+ *
+ * VOL cache-identity regression tests. Each case here corresponds to a way the
+ * CTE blob cache could claim to hold data it does not actually hold, and each
+ * one returned WRONG DATA WITH A SUCCESS STATUS before the fix. h5py cannot
+ * express these (it picks its own memory types and does not let you re-create a
+ * file underneath a live tag), so they live in C.
+ *
+ *   1. mem/file datatype mismatch (VOL_AUDIT W3). The blob image is sized by
+ *      the TRANSFER's datatype, so writing int32 into an int64 dataset cached
+ *      4n bytes while a later int64 read asked for 8n -- hit-tested chunk_0,
+ *      found it, and reassembled 8n bytes from 4n.
+ *   2. cache outliving its file (VOL_AUDIT W4). The tag is keyed on the file
+ *      NAME, which H5F_ACC_TRUNC does not change, so blobs from a previous file
+ *      of the same name survived a re-create.
+ *   3. H5Dflush as a durability barrier (VOL_AUDIT W7). dataset_specific was a
+ *      bare pass-through, so H5Dflush returned with async CTE puts in flight.
+ *
+ * Exits 0 on pass. Run through the VOL (HDF5_VOL_CONNECTOR=clio).
+ */
+#include <hdf5.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define N 512
+static const char *kFile = "/tmp/clio_vol_cache_identity.h5";
+
+static int fail(const char *msg) {
+  printf("cache_identity: %s FAIL\n", msg);
+  return 1;
+}
+
+/* Case 1: write with a NARROWER memory type than the dataset stores, then read
+ * back with a memory type matching the file. HDF5 converts on both sides, so
+ * the values must round-trip exactly; only a cache that confused the two sizes
+ * returns anything else. */
+static int case_dtype_mismatch(void) {
+  hid_t f = H5Fcreate(kFile, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+  if (f < 0) return fail("case1 create");
+
+  hsize_t dims[1] = {N};
+  hid_t sp = H5Screate_simple(1, dims, NULL);
+  /* Dataset stores 64-bit ints ... */
+  hid_t d = H5Dcreate2(f, "mixed", H5T_STD_I64LE, sp, H5P_DEFAULT, H5P_DEFAULT,
+                       H5P_DEFAULT);
+  if (d < 0) return fail("case1 create dataset");
+
+  /* ... but the application writes 32-bit ints. */
+  int32_t w[N];
+  for (int i = 0; i < N; ++i) w[i] = i * 3 - 7;
+  if (H5Dwrite(d, H5T_NATIVE_INT32, H5S_ALL, H5S_ALL, H5P_DEFAULT, w) < 0)
+    return fail("case1 write int32");
+  H5Dclose(d);
+  H5Sclose(sp);
+  H5Fclose(f);
+
+  /* Read back with a 64-bit memory type -- a different transfer size for the
+     same dataset. Then read again with int32 to exercise both orders. */
+  f = H5Fopen(kFile, H5F_ACC_RDONLY, H5P_DEFAULT);
+  if (f < 0) return fail("case1 reopen");
+  d = H5Dopen2(f, "mixed", H5P_DEFAULT);
+  if (d < 0) return fail("case1 open dataset");
+
+  int64_t got64[N];
+  memset(got64, 0, sizeof(got64));
+  if (H5Dread(d, H5T_NATIVE_INT64, H5S_ALL, H5S_ALL, H5P_DEFAULT, got64) < 0)
+    return fail("case1 read int64");
+  for (int i = 0; i < N; ++i) {
+    if (got64[i] != (int64_t)w[i]) {
+      printf("cache_identity: case1 int64 read mismatch at %d: got %lld want %lld\n",
+             i, (long long)got64[i], (long long)w[i]);
+      return fail("case1 dtype mismatch served wrong bytes");
+    }
+  }
+
+  int32_t got32[N];
+  memset(got32, 0, sizeof(got32));
+  if (H5Dread(d, H5T_NATIVE_INT32, H5S_ALL, H5S_ALL, H5P_DEFAULT, got32) < 0)
+    return fail("case1 read int32");
+  for (int i = 0; i < N; ++i) {
+    if (got32[i] != w[i]) {
+      printf("cache_identity: case1 int32 read mismatch at %d: got %d want %d\n",
+             i, got32[i], w[i]);
+      return fail("case1 second-type read served wrong bytes");
+    }
+  }
+  H5Dclose(d);
+  H5Fclose(f);
+  return 0;
+}
+
+/* Case 2: re-create the SAME FILENAME with H5F_ACC_TRUNC, re-create a dataset
+ * of the SAME NAME, and leave it UNWRITTEN. Native semantics say an unwritten
+ * dataset reads as its fill value (0). The blob cache is keyed on the file name
+ * and the dataset path -- neither of which the truncate changed -- so a tag that
+ * survives the re-create still holds the OLD file's bytes under that exact key
+ * and serves them as a hit.
+ *
+ * Leaving the dataset unwritten is what makes this observable: any write through
+ * the connector would re-stage the chunks and paper over the stale tag. */
+static int case_truncate_drops_cache(void) {
+  hsize_t dims[1] = {N};
+  hid_t sp = H5Screate_simple(1, dims, NULL);
+
+  /* Run 1: populate "d" and read it back so it is definitely staged. */
+  hid_t f = H5Fcreate(kFile, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+  if (f < 0) return fail("case2 create #1");
+  hid_t d = H5Dcreate2(f, "d", H5T_NATIVE_INT32, sp, H5P_DEFAULT, H5P_DEFAULT,
+                       H5P_DEFAULT);
+  int32_t w[N];
+  for (int i = 0; i < N; ++i) w[i] = 1000 + i;
+  if (d < 0 || H5Dwrite(d, H5T_NATIVE_INT32, H5S_ALL, H5S_ALL, H5P_DEFAULT, w) < 0)
+    return fail("case2 write #1");
+  H5Dclose(d);
+  H5Fclose(f);
+
+  f = H5Fopen(kFile, H5F_ACC_RDONLY, H5P_DEFAULT);
+  d = H5Dopen2(f, "d", H5P_DEFAULT);
+  int32_t warm[N];
+  if (d < 0 || H5Dread(d, H5T_NATIVE_INT32, H5S_ALL, H5S_ALL, H5P_DEFAULT, warm) < 0)
+    return fail("case2 warm read");
+  H5Dclose(d);
+  H5Fclose(f);
+
+  /* Run 2: same filename, same dataset name, never written. */
+  f = H5Fcreate(kFile, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+  if (f < 0) return fail("case2 create #2");
+  hid_t d2 = H5Dcreate2(f, "d", H5T_NATIVE_INT32, sp, H5P_DEFAULT, H5P_DEFAULT,
+                        H5P_DEFAULT);
+  if (d2 < 0) return fail("case2 create dataset #2");
+  H5Dclose(d2);
+  H5Sclose(sp);
+  H5Fclose(f);
+
+  f = H5Fopen(kFile, H5F_ACC_RDONLY, H5P_DEFAULT);
+  if (f < 0) return fail("case2 reopen");
+  d2 = H5Dopen2(f, "d", H5P_DEFAULT);
+  int32_t got[N];
+  for (int i = 0; i < N; ++i) got[i] = -1;
+  if (d2 < 0 || H5Dread(d2, H5T_NATIVE_INT32, H5S_ALL, H5S_ALL, H5P_DEFAULT, got) < 0)
+    return fail("case2 read unwritten dataset");
+  H5Dclose(d2);
+  H5Fclose(f);
+  for (int i = 0; i < N; ++i) {
+    if (got[i] != 0) {
+      printf("cache_identity: case2 unwritten dataset at %d: got %d want 0 "
+             "(this is run 1's value %d)\n", i, got[i], w[i]);
+      return fail("case2 cache outlived H5F_ACC_TRUNC of its file");
+    }
+  }
+  return 0;
+}
+
+/* Case 3: H5Dflush must leave a complete, readable image in the native file for
+ * an independent reader while the writer is still open.
+ *
+ * NOTE on what this does and does not prove. The connector writes through to
+ * native synchronously, so native visibility here is not the thing that was
+ * broken -- the W7 gap was that H5Dflush returned with async CTE puts still in
+ * flight. That drain is internal and has no observable at this layer (the same
+ * limitation the VFD suite notes for fsync). This case pins the native-side
+ * contract and guards the pass-through wiring around the new drain; it is not a
+ * test of the drain itself. */
+static int case_dataset_flush_barrier(void) {
+  hid_t fapl = H5Pcreate(H5P_FILE_ACCESS);
+  H5Pset_file_locking(fapl, 0, 1); /* reader must not be blocked by the writer */
+
+  hid_t f = H5Fcreate(kFile, H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
+  if (f < 0) return fail("case3 create");
+  hsize_t dims[1] = {N};
+  hid_t sp = H5Screate_simple(1, dims, NULL);
+  hid_t d = H5Dcreate2(f, "flushed", H5T_NATIVE_INT32, sp, H5P_DEFAULT,
+                       H5P_DEFAULT, H5P_DEFAULT);
+  int32_t w[N];
+  for (int i = 0; i < N; ++i) w[i] = i ^ 0x5a5a;
+  if (d < 0 || H5Dwrite(d, H5T_NATIVE_INT32, H5S_ALL, H5S_ALL, H5P_DEFAULT, w) < 0)
+    return fail("case3 write");
+
+  if (H5Dflush(d) < 0) return fail("case3 H5Dflush");
+
+  /* Independent handle, writer still open. */
+  hid_t rf = H5Fopen(kFile, H5F_ACC_RDONLY, fapl);
+  if (rf < 0) return fail("case3 independent open after H5Dflush");
+  hid_t rd = H5Dopen2(rf, "flushed", H5P_DEFAULT);
+  int32_t got[N];
+  memset(got, 0, sizeof(got));
+  int ok = (rd >= 0 &&
+            H5Dread(rd, H5T_NATIVE_INT32, H5S_ALL, H5S_ALL, H5P_DEFAULT, got) >= 0 &&
+            memcmp(got, w, sizeof(w)) == 0);
+  if (rd >= 0) H5Dclose(rd);
+  H5Fclose(rf);
+  H5Dclose(d);
+  H5Sclose(sp);
+  H5Fclose(f);
+  H5Pclose(fapl);
+  if (!ok) return fail("case3 data not visible after H5Dflush");
+  return 0;
+}
+
+int main(void) {
+  /* Run every case even after one fails: these are three independent
+     regressions, and knowing which of them a change broke is the whole point. */
+  remove(kFile);
+  int bad = 0;
+  bad += case_dtype_mismatch();
+  remove(kFile);
+  bad += case_truncate_drops_cache();
+  remove(kFile);
+  bad += case_dataset_flush_barrier();
+  remove(kFile);
+  if (bad) {
+    printf("cache_identity: %d/3 cases FAIL\n", bad);
+    return 1;
+  }
+  printf("cache_identity: dtype-mismatch + truncate-drop + H5Dflush PASS\n");
+  return 0;
+}

--- a/benchmarks/hdf5-ingest/vol_c_error_propagation_test.c
+++ b/benchmarks/hdf5-ingest/vol_c_error_propagation_test.c
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved. BSD 3-Clause license.
+ *
+ * Failures reaching the application.
+ *
+ * The native VOL owns the file, so its verdict on an operation IS the
+ * connector's verdict. An operation that failed underneath must surface as a
+ * failure, never be swallowed into a success return with an untouched or
+ * partially-filled user buffer -- an application that is told its read
+ * succeeded has no reason to look at the data again.
+ *
+ * Failures are injected by damaging the file underneath HDF5 rather than by
+ * mocking, so what is exercised is the real error path.
+ *
+ * Exits 0 on pass. Run through the connector (HDF5_VOL_CONNECTOR=clio).
+ */
+#include <hdf5.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define N 4096
+static const char *kFile = "/tmp/clio_vol_error_prop.h5";
+
+static int fail(const char *msg) {
+  printf("error_propagation: %s FAIL\n", msg);
+  return 1;
+}
+
+/* Flip a byte inside the dataset's stored payload by locating the written
+ * pattern in the file. Returns 0 if the pattern was not found (the caller then
+ * skips rather than reporting a false pass). */
+static int corrupt_payload(const char *path, const int32_t *pattern,
+                           size_t pattern_bytes) {
+  FILE *f = fopen(path, "r+b");
+  if (!f) return 0;
+  fseek(f, 0, SEEK_END);
+  long len = ftell(f);
+  fseek(f, 0, SEEK_SET);
+  char *buf = (char *)malloc((size_t)len);
+  if (!buf || fread(buf, 1, (size_t)len, f) != (size_t)len) {
+    free(buf);
+    fclose(f);
+    return 0;
+  }
+  int found = 0;
+  /* Look for the first 64 bytes of the payload; enough to be unique. */
+  size_t needle = pattern_bytes < 64 ? pattern_bytes : 64;
+  for (long i = 0; i + (long)needle <= len; ++i) {
+    if (memcmp(buf + i, pattern, needle) == 0) {
+      /* Flip a bit well inside the payload so the checksum, not the layout,
+         is what disagrees. */
+      long target = i + (long)needle / 2;
+      fseek(f, target, SEEK_SET);
+      unsigned char b = (unsigned char)buf[target] ^ 0xFFu;
+      fwrite(&b, 1, 1, f);
+      found = 1;
+      break;
+    }
+  }
+  free(buf);
+  fclose(f);
+  return found;
+}
+
+/* A dataset whose stored bytes no longer match its checksum cannot be read.
+ * The connector must pass that failure up rather than returning success with
+ * whatever happened to be in the buffer. */
+static int case_read_failure_is_reported(void) {
+  remove(kFile);
+  int32_t w[N];
+  for (int i = 0; i < N; ++i) w[i] = 0x5EED0000 + i;
+
+  hid_t f = H5Fcreate(kFile, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+  if (f < 0) return fail("read: create");
+  hsize_t dims[1] = {N}, chunk[1] = {N};
+  hid_t sp = H5Screate_simple(1, dims, NULL);
+  hid_t dcpl = H5Pcreate(H5P_DATASET_CREATE);
+  H5Pset_chunk(dcpl, 1, chunk);
+  if (H5Pset_fletcher32(dcpl) < 0) return fail("read: enable checksum");
+  hid_t d = H5Dcreate2(f, "guarded", H5T_NATIVE_INT32, sp, H5P_DEFAULT, dcpl,
+                       H5P_DEFAULT);
+  if (d < 0 || H5Dwrite(d, H5T_NATIVE_INT32, H5S_ALL, H5S_ALL, H5P_DEFAULT, w) < 0)
+    return fail("read: write");
+  H5Dclose(d);
+  H5Pclose(dcpl);
+  H5Sclose(sp);
+  H5Fclose(f);
+
+  /* Filters may compress or reorder the payload; if the raw pattern is not
+     findable, say so rather than claiming a pass. */
+  if (!corrupt_payload(kFile, w, sizeof(w))) {
+    printf("error_propagation: SKIP read case (payload not locatable on disk)\n");
+    return 0;
+  }
+
+  f = H5Fopen(kFile, H5F_ACC_RDONLY, H5P_DEFAULT);
+  if (f < 0) return fail("read: reopen after corruption");
+  d = H5Dopen2(f, "guarded", H5P_DEFAULT);
+  if (d < 0) return fail("read: open dataset after corruption");
+
+  int32_t got[N];
+  for (int i = 0; i < N; ++i) got[i] = -1;
+  H5E_auto2_t af = NULL;
+  void *ad = NULL;
+  H5Eget_auto2(H5E_DEFAULT, &af, &ad);
+  H5Eset_auto2(H5E_DEFAULT, NULL, NULL); /* the failure is expected */
+  herr_t rc = H5Dread(d, H5T_NATIVE_INT32, H5S_ALL, H5S_ALL, H5P_DEFAULT, got);
+  H5Eset_auto2(H5E_DEFAULT, af, ad);
+  H5Dclose(d);
+  H5Fclose(f);
+
+  if (rc >= 0) {
+    printf("error_propagation: H5Dread returned success (%d) for a dataset "
+           "whose stored bytes fail their checksum\n", (int)rc);
+    return fail("read: a failed read was reported as success");
+  }
+  return 0;
+}
+
+/* A dataset whose raw data lives in an external file that cannot be opened
+ * fails to write. That failure originates below the connector and must arrive
+ * at the caller intact. */
+static int case_write_failure_is_reported(void) {
+  const char *path = "/tmp/clio_vol_error_prop_ext.h5";
+  remove(path);
+  int32_t w[N];
+  for (int i = 0; i < N; ++i) w[i] = i;
+
+  hid_t f = H5Fcreate(path, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+  if (f < 0) return fail("write: create");
+  hsize_t dims[1] = {N};
+  hid_t sp = H5Screate_simple(1, dims, NULL);
+  hid_t dcpl = H5Pcreate(H5P_DATASET_CREATE);
+  /* A directory that does not exist, so the backing store cannot be opened. */
+  H5Pset_external(dcpl, "/nonexistent-dir-for-clio-test/payload.dat", 0,
+                  (hsize_t)sizeof(w));
+
+  H5E_auto2_t af = NULL;
+  void *ad = NULL;
+  H5Eget_auto2(H5E_DEFAULT, &af, &ad);
+  H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
+  hid_t d = H5Dcreate2(f, "external", H5T_NATIVE_INT32, sp, H5P_DEFAULT, dcpl,
+                       H5P_DEFAULT);
+  herr_t rc = 0;
+  int reached_write = 0;
+  if (d >= 0) {
+    reached_write = 1;
+    rc = H5Dwrite(d, H5T_NATIVE_INT32, H5S_ALL, H5S_ALL, H5P_DEFAULT, w);
+    H5Dclose(d);
+  }
+  H5Eset_auto2(H5E_DEFAULT, af, ad);
+  H5Pclose(dcpl);
+  H5Sclose(sp);
+  H5Fclose(f);
+  remove(path);
+
+  if (!reached_write) {
+    /* HDF5 refused earlier than the connector; nothing was silently accepted,
+       which is the property under test, but the connector's own path was not
+       exercised. Report honestly rather than counting it as coverage. */
+    printf("error_propagation: SKIP write case (rejected before reaching the "
+           "connector)\n");
+    return 0;
+  }
+  if (rc >= 0) {
+    printf("error_propagation: H5Dwrite returned success (%d) for a dataset "
+           "whose external storage cannot be opened\n", (int)rc);
+    return fail("write: a failed write was reported as success");
+  }
+  return 0;
+}
+
+int main(void) {
+  /* Run with caching off, so what is measured is the error path and nothing
+     else.
+
+     This is not incidental. With caching on, the read case below does NOT
+     fail: the connector stages the dataset when it is written, and a read
+     after the file has been damaged underneath is served from that staged copy
+     — correct-looking data for a file that no longer contains it. That is the
+     known limitation recorded as the external-modification half of the cache
+     staleness gap: the connector detects a file being re-created, but not one
+     edited behind its back between sessions. Until that is closed, a test of
+     the error path has to bypass the cache to reach the error path at all. */
+  setenv("CLIO_VOL_CACHE", "0", /*overwrite*/ 0);
+
+  int bad = 0;
+  bad += case_read_failure_is_reported();
+  bad += case_write_failure_is_reported();
+  remove(kFile);
+  if (bad) {
+    printf("error_propagation: %d case(s) FAIL\n", bad);
+    return 1;
+  }
+  printf("error_propagation: failures reach the application PASS\n");
+  return 0;
+}

--- a/benchmarks/hdf5-ingest/vol_c_passthrough_ops_test.c
+++ b/benchmarks/hdf5-ingest/vol_c_passthrough_ops_test.c
@@ -141,9 +141,31 @@ static int case_direct_chunk_io(void) {
   int32_t back[N / 4];
   memset(back, 0, sizeof(back));
   uint32_t filters = 0;
+  /* H5Dread_chunk is a VERSIONED API symbol, and the two forms differ in
+   * arity. H5version.h resolves it through H5Dread_chunk_vers: version 2
+   * (HDF5 2.x, which added a buffer-size argument) or version 1 (the 5-argument
+   * form, which is all that exists on 1.14). CI builds against both -- HDF5
+   * 2.1.1 in deps-cpu on Linux, conda-forge 1.14.6 on macOS -- and the project
+   * supports HDF5 >= 1.14, so this has to compile either way.
+   *
+   * Branch on H5Dread_chunk_vers rather than on the library version: the API
+   * version is set independently (H5_USE_114_API on a 2.x library selects
+   * version 1), so the library version does not tell you which form you get.
+   * Do NOT instead pin this to version 1 to get a single code path -- the
+   * version-1 declaration lives inside #ifndef H5_NO_DEPRECATED_SYMBOLS, so a
+   * 2.x build with deprecated symbols disabled would not have it.
+   *
+   * Both forms read the same chunk; version 2's extra argument is a bounds
+   * check on the destination, so nothing this test asserts depends on which
+   * one ran. */
+#if defined(H5Dread_chunk_vers) && H5Dread_chunk_vers >= 2
   size_t back_size = sizeof(back);
   if (H5Dread_chunk(d, H5P_DEFAULT, off, &filters, back, &back_size) < 0)
     return fail("H5Dread_chunk");
+#else
+  if (H5Dread_chunk(d, H5P_DEFAULT, off, &filters, back) < 0)
+    return fail("H5Dread_chunk");
+#endif
   if (memcmp(back, raw, sizeof(raw)) != 0)
     return fail("a chunk did not survive a direct write/read");
 

--- a/benchmarks/hdf5-ingest/vol_c_passthrough_ops_test.c
+++ b/benchmarks/hdf5-ingest/vol_c_passthrough_ops_test.c
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved. BSD 3-Clause license.
+ *
+ * Operations that must work through the connector unchanged.
+ *
+ * A pass-through connector forwards what it does not itself implement. How an
+ * unforwarded operation behaves varies: HDF5 routes some of these through
+ * paths that survive a missing callback (a rename can be expressed as a hard
+ * link plus a delete; token comparison has a byte-wise fallback), while others
+ * fail outright. That variation is the reason to assert on the operations
+ * rather than reason about them -- checked against this connector, all of the
+ * below work, and this pins that so a future change cannot quietly remove one.
+ *
+ * These are the operations most likely to be overlooked, because none of them
+ * touch the cache path that gets all the attention:
+ *
+ *   1. Renaming a link.
+ *   2. Comparing and serialising object tokens (how H5Oget_info-driven code
+ *      establishes object identity).
+ *   3. Reading and writing chunks directly, bypassing the filter pipeline.
+ *   4. Running with the cache switched off entirely, which must be a correct
+ *      (if unaccelerated) mode rather than a broken one.
+ *   5. Reading a selection from a dataset larger than the connector is willing
+ *      to serve from cache -- the answer must still be right, just fetched
+ *      from the file instead.
+ *
+ * Exits 0 on pass. Run through the connector (HDF5_VOL_CONNECTOR=clio).
+ */
+#include <hdf5.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define N 1024
+static const char *kFile = "/tmp/clio_vol_passthrough_ops.h5";
+
+static int fail(const char *msg) {
+  printf("passthrough_ops: %s FAIL\n", msg);
+  return 1;
+}
+
+static int32_t g_vals[N];
+static void fill(void) {
+  for (int i = 0; i < N; ++i) g_vals[i] = i * 11 - 5;
+}
+
+static int write_dset(hid_t loc, const char *name) {
+  hsize_t dims[1] = {N};
+  hid_t sp = H5Screate_simple(1, dims, NULL);
+  hid_t d = H5Dcreate2(loc, name, H5T_NATIVE_INT32, sp, H5P_DEFAULT,
+                       H5P_DEFAULT, H5P_DEFAULT);
+  int ok = (d >= 0 && H5Dwrite(d, H5T_NATIVE_INT32, H5S_ALL, H5S_ALL,
+                               H5P_DEFAULT, g_vals) >= 0);
+  if (d >= 0) H5Dclose(d);
+  H5Sclose(sp);
+  return ok;
+}
+
+static int read_dset_eq(hid_t loc, const char *name) {
+  hid_t d = H5Dopen2(loc, name, H5P_DEFAULT);
+  if (d < 0) return 0;
+  int32_t got[N];
+  memset(got, 0, sizeof(got));
+  int ok = (H5Dread(d, H5T_NATIVE_INT32, H5S_ALL, H5S_ALL, H5P_DEFAULT, got) >= 0 &&
+            memcmp(got, g_vals, sizeof(g_vals)) == 0);
+  H5Dclose(d);
+  return ok;
+}
+
+/* Renaming a link, and object identity via tokens. */
+static int case_link_rename_and_tokens(void) {
+  remove(kFile);
+  hid_t f = H5Fcreate(kFile, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+  if (f < 0) return fail("create");
+  if (!write_dset(f, "original")) return fail("seed dataset");
+
+  if (H5Lmove(f, "original", f, "renamed", H5P_DEFAULT, H5P_DEFAULT) < 0)
+    return fail("H5Lmove");
+  if (H5Lexists(f, "original", H5P_DEFAULT) > 0)
+    return fail("the old link still exists after a rename");
+  if (H5Lexists(f, "renamed", H5P_DEFAULT) <= 0)
+    return fail("the new link is missing after a rename");
+  if (!read_dset_eq(f, "renamed"))
+    return fail("data changed across a rename");
+
+  /* Two links to one object must report identical tokens; a different object
+     must not. Also round-trip a token through its string form. */
+  if (H5Lcreate_hard(f, "renamed", f, "alias", H5P_DEFAULT, H5P_DEFAULT) < 0)
+    return fail("H5Lcreate_hard");
+  if (!write_dset(f, "other")) return fail("second dataset");
+
+  H5O_info2_t a, b, c;
+  if (H5Oget_info_by_name3(f, "renamed", &a, H5O_INFO_BASIC, H5P_DEFAULT) < 0 ||
+      H5Oget_info_by_name3(f, "alias", &b, H5O_INFO_BASIC, H5P_DEFAULT) < 0 ||
+      H5Oget_info_by_name3(f, "other", &c, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
+    return fail("H5Oget_info_by_name3");
+
+  int cmp = 1;
+  if (H5Otoken_cmp(f, &a.token, &b.token, &cmp) < 0)
+    return fail("H5Otoken_cmp on two links to one object");
+  if (cmp != 0) return fail("two links to one object compared as different");
+  if (H5Otoken_cmp(f, &a.token, &c.token, &cmp) < 0)
+    return fail("H5Otoken_cmp on two different objects");
+  if (cmp == 0) return fail("two different objects compared as identical");
+
+  char *tok_str = NULL;
+  H5O_token_t back;
+  if (H5Otoken_to_str(f, &a.token, &tok_str) < 0 || tok_str == NULL)
+    return fail("H5Otoken_to_str");
+  if (H5Otoken_from_str(f, tok_str, &back) < 0)
+    return fail("H5Otoken_from_str");
+  H5free_memory(tok_str);
+  if (H5Otoken_cmp(f, &a.token, &back, &cmp) < 0 || cmp != 0)
+    return fail("a token did not survive a round-trip through its string form");
+
+  H5Fclose(f);
+  return 0;
+}
+
+/* Chunk-level reads and writes, which bypass the filter pipeline entirely. */
+static int case_direct_chunk_io(void) {
+  const char *path = "/tmp/clio_vol_passthrough_chunk.h5";
+  remove(path);
+  hid_t f = H5Fcreate(path, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+  if (f < 0) return fail("chunk: create");
+  hsize_t dims[1] = {N}, chunk[1] = {N / 4};
+  hid_t sp = H5Screate_simple(1, dims, NULL);
+  hid_t dcpl = H5Pcreate(H5P_DATASET_CREATE);
+  H5Pset_chunk(dcpl, 1, chunk);
+  hid_t d = H5Dcreate2(f, "chunked", H5T_NATIVE_INT32, sp, H5P_DEFAULT, dcpl,
+                       H5P_DEFAULT);
+  if (d < 0) return fail("chunk: create dataset");
+
+  int32_t raw[N / 4];
+  for (int i = 0; i < N / 4; ++i) raw[i] = 0x1234 + i;
+  hsize_t off[1] = {0};
+  if (H5Dwrite_chunk(d, H5P_DEFAULT, 0, off, sizeof(raw), raw) < 0)
+    return fail("H5Dwrite_chunk");
+
+  int32_t back[N / 4];
+  memset(back, 0, sizeof(back));
+  uint32_t filters = 0;
+  size_t back_size = sizeof(back);
+  if (H5Dread_chunk(d, H5P_DEFAULT, off, &filters, back, &back_size) < 0)
+    return fail("H5Dread_chunk");
+  if (memcmp(back, raw, sizeof(raw)) != 0)
+    return fail("a chunk did not survive a direct write/read");
+
+  H5Dclose(d);
+  H5Pclose(dcpl);
+  H5Sclose(sp);
+  H5Fclose(f);
+  remove(path);
+  return 0;
+}
+
+/* With caching switched off the connector is a plain pass-through. Data must
+ * still be correct, and files must still be ordinary HDF5 files. */
+static int case_cache_disabled(void) {
+  const char *path = "/tmp/clio_vol_passthrough_nocache.h5";
+  remove(path);
+  setenv("CLIO_VOL_CACHE", "0", 1);
+
+  hid_t f = H5Fcreate(path, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+  if (f < 0) { unsetenv("CLIO_VOL_CACHE"); return fail("no-cache: create"); }
+  int ok = write_dset(f, "d");
+  H5Fclose(f);
+  if (!ok) { unsetenv("CLIO_VOL_CACHE"); return fail("no-cache: write"); }
+
+  f = H5Fopen(path, H5F_ACC_RDONLY, H5P_DEFAULT);
+  ok = (f >= 0 && read_dset_eq(f, "d"));
+  if (f >= 0) H5Fclose(f);
+  unsetenv("CLIO_VOL_CACHE");
+  if (!ok) return fail("no-cache: data did not round-trip with caching off");
+
+  /* And the same file re-reads correctly with caching back on. */
+  f = H5Fopen(path, H5F_ACC_RDONLY, H5P_DEFAULT);
+  ok = (f >= 0 && read_dset_eq(f, "d"));
+  if (f >= 0) H5Fclose(f);
+  remove(path);
+  if (!ok) return fail("no-cache: a file written with caching off reads wrong "
+                       "with caching on");
+  return 0;
+}
+
+/* A selection read from a dataset above the serve ceiling must fall back to
+ * the file and still return the right answer. */
+static int case_selection_above_serve_ceiling(void) {
+  const char *path = "/tmp/clio_vol_passthrough_ceiling.h5";
+  remove(path);
+  hid_t f = H5Fcreate(path, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+  if (f < 0) return fail("ceiling: create");
+  if (!write_dset(f, "big")) return fail("ceiling: write");
+  H5Fclose(f);
+
+  f = H5Fopen(path, H5F_ACC_RDONLY, H5P_DEFAULT);
+  if (f < 0) return fail("ceiling: reopen");
+  hid_t d = H5Dopen2(f, "big", H5P_DEFAULT);
+  if (d < 0) return fail("ceiling: open dataset");
+
+  /* Warm the cache with a whole read, then take a hyperslab -- the path that
+     would serve from cache if the dataset were small enough to. */
+  int32_t whole[N];
+  if (H5Dread(d, H5T_NATIVE_INT32, H5S_ALL, H5S_ALL, H5P_DEFAULT, whole) < 0)
+    return fail("ceiling: warming read");
+
+  hid_t fs = H5Dget_space(d);
+  hsize_t start[1] = {N / 4}, count[1] = {N / 2};
+  H5Sselect_hyperslab(fs, H5S_SELECT_SET, start, NULL, count, NULL);
+  hid_t ms = H5Screate_simple(1, count, NULL);
+  int32_t part[N / 2];
+  memset(part, 0, sizeof(part));
+  if (H5Dread(d, H5T_NATIVE_INT32, ms, fs, H5P_DEFAULT, part) < 0)
+    return fail("ceiling: hyperslab read");
+  for (hsize_t i = 0; i < count[0]; ++i) {
+    if (part[i] != g_vals[start[0] + i]) {
+      printf("passthrough_ops: ceiling mismatch at %llu: got %d want %d\n",
+             (unsigned long long)i, part[i], g_vals[start[0] + i]);
+      return fail("ceiling: selection above the serve ceiling read wrong data");
+    }
+  }
+  H5Sclose(ms);
+  H5Sclose(fs);
+  H5Dclose(d);
+  H5Fclose(f);
+  remove(path);
+  return 0;
+}
+
+int main(void) {
+  /* Force every dataset in this program above the cache-serving ceiling, so
+     the fallback path is what runs. Must be set before the first selection
+     read -- the limit is read once. */
+  setenv("CLIO_VOL_MAX_SERVE_BYTES", "16", /*overwrite*/ 0);
+
+  fill();
+  int bad = 0;
+  bad += case_link_rename_and_tokens();
+  bad += case_direct_chunk_io();
+  bad += case_cache_disabled();
+  bad += case_selection_above_serve_ceiling();
+  remove(kFile);
+  if (bad) {
+    printf("passthrough_ops: %d case(s) FAIL\n", bad);
+    return 1;
+  }
+  printf("passthrough_ops: rename + tokens + direct chunk I/O + cache-off + "
+         "serve ceiling PASS\n");
+  return 0;
+}

--- a/benchmarks/hdf5-ingest/vol_compat_suite.py
+++ b/benchmarks/hdf5-ingest/vol_compat_suite.py
@@ -472,12 +472,18 @@ def _run_c_tests():
     """Compile + run the isolated C tests through the VOL. Returns
     {name: {"pass": bool}}; each C program exits 0 on pass. These cover ops h5py
     cannot exercise well via a non-native VOL: modern-API iteration
-    (c_iteration), Safe-mode H5Fflush durability (c_safeflush), and
-    selection-aware read caching + partial-write invalidation (c_selection)."""
+    (c_iteration), Safe-mode H5Fflush durability (c_safeflush),
+    selection-aware read caching + partial-write invalidation (c_selection), and
+    the cache-identity regressions (c_cache_identity): mem/file datatype
+    mismatch, a cache surviving H5F_ACC_TRUNC of its file, and H5Dflush as a
+    barrier. Each of those three returned wrong data with a success status."""
     src_dir = os.path.dirname(os.path.abspath(__file__))
     tests = {"c_iteration": "vol_c_iteration_test.c",
              "c_safeflush": "vol_c_safeflush_test.c",
-             "c_selection": "vol_c_selection_test.c"}
+             "c_selection": "vol_c_selection_test.c",
+             "c_cache_identity": "vol_c_cache_identity_test.c",
+             "c_error_propagation": "vol_c_error_propagation_test.c",
+             "c_passthrough_ops": "vol_c_passthrough_ops_test.c"}
     out = {}
     for name, src in tests.items():
         binp = os.path.join(TMP, name)

--- a/benchmarks/hdf5-ingest/vol_compat_suite.py
+++ b/benchmarks/hdf5-ingest/vol_compat_suite.py
@@ -468,6 +468,70 @@ def _compile_c(binp, srcp):
     return comp
 
 
+# Probes that did not COMPILE, kept apart from probes that compiled and failed.
+# A build error means the connector's behaviour was never measured, which is a
+# different fact with a different owner and a different fix than "the connector
+# is incompatible". Both are fatal; only one of them is a statement about the
+# VOL. Populated by _build_probe, reported separately by driver().
+BUILD_ERRORS = {}
+
+# Every C probe the suite compiles, name -> source. Built up front by
+# _build_probe_set so a build error is reported before any case runs, rather
+# than surfacing mid-run as a single mysterious case failure.
+C_PROBES = {
+    "c_iteration":         "vol_c_iteration_test.c",
+    "c_safeflush":         "vol_c_safeflush_test.c",
+    "c_selection":         "vol_c_selection_test.c",
+    "c_cache_identity":    "vol_c_cache_identity_test.c",
+    "c_error_propagation": "vol_c_error_propagation_test.c",
+    "c_passthrough_ops":   "vol_c_passthrough_ops_test.c",
+}
+
+
+def _build_probe(name, binp, srcp):
+    """Compile one C probe. True on success; on failure records the reason in
+    BUILD_ERRORS and prints the compiler's FULL diagnostics.
+
+    Full, not truncated: a tail slice is the wrong end of a compiler error.
+    Compilers put the message first and the caret art last, so keeping the last
+    N characters reliably discards the sentence naming the problem and keeps
+    `~~~~~~~` -- which is exactly how an HDF5 API-arity mismatch reached CI
+    looking like an unexplained incompatibility."""
+    comp = _compile_c(binp, srcp)
+    if comp is not None and comp.returncode == 0:
+        return True
+    if comp is None:
+        BUILD_ERRORS[name] = "no C compiler (h5cc/gcc) found"
+        print(f"  {name:<20} BUILD-ERROR  no C compiler (h5cc/gcc) found")
+        return False
+    err = comp.stderr.strip() or comp.stdout.strip() or "(no compiler output)"
+    # One-line summary for the end-of-run block: the first line that actually
+    # says "error", not merely the first line -- compilers open with context
+    # ("In function 'main':") and with warnings that precede the real cause.
+    lines = err.splitlines()
+    BUILD_ERRORS[name] = next((l.strip() for l in lines if "error:" in l),
+                              lines[0].strip() if lines else "compile failed")
+    print(f"  {name:<20} BUILD-ERROR  did not compile; full output follows")
+    for line in err.splitlines():
+        print(f"      | {line}")
+    return False
+
+
+def _build_probe_set():
+    """Build every C probe before any case runs. Fails loudly and completely:
+    all build errors are reported in one pass, not one per run."""
+    src_dir = os.path.dirname(os.path.abspath(__file__))
+    os.makedirs(TMP, exist_ok=True)
+    for name, src in C_PROBES.items():
+        _build_probe(name, os.path.join(TMP, name),
+                     os.path.join(src_dir, src))
+    if BUILD_ERRORS:
+        print(f"  {len(BUILD_ERRORS)} of {len(C_PROBES)} C probes did not build; "
+              "their coverage is UNMEASURED (not 'passing', not 'incompatible')")
+    else:
+        print(f"  all {len(C_PROBES)} C probes built")
+
+
 def _run_c_tests():
     """Compile + run the isolated C tests through the VOL. Returns
     {name: {"pass": bool}}; each C program exits 0 on pass. These cover ops h5py
@@ -478,21 +542,17 @@ def _run_c_tests():
     mismatch, a cache surviving H5F_ACC_TRUNC of its file, and H5Dflush as a
     barrier. Each of those three returned wrong data with a success status."""
     src_dir = os.path.dirname(os.path.abspath(__file__))
-    tests = {"c_iteration": "vol_c_iteration_test.c",
-             "c_safeflush": "vol_c_safeflush_test.c",
-             "c_selection": "vol_c_selection_test.c",
-             "c_cache_identity": "vol_c_cache_identity_test.c",
-             "c_error_propagation": "vol_c_error_propagation_test.c",
-             "c_passthrough_ops": "vol_c_passthrough_ops_test.c"}
     out = {}
-    for name, src in tests.items():
+    for name, src in C_PROBES.items():
         binp = os.path.join(TMP, name)
         srcp = os.path.join(src_dir, src)
-        comp = _compile_c(binp, srcp)
-        if comp is None or comp.returncode != 0:
-            detail = (comp.stderr.strip()[-120:] if comp is not None
-                      else "no C compiler (h5cc/gcc) found")
-            print(f"  {name:<20} COMPILE-FAIL  {detail}")
+        # Already built (and already reported) by _build_probe_set; retry here
+        # only for a standalone caller that skipped that step.
+        if name in BUILD_ERRORS:
+            print(f"  {name:<20} BUILD-ERROR  not run: {BUILD_ERRORS[name]}")
+            out[name] = {"pass": False}
+            continue
+        if not os.path.exists(binp) and not _build_probe(name, binp, srcp):
             out[name] = {"pass": False}
             continue
         r = subprocess.run([binp], capture_output=True, text=True,
@@ -517,11 +577,8 @@ def _run_trace_check():
     src_dir = os.path.dirname(os.path.abspath(__file__))
     binp = os.path.join(TMP, "c_selection")  # reuse the c_selection binary
     srcp = os.path.join(src_dir, "vol_c_selection_test.c")
-    if not os.path.exists(binp):
-        comp = _compile_c(binp, srcp)
-        if comp is None or comp.returncode != 0:
-            print(f"  {'telemetry':<20} COMPILE-FAIL")
-            return {"telemetry": {"pass": False}}
+    if not os.path.exists(binp) and not _build_probe("telemetry", binp, srcp):
+        return {"telemetry": {"pass": False}}
     tdir = os.path.join(TMP, "trace")
     os.makedirs(tdir, exist_ok=True)
     for f in glob.glob(tdir + "/*"):
@@ -573,6 +630,11 @@ def stop_runtime():
 def driver(args):
     assert restart_runtime(), "clio_run did not become ready"
     os.makedirs(TMP, exist_ok=True)
+    # Build every C probe first. A probe that does not compile is a broken
+    # harness, and finding that out now -- with all of them reported together --
+    # beats discovering it as one opaque case failure two minutes into the run.
+    print("-- building C probes --")
+    _build_probe_set()
     results, n_fail = {}, 0
     for case in CASES:
         fn = os.path.join(TMP, case + "_native.h5")
@@ -616,17 +678,32 @@ def driver(args):
     failed = {c for c, p in results.items() if not all(p.values())}
     unexpected = sorted(failed - expect_fail)      # honest failures (or regressions)
     fixed = sorted(expect_fail - failed)           # known gap now passes
+    # A probe that never compiled says nothing about the VOL. Report it as its
+    # own category so the summary does not assert an incompatibility it did not
+    # measure. Still fatal -- unmeasured is not the same as passing either.
+    unbuilt = sorted(set(BUILD_ERRORS) & failed)
+    measured_fail = sorted(failed - set(BUILD_ERRORS))
     print(f"\n{total - len(failed)}/{total} cases fully pass. wrote {args.out}")
+    if unbuilt:
+        print(f"BUILD-ERROR — NOT MEASURED, the probe did not compile: {unbuilt}")
+        for name in unbuilt:
+            print(f"    {name}: {BUILD_ERRORS[name]}")
+        print("    This is a harness/toolchain failure, not a VOL compatibility "
+              "result. Fix the build, then re-run to learn what these cases say.")
     if expect_fail:
         # regression-gate mode: only unexpected failures are fatal
         print(f"expected gaps still failing: {sorted(failed & expect_fail)}")
         if fixed:
             print(f"NOTE: previously-failing cases now PASS (drop from --expect-fail): {fixed}")
-        if unexpected:
-            print(f"REGRESSION — these should pass but FAILED: {unexpected}")
-    elif failed:
+        # A probe that did not build is already reported above as UNMEASURED;
+        # calling it a regression would name the wrong problem. It still counts
+        # toward the exit status.
+        regressions = [c for c in unexpected if c not in BUILD_ERRORS]
+        if regressions:
+            print(f"REGRESSION — these should pass but FAILED: {regressions}")
+    elif measured_fail:
         # honest mode (default): every failure is reported and fatal
-        print(f"FAILING — VOL not yet compatible for: {sorted(failed)}")
+        print(f"FAILING — VOL not yet compatible for: {measured_fail}")
     return 1 if unexpected else 0
 
 

--- a/context-transfer-engine/adapter/hdf5_vol/README.md
+++ b/context-transfer-engine/adapter/hdf5_vol/README.md
@@ -7,15 +7,25 @@ whole-dataset `H5Dwrite`/`H5Dread` transfers of atomic datatypes are additionall
 mirrored to CTE via async `PutBlob`/`GetBlob`. Loaded transparently through the
 standard HDF5 plugin mechanism — no application source changes.
 
-The native file is always written synchronously and remains authoritative. Only
-atomic datatypes (integer, float, enum, bitfield, fixed-length string) are cached —
-compound/array (mem/file layout can differ) and vlen/reference (pointers, not bytes)
-delegate to native. **Selection-aware reads:** hyperslab/point reads are served from
-the cached linear image via HDF5 gather/scatter when it is already populated
-(serve-only; a miss falls back to native). A non-whole write invalidates the cache
-so reads never see stale data. **Safe mode:** `H5Fflush` and `H5Fclose` drain all
-in-flight async CTE puts before returning, so a successful flush/close is a real
-durability barrier for the cache path (no async write outlives it).
+The native file is always written synchronously and remains authoritative, and
+its status is this connector's status — a native operation that fails is
+reported as a failure, never masked. Only atomic datatypes (integer, float,
+enum, bitfield, fixed-length string) are cached — compound/array (mem/file
+layout can differ) and vlen/reference (pointers, not bytes) delegate to native.
+A transfer is cached only when its **memory datatype matches the size of the
+dataset's stored type**, since the cached image is sized by the transfer's type.
+**Selection-aware reads:** hyperslab/point reads are served from the cached
+linear image via HDF5 gather/scatter when it is already populated (serve-only; a
+miss falls back to native). A non-whole write, an `H5Dset_extent`, or a failed
+cache operation invalidates the image so reads never see stale data.
+**Safe mode:** `H5Fflush`, `H5Dflush` and `H5Fclose` drain all in-flight async
+CTE puts before returning, so a successful flush/close is a real durability
+barrier for the cache path (no async write outlives it).
+
+**The cache is never an authority.** Any doubt about whether it matches the file
+resolves by invalidating it and re-reading native. If the CLIO runtime is
+unreachable, or `CLIO_VOL_CACHE=0` is set, the connector degrades to a pure
+pass-through and stays correct.
 
 Files: `clio_vol.cc`, `clio_vol.h`. Connector name: **`clio`**.
 
@@ -40,11 +50,64 @@ requires HDF5 >= 1.14 and does not require ELF support (unlike the VFD adapter).
 
 ```bash
 export HDF5_PLUGIN_PATH=<build>/bin
-export HDF5_VOL_CONNECTOR=clio        # under-VOL defaults to native
-# a clio_run runtime must be reachable for the CTE cache path
+export HDF5_VOL_CONNECTOR=clio        # under-VOL is always native (see below)
+# a clio_run runtime must be reachable for the CTE cache path;
+# without one the connector runs as a pure pass-through
 ```
 Any HDF5 application (h5py, C, tools) then routes through the connector. Files it
 writes are valid native HDF5 files readable by standard tools.
+
+### Configuration reference
+
+| Knob | Default | Effect |
+|---|---|---|
+| `CLIO_VOL_CACHE` | on | `0`/`off`/`false`/`no` disables the CTE tier entirely — pure pass-through, no runtime required |
+| `CLIO_VOL_CHUNK_SIZE` | 1 MiB | Blob chunk size for staging dataset images |
+| `CLIO_VOL_MAX_SERVE_BYTES` | 1 GiB | Datasets larger than this are not served from cache for partial reads (see below) |
+| `CLIO_VOL_TRACE` | unset | Directory for access telemetry (see below) |
+
+`chunk_size` can also be set programmatically through `clio_vol_info_t` via
+`H5Pset_vol`; it is honoured identically on create and open.
+
+### Known limitations
+
+- **The under-VOL is always native.** `clio_vol_info_t::under_vol_id` is accepted
+  but not used for stacking — the connector cannot currently sit above another
+  pass-through connector. Tracked as W12 in `translation/VOL_AUDIT.md`.
+- **Partial reads materialise the whole dataset.** Serving a hyperslab or point
+  selection reassembles the full cached image and gathers out of it, so cost
+  scales with the dataset rather than the selection. `CLIO_VOL_MAX_SERVE_BYTES`
+  bounds the damage by falling back to native above the ceiling; narrowing the
+  fetch to the chunks a selection touches is the real fix (W10).
+- **No capacity limit or eviction.** The tier grows without bound (W11).
+- **Cache staleness across external modification.** The tag is dropped when a
+  file is re-created, but a file modified *without* the connector between
+  sessions is not detected.
+
+  This is sharper than "you may read slightly old data", and the error-path
+  tests ran into it head-on. A dataset was written, the file was then damaged
+  on disk so its stored bytes no longer matched their checksum, and the dataset
+  was read back: with caching **on**, the read *succeeded* and returned the
+  original values, because it was served from the staged copy. The file was
+  corrupt and the application was told everything was fine.
+
+  So the cache does not merely go stale — **it can mask the authoritative
+  file's own errors**, which inverts the property the whole design rests on
+  (the native file is the source of truth and the cache is an accelerator).
+  The tests that exercise error propagation therefore run with caching off,
+  because with it on there is no error to observe.
+
+  The architectural question this raises: **what establishes that a cached
+  image still corresponds to the file, and where does that check live?** A
+  per-connector stamp is enough for the between-sessions case, but the same
+  question recurs for byte-range residency in the VFD and for the filesystem
+  adapter's shared-memory read path, which already gives up whenever any page
+  might be missing because it cannot tell an absent page from a zero-filled
+  one. Three call sites, one missing primitive. See
+  `translation/VFD_VOL_ARCH_DECISIONS.md` §1, which argues the residency half
+  belongs at the chimod and the coherence half stays with the adapter.
+- **No `HDF5_VOL_CONNECTOR` config string** — `info_cls.from_str` is not
+  implemented, so options come from the environment variables above (W14).
 
 ## Access telemetry (observability)
 
@@ -99,6 +162,8 @@ caching, Safe-mode `H5Fflush` durability, and access telemetry.
 Feature areas the h5py cases can't reach (h5py has poor non-native VOL support) run
 through the C API / a telemetry check, all automated by the suite: iteration
 (`vol_c_iteration_test.c`), Safe-mode flush (`vol_c_safeflush_test.c`), selection
-caching + partial-write invalidation (`vol_c_selection_test.c`), and access
-telemetry (`telemetry` case — runs a workload under `CLIO_VOL_TRACE` and checks
-the summary).
+caching + partial-write invalidation (`vol_c_selection_test.c`), cache-identity
+regressions (`vol_c_cache_identity_test.c` — mem/file datatype mismatch and a
+cache surviving `H5F_ACC_TRUNC`, both of which returned wrong data with a success
+status), and access telemetry (`telemetry` case — runs a workload under
+`CLIO_VOL_TRACE` and checks the summary).

--- a/context-transfer-engine/adapter/hdf5_vol/clio_vol.cc
+++ b/context-transfer-engine/adapter/hdf5_vol/clio_vol.cc
@@ -6,11 +6,22 @@
  */
 
 /**
- * Clio HDF5 VOL Connector
+ * Clio HDF5 VOL Connector — pass-through, native-authoritative.
  *
- * Intercepts H5Dwrite/H5Dread and maps them to CTE AsyncPutBlob/AsyncGetBlob.
- * Large writes are split into configurable-size chunks and submitted
- * asynchronously. All other HDF5 operations pass through to the native VOL.
+ * EVERY operation is delegated to the native VOL, which owns the file: the
+ * on-disk HDF5 image is written synchronously and is the source of truth, so
+ * standard tools read it live and CLIO can be removed without losing data.
+ * On top of that, whole-dataset H5Dwrite/H5Dread transfers of flat datatypes
+ * are additionally MIRRORED into the CTE tier as chunked blobs, and hyperslab /
+ * point reads can be served from that mirror (serve-only; a miss falls back to
+ * native). The cache is an accelerator, never an authority: any doubt about
+ * whether it matches the file resolves by invalidating it and re-reading native.
+ *
+ * If the CLIO runtime is unreachable, or CLIO_VOL_CACHE=0 is set, the connector
+ * degrades to a pure pass-through and remains correct.
+ *
+ * See README.md for configuration and translation/VOL_AUDIT.md for the current
+ * gap list.
  */
 
 #include "clio_vol.h"
@@ -42,6 +53,13 @@
 #include <clio_cte/core/core_tasks.h>
 #include <clio_cte/core/content_transfer_engine.h>
 
+/* The connector's capability set. Defined once because it is reported from two
+   places (the class literal and introspect_get_cap_flags) that must agree. */
+#define CLIO_VOL_CAP_FLAGS                                                 \
+  (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |                \
+   H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC |                  \
+   H5VL_CAP_FLAG_LINK_BASIC | H5VL_CAP_FLAG_OBJECT_BASIC)
+
 /* ========================================================================
  * Internal state structures
  * ======================================================================== */
@@ -54,10 +72,18 @@ struct clio_dataset_t;  /* fwd */
    inherited from the containing file/group at create-time. The
    dataset_t branch reads it to find the CTE tag for AsyncPutBlob /
    AsyncGetBlob. */
+/* Which wrapper struct a void* actually points at. clio_dataset_t and
+   clio_file_t are NOT derived from clio_obj_t -- they CONTAIN one as their first
+   member -- so a `delete (clio_obj_t *)p` on a dataset is undefined behaviour
+   and leaks its std::string/vectors. Every wrapper records its kind here so the
+   generic paths (notably clio_unwrap_object) can destroy the right type. */
+enum class clio_kind_t : int { kObj = 0, kFile, kDataset };
+
 struct clio_obj_t {
   void           *under_object;
   hid_t           under_vol_id;
   clio_file_t  *parent_file;
+  clio_kind_t     kind = clio_kind_t::kObj;
 };
 
 struct clio_file_t {
@@ -65,6 +91,12 @@ struct clio_file_t {
   clio::cte::core::TagId tag_id;
   std::string file_name;
   size_t chunk_size;
+  /* False when the CTE tier is bypassed entirely for this file: either the user
+     disabled it (CLIO_VOL_CACHE=0) or the CLIO runtime was unreachable at open.
+     The connector then behaves as a pure pass-through to the native VOL, which
+     is always a correct (if unaccelerated) mode -- the native file is
+     authoritative regardless. */
+  bool cache_enabled = true;
   /* Safe mode: cacheable datasets currently open in this file. H5Fflush and
      H5Fclose drain their pending CTE puts so no async write outlives a
      successful flush/close (the native file is already written synchronously and
@@ -80,6 +112,15 @@ struct clio_dataset_t {
   clio_obj_t obj;
   clio_file_t *file;
   std::string dataset_path;
+  /* The dataset's FILE datatype, resolved lazily on first cache-eligible
+     transfer. The blob cache is a flat byte image sized by the transfer's
+     datatype, so it is only coherent when the caller's memory type is the same
+     size as what HDF5 actually stores. Without this check, writing
+     H5T_NATIVE_INT into an H5T_STD_I64LE dataset caches 4n bytes and a later
+     read with H5T_NATIVE_LONG asks for 8n, hits, and reassembles garbage. */
+  hid_t file_type = H5I_INVALID_HID;
+  size_t file_type_size = 0;
+  int file_type_probed = 0;
   /* When false the CTE cache is bypassed and every transfer goes to the native
      VOL. Set for datasets whose stable path is unknown (opened via the generic
      object-open / wrap paths), so we never key a blob by an empty/ambiguous
@@ -107,10 +148,12 @@ static clio_dataset_t *make_dataset_wrapper(void *under, hid_t under_vol_id,
   auto *dset = new clio_dataset_t;
   dset->obj.under_object = under;
   dset->obj.under_vol_id = under_vol_id;
+  dset->obj.kind = clio_kind_t::kDataset;
   dset->file = parent_file;
   dset->obj.parent_file = parent_file;
   dset->dataset_path = path ? path : "";
-  dset->cacheable = (parent_file != nullptr) && path && path[0] != '\0';
+  dset->cacheable = (parent_file != nullptr) && parent_file->cache_enabled &&
+                    path && path[0] != '\0';
   /* Register with the file so Safe-mode flush/close can drain this dataset's
      pending puts. Only cacheable datasets accumulate CTE puts. */
   if (dset->cacheable) {
@@ -121,13 +164,24 @@ static clio_dataset_t *make_dataset_wrapper(void *under, hid_t under_vol_id,
 }
 
 /* Block until every async CTE put for this dataset has completed, then release
-   the shared-memory buffers. Shared by dataset_close and Safe-mode flush/close. */
-static void drain_dataset_puts(clio_dataset_t *dset) {
+   the shared-memory buffers. Shared by dataset_close and Safe-mode flush/close.
+
+   Returns false if ANY put reported a failure. Waiting is not the same as
+   succeeding: a put that landed with a non-zero return code left the cache
+   holding less than it believes it does, so the caller invalidates the
+   dataset's cache rather than leave a partially-staged image that a later read
+   would treat as a hit. The native file is authoritative and unaffected. */
+static bool drain_dataset_puts(clio_dataset_t *dset) {
+  bool ok = true;
   for (auto &future : dset->pending_puts) {
     future.Wait();
+    if (future->GetReturnCode() != 0) {
+      ok = false;
+    }
   }
   dset->pending_puts.clear();
   dset->pending_buffers.clear();
+  return ok;
 }
 
 /* VOL object-wrap context. HDF5 uses this during link/object iteration
@@ -160,10 +214,68 @@ static clio::cte::core::Client *get_cte_client() {
      LD_PRELOAD constructor to do it (the POSIX adapter inits in
      Filesystem::Filesystem -> CLIO_CTE_CLIENT_INIT()); without this the CTE
      client singleton is unbound and the first AsyncGetOrCreateTag segfaults.
-     Config comes from CLIO_SERVER_CONF, same as the runtime. */
+     Config comes from CLIO_SERVER_CONF, same as the runtime.
+
+     Returns nullptr when the runtime is unreachable. Callers MUST check: the
+     attach result was previously discarded, so an absent runtime faulted inside
+     H5Fcreate. There is always a correct fallback -- pass everything through to
+     the native VOL -- because the native file is authoritative and the CTE tier
+     is a performance layer, not a correctness one. */
   static std::once_flag once;
-  std::call_once(once, []() { clio::cte::core::CLIO_CTE_CLIENT_INIT(); });
-  return CLIO_CTE_CLIENT;
+  static bool attached = false;
+  std::call_once(once, []() {
+    attached = clio::cte::core::CLIO_CTE_CLIENT_INIT();
+    if (!attached) {
+      fprintf(stderr,
+              "[clio-vol] CLIO runtime unavailable; running as a pure "
+              "pass-through to the native VOL (cache disabled)\n");
+    }
+  });
+  return attached ? CLIO_CTE_CLIENT : nullptr;
+}
+
+/* Is the CTE cache path usable for this file at all? One check for the two
+   independent reasons it may not be: the user turned it off, or the runtime is
+   not there. */
+static bool clio_cache_usable(clio_file_t *file) {
+  return file && file->cache_enabled && get_cte_client() != nullptr;
+}
+
+/* Read the CLIO_VOL_CACHE opt-out. Default on; "0"/"off"/"false"/"no" disable
+   the CTE tier and make the connector a pure pass-through. Without this there
+   was NO configuration in which the connector could be loaded and not require a
+   CLIO runtime, which is what Safe mode's environment-robustness clause needs. */
+static bool clio_cache_env_enabled() {
+  const char *v = std::getenv("CLIO_VOL_CACHE");
+  if (!v || !*v) return true;
+  return !(std::strcmp(v, "0") == 0 || std::strcmp(v, "off") == 0 ||
+           std::strcmp(v, "false") == 0 || std::strcmp(v, "no") == 0);
+}
+
+/* Drop this dataset's cached image so later reads miss and re-stage from the
+   authoritative native file. Used whenever the cache may no longer mirror the
+   file: a partial write, or a put that failed to land. Deleting chunk_0 (the
+   hit-test key) is sufficient -- a miss re-stages every chunk -- but the delete
+   itself must be CHECKED, because a failed invalidation leaves the cache
+   claiming to hold pre-write data. On failure the dataset is marked
+   uncacheable for the rest of the session, which is the fail-closed choice. */
+static void clio_invalidate_dataset(clio_dataset_t *dset) {
+  if (!dset || !dset->file || !dset->cacheable) return;
+  auto *cte_client = get_cte_client();
+  if (!cte_client) {
+    dset->cacheable = false;
+    return;
+  }
+  auto del = cte_client->AsyncDelBlob(dset->file->tag_id,
+                                      dset->dataset_path + "/chunk_0");
+  del.Wait();
+  if (del->GetReturnCode() != 0) {
+    fprintf(stderr,
+            "[clio-vol] cache invalidation failed for %s; bypassing the cache "
+            "for this dataset (native file is authoritative)\n",
+            dset->dataset_path.c_str());
+    dset->cacheable = false;
+  }
 }
 
 /* ========================================================================
@@ -242,12 +354,40 @@ static void *clio_wrap_object(void *under_obj, H5I_type_t obj_type,
   return o;
 }
 
+/* Destroy a wrapper through its ACTUAL type. clio_dataset_t contains (does not
+   inherit) a clio_obj_t, so deleting one as a clio_obj_t* is undefined
+   behaviour and leaks its std::string, its two vectors, and the SHM buffers
+   they own. The kind tag exists to make this dispatch possible. */
+static void clio_destroy_wrapper(clio_obj_t *o) {
+  if (!o) return;
+  switch (o->kind) {
+    case clio_kind_t::kDataset: {
+      auto *dset = reinterpret_cast<clio_dataset_t *>(o);
+      if (dset->file && dset->cacheable) {
+        std::lock_guard<std::mutex> lk(dset->file->ds_mtx);
+        dset->file->open_datasets.erase(dset);
+      }
+      if (dset->file_type >= 0) H5Tclose(dset->file_type);
+      delete dset;
+      break;
+    }
+    case clio_kind_t::kFile:
+      delete reinterpret_cast<clio_file_t *>(o);
+      break;
+    case clio_kind_t::kObj:
+    default:
+      delete o;
+      break;
+  }
+}
+
 static void *clio_unwrap_object(void *obj) {
   auto *o = static_cast<clio_obj_t *>(obj);
   /* Symmetric with clio_wrap_object()'s H5VLwrap_object(): peel the native
      wrapper back off before discarding our wrapper. */
   void *under = H5VLunwrap_object(o->under_object, o->under_vol_id);
-  if (under) delete o;
+  /* Free the wrapper either way -- returning NULL previously leaked it. */
+  clio_destroy_wrapper(o);
   return under;
 }
 
@@ -270,33 +410,70 @@ static herr_t clio_free_wrap_ctx(void *_wrap_ctx) {
  * File callbacks
  * ======================================================================== */
 
-static void *clio_file_create(const char *name, unsigned flags,
-                                hid_t fcpl_id, hid_t fapl_id,
-                                hid_t dxpl_id, void **req) {
-  /* Get underlying VOL info */
-  hid_t under_vol_id = H5VL_NATIVE;
-  void *under_vol_info = nullptr;
-
-  /* Check if user provided Clio VOL info.
-   * HDF5 2.x split H5Pget_vol() into H5Pget_vol_id() + H5Pget_vol_info();
-     we only care about the info blob here. */
+/* Resolve the CTE chunk size for a file: connector info, then CLIO_VOL_CHUNK_SIZE,
+   then the built-in default. Shared so create and open cannot disagree -- open
+   previously never read the info struct at all, so a chunk_size set through
+   H5Pset_vol was silently honoured on create and ignored on open. */
+static size_t clio_resolve_chunk_size(hid_t fapl_id) {
+  size_t chunk_size = CLIO_VOL_DEFAULT_CHUNK_SIZE;
   clio_vol_info_t *vol_info = nullptr;
   H5Pget_vol_info(fapl_id, reinterpret_cast<void **>(&vol_info));
-  size_t chunk_size = CLIO_VOL_DEFAULT_CHUNK_SIZE;
-  if (vol_info) {
-    under_vol_id = vol_info->under_vol_id;
-    under_vol_info = vol_info->under_vol_info;
-    if (vol_info->chunk_size > 0) {
-      chunk_size = vol_info->chunk_size;
-    }
+  if (vol_info && vol_info->chunk_size > 0) {
+    chunk_size = vol_info->chunk_size;
   }
-
-  /* Check environment variable for chunk size */
   const char *env_chunk = std::getenv("CLIO_VOL_CHUNK_SIZE");
   if (env_chunk) {
     chunk_size = std::strtoul(env_chunk, nullptr, 10);
     if (chunk_size == 0) chunk_size = CLIO_VOL_DEFAULT_CHUNK_SIZE;
   }
+  return chunk_size;
+}
+
+/* Build the connector's file wrapper around an already-opened native file, and
+   bind its CTE tag if the cache is usable. `truncated` means the native file was
+   just emptied (H5F_ACC_TRUNC), so any tag left over from a PREVIOUS file of the
+   same name describes data that no longer exists and must be dropped -- the tag
+   is keyed on the filename, which a truncate does not change. Without this,
+   creating a file over an old one and then reading a dataset the new file never
+   wrote would hit the old file's cached blobs. */
+static clio_file_t *clio_make_file(void *under_file, const char *name,
+                                     size_t chunk_size, bool truncated) {
+  auto *file = new clio_file_t;
+  file->obj.under_object = under_file;
+  file->obj.under_vol_id = H5VL_NATIVE;
+  file->obj.parent_file = file;          /* self-pointer */
+  file->obj.kind = clio_kind_t::kFile;
+  file->file_name = name;
+  file->chunk_size = chunk_size;
+  file->cache_enabled = clio_cache_env_enabled();
+  file->trace = clio::trace::open_file(name);
+
+  auto *cte_client = file->cache_enabled ? get_cte_client() : nullptr;
+  if (!cte_client) {
+    /* Pure pass-through: no tag, no cache. Correct, just unaccelerated. */
+    file->cache_enabled = false;
+    return file;
+  }
+
+  const std::string tag_name = std::string("hdf5:") + name;
+  if (truncated) {
+    auto del = cte_client->AsyncDelTag(tag_name);
+    del.Wait();  /* absent tag is a harmless no-op */
+  }
+  auto tag_task = cte_client->AsyncGetOrCreateTag(tag_name);
+  tag_task.Wait();
+  if (tag_task->GetReturnCode() != 0) {
+    file->cache_enabled = false;
+    return file;
+  }
+  file->tag_id = tag_task->tag_id_;
+  return file;
+}
+
+static void *clio_file_create(const char *name, unsigned flags,
+                                hid_t fcpl_id, hid_t fapl_id,
+                                hid_t dxpl_id, void **req) {
+  size_t chunk_size = clio_resolve_chunk_size(fapl_id);
 
   /* Create file via native VOL */
   hid_t native_fapl = H5Pcopy(fapl_id);
@@ -306,32 +483,14 @@ static void *clio_file_create(const char *name, unsigned flags,
   H5Pclose(native_fapl);
   if (!under_file) return nullptr;
 
-  /* Create CTE tag for this file */
-  auto *cte_client = get_cte_client();
-  auto tag_task = cte_client->AsyncGetOrCreateTag(std::string("hdf5:") + name);
-  tag_task.Wait();
-
-  /* Create file state */
-  auto *file = new clio_file_t;
-  file->obj.under_object = under_file;
-  file->obj.under_vol_id = H5VL_NATIVE;
-  file->obj.parent_file = file;          /* self-pointer */
-  file->tag_id = tag_task->tag_id_;
-  file->file_name = name;
-  file->chunk_size = chunk_size;
-  file->trace = clio::trace::open_file(name);
-
-  return file;
+  /* H5Fcreate always yields an empty file (TRUNC replaces an existing one,
+     EXCL/CREAT means there was none), so any pre-existing tag is stale. */
+  return clio_make_file(under_file, name, chunk_size, /*truncated*/ true);
 }
 
 static void *clio_file_open(const char *name, unsigned flags,
                               hid_t fapl_id, hid_t dxpl_id, void **req) {
-  size_t chunk_size = CLIO_VOL_DEFAULT_CHUNK_SIZE;
-  const char *env_chunk = std::getenv("CLIO_VOL_CHUNK_SIZE");
-  if (env_chunk) {
-    chunk_size = std::strtoul(env_chunk, nullptr, 10);
-    if (chunk_size == 0) chunk_size = CLIO_VOL_DEFAULT_CHUNK_SIZE;
-  }
+  size_t chunk_size = clio_resolve_chunk_size(fapl_id);
 
   /* Open file via native VOL */
   hid_t native_fapl = H5Pcopy(fapl_id);
@@ -340,21 +499,7 @@ static void *clio_file_open(const char *name, unsigned flags,
   H5Pclose(native_fapl);
   if (!under_file) return nullptr;
 
-  /* Get or create CTE tag */
-  auto *cte_client = get_cte_client();
-  auto tag_task = cte_client->AsyncGetOrCreateTag(std::string("hdf5:") + name);
-  tag_task.Wait();
-
-  auto *file = new clio_file_t;
-  file->obj.under_object = under_file;
-  file->obj.under_vol_id = H5VL_NATIVE;
-  file->obj.parent_file = file;          /* self-pointer */
-  file->tag_id = tag_task->tag_id_;
-  file->file_name = name;
-  file->chunk_size = chunk_size;
-  file->trace = clio::trace::open_file(name);
-
-  return file;
+  return clio_make_file(under_file, name, chunk_size, /*truncated*/ false);
 }
 
 static herr_t clio_file_get(void *obj, H5VL_file_get_args_t *args,
@@ -367,15 +512,61 @@ static herr_t clio_file_get(void *obj, H5VL_file_get_args_t *args,
 static herr_t clio_file_specific(void *obj,
                                    H5VL_file_specific_args_t *args,
                                    hid_t dxpl_id, void **req) {
+  /* OBJECT-LESS OPERATIONS COME FIRST -- they are called with obj == NULL.
+     H5VL_FILE_IS_ACCESSIBLE and H5VL_FILE_DELETE act on a FILENAME, not on an
+     open file, so there is no object to unwrap and the cast below would be a
+     NULL dereference.
+
+     This is not a theoretical path. HDF5 walks it whenever an H5Fopen has to
+     work out WHICH connector can open a file: H5VL__file_open_find_connector_cb
+     iterates every plugin on HDF5_PLUGIN_PATH and asks each one
+     IS_ACCESSIBLE. So merely having this .so sitting in the plugin directory
+     was enough to turn a plain `H5Fopen` of a missing (or non-HDF5) file into a
+     SEGFAULT -- with the clio connector not selected, not requested, and
+     nothing in the application referring to it. Selecting it explicitly hid the
+     bug, because that path opens directly and never probes.
+
+     Delegation mirrors clio_file_open/create: copy the caller's FAPL, point it
+     at the native connector, and hand the operation to native with a NULL
+     object. args->args.*.fapl_id must be swapped too -- it is the FAPL native
+     will re-read, and leaving it pointing at a clio-VOL FAPL sends HDF5 straight
+     back into this connector (infinite recursion instead of an answer). */
+  if (args && (args->op_type == H5VL_FILE_IS_ACCESSIBLE ||
+               args->op_type == H5VL_FILE_DELETE)) {
+    hid_t *fapl_slot = (args->op_type == H5VL_FILE_IS_ACCESSIBLE)
+                           ? &args->args.is_accessible.fapl_id
+                           : &args->args.del.fapl_id;
+    hid_t saved_fapl = *fapl_slot;
+    hid_t native_fapl = H5Pcopy(saved_fapl);
+    if (native_fapl < 0) return -1;
+    H5Pset_vol(native_fapl, H5VL_NATIVE, nullptr);
+    *fapl_slot = native_fapl;
+    herr_t ret = H5VLfile_specific(nullptr, H5VL_NATIVE, args, dxpl_id, req);
+    *fapl_slot = saved_fapl; /* the caller owns theirs; give it back intact */
+    H5Pclose(native_fapl);
+    return ret;
+  }
+
   auto *file = static_cast<clio_file_t *>(obj);
+  if (!file) return -1; /* every remaining op requires an open file */
   /* Safe mode: on H5Fflush, drain every open cacheable dataset's pending CTE
-     puts BEFORE delegating the flush to native. This makes the flush a real
-     durability barrier for the cache path (fail-closed: we only return once all
-     async puts have landed), with the native file remaining authoritative. */
+     puts BEFORE delegating the flush to native, so no async write outlives a
+     successful flush. A put that failed invalidates that dataset's cache rather
+     than leaving a half-staged image a later read would treat as a hit. The
+     native file is written synchronously and stays authoritative throughout. */
   if (args && args->op_type == H5VL_FILE_FLUSH) {
-    std::lock_guard<std::mutex> lk(file->ds_mtx);
-    for (auto *dset : file->open_datasets) {
-      drain_dataset_puts(dset);
+    /* Snapshot under the lock, drain outside it: draining blocks on every
+       in-flight put, and holding ds_mtx across that serialises flush against
+       every concurrent dataset open/close. */
+    std::vector<clio_dataset_t *> to_drain;
+    {
+      std::lock_guard<std::mutex> lk(file->ds_mtx);
+      to_drain.assign(file->open_datasets.begin(), file->open_datasets.end());
+    }
+    for (auto *dset : to_drain) {
+      if (!drain_dataset_puts(dset)) {
+        clio_invalidate_dataset(dset);
+      }
     }
   }
   return H5VLfile_specific(file->obj.under_object, file->obj.under_vol_id,
@@ -401,9 +592,15 @@ static herr_t clio_file_close(void *obj, hid_t dxpl_id, void **req) {
      close degree) so no async CTE put outlives the file. Datasets closed the
      normal way have already drained and unregistered themselves. */
   {
-    std::lock_guard<std::mutex> lk(file->ds_mtx);
-    for (auto *dset : file->open_datasets) {
-      drain_dataset_puts(dset);
+    std::vector<clio_dataset_t *> to_drain;
+    {
+      std::lock_guard<std::mutex> lk(file->ds_mtx);
+      to_drain.assign(file->open_datasets.begin(), file->open_datasets.end());
+    }
+    for (auto *dset : to_drain) {
+      if (!drain_dataset_puts(dset)) {
+        clio_invalidate_dataset(dset);
+      }
     }
   }
   herr_t ret = H5VLfile_close(file->obj.under_object, file->obj.under_vol_id,
@@ -588,6 +785,46 @@ static bool clio_read_is_whole(hid_t mem_space_id, hid_t file_space_id) {
          clio_space_is_natural_full(file_space_id);
 }
 
+/**
+ * True when the transfer's MEMORY datatype has the same element size as what
+ * HDF5 stores on disk for this dataset.
+ *
+ * The blob cache is a flat byte image whose length is derived from the
+ * transfer's datatype size (nelem * H5Tget_size(mem_type)). That is only a
+ * coherent key when the memory image and the file image agree on element size;
+ * otherwise the SAME dataset has different cached lengths depending on which
+ * type the caller happened to use, and a hit computed with one size reassembles
+ * blobs written with another. Concretely, without this check:
+ *
+ *   H5Dwrite(d, H5T_NATIVE_INT,  ...)   on an H5T_STD_I64LE dataset -> caches 4n
+ *   H5Dread (d, H5T_NATIVE_LONG, ...)   asks for 8n, hit-tests chunk_0 (present),
+ *                                       and reassembles 8n bytes from 4n -> the
+ *                                       tail is short/zero-filled garbage,
+ *                                       returned with a success status.
+ *
+ * HDF5 converts between memory and file types freely, so this is a legal and
+ * unremarkable thing for an application to do. The dataset's file type is
+ * fetched once and cached on the wrapper.
+ */
+static bool clio_type_matches_file(clio_dataset_t *dataset, hid_t mem_type_id,
+                                     hid_t dxpl_id) {
+  if (mem_type_id < 0) return false;
+  if (!dataset->file_type_probed) {
+    dataset->file_type_probed = 1;
+    H5VL_dataset_get_args_t ga;
+    ga.op_type = H5VL_DATASET_GET_TYPE;
+    ga.args.get_type.type_id = H5I_INVALID_HID;
+    if (H5VLdataset_get(dataset->obj.under_object, dataset->obj.under_vol_id,
+                        &ga, dxpl_id, nullptr) >= 0 &&
+        ga.args.get_type.type_id >= 0) {
+      dataset->file_type = ga.args.get_type.type_id;
+      dataset->file_type_size = H5Tget_size(dataset->file_type);
+    }
+  }
+  if (dataset->file_type_size == 0) return false;  /* unknown -> don't cache */
+  return H5Tget_size(mem_type_id) == dataset->file_type_size;
+}
+
 static void *clio_dataset_create(void *obj,
                                    const H5VL_loc_params_t *loc_params,
                                    const char *name, hid_t lcpl_id,
@@ -756,9 +993,8 @@ static herr_t clio_dataset_write(size_t count, void *dset[],
                                    hid_t file_space_id[],
                                    hid_t dxpl_id, const void *buf[],
                                    void **req) {
-  auto *cte_client = get_cte_client();
-
   const bool tracing = clio::trace::enabled();
+  herr_t ret_value = 0;
   for (size_t d = 0; d < count; ++d) {
     auto *dataset = static_cast<clio_dataset_t *>(dset[d]);
     if (!dataset || !buf[d]) continue;
@@ -768,22 +1004,26 @@ static herr_t clio_dataset_write(size_t count, void *dset[],
        CTE chunk cache. For no-file-reference, partial (hyperslab), or
        collective writes, persist to the native VOL only — caching a partial
        write under a whole-dataset key would poison a later whole read. */
-    if (!dataset->file || !dataset->cacheable ||
+    if (!clio_cache_usable(dataset->file) || !dataset->cacheable ||
         !clio_is_whole_read(mem_space_id[d], file_space_id[d]) ||
         !clio_type_is_cacheable(mem_type_id[d]) ||
+        !clio_type_matches_file(dataset, mem_type_id[d], dxpl_id) ||
         clio_is_collective(dxpl_id)) {
-      H5VLdataset_write(1, &dataset->obj.under_object,
+      /* The native VOL is the authoritative store: its status IS this call's
+         status. Discarding it (as this did) reported success for writes that
+         never reached the file -- ENOSPC, filter failure, a bad selection. */
+      herr_t rc = H5VLdataset_write(1, &dataset->obj.under_object,
                          dataset->obj.under_vol_id,
                          &mem_type_id[d], &mem_space_id[d], &file_space_id[d],
                          dxpl_id, &buf[d], req);
+      if (rc < 0) ret_value = rc;
       /* This write did NOT refresh the whole linear image, so any cached image
          is now stale. Invalidate it (drop the chunk_0 hit-test key) so later
          whole/selection reads miss and re-stage fresh data from native. Without
-         this, a partial write followed by a cached read returns pre-write data. */
-      if (dataset->file && dataset->cacheable) {
-        auto del = cte_client->AsyncDelBlob(
-            dataset->file->tag_id, dataset->dataset_path + "/chunk_0");
-        del.Wait();
+         this, a partial write followed by a cached read returns pre-write data.
+         Only meaningful if the write actually landed. */
+      if (rc >= 0) {
+        clio_invalidate_dataset(dataset);
       }
       if (tracing)
         clio_trace_access(dataset, clio::trace::Op::kWrite, mem_type_id[d],
@@ -792,9 +1032,13 @@ static herr_t clio_dataset_write(size_t count, void *dset[],
                             clio_since_us(t0));
       continue;
     }
+    auto *cte_client = get_cte_client();
 
-    /* Compute total data size from memory dataspace */
+    /* Compute total data size from memory dataspace. When we had to ask the
+       native dataset for its space we own that hid_t and must close it -- the
+       previous code leaked one per whole-dataset write. */
     hid_t space = mem_space_id[d];
+    hid_t owned_space = H5I_INVALID_HID;
     if (space == H5S_ALL) {
       /* Get dataspace from the native dataset */
       H5VL_dataset_get_args_t get_args;
@@ -803,8 +1047,10 @@ static herr_t clio_dataset_write(size_t count, void *dset[],
       H5VLdataset_get(dataset->obj.under_object, dataset->obj.under_vol_id,
                        &get_args, dxpl_id, nullptr);
       space = get_args.args.get_space.space_id;
+      owned_space = space;
     }
-    hssize_t nelem = H5Sget_simple_extent_npoints(space);
+    hssize_t nelem = (space >= 0) ? H5Sget_simple_extent_npoints(space) : -1;
+    if (owned_space >= 0) H5Sclose(owned_space);
     if (nelem <= 0) continue;
 
     size_t type_size = H5Tget_size(mem_type_id[d]);
@@ -834,18 +1080,27 @@ static herr_t clio_dataset_write(size_t count, void *dset[],
       dataset->pending_buffers.push_back(std::move(buffer));
     }
 
-    /* Also write to native VOL for metadata consistency */
-    H5VLdataset_write(1, &dataset->obj.under_object,
+    /* Write to the native VOL -- the authoritative store. Its status is this
+       call's status; if it failed, the bytes we just staged into CTE describe
+       data the file does not contain, so drop them. */
+    herr_t rc = H5VLdataset_write(1, &dataset->obj.under_object,
                        dataset->obj.under_vol_id,
                        &mem_type_id[d], &mem_space_id[d], &file_space_id[d],
                        dxpl_id, &buf[d], req);
+    if (rc < 0) {
+      ret_value = rc;
+      drain_dataset_puts(dataset);
+      clio_invalidate_dataset(dataset);
+    }
     if (tracing)
       clio_trace_access(dataset, clio::trace::Op::kWrite, mem_type_id[d],
                           mem_space_id[d], file_space_id[d], dxpl_id,
-                          clio::trace::Served::kCache, clio_since_us(t0));
+                          rc < 0 ? clio::trace::Served::kUncacheable
+                                 : clio::trace::Served::kCache,
+                          clio_since_us(t0));
   }
 
-  return 0;
+  return ret_value;
 }
 
 /* True when the dataset's linear chunk cache is populated (a fully-staged cache
@@ -935,6 +1190,22 @@ static bool clio_serve_selection(clio_dataset_t *dataset, hid_t mem_type_id,
     if (total_nelem <= 0 || type_size == 0) break;
     size_t total_size = static_cast<size_t>(total_nelem) * type_size;
 
+    /* INTERIM GUARD. Serving a selection currently materialises the WHOLE
+       dataset and gathers out of it, so a 1 KiB hyperslab against a 100 GiB
+       dataset would allocate 100 GiB -- an OOM, and strictly worse than simply
+       letting native do the read. Until the fetch is narrowed to the chunks the
+       selection actually touches (Q2.3), refuse to serve above a ceiling and
+       fall back to native. Tunable via CLIO_VOL_MAX_SERVE_BYTES; default 1 GiB. */
+    static const size_t kMaxServeBytes = []() -> size_t {
+      const char *v = std::getenv("CLIO_VOL_MAX_SERVE_BYTES");
+      if (v && *v) {
+        size_t n = std::strtoull(v, nullptr, 10);
+        if (n > 0) return n;
+      }
+      return (size_t)1 << 30;
+    }();
+    if (total_size > kMaxServeBytes) break;
+
     std::vector<char> full(total_size);
     if (!clio_read_cached_image(dataset, total_size, full.data())) break;
 
@@ -984,24 +1255,32 @@ static herr_t clio_dataset_read(size_t count, void *dset[],
                                   hid_t file_space_id[],
                                   hid_t dxpl_id, void *buf[],
                                   void **req) {
-  auto *cte_client = get_cte_client();
   const bool tracing = clio::trace::enabled();
+  herr_t ret_value = 0;
 
   for (size_t d = 0; d < count; ++d) {
     auto *dataset = static_cast<clio_dataset_t *>(dset[d]);
     if (!dataset || !buf[d]) continue;
     auto t0 = std::chrono::steady_clock::now();
 
-    /* Native passthrough when there is no file reference, the type is not flat,
-       or the read is collective. The native VOL always produces correct data. */
-    bool cacheable_flat = dataset->file && dataset->cacheable &&
+    /* Native passthrough when the cache is unusable, there is no file
+       reference, the type is not flat, the memory type disagrees in size with
+       the stored type, or the read is collective. The native VOL always
+       produces correct data. */
+    bool cacheable_flat = clio_cache_usable(dataset->file) &&
+                          dataset->cacheable &&
                           clio_type_is_read_cacheable(mem_type_id[d]) &&
+                          clio_type_matches_file(dataset, mem_type_id[d],
+                                                 dxpl_id) &&
                           !clio_is_collective(dxpl_id);
     if (!cacheable_flat) {
-      H5VLdataset_read(1, &dataset->obj.under_object,
+      /* Propagate the native status: a failed read previously returned success
+         with the user's buffer untouched. */
+      herr_t rc = H5VLdataset_read(1, &dataset->obj.under_object,
                         dataset->obj.under_vol_id,
                         &mem_type_id[d], &mem_space_id[d], &file_space_id[d],
                         dxpl_id, &buf[d], req);
+      if (rc < 0) ret_value = rc;
       if (tracing)
         clio_trace_access(dataset, clio::trace::Op::kRead, mem_type_id[d],
                             mem_space_id[d], file_space_id[d], dxpl_id,
@@ -1009,6 +1288,7 @@ static herr_t clio_dataset_read(size_t count, void *dset[],
                             clio_since_us(t0));
       continue;
     }
+    auto *cte_client = get_cte_client();
 
     /* Partial (non-full-extent) selection → serve from the CTE tier when the
        linear cache is already populated (serve-only). On a miss, fall back to
@@ -1019,10 +1299,11 @@ static herr_t clio_dataset_read(size_t count, void *dset[],
                                            mem_space_id[d], file_space_id[d],
                                            dxpl_id, buf[d]);
       if (!served) {
-        H5VLdataset_read(1, &dataset->obj.under_object,
+        herr_t rc = H5VLdataset_read(1, &dataset->obj.under_object,
                           dataset->obj.under_vol_id,
                           &mem_type_id[d], &mem_space_id[d], &file_space_id[d],
                           dxpl_id, &buf[d], req);
+        if (rc < 0) ret_value = rc;
       }
       if (tracing)
         clio_trace_access(dataset, clio::trace::Op::kRead, mem_type_id[d],
@@ -1044,10 +1325,11 @@ static herr_t clio_dataset_read(size_t count, void *dset[],
     if (space >= 0) H5Sclose(space);
     if (nelem <= 0) {
       /* Can't size it — fall back to native for safety. */
-      H5VLdataset_read(1, &dataset->obj.under_object,
+      herr_t rc = H5VLdataset_read(1, &dataset->obj.under_object,
                         dataset->obj.under_vol_id,
                         &mem_type_id[d], &mem_space_id[d], &file_space_id[d],
                         dxpl_id, &buf[d], req);
+      if (rc < 0) ret_value = rc;
       if (tracing)
         clio_trace_access(dataset, clio::trace::Op::kRead, mem_type_id[d],
                             mem_space_id[d], file_space_id[d], dxpl_id,
@@ -1077,11 +1359,16 @@ static herr_t clio_dataset_read(size_t count, void *dset[],
                                    &mem_type_id[d], &mem_space_id[d],
                                    &file_space_id[d], dxpl_id, &buf[d], req);
       if (rc < 0) return rc;
-      for (size_t i = 0; i < num_chunks; ++i) {
+      /* Stage into the tier. Best-effort, but a PARTIAL stage must not be left
+         behind: chunk_0 present is the hit test, so a run that stages chunk_0
+         and then fails would make the next read a "hit" on an incomplete image.
+         Track it and invalidate rather than leave that trap. */
+      bool staged_ok = true;
+      for (size_t i = 0; i < num_chunks && staged_ok; ++i) {
         size_t offset = i * chunk_size;
         size_t this_size = std::min(chunk_size, total_size - offset);
         auto buffer = CLIO_IPC->AllocateBuffer(this_size);
-        if (buffer.IsNull()) break;            /* caching is best-effort */
+        if (buffer.IsNull()) { staged_ok = false; break; }
         std::memcpy(buffer.ptr_, dst + offset, this_size);
         ctp::ipc::ShmPtr<> blob_data = buffer.shm_.template Cast<void>();
         std::string blob_name = dataset->dataset_path + "/chunk_" +
@@ -1090,10 +1377,23 @@ static herr_t clio_dataset_read(size_t count, void *dset[],
             dataset->file->tag_id, blob_name, offset, this_size, blob_data,
             -1.0f, clio::cte::core::Context(), 0);
         fut.Wait();
+        if (fut->GetReturnCode() != 0) staged_ok = false;
+      }
+      if (!staged_ok) {
+        clio_invalidate_dataset(dataset);
       }
     } else {
-      /* HIT — serve the whole image from the CTE tier. */
-      if (!clio_read_cached_image(dataset, total_size, dst)) return -1;
+      /* HIT — serve the whole image from the CTE tier. If reassembly fails we
+         have no data to return, so fall back to native rather than handing back
+         a partially-filled buffer with a success status. */
+      if (!clio_read_cached_image(dataset, total_size, dst)) {
+        clio_invalidate_dataset(dataset);
+        herr_t rc = H5VLdataset_read(1, &dataset->obj.under_object,
+                          dataset->obj.under_vol_id,
+                          &mem_type_id[d], &mem_space_id[d], &file_space_id[d],
+                          dxpl_id, &buf[d], req);
+        if (rc < 0) ret_value = rc;
+      }
     }
     if (tracing)
       clio_trace_access(dataset, clio::trace::Op::kRead, mem_type_id[d],
@@ -1103,7 +1403,7 @@ static herr_t clio_dataset_read(size_t count, void *dset[],
                           clio_since_us(t0));
   }
 
-  return 0;
+  return ret_value;
 }
 
 static herr_t clio_dataset_get(void *obj, H5VL_dataset_get_args_t *args,
@@ -1117,6 +1417,25 @@ static herr_t clio_dataset_specific(void *obj,
                                       H5VL_dataset_specific_args_t *args,
                                       hid_t dxpl_id, void **req) {
   auto *dset = static_cast<clio_dataset_t *>(obj);
+  /* Safe mode: H5Dflush is a durability barrier at DATASET granularity, and the
+     spec names it alongside H5Fflush -- so drain this dataset's pending CTE puts
+     before delegating, exactly as file_specific does for the whole file. This
+     was previously a bare pass-through, so H5Dflush returned with async puts
+     still in flight.
+
+     H5Dset_extent changes the dataset's element count, which is what the linear
+     blob image is sized by, so the cached image no longer describes the dataset:
+     invalidate rather than serve a stale-length image. */
+  if (args) {
+    if (args->op_type == H5VL_DATASET_FLUSH) {
+      if (!drain_dataset_puts(dset)) {
+        clio_invalidate_dataset(dset);
+      }
+    } else if (args->op_type == H5VL_DATASET_SET_EXTENT) {
+      drain_dataset_puts(dset);
+      clio_invalidate_dataset(dset);
+    }
+  }
   return H5VLdataset_specific(dset->obj.under_object, dset->obj.under_vol_id,
                                args, dxpl_id, req);
 }
@@ -1131,9 +1450,13 @@ static herr_t clio_dataset_close(void *obj, hid_t dxpl_id, void **req) {
     dset->file->open_datasets.erase(dset);
   }
 
-  /* Flush all pending async writes */
-  drain_dataset_puts(dset);
+  /* Flush all pending async writes; a failed put leaves a partial image, so
+     invalidate rather than let the next open treat it as a hit. */
+  if (!drain_dataset_puts(dset)) {
+    clio_invalidate_dataset(dset);
+  }
 
+  if (dset->file_type >= 0) H5Tclose(dset->file_type);
   herr_t ret = H5VLdataset_close(dset->obj.under_object,
                                   dset->obj.under_vol_id, dxpl_id, req);
   delete dset;
@@ -1294,6 +1617,23 @@ static herr_t clio_link_create(H5VL_link_create_args_t *args,
   return H5VLlink_create(args, o ? o->under_object : nullptr, loc_params,
                           o ? o->under_vol_id : H5VL_NATIVE,
                           lcpl_id, lapl_id, dxpl_id, req);
+}
+
+/* H5Lmove / H5Lrename. Left null, these failed outright through the connector —
+   a pass-through must forward every op it does not itself implement. */
+static herr_t clio_link_move(void *src_obj,
+                               const H5VL_loc_params_t *loc_params1,
+                               void *dst_obj,
+                               const H5VL_loc_params_t *loc_params2,
+                               hid_t lcpl_id, hid_t lapl_id,
+                               hid_t dxpl_id, void **req) {
+  auto *s = static_cast<clio_obj_t *>(src_obj);
+  auto *d = static_cast<clio_obj_t *>(dst_obj);
+  /* Either endpoint may be null (a move can name one side purely by path). */
+  hid_t vol_id = s ? s->under_vol_id : (d ? d->under_vol_id : H5VL_NATIVE);
+  return H5VLlink_move(s ? s->under_object : nullptr, loc_params1,
+                        d ? d->under_object : nullptr, loc_params2,
+                        vol_id, lcpl_id, lapl_id, dxpl_id, req);
 }
 
 static herr_t clio_link_copy(void *src_obj,
@@ -1460,9 +1800,10 @@ static herr_t clio_introspect_get_conn_cls(void *obj,
 static herr_t clio_introspect_get_cap_flags(const void *info,
                                               uint64_t *cap_flags) {
   (void)info;
-  *cap_flags = H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
-               H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC |
-               H5VL_CAP_FLAG_LINK_BASIC | H5VL_CAP_FLAG_OBJECT_BASIC;
+  /* Same constant the class advertises. These previously disagreed -- the class
+     literal omitted LINK_BASIC and OBJECT_BASIC that this callback reported --
+     so what the connector claimed depended on which one HDF5 asked. */
+  *cap_flags = CLIO_VOL_CAP_FLAGS;
   return 0;
 }
 
@@ -1513,6 +1854,109 @@ static herr_t clio_blob_optional(void *obj, void *blob_id,
   return H5VLblob_optional(o->under_object, o->under_vol_id, blob_id, args);
 }
 
+/* ------------------------------------------------------------------------
+ * Optional-op passthrough. Every subclass's `optional` callback carries the
+ * connector-specific ops HDF5 (and other pass-through connectors) dispatch
+ * through the VOL — for datasets that includes direct chunk I/O
+ * (H5Dread_chunk / H5Dwrite_chunk / H5Dchunk_iter). Left null, those calls fail
+ * through this connector even though the native VOL beneath supports them. The
+ * file subclass already forwarded (it must, for H5VL_NATIVE_FILE_POST_OPEN);
+ * these complete the set. Mirrors H5VLpassthru.
+ * ------------------------------------------------------------------------ */
+static herr_t clio_attr_optional(void *obj, H5VL_optional_args_t *args,
+                                   hid_t dxpl_id, void **req) {
+  auto *o = static_cast<clio_obj_t *>(obj);
+  return H5VLattr_optional(o->under_object, o->under_vol_id, args, dxpl_id, req);
+}
+
+static herr_t clio_dataset_optional(void *obj, H5VL_optional_args_t *args,
+                                      hid_t dxpl_id, void **req) {
+  auto *o = static_cast<clio_obj_t *>(obj);
+  return H5VLdataset_optional(o->under_object, o->under_vol_id, args, dxpl_id,
+                               req);
+}
+
+static herr_t clio_datatype_optional(void *obj, H5VL_optional_args_t *args,
+                                       hid_t dxpl_id, void **req) {
+  auto *o = static_cast<clio_obj_t *>(obj);
+  return H5VLdatatype_optional(o->under_object, o->under_vol_id, args, dxpl_id,
+                                req);
+}
+
+static herr_t clio_group_optional(void *obj, H5VL_optional_args_t *args,
+                                    hid_t dxpl_id, void **req) {
+  auto *o = static_cast<clio_obj_t *>(obj);
+  return H5VLgroup_optional(o->under_object, o->under_vol_id, args, dxpl_id,
+                             req);
+}
+
+static herr_t clio_link_optional(void *obj,
+                                   const H5VL_loc_params_t *loc_params,
+                                   H5VL_optional_args_t *args, hid_t dxpl_id,
+                                   void **req) {
+  auto *o = static_cast<clio_obj_t *>(obj);
+  return H5VLlink_optional(o->under_object, loc_params, o->under_vol_id, args,
+                            dxpl_id, req);
+}
+
+static herr_t clio_object_optional(void *obj,
+                                     const H5VL_loc_params_t *loc_params,
+                                     H5VL_optional_args_t *args, hid_t dxpl_id,
+                                     void **req) {
+  auto *o = static_cast<clio_obj_t *>(obj);
+  return H5VLobject_optional(o->under_object, loc_params, o->under_vol_id, args,
+                              dxpl_id, req);
+}
+
+/* ------------------------------------------------------------------------
+ * Object tokens — passthrough. Tokens are the VOL-agnostic identity of an
+ * object; H5Oget_info-driven code compares and serialises them via these. Left
+ * null, H5Otoken_cmp/to_str/from_str fail through the connector.
+ * ------------------------------------------------------------------------ */
+static herr_t clio_token_cmp(void *obj, const H5O_token_t *token1,
+                               const H5O_token_t *token2, int *cmp_value) {
+  auto *o = static_cast<clio_obj_t *>(obj);
+  return H5VLtoken_cmp(o->under_object, o->under_vol_id, token1, token2,
+                        cmp_value);
+}
+
+static herr_t clio_token_to_str(void *obj, H5I_type_t obj_type,
+                                  const H5O_token_t *token, char **token_str) {
+  auto *o = static_cast<clio_obj_t *>(obj);
+  return H5VLtoken_to_str(o->under_object, obj_type, o->under_vol_id, token,
+                           token_str);
+}
+
+static herr_t clio_token_from_str(void *obj, H5I_type_t obj_type,
+                                    const char *token_str, H5O_token_t *token) {
+  auto *o = static_cast<clio_obj_t *>(obj);
+  return H5VLtoken_from_str(o->under_object, obj_type, o->under_vol_id,
+                             token_str, token);
+}
+
+/* Connector-info comparison. HDF5 uses this to decide whether two FAPLs select
+   the same connector configuration; without it, infos that differ are treated
+   as equal. Compares the fields that actually change behaviour. */
+static herr_t clio_info_cmp(int *cmp_value, const void *_info1,
+                              const void *_info2) {
+  const auto *i1 = static_cast<const clio_vol_info_t *>(_info1);
+  const auto *i2 = static_cast<const clio_vol_info_t *>(_info2);
+  if (!i1 || !i2) {
+    *cmp_value = (i1 == i2) ? 0 : (i1 ? 1 : -1);
+    return 0;
+  }
+  if (i1->under_vol_id != i2->under_vol_id) {
+    *cmp_value = (i1->under_vol_id < i2->under_vol_id) ? -1 : 1;
+    return 0;
+  }
+  if (i1->chunk_size != i2->chunk_size) {
+    *cmp_value = (i1->chunk_size < i2->chunk_size) ? -1 : 1;
+    return 0;
+  }
+  *cmp_value = 0;
+  return 0;
+}
+
 /* ========================================================================
  * VOL connector class definition
  * ======================================================================== */
@@ -1522,15 +1966,14 @@ const H5VL_class_t H5VL_clio_cls = {
     /* value        */ CLIO_VOL_CONNECTOR_VALUE,
     /* name         */ CLIO_VOL_CONNECTOR_NAME,
     /* conn_version */ CLIO_VOL_CONNECTOR_VERSION,
-    /* cap_flags    */ H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
-                       H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC,
+    /* cap_flags    */ CLIO_VOL_CAP_FLAGS,
     /* initialize   */ nullptr,
     /* terminate    */ nullptr,
 
     /* info_cls */ {
         /* size    */ sizeof(clio_vol_info_t),
         /* copy    */ clio_info_copy,
-        /* cmp     */ nullptr,
+        /* cmp     */ clio_info_cmp,
         /* free    */ clio_info_free,
         /* to_str  */ nullptr,
         /* from_str*/ nullptr,
@@ -1551,7 +1994,7 @@ const H5VL_class_t H5VL_clio_cls = {
         /* write    */ clio_attr_write,
         /* get      */ clio_attr_get,
         /* specific */ clio_attr_specific,
-        /* optional */ nullptr,
+        /* optional */ clio_attr_optional,
         /* close    */ clio_attr_close,
     },
 
@@ -1562,7 +2005,7 @@ const H5VL_class_t H5VL_clio_cls = {
         /* write    */ clio_dataset_write,
         /* get      */ clio_dataset_get,
         /* specific */ clio_dataset_specific,
-        /* optional */ nullptr,
+        /* optional */ clio_dataset_optional,
         /* close    */ clio_dataset_close,
     },
 
@@ -1571,7 +2014,7 @@ const H5VL_class_t H5VL_clio_cls = {
         /* open     */ clio_datatype_open,
         /* get      */ clio_datatype_get,
         /* specific */ clio_datatype_specific,
-        /* optional */ nullptr,
+        /* optional */ clio_datatype_optional,
         /* close    */ clio_datatype_close,
     },
 
@@ -1589,17 +2032,17 @@ const H5VL_class_t H5VL_clio_cls = {
         /* open     */ clio_group_open,
         /* get      */ clio_group_get,
         /* specific */ clio_group_specific,
-        /* optional */ nullptr,
+        /* optional */ clio_group_optional,
         /* close    */ clio_group_close,
     },
 
     /* link_cls */ {
         /* create   */ clio_link_create,
         /* copy     */ clio_link_copy,
-        /* move     */ nullptr,
+        /* move     */ clio_link_move,
         /* get      */ clio_link_get,
         /* specific */ clio_link_specific,
-        /* optional */ nullptr,
+        /* optional */ clio_link_optional,
     },
 
     /* object_cls */ {
@@ -1607,7 +2050,7 @@ const H5VL_class_t H5VL_clio_cls = {
         /* copy     */ clio_object_copy,
         /* get      */ clio_object_get,
         /* specific */ clio_object_specific,
-        /* optional */ nullptr,
+        /* optional */ clio_object_optional,
         /* (no close — objects are closed by their specific type class) */
     },
 
@@ -1626,7 +2069,7 @@ const H5VL_class_t H5VL_clio_cls = {
     },
 
     /* token_cls */ {
-        nullptr, nullptr,
+        clio_token_cmp, clio_token_to_str, clio_token_from_str,
     },
 
     /* optional */ nullptr,

--- a/context-transfer-engine/adapter/vfd/H5FDclio.cc
+++ b/context-transfer-engine/adapter/vfd/H5FDclio.cc
@@ -74,6 +74,16 @@ static hid_t H5FDclio_err_minor_g = H5I_INVALID_HID;
 unsigned long H5FDclio_read_vector_calls_g = 0;
 unsigned long H5FDclio_write_vector_calls_g = 0;
 
+/* Observability: CTE cache-tier operations that FAILED. The cache is populate-
+ * only today, so a failure is survivable (the authoritative native file already
+ * has the bytes) -- but it must not be invisible: once the read tier lands, a
+ * dropped Pwrite is a range the cache believes it holds and does not, which is
+ * exactly the stale-data hazard VFD_2.1_READ_CACHE_SCOPING.md is written to
+ * contain. Counted and logged here so residency work has a signal to build on.
+ * Exported (not static) so tests can assert on them. */
+unsigned long H5FDclio_cache_write_failures_g = 0;
+unsigned long H5FDclio_cache_truncate_failures_g = 0;
+
 /* Push a driver error onto HDF5's default error stack. Callbacks still return
  * FAIL/NULL to signal the failure to the library; this records a diagnosable
  * reason (incl. errno) that composes with HDF5's own stack and is surfaced by
@@ -101,6 +111,84 @@ unsigned long H5FDclio_write_vector_calls_g = 0;
 #define SUCCEED 0
 #define FAIL (-1)
 
+/* Largest byte count handed to a single pread/pwrite. Linux caps a single
+ * transfer at 0x7ffff000 and returns a SHORT count above it, so an unlooped
+ * call would silently transfer less than asked. sec2 chunks for the same
+ * reason (H5_POSIX_MAX_IO_BYTES); 1 GiB is comfortably under every platform
+ * limit and keeps the loop count trivial for realistic HDF5 requests.
+ *
+ * CLIO_VFD_MAX_IO_BYTES overrides it. This exists so the multi-pass path can be
+ * exercised with ordinary kilobyte-sized transfers instead of requiring a
+ * multi-gigabyte one: the splitting/resume logic is identical at any threshold,
+ * and a test that needs 2 GiB of disk and memory to run is a test that does not
+ * get run. Read once, on first use. */
+static size_t H5FD__clio_max_io_bytes(void) {
+  static const size_t limit = []() -> size_t {
+    const char *v = getenv("CLIO_VFD_MAX_IO_BYTES");
+    if (v && *v) {
+      unsigned long long n = strtoull(v, nullptr, 10);
+      if (n > 0) {
+        return (size_t)n;
+      }
+    }
+    return (size_t)1 << 30;
+  }();
+  return limit;
+}
+
+/* Attach to the CLIO runtime, at most once per process, and remember the
+ * answer.
+ *
+ * Attaching to an absent runtime is not cheap: the client retries for
+ * CLIO_CLIENT_RETRY_TIMEOUT seconds (60 by default) before giving up. Asking
+ * again on every H5Fopen would make a down runtime cost that timeout per file
+ * rather than once per process -- a workload opening a hundred files would
+ * appear to hang. Cache it.
+ *
+ * Consequence, accepted deliberately: a runtime that starts AFTER the first
+ * open is not picked up for the life of the process. Files stay native-only,
+ * which is correct, just unaccelerated. */
+static bool H5FD__clio_cache_available(void) {
+  static const bool available = clio::cte::core::CLIO_CTE_CLIENT_INIT();
+  return available;
+}
+
+/* Read the CLIO_VFD_CACHE opt-out. Default on; "0"/"off"/"false"/"no" disable
+ * the CTE tier and make the driver pure write-through to the native file.
+ *
+ * Deliberately identical in name-shape and accepted values to the VOL's
+ * CLIO_VOL_CACHE, because the two connectors should not need different muscle
+ * memory to switch off the same thing.
+ *
+ * Why an env var when H5Pset_fapl_clio(fapl, false) already exists: the FAPL
+ * property requires editing and recompiling the application, and the entire
+ * deployment story for this driver is HDF5_DRIVER=clio_vfd with NO source
+ * edits. A switch reachable only from source is not reachable at all for the
+ * workloads this driver targets. §1.4 of VFD_VOL_TECHNICAL_GOALS.md asks for
+ * exactly this shape -- "one env var and one FAPL property, either of which is
+ * sufficient" -- and only the FAPL half existed.
+ *
+ * Precedence: the env var is an opt-OUT only. It can force the cache off, but
+ * it never forces it on over an explicit H5Pset_fapl_clio(fapl, false). "Either
+ * is sufficient" means either is sufficient to DISABLE, which is the
+ * fail-closed direction; a caller that asked for native-only in code must not
+ * have the cache switched back on underneath by an environment it did not set.
+ */
+static bool H5FD__clio_cache_env_enabled(void) {
+  const char *v = getenv("CLIO_VFD_CACHE");
+  if (!v || !*v) return true;
+  return !(strcmp(v, "0") == 0 || strcmp(v, "off") == 0 ||
+           strcmp(v, "false") == 0 || strcmp(v, "no") == 0);
+}
+
+/* True when addr/size cannot be expressed as a POSIX file region: an undefined
+ * address, an address past the driver's advertised maxaddr, or a length that
+ * wraps when added to the address. sec2 performs the equivalent checks; without
+ * them the casts below silently produce a nonsense off_t. */
+#define H5FD_CLIO_REGION_INVALID(addr, size)                               \
+  (HADDR_UNDEF == (addr) || (addr) > MAXADDR ||                            \
+   (haddr_t)(size) > (haddr_t)(MAXADDR - (addr)))
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -127,6 +215,14 @@ typedef struct H5FD_clio_t {
   char *filename_;    /* the name of the file (NULL if empty)  */
   unsigned flags;     /* the flags passed from H5Fcreate/H5Fopen */
   H5FD_clio_fapl_t fa; /* driver-specific FAPL config for this file */
+  /* Filesystem identity of the authoritative native file, captured at open.
+   * This -- NOT the filename -- is what cmp() compares: HDF5 uses cmp() to
+   * decide whether an already-open file IS the same file, and two spellings of
+   * one path (relative vs absolute, symlink vs target, with vs without the
+   * clio:: marker) must compare equal or the library opens the same file twice
+   * with two independent metadata caches, which corrupts it. sec2 parity. */
+  dev_t st_dev;       /* device id of the authoritative native file */
+  ino_t st_ino;       /* inode number of the authoritative native file */
 } H5FD_clio_t;
 
 /* Prototypes */
@@ -166,7 +262,12 @@ static const H5FD_class_t H5FD_clio_g = {
     H5FD_CLIO_VALUE,   /* value                */
     H5FD_CLIO_NAME,    /* name                 */
     MAXADDR,              /* maxaddr              */
-    H5F_CLOSE_STRONG,     /* fc_degree            */
+    /* sec2 parity: the driver's DEFAULT file-close degree. Under STRONG (the
+     * previous value) H5Fclose tears the file down even with objects still
+     * open, invalidating their ids; under WEAK the close defers until the last
+     * object closes. Applications observe the difference, so differing from
+     * sec2 here is a silent native-compatibility deviation. */
+    H5F_CLOSE_WEAK,       /* fc_degree            */
     H5FD__clio_term,    /* terminate            */
     NULL,                 /* sb_size              */
     NULL,                 /* sb_encode            */
@@ -283,14 +384,52 @@ static herr_t H5FD__clio_term(void) {
  */
 static H5FD_t *H5FD__clio_open(const char *name, unsigned flags,
                                  hid_t fapl_id, haddr_t maxaddr) {
-  (void)maxaddr;
-  clio::cte::core::CLIO_CTE_CLIENT_INIT();
+  // Argument validation, sec2 parity. Without these a NULL name dereferences in
+  // StripClioPrefix below, and an out-of-range maxaddr is accepted despite the
+  // class advertising MAXADDR.
+  if (!name || !*name) {
+    errno = EINVAL;
+    H5FD_CLIO_ERROR("invalid file name (NULL or empty)");
+    return nullptr;
+  }
+  if (0 == maxaddr || HADDR_UNDEF == maxaddr) {
+    errno = EINVAL;
+    H5FD_CLIO_ERROR("invalid maxaddr");
+    return nullptr;
+  }
+  if (maxaddr > MAXADDR) {
+    errno = EINVAL;
+    H5FD_CLIO_ERROR("maxaddr exceeds the driver's addressable range");
+    return nullptr;
+  }
 
   // Driver-specific FAPL config: use the caller's policy if a driver-info block
   // was set (H5Pset_fapl_clio), else the default (cache on).
   const H5FD_clio_fapl_t *fa_in =
       (const H5FD_clio_fapl_t *)H5Pget_driver_info(fapl_id);
   H5FD_clio_fapl_t fa = fa_in ? *fa_in : H5FD_clio_fapl_default_g;
+
+  /* Environment opt-out, applied before the runtime probe below so that
+     CLIO_VFD_CACHE=0 also skips the attach attempt entirely (and therefore its
+     retry timeout) rather than attaching and then not using it. */
+  if (fa.cache_enabled && !H5FD__clio_cache_env_enabled()) {
+    fa.cache_enabled = 0;
+  }
+
+  // Attach to the CLIO runtime ONLY when this file actually wants the cache
+  // tier. Model A keeps the native file authoritative, so the native-only
+  // configuration (H5Pset_fapl_clio(fapl, false)) is a complete, correct driver
+  // on its own and must not require CLIO to be running -- previously this ran
+  // unconditionally and with its result discarded, so a down/absent runtime
+  // broke even the native-only path. If attach fails we degrade to native-only
+  // for this file rather than failing the open: the authoritative store is
+  // unaffected, and the cache is a performance tier, not a correctness one.
+  if (fa.cache_enabled && !H5FD__clio_cache_available()) {
+    HLOG(kWarning,
+         "CLIO runtime unavailable; opening {} native-only (cache disabled)",
+         name);
+    fa.cache_enabled = 0;
+  }
 
   /* Build the open flags */
   int o_flags = (H5F_ACC_RDWR & flags) ? O_RDWR : O_RDONLY;
@@ -345,19 +484,42 @@ static H5FD_t *H5FD__clio_open(const char *name, unsigned flags,
     return nullptr;
   }
 
+  // Identity + size from ONE fstat of the authoritative file. cmp() depends on
+  // dev/ino, so a failed fstat is fail-closed: without identity the library
+  // could not tell this file apart from another and might open it twice.
+  struct stat st;
+  if (fstat(posix_fd, &st) < 0) {
+    H5FD_CLIO_ERROR("fstat() of authoritative native file failed");
+    close(posix_fd);
+    if (fd >= 0) {
+      CLIO_CTE_CFS->Close(fd);
+    }
+    free(file);
+    return nullptr;
+  }
+
   /* Pack file */
-  if (name && *name) {
-    file->filename_ = strdup(name);
+  file->filename_ = strdup(name);
+  if (!file->filename_) {
+    errno = ENOMEM;
+    H5FD_CLIO_ERROR("strdup() of file name failed");
+    close(posix_fd);
+    if (fd >= 0) {
+      CLIO_CTE_CFS->Close(fd);
+    }
+    free(file);
+    return nullptr;
   }
   file->fd = fd;
   file->posix_fd = posix_fd;
   file->flags = flags;
   file->fa = fa;
+  file->st_dev = st.st_dev;
+  file->st_ino = st.st_ino;
 
   // EOF is the authoritative on-disk size (durable across reopen/append), not a
   // session-local counter or the cache's logical size.
-  struct stat st;
-  file->eof = (fstat(posix_fd, &st) == 0) ? (haddr_t)st.st_size : 0;
+  file->eof = (haddr_t)st.st_size;
 
   return (H5FD_t *)file;
 } /* end H5FD__clio_open() */
@@ -384,7 +546,13 @@ static herr_t H5FD__clio_close(H5FD_t *_file) {
       H5FD_CLIO_ERROR("fsync() on close failed");
       ret_value = FAIL; /* fail-closed: a close that did not persist fails */
     }
-    close(file->posix_fd);
+    // close() itself can fail (EIO, and notably deferred write errors on NFS).
+    // A close that reports an error has not necessarily persisted, so it is
+    // fail-closed too -- the whole point of the barrier.
+    if (close(file->posix_fd) < 0) {
+      H5FD_CLIO_ERROR("close() of authoritative native file failed");
+      ret_value = FAIL;
+    }
   }
   // Release the CTE cache handle, if this session had one.
   if (file->fd >= 0) {
@@ -413,11 +581,17 @@ static herr_t H5FD__clio_close(H5FD_t *_file) {
 static int H5FD__clio_cmp(const H5FD_t *_f1, const H5FD_t *_f2) {
   const H5FD_clio_t *f1 = (const H5FD_clio_t *)_f1;
   const H5FD_clio_t *f2 = (const H5FD_clio_t *)_f2;
-  // filename_ is only set for a non-empty name; guard against NULL so an
-  // empty-name file cannot crash strcmp.
-  const char *n1 = f1->filename_ ? f1->filename_ : "";
-  const char *n2 = f2->filename_ ? f2->filename_ : "";
-  return strcmp(n1, n2);
+  // Compare filesystem IDENTITY (device + inode), not the filename string.
+  // HDF5 uses this to decide whether an already-open file is the same file;
+  // comparing names made "/tmp/f.h5", "./f.h5", "clio::/tmp/f.h5" and a symlink
+  // to any of them look like four different files, so the library could open
+  // one file several times with independent metadata caches and corrupt it.
+  // sec2 compares dev/ino for exactly this reason.
+  if (f1->st_dev < f2->st_dev) return -1;
+  if (f1->st_dev > f2->st_dev) return 1;
+  if (f1->st_ino < f2->st_ino) return -1;
+  if (f1->st_ino > f2->st_ino) return 1;
+  return 0;
 } /* end H5FD__clio_cmp() */
 
 /*-------------------------------------------------------------------------
@@ -536,32 +710,98 @@ static haddr_t H5FD__clio_get_eof(const H5FD_t *_file, H5FD_mem_t type) {
  */
 static herr_t H5FD__clio_do_read(H5FD_clio_t *file, haddr_t addr, size_t size,
                                  void *buf) {
-  ssize_t got = pread(file->posix_fd, buf, size, static_cast<off_t>(addr));
-  if (getenv("CLIO_VFD_DEBUG"))
-    fprintf(stderr, "[vfd] READ  addr=%llu size=%llu got=%lld\n",
-            (unsigned long long)addr, (unsigned long long)size, (long long)got);
-  if (got < 0) {
-    H5FD_CLIO_ERROR("pread() of authoritative native file failed");
+  if (H5FD_CLIO_REGION_INVALID(addr, size)) {
+    errno = EINVAL;
+    H5FD_CLIO_ERROR("read region is undefined or out of range");
     return FAIL;
   }
-  if (static_cast<size_t>(got) < size) {
-    memset(static_cast<char *>(buf) + got, 0, size - static_cast<size_t>(got));
+  char *dst = static_cast<char *>(buf);
+  size_t remaining = size;
+  off_t off = static_cast<off_t>(addr);
+
+  // Loop rather than issue one pread. A short return is NOT proof of EOF: the
+  // kernel caps a single transfer (0x7ffff000 on Linux) and a signal can cut
+  // one short via EINTR. The previous single-shot version zero-filled whatever
+  // it did not get, so a >2 GiB read -- or any interrupted one -- silently
+  // handed back zeros in place of real data WITH a success status. Only a
+  // pread returning exactly 0 is true EOF; HDF5 treats the file as a flat byte
+  // array, so the tail past EOF is legitimately zero-filled.
+  while (remaining > 0) {
+    const size_t cap = H5FD__clio_max_io_bytes();
+    size_t want = (remaining > cap) ? cap : remaining;
+    ssize_t got = pread(file->posix_fd, dst, want, off);
+    if (got < 0) {
+      if (errno == EINTR) {
+        continue; /* interrupted before transferring anything: retry */
+      }
+      H5FD_CLIO_ERROR("pread() of authoritative native file failed");
+      return FAIL;
+    }
+    if (got == 0) {
+      memset(dst, 0, remaining); /* genuine EOF: zero-fill the remainder */
+      break;
+    }
+    dst += got;
+    off += got;
+    remaining -= static_cast<size_t>(got);
   }
+  if (getenv("CLIO_VFD_DEBUG"))
+    fprintf(stderr, "[vfd] READ  addr=%llu size=%llu\n",
+            (unsigned long long)addr, (unsigned long long)size);
   return SUCCEED;
 }
 
 static herr_t H5FD__clio_do_write(H5FD_clio_t *file, haddr_t addr, size_t size,
                                   const void *buf) {
-  ssize_t put = pwrite(file->posix_fd, buf, size, static_cast<off_t>(addr));
-  if (getenv("CLIO_VFD_DEBUG"))
-    fprintf(stderr, "[vfd] WRITE addr=%llu size=%llu put=%lld\n",
-            (unsigned long long)addr, (unsigned long long)size, (long long)put);
-  if (put < 0 || static_cast<size_t>(put) < size) {
-    H5FD_CLIO_ERROR("pwrite() to authoritative native file failed/short");
+  if (H5FD_CLIO_REGION_INVALID(addr, size)) {
+    errno = EINVAL;
+    H5FD_CLIO_ERROR("write region is undefined or out of range");
     return FAIL;
   }
+  const char *src = static_cast<const char *>(buf);
+  size_t remaining = size;
+  off_t off = static_cast<off_t>(addr);
+
+  // Same loop as the read path: chunk to stay under the kernel's per-call cap
+  // and retry on EINTR. A short pwrite is a partial transfer to be continued,
+  // not a failure -- unlooped, a >2 GiB write failed outright.
+  while (remaining > 0) {
+    const size_t cap = H5FD__clio_max_io_bytes();
+    size_t want = (remaining > cap) ? cap : remaining;
+    ssize_t put = pwrite(file->posix_fd, src, want, off);
+    if (put < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      H5FD_CLIO_ERROR("pwrite() to authoritative native file failed");
+      return FAIL;
+    }
+    if (put == 0) {
+      // No progress and no error: cannot complete the write. Fail closed
+      // rather than spin.
+      H5FD_CLIO_ERROR("pwrite() to authoritative native file made no progress");
+      return FAIL;
+    }
+    src += put;
+    off += put;
+    remaining -= static_cast<size_t>(put);
+  }
+  if (getenv("CLIO_VFD_DEBUG"))
+    fprintf(stderr, "[vfd] WRITE addr=%llu size=%llu\n",
+            (unsigned long long)addr, (unsigned long long)size);
+
+  // Populate the cache tier. Best-effort by design (the authoritative write
+  // already succeeded), but NOT silent: a dropped populate is a range the tier
+  // does not hold, which the future read tier must not mistake for resident
+  // data. Count it and log once per failure so residency work has a signal.
   if (file->fd >= 0) {
-    CLIO_CTE_CFS->Pwrite(file->fd, buf, size, static_cast<off_t>(addr));
+    if (CLIO_CTE_CFS->Pwrite(file->fd, buf, size, static_cast<off_t>(addr)) < 0) {
+      H5FDclio_cache_write_failures_g++;
+      HLOG(kWarning,
+           "CTE cache populate failed at addr={} size={} (native file is "
+           "unaffected and remains authoritative)",
+           (unsigned long long)addr, (unsigned long long)size);
+    }
   }
   if ((haddr_t)(addr + size) > file->eof) {
     file->eof = (haddr_t)(addr + size);
@@ -752,9 +992,16 @@ static herr_t H5FD__clio_truncate(H5FD_t *_file, hid_t dxpl_id, bool closing) {
       return FAIL;
     }
     // Keep the CTE cache's logical size in step (best-effort; populate-only
-    // tier, see the write callback).
+    // tier, see the write callback). Counted on failure for the same reason:
+    // a tier that did not shrink still holds bytes past the new EOF.
     if (file->fd >= 0) {
-      CLIO_CTE_CFS->FtruncateFd(file->fd, (off_t)file->eoa);
+      if (CLIO_CTE_CFS->FtruncateFd(file->fd, (off_t)file->eoa) < 0) {
+        H5FDclio_cache_truncate_failures_g++;
+        HLOG(kWarning,
+             "CTE cache truncate to {} failed (native file is unaffected and "
+             "remains authoritative)",
+             (unsigned long long)file->eoa);
+      }
     }
     file->eof = file->eoa;
   }
@@ -783,6 +1030,10 @@ static herr_t H5FD__clio_lock(H5FD_t *_file, bool rw) {
     if (errno == ENOSYS) {
       return SUCCEED; /* locking unsupported here: not an error (sec2 parity) */
     }
+    // Push a diagnosable error like every other failure path. Lock contention
+    // (EWOULDBLOCK: another process holds the file) is exactly the failure a
+    // user needs named, and it was the one case the driver stayed silent on.
+    H5FD_CLIO_ERROR("flock() of authoritative native file failed");
     return FAIL;
   }
   return SUCCEED;
@@ -797,6 +1048,7 @@ static herr_t H5FD__clio_unlock(H5FD_t *_file) {
     if (errno == ENOSYS) {
       return SUCCEED;
     }
+    H5FD_CLIO_ERROR("flock(LOCK_UN) of authoritative native file failed");
     return FAIL;
   }
   return SUCCEED;
@@ -859,6 +1111,43 @@ herr_t H5Pset_fapl_clio(hid_t fapl_id, hbool_t cache_enabled) {
 }
 
 /*-------------------------------------------------------------------------
+ * Function:    H5Pget_fapl_clio
+ *
+ * Purpose:     Read back the driver-specific tiering policy from a FAPL that
+ *              selects this driver. The symmetric counterpart to
+ *              H5Pset_fapl_clio -- HDF5 convention pairs every H5Pset_fapl_*
+ *              with a getter, and without one a caller cannot inspect (or
+ *              round-trip) the config it set.
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t H5Pget_fapl_clio(hid_t fapl_id, hbool_t *cache_enabled /*out*/) {
+  if (H5Pisa_class(fapl_id, H5P_FILE_ACCESS) <= 0) {
+    H5FD_CLIO_ERROR("H5Pget_fapl_clio: not a file access property list");
+    return FAIL;
+  }
+  if (!cache_enabled) {
+    errno = EINVAL;
+    H5FD_CLIO_ERROR("H5Pget_fapl_clio: NULL out parameter");
+    return FAIL;
+  }
+  if (H5Pget_driver(fapl_id) != H5FD_clio_init()) {
+    H5FD_CLIO_ERROR("H5Pget_fapl_clio: FAPL does not select the CLIO VFD");
+    return FAIL;
+  }
+  // No driver-info block means the file would open with the default policy
+  // (H5Pset_driver(fapl, driver, NULL)); report that same default so the getter
+  // always describes what an open would actually do.
+  const H5FD_clio_fapl_t *fa =
+      (const H5FD_clio_fapl_t *)H5Pget_driver_info(fapl_id);
+  *cache_enabled =
+      fa ? fa->cache_enabled : H5FD_clio_fapl_default_g.cache_enabled;
+  return SUCCEED;
+}
+
+/*-------------------------------------------------------------------------
  * Function:    H5FD__clio_del
  *
  * Purpose:     Delete the file NAME (H5Fdelete). Removes BOTH stores so neither
@@ -874,12 +1163,21 @@ herr_t H5Pset_fapl_clio(hid_t fapl_id, hbool_t cache_enabled) {
  */
 static herr_t H5FD__clio_del(const char *name, hid_t fapl) {
   (void)fapl;
-  clio::cte::core::CLIO_CTE_CLIENT_INIT();
+  if (!name || !*name) {
+    errno = EINVAL;
+    H5FD_CLIO_ERROR("H5Fdelete: invalid file name (NULL or empty)");
+    return FAIL;
+  }
 
   // Drop the CTE cache tag first so it can never be orphaned behind a deleted
   // native file. Best-effort: keyed by the same full name open() used, and
-  // absence (cache off / never populated) is a harmless no-op.
-  CLIO_CTE_CFS->RemovePath(name);
+  // absence (cache off / never populated) is a harmless no-op. If the runtime
+  // is not reachable there is no cache entry to orphan, so deleting the native
+  // file alone is still correct -- the delete must not fail just because CLIO
+  // is down (same reasoning as open()).
+  if (H5FD__clio_cache_available()) {
+    CLIO_CTE_CFS->RemovePath(name);
+  }
 
   // Remove the authoritative native file at the stripped path. Fail-closed on
   // error (sec2 parity) so a failed delete is reported, not masked.

--- a/context-transfer-engine/adapter/vfd/H5FDclio.h
+++ b/context-transfer-engine/adapter/vfd/H5FDclio.h
@@ -53,8 +53,19 @@ hid_t H5FD_clio_init();
 /* Select the CLIO VFD and attach its tiering policy.
  *   cache_enabled: populate the CTE cache tier (false = native-only, which
  *                  avoids the current write-amplification of the populate-only
- *                  cache). */
+ *                  cache, and does not require a running CLIO runtime).
+ *
+ * The same tier can be switched off without touching source by setting
+ * CLIO_VFD_CACHE=0 (also "off"/"false"/"no") in the environment -- the shape
+ * VFD_VOL_TECHNICAL_GOALS.md §1.4 asks for, and the only shape available to an
+ * application loaded via HDF5_DRIVER=clio_vfd. The env var is an opt-OUT only:
+ * it can force the cache off, but never on over an explicit
+ * H5Pset_fapl_clio(fapl, false). */
 herr_t H5Pset_fapl_clio(hid_t fapl_id, hbool_t cache_enabled);
+/* Read back the tiering policy from a FAPL that selects this driver. Reports
+ * the default when no driver-info block was attached, so it always describes
+ * what an open through this FAPL would actually do. */
+herr_t H5Pget_fapl_clio(hid_t fapl_id, hbool_t *cache_enabled /*out*/);
 
 H5PL_type_t H5PLget_plugin_type(void);
 const void* H5PLget_plugin_info(void);

--- a/context-transfer-engine/adapter/vfd/README.md
+++ b/context-transfer-engine/adapter/vfd/README.md
@@ -1,101 +1,139 @@
-# HDF5 Clio VFD
+# CLIO HDF5 VFD (`H5FDclio`)
 
-## 1. Description
-The HDF5 Clio VFD is a [Virtual File
-Driver](https://portal.hdfgroup.org/display/HDF5/Virtual+File+Drivers) (VFD) for
-HDF5 that can be used to interface with the Clio API. The driver is built as a
-plugin library that is external to HDF5.
+A [Virtual File Driver](https://portal.hdfgroup.org/display/HDF5/Virtual+File+Drivers)
+that writes every byte through to an **authoritative on-disk native HDF5 file**,
+while optionally populating a CLIO CTE cache tier alongside it.
 
-## 2. Dependencies
-The Clio VFD requires [HDF5](https://github.com/HDFGroup/hdf5) >= `1.13.0`,
-which is the version that first introduced dynamically loadable VFDs.
+The native file is the source of truth. Standard tools (`h5dump`, `h5ls`,
+`h5repack`, `h5diff`) read it live, with or without CLIO running, because the
+driver adds no superblock driver-info message — the artifact is a plain native
+HDF5 file. Reads are served from it; writes are committed to it synchronously
+before the call returns. The CTE tier is **populate-only** today: writes push
+into it, reads never come from it. Turning it into a read-serving tier is scoped
+in `translation/VFD_2.1_READ_CACHE_SCOPING.md` and is not implemented.
 
-## 3. Usage
-To use the HDF5 Clio VFD in an HDF5 application, the driver can either be
-linked with the application during compilation, or it can be dynamically loaded
-via an environment variable. It is more convenient to load the VFD as a dynamic
-plugin because it does not require code changes or recompilation.
+Files: `H5FDclio.cc`, `H5FDclio.h`. Driver name: **`clio_vfd`**. Driver value: `3200`.
 
-### Method 1: Dynamically loaded by environment variable (recommended)
+## Requirements
 
-As of HDF5 `1.13.0` each file in an HDF5 app opened or created with the default
-file access property list (FAPL) will use the VFD specified in the `HDF5_DRIVER`
-environment variable rather than the default "sec2" (POSIX) driver. To use the
-Clio VFD, simply set
+HDF5 **>= 1.14** — the driver uses the multi-version `H5FD_class_t` API
+(`H5FD_CLASS_VERSION`, `read_vector`/`write_vector`). Point the build at a
+suitable install with `-DHDF5_ROOT=<prefix>` or `CMAKE_PREFIX_PATH`.
 
-```sh
-HDF5_DRIVER=clio
-```
-
-Now we must tell the HDF5 library where to find the Clio VFD. That is done
-with the following environment variable:
+**HDF5 linkage matters.** A dynamically loaded driver is ABI-coupled to the
+`libhdf5` of the application that loads it. Confirm with:
 
 ```sh
-HDF5_PLUGIN_PATH=<HRUN_INSTALL_prefix>/lib/clio_vfd
+ldd <build>/bin/libclio_vfd.so | grep -i hdf5
 ```
 
-The Clio VFD has two configuration options.
-1. persistence - if `true`, the HDF5 application will produce the same output
-   files with the Clio VFD as it would without it. If `false`, the files are
-   buffered in Clio during the application run, but are not persisted when the
-   application terminates. Thus, no files are produced.
-2. page size - The Clio VFD works by mapping HDF5 files into its internal data
-   structures. This happens in pages. The `page size` configuration option
-   allows the user to specify the size, in bytes, of these pages. If your app
-   does lots 2 MiB writes, then it's a good idea to set the page size to 2
-   MiB. A smaller page size, 1 KiB for example, would convert each 2 MiB write
-   into 2048 1 KiB writes. However, be aware that using pages that are too large
-   can slow down metadata operations, which are usually less than 2 KiB. To
-   combat the tradeoff between small metadata pages and large raw data pages,
-   the Clio VFD can be stacked underneath the [split VFD](https://docs.hdfgroup.org/hdf5/develop/group___f_a_p_l.html#ga502f1ad38f5143cf281df8282fef26ed).
-
-
-These two configuration options are passed as a space-delimited string through
-an environment variable:
+## Building
 
 ```sh
-# Example of configuring the Clio VFD with `persistent_mode=true` and
-# `page_size=64KiB`
-HDF5_DRIVER_CONFIG="true 65536"
+cmake -S <repo> -B <build> -DCLIO_CTE_ENABLE_VFD=ON
+cmake --build <build> --target clio_vfd -j
+# -> <build>/bin/libclio_vfd.so   (installs to <prefix>/lib)
 ```
 
-Finally we need to provide a configuration file for Clio itself, and
-`LD_PRELOAD` the Clio VFD so we can intercept HDF5 and MPI calls for proper
-initialization and finalization:
+## Using it
+
+### Method 1 — linked into the application
+
+Include `H5FDclio.h`, link `libclio_vfd.so`, and select the driver on a FAPL:
+
+```c
+herr_t H5Pset_fapl_clio(hid_t fapl_id, hbool_t cache_enabled);
+herr_t H5Pget_fapl_clio(hid_t fapl_id, hbool_t *cache_enabled /*out*/);
+```
+
+`cache_enabled` is the only configuration option:
+
+- `true` — populate the CTE cache tier on write. Requires a reachable CLIO
+  runtime; if none is found the file opens native-only and a warning is logged.
+- `false` — native-only. No CTE traffic, no write amplification, and **no CLIO
+  runtime required**. In this mode the driver is a complete, correct HDF5 driver
+  on its own.
+
+```c
+hid_t fapl = H5Pcreate(H5P_FILE_ACCESS);
+H5Pset_fapl_clio(fapl, /*cache_enabled*/ 1);
+hid_t f = H5Fcreate("/tmp/data.h5", H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
+```
+
+### Method 2 — loaded by environment variable (no source changes)
 
 ```sh
-CLIO_CONF=<path_to>/clio.yaml
-LD_PRELOAD=<HRUN_INSTALL_prefix>/clio_vfd/libclio_vfd.so
+export HDF5_PLUGIN_PATH=<build>/bin
+export HDF5_DRIVER=clio_vfd
+./my_hdf5_app
 ```
 
-Heres is a full example of running an HDF5 app with the Clio VFD:
+**Known gap:** the driver does not yet parse `HDF5_DRIVER_CONFIG`, so
+`cache_enabled` cannot be set on this path (it uses the default, cache on).
+This path is also not yet covered by the test suite. Both are tracked as Q2.1
+work in `translation/VFD_AUDIT.md` (F13).
+
+## File naming
+
+The driver accepts either a plain path (`/tmp/data.h5`) or a `clio::`-marked one
+(`clio::/tmp/data.h5`). The marker is stripped to locate the authoritative native
+file, so both forms write the same on-disk file; the full name is used as the CTE
+cache key. Plain paths are the normal case — the marker exists for callers that
+also address the file through other CLIO adapters.
+
+## Configuration reference
+
+| Knob | Where | Default | Effect |
+|---|---|---|---|
+| `cache_enabled` | `H5Pset_fapl_clio` | on | Populate the CTE tier on write |
+| `HDF5_DRIVER=clio_vfd` | env | — | Select the driver without source changes |
+| `HDF5_PLUGIN_PATH` | env | — | Where HDF5 looks for the `.so` |
+| `CLIO_VFD_DEBUG` | env | off | Print every read/write addr+size to stderr |
+| `CLIO_VFD_MAX_IO_BYTES` | env | 1 GiB | Largest single `pread`/`pwrite`; larger transfers are split and resumed. Lower it to exercise the multi-pass path in tests |
+| `CLIO_CLIENT_RETRY_TIMEOUT` | env | 60s | How long the runtime attach retries before giving up. `0` fails immediately — worth setting when you expect no runtime |
+
+## Runtime availability
+
+The driver attaches to the CLIO runtime **once per process**, on the first open
+that wants the cache, and remembers the result. Three cases:
+
+- **`cache_enabled=false`** — no attach is attempted at all. The driver is a
+  complete HDF5 driver on its own.
+- **Runtime absent** — the attach fails and the file opens native-only, with a
+  warning. Everything still works; nothing is cached. Note the attach costs
+  `CLIO_CLIENT_RETRY_TIMEOUT` seconds before it gives up, paid once per process.
+- **Runtime *misconfigured*** — e.g. `CLIO_SERVER_CONF` pointing at a file that
+  cannot be parsed. This is **fatal inside the runtime client**: the process
+  aborts before the driver can decide anything. The driver can survive a
+  missing runtime; it cannot survive a broken configuration.
+
+A runtime that starts *after* the first open is not picked up for the lifetime
+of the process — files stay native-only, which is correct but unaccelerated.
+
+## Durability
+
+- `H5Fflush` / `H5Dflush` → `fsync` on the authoritative file. Fail-closed: a
+  flush that did not reach disk returns an error rather than reporting success.
+- `H5Fclose` → `fsync` then `close`, both checked. After a successful close the
+  on-disk file is a complete native HDF5 image and CLIO holds nothing needed to
+  read it.
+- Any driver failure either falls through to the native path or returns a real
+  HDF5 error with a populated error stack. It never reports success for data that
+  was not committed.
+
+## Testing
 
 ```sh
-HDF5_DRIVER=clio                                                    \
-  HDF5_PLUGIN_PATH=<HRUN_INSTALL_prefix/lib/clio_vfd              \
-  HDF5_DRIVER_CONFIG="true 65536"                                     \
-  CLIO_CONF=<path_to>/clio.yaml                                   \
-  ./my_hdf5_app
+ctest --test-dir <build> -R vfd --output-on-failure
 ```
 
-### Method 2: Linked into application
+`clio_cte_vfd_unit_tests` covers the rich round-trip, reopen+append, a
+differential against `sec2` as oracle, partial hyperslab overwrite, two files
+open at once, flush/`get_handle`, `flock` exclusion, fail-closed error reporting,
+on-disk size parity with `sec2`, SWMR, the driver FAPL, vectored I/O, `H5Fdelete`
+of both stores, and the no-pending-dirty-state flush barrier.
+CI: `.github/workflows/ci-vfd.yml`.
 
-To link the Clio VFD into an HDF5 application, the application should include
-the `H5FDclio.h` header and should link the installed VFD library,
-`libclio_vfd.so`, into the application. Once this has been done, Clio
-VFD access can be set up by calling `H5Pset_fapl_clio()` on a FAPL within the
-HDF5 application. In this case, the `persistence` and `page_size` configuration
-options are pass directly to this function:
-
-```C
-herr_t H5Pset_fapl_clio(hid_t fapl_id, hbool_t persistence, size_t page_size)
-```
-
-The resulting `fapl_id` should then be passed to each file open or creation for
-which you wish to use the Clio VFD.
-
-## 4. More Information
-* [Clio VFD performance results](https://github.com/HDFGroup/clio/wiki/HDF5-Clio-VFD)
-
-* [Clio VFD with hdf5-iotest](https://github.com/HDFGroup/clio/tree/master/benchmarks/ClioVFD)
-* [HDF5 VFD Plugins RFC](https://github.com/HDFGroup/hdf5doc/blob/master/RFCs/HDF5_Library/VFL_DriverPlugins/RFC__A_Plugin_Interface_for_HDF5_Virtual_File_Drivers.pdf)
+For the current gap list — including what this suite does **not** cover
+(multi-process, crash consistency, >2 GiB transfers, the env-var path) — see
+`translation/VFD_AUDIT.md`.

--- a/context-transfer-engine/test/unit/adapters/vfd/CMakeLists.txt
+++ b/context-transfer-engine/test/unit/adapters/vfd/CMakeLists.txt
@@ -29,8 +29,28 @@ add_dependencies(clio_cte_vfd_unit_tests
     clio_bdev_runtime
     clio_admin_runtime)
 
+# The driver's behaviour when no CLIO runtime is reachable. Separate binary on
+# purpose: the suite above starts a runtime before its first case, so it cannot
+# express "no runtime" from the inside. No runtime dependencies, no fixtures.
+add_executable(clio_cte_vfd_no_runtime_tests
+    test_vfd_no_runtime.cc
+)
+
+target_include_directories(clio_cte_vfd_no_runtime_tests SYSTEM PUBLIC
+    ${HDF5_INCLUDE_DIRS})
+
+target_link_libraries(clio_cte_vfd_no_runtime_tests
+    clio_vfd
+    clio_cte_cfs_adapter
+    clio_cte_filesystem_client
+    clio_cte_core_client
+    ctp::cxx
+    ctp::interceptor
+    ${HDF5_LIBRARIES}
+)
+
 install(
-    TARGETS clio_cte_vfd_unit_tests
+    TARGETS clio_cte_vfd_unit_tests clio_cte_vfd_no_runtime_tests
     RUNTIME DESTINATION bin
 )
 
@@ -43,6 +63,18 @@ if(CLIO_CORE_ENABLE_TESTS)
     set_tests_properties(clio_cte_vfd_unit_tests PROPERTIES
         ENVIRONMENT "CLIO_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CLIO_BIND_ADDR=127.0.0.1"
         RESOURCE_LOCK "clio_runtime_port"
+        TIMEOUT 120
+        LABELS "msan_skip")
+
+    # No runtime, no fixtures, no resource lock -- the point is that this one
+    # needs nothing brought up first.
+    add_test(
+        NAME clio_cte_vfd_no_runtime_tests
+        COMMAND clio_cte_vfd_no_runtime_tests
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+    )
+    set_tests_properties(clio_cte_vfd_no_runtime_tests PROPERTIES
+        ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
         TIMEOUT 120
         LABELS "msan_skip")
 endif()

--- a/context-transfer-engine/test/unit/adapters/vfd/test_vfd_adapter.cc
+++ b/context-transfer-engine/test/unit/adapters/vfd/test_vfd_adapter.cc
@@ -254,6 +254,15 @@ herr_t FindClioErr(unsigned n, const H5E_error2_t *err, void *data) {
 }  // namespace
 
 int main() {
+  // Cap a single kernel I/O call at 4 KiB for the whole suite. The driver
+  // splits any larger transfer into bounded passes and resumes; in production
+  // that threshold is 1 GiB and only enormous transfers reach it, which would
+  // make the multi-pass path effectively untestable. Lowering it here means
+  // every section exercises splitting and resuming, while the constant stream
+  // of sub-4 KiB metadata I/O still covers the single-pass case. Must be set
+  // before the driver's first use -- it is read once.
+  setenv("CLIO_VFD_MAX_IO_BYTES", "4096", /*overwrite*/ 0);
+
   if (!InitRuntime()) {
     std::fprintf(stderr, "[vfd-suite] FAIL: runtime/CTE init\n");
     return 1;
@@ -785,6 +794,258 @@ int main() {
     H5Pclose(rfapl);
     H5Pclose(wfapl);
     std::printf("[vfd-suite] ok 15: no-pending-dirty-state barrier (flush finalizes the image)\n");
+  }
+
+  // === 16. cmp() compares file IDENTITY, not the filename string ==========
+  // HDF5 uses the driver's cmp() to decide whether an already-open file IS the
+  // same file. Comparing names made every spelling of one path look like a
+  // different file, so the library could open it twice with two independent
+  // metadata caches -- corruption, not a performance bug. H5Fget_fileno exposes
+  // the shared file struct HDF5 settled on, so equal filenos == cmp() matched.
+  // Three spellings that must all resolve to one file: with the clio:: marker,
+  // without it, and via a redundant path component.
+  {
+    const char *kClioId = "clio::/tmp/clio_cte_vfd_ident.h5";
+    const char *kNativeId = "/tmp/clio_cte_vfd_ident.h5";
+    const char *kDotted = "/tmp/../tmp/clio_cte_vfd_ident.h5";
+    std::remove(kNativeId);
+    hid_t fapl_id_ = H5Pcopy(fapl);
+    CHECK(fapl_id_ >= 0 &&
+              H5Pset_file_locking(fapl_id_, /*use*/ false, /*ignore*/ true) >= 0,
+          "16: fapl (locking off so the same file can be opened twice)");
+
+    hid_t c = H5Fcreate(kClioId, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id_);
+    CHECK(c >= 0 && WriteDset(c, "d", H5T_NATIVE_INT32, MakeI32(kSmall)) &&
+              H5Fclose(c) >= 0,
+          "16: seed the file");
+
+    hid_t a = H5Fopen(kClioId, H5F_ACC_RDONLY, fapl_id_);
+    hid_t b = H5Fopen(kNativeId, H5F_ACC_RDONLY, fapl_id_);
+    hid_t e = H5Fopen(kDotted, H5F_ACC_RDONLY, fapl_id_);
+    CHECK(a >= 0 && b >= 0 && e >= 0, "16: open the same file three ways");
+
+    unsigned long fa_no = 0, fb_no = 0, fe_no = 0;
+    CHECK(H5Fget_fileno(a, &fa_no) >= 0 && H5Fget_fileno(b, &fb_no) >= 0 &&
+              H5Fget_fileno(e, &fe_no) >= 0,
+          "16: H5Fget_fileno on all three");
+    CHECK(fa_no == fb_no,
+          "16: clio::-marked and bare paths are ONE file (cmp by dev/ino)");
+    CHECK(fa_no == fe_no,
+          "16: redundant path components resolve to the same file");
+
+    // Two genuinely different files must still compare different.
+    const char *kOther = "clio::/tmp/clio_cte_vfd_ident_other.h5";
+    std::remove("/tmp/clio_cte_vfd_ident_other.h5");
+    hid_t o = H5Fcreate(kOther, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id_);
+    CHECK(o >= 0 && WriteDset(o, "d", H5T_NATIVE_INT32, MakeI32(kSmall)) &&
+              H5Fclose(o) >= 0,
+          "16: seed a second file");
+    hid_t o2 = H5Fopen(kOther, H5F_ACC_RDONLY, fapl_id_);
+    unsigned long fo_no = 0;
+    CHECK(o2 >= 0 && H5Fget_fileno(o2, &fo_no) >= 0, "16: fileno of file 2");
+    CHECK(fo_no != fa_no, "16: distinct files still compare distinct");
+
+    CHECK(H5Fclose(a) >= 0 && H5Fclose(b) >= 0 && H5Fclose(e) >= 0 &&
+              H5Fclose(o2) >= 0,
+          "16: close all");
+    H5Pclose(fapl_id_);
+    std::printf("[vfd-suite] ok 16: cmp() by device+inode, not filename\n");
+  }
+
+  // === 17. H5Pget_fapl_clio round-trips the policy ========================
+  {
+    hid_t p = H5Pcreate(H5P_FILE_ACCESS);
+    CHECK(p >= 0, "17: H5Pcreate");
+    hbool_t got = 1;
+    CHECK(H5Pset_fapl_clio(p, /*cache_enabled*/ 0) >= 0, "17: set cache off");
+    CHECK(H5Pget_fapl_clio(p, &got) >= 0 && got == 0, "17: get reports off");
+    CHECK(H5Pset_fapl_clio(p, /*cache_enabled*/ 1) >= 0, "17: set cache on");
+    CHECK(H5Pget_fapl_clio(p, &got) >= 0 && got == 1, "17: get reports on");
+
+    // Driver selected with no driver-info block: the getter must report the
+    // default the open would actually use, not fail.
+    hid_t q = H5Pcreate(H5P_FILE_ACCESS);
+    CHECK(q >= 0 && H5Pset_driver(q, H5FD_clio_init(), nullptr) >= 0,
+          "17: H5Pset_driver with NULL info");
+    got = 0;
+    CHECK(H5Pget_fapl_clio(q, &got) >= 0 && got == 1,
+          "17: default policy reported when no driver-info block is set");
+
+    // Negative: a FAPL that does not select this driver, and a NULL out-param.
+    H5E_auto2_t of = nullptr;
+    void *od = nullptr;
+    H5Eget_auto2(H5E_DEFAULT, &of, &od);
+    H5Eset_auto2(H5E_DEFAULT, nullptr, nullptr);
+    hid_t plain = H5Pcreate(H5P_FILE_ACCESS);
+    herr_t bad_drv = H5Pget_fapl_clio(plain, &got);
+    herr_t bad_out = H5Pget_fapl_clio(p, nullptr);
+    H5Eset_auto2(H5E_DEFAULT, of, od);
+    CHECK(bad_drv < 0, "17: rejects a FAPL not using the CLIO VFD");
+    CHECK(bad_out < 0, "17: rejects a NULL out parameter");
+
+    H5Pclose(plain);
+    H5Pclose(q);
+    H5Pclose(p);
+    std::printf("[vfd-suite] ok 17: H5Pget_fapl_clio round-trip\n");
+  }
+
+  // === 18. Transfers larger than one kernel I/O call ======================
+  // A single pread/pwrite is capped by the kernel (~2 GiB on Linux) and can
+  // also be cut short by a signal, so the driver splits every transfer into
+  // bounded passes and resumes. A short result must be treated as "continue
+  // from here", NOT as end-of-file -- treating it as EOF zero-fills the
+  // remainder and hands back zeros in place of real data. Exercised at a small
+  // threshold (CLIO_VFD_MAX_IO_BYTES, set by the parent process below) so the
+  // multi-pass path runs on kilobytes instead of needing gigabytes; the split
+  // and resume logic is identical at any threshold.
+  //
+  // The value must survive intact across many passes, including a final pass
+  // shorter than the cap and a dataset that is an exact multiple of it.
+  {
+    const char *kClioMp = "clio::/tmp/clio_cte_vfd_multipass.h5";
+    std::remove("/tmp/clio_cte_vfd_multipass.h5");
+    // 64 KiB of doubles against a 4 KiB cap => 16+ passes per transfer.
+    const hsize_t kN = 8192;
+    std::vector<double> w = MakeF64(kN);
+
+    hid_t f = H5Fcreate(kClioMp, H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
+    CHECK(f >= 0, "18: create");
+    CHECK(WriteDset(f, "multipass", H5T_NATIVE_DOUBLE, w), "18: write");
+    // An exact multiple of the cap: the loop must terminate cleanly with no
+    // trailing zero-length pass.
+    std::vector<int32_t> aligned = MakeI32(1024);  // 4096 B == the cap
+    CHECK(WriteDset(f, "aligned", H5T_NATIVE_INT32, aligned),
+          "18: write an exact multiple of the transfer cap");
+    CHECK(H5Fclose(f) >= 0, "18: close");
+
+    hid_t f2 = H5Fopen(kClioMp, H5F_ACC_RDONLY, fapl);
+    CHECK(f2 >= 0, "18: reopen");
+    CHECK(ReadDsetEq(f2, "multipass", H5T_NATIVE_DOUBLE, w),
+          "18: multi-pass transfer round-trips byte-clean (no zero-filled tail)");
+    CHECK(ReadDsetEq(f2, "aligned", H5T_NATIVE_INT32, aligned),
+          "18: cap-aligned transfer round-trips byte-clean");
+    CHECK(H5Fclose(f2) >= 0, "18: close");
+
+    // Read it back with NO VFD to prove the bytes really are on disk, rather
+    // than a matching pair of bugs in the write and read paths.
+    hid_t fn = H5Fopen("/tmp/clio_cte_vfd_multipass.h5", H5F_ACC_RDONLY,
+                       H5P_DEFAULT);
+    CHECK(fn >= 0, "18: reopen natively");
+    CHECK(ReadDsetEq(fn, "multipass", H5T_NATIVE_DOUBLE, w),
+          "18: native reader sees the same bytes");
+    CHECK(H5Fclose(fn) >= 0, "18: close native");
+    std::printf("[vfd-suite] ok 18: transfers split across multiple I/O passes\n");
+  }
+
+  // === 19. Closing a file with objects still open ========================
+  // The driver's default close degree decides what H5Fclose does when datasets
+  // are still open: close the file immediately and invalidate them, or defer
+  // until the last one closes. Applications observe the difference, so it must
+  // match what they would get natively. Compare against sec2 rather than
+  // asserting one particular behavior.
+  {
+    const char *kClioCd = "clio::/tmp/clio_cte_vfd_closedeg.h5";
+    const char *kSec2Cd = "/tmp/clio_cte_vfd_closedeg_sec2.h5";
+    std::remove("/tmp/clio_cte_vfd_closedeg.h5");
+    std::remove(kSec2Cd);
+
+    auto close_with_open_dataset = [&](const char *path, hid_t fa) -> int {
+      hid_t f = H5Fcreate(path, H5F_ACC_TRUNC, H5P_DEFAULT, fa);
+      if (f < 0) return -99;
+      hsize_t dims[1] = {16};
+      hid_t sp = H5Screate_simple(1, dims, nullptr);
+      hid_t d = H5Dcreate2(f, "d", H5T_NATIVE_INT32, sp, H5P_DEFAULT,
+                           H5P_DEFAULT, H5P_DEFAULT);
+      if (d < 0) return -99;
+      // Close the FILE while the dataset is still open, then ask whether the
+      // dataset id is still usable. That answer is the close degree.
+      herr_t fc = H5Fclose(f);
+      H5E_auto2_t af = nullptr;
+      void *ad = nullptr;
+      H5Eget_auto2(H5E_DEFAULT, &af, &ad);
+      H5Eset_auto2(H5E_DEFAULT, nullptr, nullptr);
+      hid_t still = H5Dget_space(d);
+      H5Eset_auto2(H5E_DEFAULT, af, ad);
+      int alive = (still >= 0) ? 1 : 0;
+      if (still >= 0) H5Sclose(still);
+      // Only close the dataset if it survived; under the other degree the file
+      // close already took it, and closing a dead id just logs a spurious error.
+      if (alive) H5Dclose(d);
+      H5Sclose(sp);
+      return (fc < 0) ? -1 : alive;
+    };
+
+    int clio_behavior = close_with_open_dataset(kClioCd, fapl);
+    int sec2_behavior = close_with_open_dataset(kSec2Cd, H5P_DEFAULT);
+    CHECK(clio_behavior != -99 && sec2_behavior != -99,
+          "19: both close-degree probes ran");
+    CHECK(clio_behavior == sec2_behavior,
+          "19: closing with an open dataset behaves the same as sec2");
+    std::printf("[vfd-suite] ok 19: close-with-open-objects matches sec2 "
+                "(objects %s)\n",
+                clio_behavior == 1 ? "stay usable" : "are invalidated");
+  }
+
+  // === 20. Rejecting unusable file names =================================
+  // An empty name -- directly, or one that is empty once the clio:: marker is
+  // stripped -- has no authoritative file behind it. It must be refused with a
+  // real error, not dereferenced.
+  {
+    H5E_auto2_t of = nullptr;
+    void *od = nullptr;
+    H5Eget_auto2(H5E_DEFAULT, &of, &od);
+    H5Eset_auto2(H5E_DEFAULT, nullptr, nullptr);
+    hid_t empty = H5Fcreate("", H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
+    hid_t marker_only = H5Fcreate("clio::", H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
+    H5Eset_auto2(H5E_DEFAULT, of, od);
+    CHECK(empty < 0, "20: an empty file name is refused");
+    CHECK(marker_only < 0, "20: a name that is empty once stripped is refused");
+    if (empty >= 0) H5Fclose(empty);
+    if (marker_only >= 0) H5Fclose(marker_only);
+    std::printf("[vfd-suite] ok 20: unusable file names are refused\n");
+  }
+
+  // === 21. A file already locked by another opener =======================
+  // Section 8 proves the driver TAKES the lock. This is the other direction:
+  // when someone else already holds it, the open must fail closed AND say why.
+  // Lock contention is the failure a user is most likely to hit and least able
+  // to diagnose from a bare error code.
+  {
+    const char *kClioBusy = "clio::/tmp/clio_cte_vfd_busy.h5";
+    const char *kNativeBusy = "/tmp/clio_cte_vfd_busy.h5";
+    std::remove(kNativeBusy);
+    hid_t fapl_lk = H5Pcopy(fapl);
+    CHECK(fapl_lk >= 0 &&
+              H5Pset_file_locking(fapl_lk, /*use*/ true, /*ignore*/ false) >= 0,
+          "21: force file locking on");
+    hid_t seed = H5Fcreate(kClioBusy, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_lk);
+    CHECK(seed >= 0 && WriteDset(seed, "d", H5T_NATIVE_INT32, MakeI32(kSmall)) &&
+              H5Fclose(seed) >= 0,
+          "21: seed the file");
+
+    // An unrelated process-level lock holder.
+    int holder = ::open(kNativeBusy, O_RDWR);
+    CHECK(holder >= 0 && ::flock(holder, LOCK_EX | LOCK_NB) == 0,
+          "21: take an exclusive lock outside HDF5");
+
+    H5E_auto2_t of = nullptr;
+    void *od = nullptr;
+    H5Eget_auto2(H5E_DEFAULT, &of, &od);
+    H5Eset_auto2(H5E_DEFAULT, nullptr, nullptr);
+    H5Eclear2(H5E_DEFAULT);
+    hid_t blocked = H5Fopen(kClioBusy, H5F_ACC_RDWR, fapl_lk);
+    bool found_clio_err = false;
+    H5Ewalk2(H5E_DEFAULT, H5E_WALK_UPWARD, FindClioErr, &found_clio_err);
+    H5Eset_auto2(H5E_DEFAULT, of, od);
+
+    CHECK(blocked < 0, "21: opening a file locked by another holder fails");
+    CHECK(found_clio_err,
+          "21: the driver explains WHY the locked open failed");
+    ::flock(holder, LOCK_UN);
+    ::close(holder);
+    H5Pclose(fapl_lk);
+    std::printf("[vfd-suite] ok 21: a file locked elsewhere fails with a "
+                "diagnosable error\n");
   }
 
   H5Pclose(fapl);

--- a/context-transfer-engine/test/unit/adapters/vfd/test_vfd_no_runtime.cc
+++ b/context-transfer-engine/test/unit/adapters/vfd/test_vfd_no_runtime.cc
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved. BSD 3-Clause license.
+ *
+ * The CLIO VFD without a CLIO runtime.
+ *
+ * The authoritative store is a plain on-disk native HDF5 file, so the driver is
+ * a complete and correct HDF5 driver whether or not a CLIO runtime is running.
+ * The CTE tier is an accelerator layered on top of that, not a prerequisite.
+ * This asserts the guarantee directly: with no runtime reachable, applications
+ * must still be able to create, write, close, reopen and read their files.
+ *
+ * Two configurations are covered:
+ *   1. Cache explicitly disabled -- the documented native-only mode, which must
+ *      never touch CLIO at all.
+ *   2. Cache requested but unavailable -- the accident case. The open must
+ *      SUCCEED and fall back to native-only rather than failing the
+ *      application, because nothing about the file's correctness depends on the
+ *      tier.
+ *
+ * This deliberately lives in its own binary. The main VFD suite brings a
+ * runtime up before its first case, so it structurally cannot express "no
+ * runtime"; a test of the no-runtime path has to be a process that never
+ * starts one.
+ */
+#include <hdf5.h>
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "adapter/vfd/H5FDclio.h"
+
+namespace {
+constexpr hsize_t kN = 4096;
+
+#define CHECK(cond, msg)                                              \
+  do {                                                                \
+    if (!(cond)) {                                                    \
+      std::fprintf(stderr, "[vfd-no-runtime] FAIL: %s\n", (msg));     \
+      return 1;                                                       \
+    }                                                                 \
+  } while (0)
+
+std::vector<double> MakeF64(hsize_t n) {
+  std::vector<double> v(n);
+  for (hsize_t i = 0; i < n; ++i) v[i] = static_cast<double>(i) * 3.5 - 11.0;
+  return v;
+}
+
+bool WriteDset(hid_t loc, const char *name, const std::vector<double> &v) {
+  hsize_t dims[1] = {static_cast<hsize_t>(v.size())};
+  hid_t space = H5Screate_simple(1, dims, nullptr);
+  hid_t dset = H5Dcreate2(loc, name, H5T_NATIVE_DOUBLE, space, H5P_DEFAULT,
+                          H5P_DEFAULT, H5P_DEFAULT);
+  bool ok = dset >= 0 && H5Dwrite(dset, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL,
+                                  H5P_DEFAULT, v.data()) >= 0;
+  if (dset >= 0) H5Dclose(dset);
+  H5Sclose(space);
+  return ok;
+}
+
+bool ReadDsetEq(hid_t loc, const char *name, const std::vector<double> &want) {
+  hid_t dset = H5Dopen2(loc, name, H5P_DEFAULT);
+  if (dset < 0) return false;
+  std::vector<double> got(want.size());
+  bool ok = H5Dread(dset, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT,
+                    got.data()) >= 0;
+  H5Dclose(dset);
+  return ok && std::memcmp(got.data(), want.data(),
+                           want.size() * sizeof(double)) == 0;
+}
+
+// Full lifecycle through the driver, then an independent native read of the
+// same file with no driver loaded -- which is what proves the bytes really
+// landed in a valid native HDF5 image rather than anywhere CLIO-specific.
+int RoundTrip(const char *label, hbool_t cache_enabled, const char *path) {
+  const std::vector<double> w = MakeF64(kN);
+  std::remove(path);
+
+  hid_t fapl = H5Pcreate(H5P_FILE_ACCESS);
+  CHECK(fapl >= 0, "H5Pcreate");
+  CHECK(H5Pset_fapl_clio(fapl, cache_enabled) >= 0, "H5Pset_fapl_clio");
+
+  hid_t f = H5Fcreate(path, H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
+  CHECK(f >= 0, "H5Fcreate with no runtime running");
+  CHECK(WriteDset(f, "d", w), "write with no runtime running");
+  CHECK(H5Fflush(f, H5F_SCOPE_GLOBAL) >= 0, "flush with no runtime running");
+  CHECK(H5Fclose(f) >= 0, "close with no runtime running");
+
+  hid_t f2 = H5Fopen(path, H5F_ACC_RDONLY, fapl);
+  CHECK(f2 >= 0, "reopen with no runtime running");
+  CHECK(ReadDsetEq(f2, "d", w), "data reads back intact with no runtime");
+  CHECK(H5Fclose(f2) >= 0, "close after read");
+  H5Pclose(fapl);
+
+  hid_t fn = H5Fopen(path, H5F_ACC_RDONLY, H5P_DEFAULT);
+  CHECK(fn >= 0, "the file opens with no driver at all");
+  CHECK(ReadDsetEq(fn, "d", w), "a plain native reader sees the same data");
+  CHECK(H5Fclose(fn) >= 0, "close native");
+
+  std::printf("[vfd-no-runtime] ok: %s\n", label);
+  return 0;
+}
+}  // namespace
+
+int main() {
+  // Give up on a missing runtime immediately instead of retrying for the
+  // default 60s. Without this the second case below spends a minute confirming
+  // what it already knows, and the fallback it is checking looks like a hang.
+  setenv("CLIO_CLIENT_RETRY_TIMEOUT", "0", /*overwrite*/ 0);
+
+  hid_t driver = H5FD_clio_init();
+  CHECK(driver >= 0, "the driver registers without a runtime");
+
+  if (RoundTrip("native-only mode never needs CLIO", /*cache_enabled*/ 0,
+                "/tmp/clio_cte_vfd_nort_off.h5")) {
+    return 1;
+  }
+  if (RoundTrip("caching requested but unavailable falls back to native",
+                /*cache_enabled*/ 1, "/tmp/clio_cte_vfd_nort_on.h5")) {
+    return 1;
+  }
+
+  // Deleting a file must also not depend on the runtime: there is no cache
+  // entry to orphan when there is no cache.
+  {
+    const char *path = "/tmp/clio_cte_vfd_nort_del.h5";
+    std::remove(path);
+    hid_t fapl = H5Pcreate(H5P_FILE_ACCESS);
+    CHECK(fapl >= 0 && H5Pset_fapl_clio(fapl, 0) >= 0, "delete: fapl");
+    hid_t f = H5Fcreate(path, H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
+    CHECK(f >= 0 && WriteDset(f, "d", MakeF64(64)) && H5Fclose(f) >= 0,
+          "delete: seed the file");
+    CHECK(H5Fdelete(path, fapl) >= 0, "H5Fdelete succeeds with no runtime");
+    hid_t gone = H5Fopen(path, H5F_ACC_RDONLY, H5P_DEFAULT);
+    CHECK(gone < 0, "the deleted file is really gone");
+    H5Pclose(fapl);
+    std::printf("[vfd-no-runtime] ok: delete works with no runtime\n");
+  }
+
+  std::printf("[vfd-no-runtime] PASS: the driver is complete without CLIO\n");
+  return 0;
+}


### PR DESCRIPTION
Both HDF5 connectors were audited against explicit criteria and the problems found were fixed. Most of these were cases where the connector returned wrong data but reported success, preventing anything downstream from noticing a problem. The VFD compared files by name instead of by identity, and treated a short read as the end of the file. The VOL sized its cache from the caller's memory type rather than the type
actually stored on disk, and kept serving a cached copy of a file that had since been truncated. The VOL also reported success for native reads and writes that had actually failed in some of its data paths. Separately, simply having the VOL library sitting in the plugin directory could crash a plain H5Fopen of a missing or non-HDF5 file, because HDF5 asks every plugin it finds whether it can open the file and the connector dereferenced an object that is null on that path. The connector did not have to be selected or requested for this to happen.

Neither connector could previously run without CLIO present; both now fall back to plain pass-through behaviour. The VFD also gains a CLIO_VFD_CACHE environment variable to switch its cache tier off, matching the VOL's existing CLIO_VOL_CACHE, so the cache can be disabled without editing application source -- which matters because the deployment this driver targets sets HDF5_DRIVER on an unmodified program. Test coverage roughly doubled: the VFD suite went from 15 to 21 sections plus a new no-runtime binary, and the VOL compatibility suite from 20 to 23 cases, with three of the fixes verified to fail on the previous code. The READMEs record what the error-path tests exposed, including one gap that is still open: the VOL cache can hide errors in the file itself, since it has no way to know that the file changed outside HDF5.