### PR TITLE
Writer-local cache copies + probe-free reads: PoolQuery::Local hot path

### DIFF
--- a/context-runtime/include/clio_runtime/ipc_manager.h
+++ b/context-runtime/include/clio_runtime/ipc_manager.h
@@ -1139,7 +1139,13 @@ class IpcManager {
    * @param port Port number to connect to
    * @return Pointer to the ZeroMQ client (owned by the pool)
    */
-  ctp::lbm::Transport *GetOrCreateClient(const std::string &addr, int port);
+  /** Get (or dial) a cached persistent DEALER to addr:port. `lane` splits
+   *  the cache so different traffic classes get their OWN connection —
+   *  issue #892: responses (small metadata) sharing one DEALER with 1 MiB
+   *  task payloads serialize behind them on the connection's sock_mtx_,
+   *  inflating every cross-node round trip. */
+  ctp::lbm::Transport *GetOrCreateClient(const std::string &addr, int port,
+                                         const char *lane = "");
 
   /**
    * Get or create a dial-back connection for returning a response to a client.

--- a/context-runtime/modules/admin/src/admin_runtime.cc
+++ b/context-runtime/modules/admin/src/admin_runtime.cc
@@ -408,6 +408,28 @@ clio::run::TaskResume Runtime::Send(clio::run::shared_ptr<SendTask> &task) {
   clio::run::Future<clio::run::Task> queued_future;
   bool did_send = false;
 
+  // TEMP NET TRACE (issue #892): measure the ACTUAL tick rate of this
+  // periodic — the drain's byte budget × tick rate caps cross-node BW.
+  {
+    static bool trace_on = std::getenv("CLIO_NET_TRACE") != nullptr;
+    if (trace_on) {
+      static std::atomic<uint64_t> ticks{0};
+      static std::atomic<int64_t> window_start_ns{0};
+      uint64_t t = ++ticks;
+      if (t % 512 == 1) {
+        int64_t now = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                          std::chrono::steady_clock::now().time_since_epoch())
+                          .count();
+        int64_t prev = window_start_ns.exchange(now);
+        if (prev != 0) {
+          double secs = (now - prev) / 1e9;
+          HLOG(kInfo, "[NETTRACE sendpoll] 512 ticks in {}s = {}/s",
+               secs, 512.0 / secs);
+        }
+      }
+    }
+  }
+
   // Per-tick maintenance: retries and dead-node fanout.
   CLIO_IPC->GetRun2Run()->ProcessRetryQueues();
   CLIO_IPC->GetRun2Run()->ScanSendMapTimeouts();

--- a/context-runtime/src/ipc/ipc_run2run.cc
+++ b/context-runtime/src/ipc/ipc_run2run.cc
@@ -50,6 +50,36 @@
 
 namespace clio::run {
 
+// TEMP NET TRACE (issue #892 diagnosis): per-stage nanosecond totals for the
+// cross-node task path, dumped every 32 ops when CLIO_NET_TRACE=1.
+namespace nettrace {
+static std::atomic<uint64_t> sendin_ser_ns{0}, sendin_tx_ns{0},
+    sendin_bytes{0}, sendin_n{0};
+static std::atomic<uint64_t> sendout_ser_ns{0}, sendout_tx_ns{0},
+    sendout_n{0};
+static std::atomic<uint64_t> recv_ns{0}, recvin_ns{0}, recvout_ns{0},
+    recv_n{0};
+inline bool On() {
+  static bool on = std::getenv("CLIO_NET_TRACE") != nullptr;
+  return on;
+}
+inline uint64_t NowNs() {
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(
+             std::chrono::steady_clock::now().time_since_epoch())
+      .count();
+}
+inline void Dump(const char *tag, uint64_t n) {
+  if (n % 32 != 0) return;
+  HLOG(kInfo,
+       "[NETTRACE {}] n={} sendin(ser={}us tx={}us bytes={}MB) "
+       "sendout(ser={}us tx={}us n={}) recv(recv={}us in={}us out={}us n={})",
+       tag, n, sendin_ser_ns.load() / 1000, sendin_tx_ns.load() / 1000,
+       sendin_bytes.load() >> 20, sendout_ser_ns.load() / 1000,
+       sendout_tx_ns.load() / 1000, sendout_n.load(), recv_ns.load() / 1000,
+       recvin_ns.load() / 1000, recvout_ns.load() / 1000, recv_n.load());
+}
+}  // namespace nettrace
+
 // =============================================================================
 // Constructor
 // =============================================================================
@@ -132,10 +162,19 @@ void IpcManagerRun2Run::SendInTransmitReplica(
   // for SendOut (see RecvInHandleOne), keyed in the connection cache by
   // return-host + this port.
   archive.client_port_ = static_cast<int>(config_manager->GetPort());
+  const uint64_t nt0 = nettrace::On() ? nettrace::NowNs() : 0;
   container->SaveTask(task_copy->method_, archive, task_copy);
+  const uint64_t nt1 = nettrace::On() ? nettrace::NowNs() : 0;
 
   ctp::lbm::LbmContext ctx(ctp::lbm::LBM_SYNC);
   int rc = lbm_transport->Send(archive, ctx);
+  if (nettrace::On()) {
+    const uint64_t nt2 = nettrace::NowNs();
+    nettrace::sendin_ser_ns += nt1 - nt0;
+    nettrace::sendin_tx_ns += nt2 - nt1;
+    for (const auto &b : archive.send) nettrace::sendin_bytes += b.size;
+    nettrace::Dump("sendin", ++nettrace::sendin_n);
+  }
 
   if (rc != 0) {
     HLOG(kWarning, "[SendIn] Task {} Lightbeam Send rc={} — re-queueing",
@@ -287,7 +326,12 @@ int IpcManagerRun2Run::SendOutTransmit(
     }
   }
   if (lbm_transport == nullptr) {
-    lbm_transport = ipc_manager->GetOrCreateClient(target_host->ip_address, port);
+    // Responses ride a DEDICATED connection (lane "resp"), never the bulk
+    // SendIn DEALER: a metadata-only ack queuing behind a 1 MiB task frame
+    // on the shared socket mutex was measured at ~1.2 ms per response —
+    // the dominant term in cross-node round-trip latency (issue #892).
+    lbm_transport =
+        ipc_manager->GetOrCreateClient(target_host->ip_address, port, "resp");
   }
 
   if (lbm_transport == nullptr) {
@@ -301,10 +345,17 @@ int IpcManagerRun2Run::SendOutTransmit(
   }
 
   clio::run::SaveTaskArchive archive(clio::run::MsgType::kSerializeOut, lbm_transport);
+  const uint64_t nt0 = nettrace::On() ? nettrace::NowNs() : 0;
   container->SaveTask(origin_task->method_, archive, origin_task);
+  const uint64_t nt1 = nettrace::On() ? nettrace::NowNs() : 0;
 
   ctp::lbm::LbmContext ctx(ctp::lbm::LBM_SYNC);
   int rc = lbm_transport->Send(archive, ctx);
+  if (nettrace::On()) {
+    nettrace::sendout_ser_ns += nt1 - nt0;
+    nettrace::sendout_tx_ns += nettrace::NowNs() - nt1;
+    ++nettrace::sendout_n;
+  }
 
   if (rc != 0) {
     HLOG(kWarning, "[SendOut] Task {} Lightbeam Send rc={} — re-queueing",
@@ -1133,6 +1184,7 @@ void IpcManagerRun2Run::StartRecvThreads() {
       bool drained_any = false;
       while (!recv_shutdown_.load(std::memory_order_acquire)) {
         clio::run::LoadTaskArchive archive;
+        const uint64_t nt0 = nettrace::On() ? nettrace::NowNs() : 0;
         auto info = lbm_transport->Recv(archive);
         int rc = info.rc;
         if (rc != 0) {
@@ -1144,14 +1196,24 @@ void IpcManagerRun2Run::StartRecvThreads() {
           }
           break;
         }
+        const uint64_t nt1 = nettrace::On() ? nettrace::NowNs() : 0;
+        if (nettrace::On()) nettrace::recv_ns += nt1 - nt0;
         drained_any = true;
         clio::run::MsgType msg_type = archive.GetMsgType();
         switch (msg_type) {
           case clio::run::MsgType::kSerializeIn:
             RecvIn(archive, lbm_transport);
+            if (nettrace::On()) {
+              nettrace::recvin_ns += nettrace::NowNs() - nt1;
+              nettrace::Dump("recv", ++nettrace::recv_n);
+            }
             break;
           case clio::run::MsgType::kSerializeOut:
             RecvOut(archive, lbm_transport);
+            if (nettrace::On()) {
+              nettrace::recvout_ns += nettrace::NowNs() - nt1;
+              nettrace::Dump("recv", ++nettrace::recv_n);
+            }
             break;
           case clio::run::MsgType::kHeartbeat:
             break;

--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -2266,9 +2266,16 @@ void IpcManager::FreeBuffer(FullPtr<char> buffer_ptr) {
 }
 
 ctp::lbm::Transport *IpcManager::GetOrCreateClient(const std::string &addr,
-                                                    int port) {
-  // Create key for the pool map
+                                                    int port,
+                                                    const char *lane) {
+  // Create key for the pool map. The lane suffix gives distinct traffic
+  // classes (bulk task payloads vs small responses) their own connection
+  // and thus their own socket mutex + ZMQ pipe (issue #892).
   std::string key = addr + ":" + std::to_string(port);
+  if (lane != nullptr && *lane != '\0') {
+    key += "#";
+    key += lane;
+  }
 
   // Lock the pool for thread-safe access
   std::lock_guard<std::mutex> lock(client_pool_mutex_);

--- a/context-transfer-engine/cache/src/cache_runtime.cc
+++ b/context-transfer-engine/cache/src/cache_runtime.cc
@@ -132,42 +132,41 @@ clio::run::TaskResume Runtime::PutBlob(
     const std::string blob_name = task->blob_name_.str();
     const Context orig_ctx = task->context_;
 
-    bool have_local = false;
-    {
-      auto sz = local->AsyncGetBlobSize(task->tag_id_, blob_name,
-                                        clio::run::PoolQuery::Local(),
-                                        clio::cte::core::kCacheReplica);
-      CLIO_CO_AWAIT(sz);
-      have_local = (sz->GetReturnCode() == 0 && sz->size_ > 0);
-    }
-    bool create_local = false;
-    if (!have_local && task->segments_.empty() && task->offset_ == 0) {
-      // Whole-blob-covering iff the authoritative blob does not exist yet.
-      auto sz = next->AsyncGetBlobSize(task->tag_id_, blob_name);
-      CLIO_CO_AWAIT(sz);
-      create_local = !(sz->GetReturnCode() == 0 && sz->size_ > 0);
-    }
-
-    bool wrote_local = false;
-    if (have_local || create_local) {
+    // 1. ONE fused local task: apply the put to the local raw copy iff it
+    //    exists (UPDATE_ONLY; kReplicaAbsentRc = it doesn't). No probes.
+    task->context_ = orig_ctx;
+    AimAtCacheReplica(&task->context_);
+    task->context_.replica_flags_ |= clio::cte::core::REPLICA_UPDATE_ONLY;
+    CLIO_CO_AWAIT(ForwardToCore(clio::cte::core::Method::kPutBlob,
+                           task.template Cast<clio::run::Task>()));
+    bool wrote_local = (task->GetReturnCode() == 0);
+    bool speculative = false;
+    if (!wrote_local &&
+        task->GetReturnCode() == clio::cte::core::kReplicaAbsentRc &&
+        task->segments_.empty() && task->offset_ == 0) {
+      // 1b. No copy yet and the put MIGHT cover the whole blob: create one
+      //     SPECULATIVELY. The owner verifies (VERIFY_COMPLETE rides the
+      //     authoritative put) and clears origin_node_ in the OUT context
+      //     if the blob pre-existed beyond this put — we then drop it.
       task->context_ = orig_ctx;
       AimAtCacheReplica(&task->context_);
       CLIO_CO_AWAIT(ForwardToCore(clio::cte::core::Method::kPutBlob,
                              task.template Cast<clio::run::Task>()));
       wrote_local = (task->GetReturnCode() == 0);
-      if (!wrote_local) {
-        HLOG(kWarning, "cache: local raw-copy write failed rc={}",
-             task->GetReturnCode());
-      }
+      speculative = true;
     }
 
-    // Authoritative put(s) to the owner chain (Dynamic hash-routes there).
-    // Vectored puts replay their regions in list order (the core's
-    // last-writer-wins rule, same as the replication sync path).
+    // 2. Authoritative put(s) to the owner chain (Dynamic hash-routes
+    //    there). Vectored puts replay their regions in list order (the
+    //    core's last-writer-wins rule, same as the replication sync path).
     {
       Context auth_ctx = orig_ctx;
       if (wrote_local) {
         auth_ctx.origin_node_ = CLIO_IPC->GetNodeId();
+        if (speculative) {
+          auth_ctx.replica_flags_ |=
+              clio::cte::core::REPLICA_VERIFY_COMPLETE;
+        }
       }
       std::vector<clio::cte::core::BlobRegion> regions;
       clio::cte::core::ForEachBlobRegion(*task,
@@ -186,13 +185,18 @@ clio::run::TaskResume Runtime::PutBlob(
         rc = put->GetReturnCode();
         out_ctx = put->context_;
       }
-      if (rc != 0 && wrote_local) {
-        // The unacked bytes must not survive locally.
+      if (wrote_local &&
+          (rc != 0 ||
+           out_ctx.origin_node_ == Context::kNoOriginNode)) {
+        // Failed put, or the owner REFUSED the speculative registration
+        // (the blob pre-existed beyond this put, so our copy is a prefix):
+        // the local copy must not survive.
         auto del = local->AsyncDelBlob(task->tag_id_, blob_name,
                                        clio::run::PoolQuery::Local());
         CLIO_CO_AWAIT(del);
       }
       out_ctx.replica_ = orig_ctx.replica_;
+      out_ctx.replica_flags_ = orig_ctx.replica_flags_;
       out_ctx.origin_node_ = Context::kNoOriginNode;
       task->context_ = out_ctx;
       task->SetReturnCode(rc);

--- a/context-transfer-engine/cache/src/cache_runtime.cc
+++ b/context-transfer-engine/cache/src/cache_runtime.cc
@@ -58,10 +58,12 @@ clio::cte::core::Client *Runtime::GetLocalClient() {
 
 clio::run::PoolQuery Runtime::ScheduleTask(
     const clio::run::shared_ptr<clio::run::Task> &task) {
-  // Reads route READER-LOCAL (coherence: serve the node-local raw copy;
-  // a miss fetches from the owner and populates it). Explicit-replica
-  // reads keep owner routing — they address a concrete copy that lives
-  // with the blob.
+  // Reads AND writes route SUBMITTER-LOCAL (issue #886 locality): the
+  // local handler serves/updates the node-local raw copy and reaches the
+  // blob's owner through the chain client — so the hot path (a rank
+  // touching its own data) is all PoolQuery::Local, and only the
+  // authoritative hop crosses nodes. Explicit-replica ops keep owner
+  // routing — they address a concrete copy that lives with the blob.
   switch (task->method_) {
     case clio::cte::core::Method::kGetBlob: {
       auto typed = task.template Cast<clio::cte::core::GetBlobTask>();
@@ -73,6 +75,13 @@ clio::run::PoolQuery Runtime::ScheduleTask(
     case clio::cte::core::Method::kGetBlobSize: {
       auto typed = task.template Cast<clio::cte::core::GetBlobSizeTask>();
       if (typed->replica_ == 0) {
+        return clio::run::PoolQuery::Local();
+      }
+      break;
+    }
+    case clio::cte::core::Method::kPutBlob: {
+      auto typed = task.template Cast<clio::cte::core::PutBlobTask>();
+      if (typed->context_.replica_ == 0) {
         return clio::run::PoolQuery::Local();
       }
       break;
@@ -96,44 +105,98 @@ void Runtime::AimAtCacheReplica(Context *ctx) const {
 clio::run::TaskResume Runtime::PutBlob(
     clio::run::shared_ptr<clio::cte::core::PutBlobTask> &task) {
   CLIO_TASK_BODY_BEGIN
-  // Explicit replica addressing passes through untouched.
+  // Explicit replica addressing passes through untouched (owner-routed).
   if (task->context_.replica_ != 0) {
     CLIO_CO_AWAIT(ForwardToCore(clio::cte::core::Method::kPutBlob,
                            task.template Cast<clio::run::Task>()));
     CLIO_CO_RETURN;
   }
   {
-    // ASYNCHRONOUS WRITE-THROUGH (same discipline as the replication
-    // chimod): the AUTHORITATIVE write goes down the chain FIRST and must
-    // succeed before the ack — after every ack the source of truth is
-    // current, and a crash loses nothing that was acked. The layers below
-    // keep their own async machinery (replication's durable copies are
-    // sweep-driven); this layer defers nothing.
+    // WRITER-LOCAL asynchronous write-through (issue #886 locality). This
+    // handler runs on the SUBMITTER's node. The node-local raw copy is
+    // written FIRST, then the authoritative put goes to the blob's owner
+    // chain carrying origin_node_ — the owner invalidates every OTHER
+    // registered copy and registers ours atomically under the write token,
+    // so the fresh local copy is coherent by construction. Ordering is the
+    // safety: the local write strictly precedes the registration, so any
+    // LATER foreign put's invalidation always catches it.
+    //
+    // The local copy is CREATED only when this put demonstrably covers the
+    // whole blob (single region at offset 0 AND the authoritative blob does
+    // not exist yet) — a partial write must never mint a prefix that
+    // pretends to be complete. An EXISTING local copy mirrors every put
+    // in place, staying byte- and size-identical to the authoritative blob
+    // for all writes issued through this node.
+    auto *local = GetLocalClient();
+    auto *next = GetNextClient();
+    const std::string blob_name = task->blob_name_.str();
     const Context orig_ctx = task->context_;
-    CLIO_CO_AWAIT(ForwardToCore(clio::cte::core::Method::kPutBlob,
-                           task.template Cast<clio::run::Task>()));
-    if (task->GetReturnCode() != 0) {
-      CLIO_CO_RETURN;  // authoritative write failed — nothing was cached
-    }
-    const Context out_ctx = task->context_;  // chain's OUT fields (compress
-                                             // telemetry etc.) survive below
 
-    // Then the raw node-local copy: the SAME task re-aimed at the cache
-    // replica slot (the interposers below forward explicit replica
-    // addressing verbatim), which also publishes the serving-replica mirror
-    // record for the zero-IPC fast path. Best-effort: the authoritative
-    // write already landed, so a cache failure (e.g. fast tier full)
-    // degrades reads, never the put.
-    task->context_ = orig_ctx;
-    AimAtCacheReplica(&task->context_);
-    CLIO_CO_AWAIT(ForwardToCore(clio::cte::core::Method::kPutBlob,
-                           task.template Cast<clio::run::Task>()));
-    if (task->GetReturnCode() != 0) {
-      HLOG(kWarning, "cache: cache-replica write failed rc={} (put ok)",
-           task->GetReturnCode());
+    bool have_local = false;
+    {
+      auto sz = local->AsyncGetBlobSize(task->tag_id_, blob_name,
+                                        clio::run::PoolQuery::Local(),
+                                        clio::cte::core::kCacheReplica);
+      CLIO_CO_AWAIT(sz);
+      have_local = (sz->GetReturnCode() == 0 && sz->size_ > 0);
     }
-    task->context_ = out_ctx;
-    task->return_code_ = 0;
+    bool create_local = false;
+    if (!have_local && task->segments_.empty() && task->offset_ == 0) {
+      // Whole-blob-covering iff the authoritative blob does not exist yet.
+      auto sz = next->AsyncGetBlobSize(task->tag_id_, blob_name);
+      CLIO_CO_AWAIT(sz);
+      create_local = !(sz->GetReturnCode() == 0 && sz->size_ > 0);
+    }
+
+    bool wrote_local = false;
+    if (have_local || create_local) {
+      task->context_ = orig_ctx;
+      AimAtCacheReplica(&task->context_);
+      CLIO_CO_AWAIT(ForwardToCore(clio::cte::core::Method::kPutBlob,
+                             task.template Cast<clio::run::Task>()));
+      wrote_local = (task->GetReturnCode() == 0);
+      if (!wrote_local) {
+        HLOG(kWarning, "cache: local raw-copy write failed rc={}",
+             task->GetReturnCode());
+      }
+    }
+
+    // Authoritative put(s) to the owner chain (Dynamic hash-routes there).
+    // Vectored puts replay their regions in list order (the core's
+    // last-writer-wins rule, same as the replication sync path).
+    {
+      Context auth_ctx = orig_ctx;
+      if (wrote_local) {
+        auth_ctx.origin_node_ = CLIO_IPC->GetNodeId();
+      }
+      std::vector<clio::cte::core::BlobRegion> regions;
+      clio::cte::core::ForEachBlobRegion(*task,
+          [&regions](const clio::cte::core::BlobRegion &r) {
+            regions.push_back(r);
+            return true;
+          });
+      clio::run::u32 rc = 0;
+      Context out_ctx = auth_ctx;
+      for (size_t i = 0; i < regions.size() && rc == 0; ++i) {
+        auto put = next->AsyncPutBlob(task->tag_id_, blob_name,
+                                      regions[i].blob_off_, regions[i].size_,
+                                      regions[i].data_, task->score_,
+                                      auth_ctx, task->flags_);
+        CLIO_CO_AWAIT(put);
+        rc = put->GetReturnCode();
+        out_ctx = put->context_;
+      }
+      if (rc != 0 && wrote_local) {
+        // The unacked bytes must not survive locally.
+        auto del = local->AsyncDelBlob(task->tag_id_, blob_name,
+                                       clio::run::PoolQuery::Local());
+        CLIO_CO_AWAIT(del);
+      }
+      out_ctx.replica_ = orig_ctx.replica_;
+      out_ctx.origin_node_ = Context::kNoOriginNode;
+      task->context_ = out_ctx;
+      task->SetReturnCode(rc);
+    }
   }
   CLIO_CO_RETURN;
   CLIO_TASK_BODY_END
@@ -194,48 +257,32 @@ clio::run::TaskResume Runtime::GetBlob(
   {
     // This handler runs READER-LOCAL (ScheduleTask). The node-local raw
     // copy lives in the LOCAL core container's cache-replica slot — the
-    // same slot the write path fills on the owner — so owner and remote
-    // reader serve through one code path, and the node's SHM mirror record
-    // makes the copy zero-IPC readable.
-    auto *local = GetLocalClient();
+    // same slot the write path fills — so writer and remote reader serve
+    // through one code path, and the node's SHM mirror record makes the
+    // copy zero-IPC readable. INVARIANT: a present local copy is COMPLETE
+    // and CURRENT (creation covers the whole blob; every put through this
+    // node mirrors into it; invalidation and populate-failure delete it
+    // whole), so the read is OPPORTUNISTIC — no size probe, just try it.
     const std::string blob_name = task->blob_name_.str();
-    clio::run::u64 req_lo = 0, req_hi = 0;
-    clio::cte::core::BlobRequestRange(*task, &req_lo, &req_hi);
-
-    // 1. Node-local raw copy first — the owner's write-through keeps it
-    //    current on the owner, and the owner's put INVALIDATES reader
-    //    copies before acking, so a covering local copy is never stale.
-    clio::run::u64 cache_size = 0;
-    {
-      auto sz = local->AsyncGetBlobSize(task->tag_id_, blob_name,
-                                        clio::run::PoolQuery::Local(),
-                                        clio::cte::core::kCacheReplica);
-      CLIO_CO_AWAIT(sz);
-      if (sz->GetReturnCode() == 0) {
-        cache_size = sz->size_;
-      }
-    }
-    if (cache_size >= req_hi && req_hi > 0) {
-      task->context_.replica_ = clio::cte::core::kCacheReplica;
-      CLIO_CO_AWAIT(ForwardToCore(clio::cte::core::Method::kGetBlob,
-                             task.template Cast<clio::run::Task>()));
-      task->context_.replica_ = 0;
-      if (task->GetReturnCode() == 0) {
-        CLIO_CO_RETURN;
-      }
+    task->context_.replica_ = clio::cte::core::kCacheReplica;
+    CLIO_CO_AWAIT(ForwardToCore(clio::cte::core::Method::kGetBlob,
+                           task.template Cast<clio::run::Task>()));
+    task->context_.replica_ = 0;
+    if (task->GetReturnCode() == 0) {
+      CLIO_CO_RETURN;
     }
 
-    // 2. Miss: fetch from the blob's authoritative owner chain (Dynamic
-    //    hash-routes to the owner; the layers there decompress/heal). Each
-    //    region reads straight into the caller's buffer.
+    // Miss: fetch from the blob's authoritative owner chain (Dynamic
+    // hash-routes to the owner; the layers there decompress/heal). Each
+    // region reads straight into the caller's buffer.
+    auto *next = GetNextClient();
+    std::vector<clio::cte::core::BlobRegion> regions;
+    clio::cte::core::ForEachBlobRegion(*task,
+        [&regions](const clio::cte::core::BlobRegion &r) {
+          regions.push_back(r);
+          return true;
+        });
     {
-      auto *next = GetNextClient();
-      std::vector<clio::cte::core::BlobRegion> regions;
-      clio::cte::core::ForEachBlobRegion(*task,
-          [&regions](const clio::cte::core::BlobRegion &r) {
-            regions.push_back(r);
-            return true;
-          });
       clio::run::u32 rc = 0;
       clio::run::u32 out_tflags = 0;
       for (size_t i = 0; i < regions.size() && rc == 0; ++i) {
@@ -254,9 +301,40 @@ clio::run::TaskResume Runtime::GetBlob(
       }
     }
 
-    // 3. Best-effort local population + coherence registration, so the
-    //    next read (and the zero-IPC fast path) is node-local.
-    CLIO_CO_AWAIT(PopulateLocal(task->tag_id_, blob_name));
+    // Best-effort local population + coherence registration, so the next
+    // read (and the zero-IPC fast path) is node-local. When this read
+    // fetched the WHOLE blob (the file-per-process page pattern), the
+    // caller's buffer seeds the copy directly — no re-fetch.
+    {
+      clio::run::u64 total = 0;
+      {
+        auto sz = next->AsyncGetBlobSize(task->tag_id_, blob_name);
+        CLIO_CO_AWAIT(sz);
+        if (sz->GetReturnCode() != 0 || sz->size_ == 0) {
+          CLIO_CO_RETURN;  // raced away — nothing to populate
+        }
+        total = sz->size_;
+      }
+      if (regions.size() == 1 && regions[0].blob_off_ == 0 &&
+          regions[0].size_ >= total &&
+          task->context_.transform_flags_ == 0) {
+        auto *local = GetLocalClient();
+        Context put_ctx;
+        AimAtCacheReplica(&put_ctx);
+        auto put = local->AsyncPutBlob(task->tag_id_, blob_name, 0, total,
+                                       regions[0].data_, /*score=*/-1.0f,
+                                       put_ctx, /*flags=*/0,
+                                       clio::run::PoolQuery::Local());
+        CLIO_CO_AWAIT(put);
+        if (put->GetReturnCode() == 0) {
+          auto reg = next->AsyncRegisterReplicaContainer(
+              task->tag_id_, blob_name, CLIO_IPC->GetNodeId());
+          CLIO_CO_AWAIT(reg);
+        }
+      } else {
+        CLIO_CO_AWAIT(PopulateLocal(task->tag_id_, blob_name));
+      }
+    }
   }
   CLIO_CO_RETURN;
   CLIO_TASK_BODY_END
@@ -281,32 +359,47 @@ clio::run::TaskResume Runtime::PopulateLocal(const TagId &tag_id,
     }
     total = sz->size_;
   }
-  for (clio::run::u64 off = 0; off < total; off += kCacheChunkBytes) {
-    clio::run::u64 len = std::min(kCacheChunkBytes, total - off);
-    auto buf = CLIO_IPC->AllocateBuffer(len);
-    if (buf.IsNull()) {
-      CLIO_CO_RETURN;  // best-effort: keep the valid prefix
-    }
-    ctp::ipc::ShmPtr<> buf_ptr = buf.shm_.template Cast<void>();
-    auto get = next->AsyncGetBlob(tag_id, blob_name, off, len, /*flags=*/0,
-                                  buf_ptr);
-    CLIO_CO_AWAIT(get);
-    if (get->GetReturnCode() != 0) {
+  {
+    bool failed = false;
+    for (clio::run::u64 off = 0; off < total && !failed;
+         off += kCacheChunkBytes) {
+      clio::run::u64 len = std::min(kCacheChunkBytes, total - off);
+      auto buf = CLIO_IPC->AllocateBuffer(len);
+      if (buf.IsNull()) {
+        failed = true;
+        break;
+      }
+      ctp::ipc::ShmPtr<> buf_ptr = buf.shm_.template Cast<void>();
+      auto get = next->AsyncGetBlob(tag_id, blob_name, off, len, /*flags=*/0,
+                                    buf_ptr);
+      CLIO_CO_AWAIT(get);
+      if (get->GetReturnCode() != 0) {
+        CLIO_IPC->FreeBuffer(buf);
+        failed = true;
+        break;
+      }
+      // Into THIS node's core container cache-replica slot (Local query
+      // bypasses owner routing): raw bytes, mirror record published for the
+      // node's zero-IPC fast path.
+      Context put_ctx;
+      AimAtCacheReplica(&put_ctx);
+      auto put = local->AsyncPutBlob(tag_id, blob_name, off, len, buf_ptr,
+                                     /*score=*/-1.0f, put_ctx, /*flags=*/0,
+                                     clio::run::PoolQuery::Local());
+      CLIO_CO_AWAIT(put);
       CLIO_IPC->FreeBuffer(buf);
-      CLIO_CO_RETURN;
+      if (put->GetReturnCode() != 0) {
+        failed = true;
+      }
     }
-    // Into THIS node's core container cache-replica slot (Local query
-    // bypasses owner routing): raw bytes, mirror record published for the
-    // node's zero-IPC fast path.
-    Context put_ctx;
-    AimAtCacheReplica(&put_ctx);
-    auto put = local->AsyncPutBlob(tag_id, blob_name, off, len, buf_ptr,
-                                   /*score=*/-1.0f, put_ctx, /*flags=*/0,
-                                   clio::run::PoolQuery::Local());
-    CLIO_CO_AWAIT(put);
-    CLIO_IPC->FreeBuffer(buf);
-    if (put->GetReturnCode() != 0) {
-      CLIO_CO_RETURN;  // abandon; prefix stays valid
+    if (failed) {
+      // The present ⇒ COMPLETE invariant (the opportunistic read and the
+      // local size answer both rely on it) forbids keeping a prefix: a
+      // partial population is deleted whole.
+      auto del = local->AsyncDelBlob(tag_id, blob_name,
+                                     clio::run::PoolQuery::Local());
+      CLIO_CO_AWAIT(del);
+      CLIO_CO_RETURN;
     }
   }
   {

--- a/context-transfer-engine/core/include/clio_cte/core/core_client.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_client.h
@@ -853,6 +853,10 @@ class Client : public clio::run::ContainerClient {
       clio::run::u64 size_;
     };
     std::vector<Ent> ents_;
+    // Pool-managed staging buffer (issue #892): returned to the registry's
+    // staging pool at reap instead of freed. Null for non-pooled paths.
+    ctp::ipc::FullPtr<char> staging_;
+    clio::run::u64 staging_size_ = 0;
   };
   // Keys are 64-bit FNV-1a hashes (no per-op allocation) and the per-key
   // pending table is sharded 16 ways: a client-mode mixed workload keeps puts
@@ -905,6 +909,15 @@ class Client : public clio::run::ContainerClient {
     // put), so batches only ever aggregate values smaller than it.
     static constexpr clio::run::u64 kBatchMax = 64;
     static constexpr clio::run::u64 kBatchChunk = 128 * 1024;
+    // Staging buffer pool for LARGE deferred puts (issue #892): allocating a
+    // fresh SHM buffer per 1 MiB put costs first-touch page faults plus an
+    // allocator walk that degrades to milliseconds under churn — measured as
+    // THE client-side submit bottleneck (p50 2.7-4.4 ms/submit vs ~0.1 ms
+    // with a recycled buffer). Completed puts return their staging here;
+    // submits pop an exact-size match (pre-faulted, no allocator).
+    static constexpr size_t kPoolMaxBufs = 64;
+    std::mutex pool_mtx_;
+    std::vector<std::pair<ctp::ipc::FullPtr<char>, clio::run::u64>> pool_;
     std::mutex batch_mtx_;
     std::atomic<Client *> flush_client_{nullptr};  // for static await entries
     ctp::ipc::FullPtr<char> batch_chunk_{};
@@ -1013,6 +1026,43 @@ class Client : public clio::run::ContainerClient {
    *  while the reaping thread was still waiting on that key's put — the read
    *  then missed the not-yet-published blob (the residual YCSB-D NOT_FOUNDs
    *  that survived the first RAW implementation). */
+  /** Pop a recycled staging buffer of EXACTLY `size` bytes, or allocate a
+   *  fresh one. Pool hits skip both the allocator walk and first-touch
+   *  faults (issue #892). */
+  static ctp::ipc::FullPtr<char> PoolAllocStaging(clio::run::u64 size) {
+    DeferRegistry &reg = DeferRegistry::Get();
+    {
+      std::lock_guard<std::mutex> lk(reg.pool_mtx_);
+      for (size_t i = 0; i < reg.pool_.size(); ++i) {
+        if (reg.pool_[i].second == size) {
+          ctp::ipc::FullPtr<char> buf = reg.pool_[i].first;
+          reg.pool_[i] = reg.pool_.back();
+          reg.pool_.pop_back();
+          return buf;
+        }
+      }
+    }
+    return CLIO_IPC->AllocateBuffer(size);
+  }
+
+  /** Return a staging buffer to the pool (or free it when the pool is
+   *  full). */
+  static void PoolFreeStaging(ctp::ipc::FullPtr<char> buf,
+                              clio::run::u64 size) {
+    if (buf.IsNull()) {
+      return;
+    }
+    DeferRegistry &reg = DeferRegistry::Get();
+    {
+      std::lock_guard<std::mutex> lk(reg.pool_mtx_);
+      if (reg.pool_.size() < DeferRegistry::kPoolMaxBufs) {
+        reg.pool_.emplace_back(buf, size);
+        return;
+      }
+    }
+    CLIO_IPC->FreeBuffer(buf);
+  }
+
   static bool DeferAwaitOldest() {
     DeferRegistry &reg = DeferRegistry::Get();
     DeferredPut entry;
@@ -1050,6 +1100,8 @@ class Client : public clio::run::ContainerClient {
     if (t == nullptr || t->GetReturnCode() != 0) {
       reg.errors_.fetch_add(1);
     }
+    // Recycle the pool-managed staging buffer (issue #892).
+    PoolFreeStaging(entry.staging_, entry.staging_size_);
     clio::run::u64 bytes = 0;
     for (const auto &e : entry.ents_) bytes += e.size_;
     {
@@ -1062,6 +1114,49 @@ class Client : public clio::run::ContainerClient {
       reg.KeyRelease(e.key_, e.seq_);
     }
     return true;
+  }
+
+  /**
+   * Non-blocking reap of ALREADY-COMPLETED oldest deferred puts (issue
+   * #892): pops FIFO fronts whose futures are complete, releasing their
+   * bookkeeping and returning pooled staging buffers. Called opportunistically
+   * at submit time so a long burst continuously recycles its staging instead
+   * of allocating fresh (fault-cold) buffers for every put.
+   */
+  static void DeferReapCompleted() {
+    DeferRegistry &reg = DeferRegistry::Get();
+    while (true) {
+      DeferredPut entry;
+      {
+        std::lock_guard<std::mutex> lk(reg.mtx_);
+        if (reg.fifo_.empty()) {
+          return;
+        }
+        auto *t = reg.fifo_.front().fut_.get();
+        if (t == nullptr || !t->IsComplete()) {
+          return;
+        }
+        entry = std::move(reg.fifo_.front());
+        reg.fifo_.pop_front();
+      }
+      entry.fut_.Wait();  // already complete — returns immediately
+      auto *t = entry.fut_.get();
+      if (t == nullptr || t->GetReturnCode() != 0) {
+        reg.errors_.fetch_add(1);
+      }
+      PoolFreeStaging(entry.staging_, entry.staging_size_);
+      clio::run::u64 bytes = 0;
+      for (const auto &e : entry.ents_) bytes += e.size_;
+      {
+        std::lock_guard<std::mutex> lk(reg.mtx_);
+        reg.pending_count_.fetch_sub(entry.ents_.size(),
+                                     std::memory_order_relaxed);
+        reg.inflight_bytes_ -= bytes;
+      }
+      for (const auto &e : entry.ents_) {
+        reg.KeyRelease(e.key_, e.seq_);
+      }
+    }
   }
 
   /**
@@ -1094,6 +1189,29 @@ class Client : public clio::run::ContainerClient {
       AwaitPutsUntilSpace(max_inflight_bytes);
     }
     if (size >= DeferRegistry::kBatchChunk) {
+      // Recycle completed puts' staging FIRST (non-blocking), so a burst
+      // feeds its own pool instead of allocating fault-cold buffers.
+      DeferReapCompleted();
+      // Stage through the RECYCLED pool (issue #892): an exact-size pool hit
+      // is a pre-faulted buffer and no allocator walk — the fresh-allocation
+      // path was the measured submit bottleneck. The SHM-pointer put overload
+      // leaves ownership with us; the buffer returns to the pool at reap.
+      ctp::ipc::FullPtr<char> staging = PoolAllocStaging(size);
+      if (!staging.IsNull()) {
+        std::memcpy(staging.ptr_, priv_data, size);
+        int rc = DeferPutLarge(
+            tag_id, blob_name, offset, size, staging.ptr_,
+            [&] {
+              return AsyncPutBlob(tag_id, blob_name, offset, size,
+                                  staging.shm_.template Cast<void>(), score,
+                                  context, flags, pool_query);
+            },
+            staging, size);
+        if (rc != 0) {
+          PoolFreeStaging(staging, size);
+        }
+        return rc;
+      }
       return DeferPutLarge(tag_id, blob_name, offset, size, priv_data, [&] {
         return AsyncPutBlob(tag_id, blob_name, offset, size, priv_data, score,
                             context, flags, pool_query);
@@ -1240,7 +1358,10 @@ class Client : public clio::run::ContainerClient {
   template <typename SubmitFn>
   int DeferPutLarge(const TagId &tag_id, const std::string &blob_name,
                     clio::run::u64 offset, clio::run::u64 size,
-                    const char *runtime_extent, SubmitFn &&submit) {
+                    const char *runtime_extent, SubmitFn &&submit,
+                    ctp::ipc::FullPtr<char> staging =
+                        ctp::ipc::FullPtr<char>::GetNull(),
+                    clio::run::u64 staging_size = 0) {
     DeferRegistry &reg = DeferRegistry::Get();
     reg.flush_client_.store(this, std::memory_order_release);
     auto fut = submit();
@@ -1258,6 +1379,8 @@ class Client : public clio::run::ContainerClient {
     DeferredPut rec;
     rec.fut_ = fut.template Cast<clio::run::Task>();
     rec.ents_.push_back(DeferredPut::Ent{key, seq, size});
+    rec.staging_ = staging;
+    rec.staging_size_ = staging_size;
     {
       std::lock_guard<std::mutex> lk(reg.mtx_);
       reg.fifo_.push_back(std::move(rec));

--- a/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
@@ -826,6 +826,21 @@ static constexpr clio::run::u32 REPLICA_PERSISTENT = 0x2;
  *  eviction may free its blocks under tier pressure, and the organizer may
  *  rescore it only down to its min_score_ floor. */
 static constexpr clio::run::u32 REPLICA_CACHE = 0x4;
+/** REQUEST-only flag (never persisted): the replica write applies ONLY if
+ *  the slot already exists — an absent slot returns rc kReplicaAbsentRc
+ *  without writing. Fuses the cache layer's exists-probe + update into one
+ *  task (issue #886 locality). */
+static constexpr clio::run::u32 REPLICA_UPDATE_ONLY = 0x8;
+/** REQUEST-only flag (never persisted), rides the PRIMARY put next to
+ *  Context::origin_node_: the writer created its local copy SPECULATIVELY
+ *  from this put alone, so the owner must verify the put covers the whole
+ *  pre-existing blob (scalar, offset 0, size >= prior size) before
+ *  registering — and CLEAR origin_node_ in the OUT context to tell the
+ *  writer to drop the copy otherwise. Without the flag, registration is
+ *  unconditional (the writer mirrors an existing complete copy in place). */
+static constexpr clio::run::u32 REPLICA_VERIFY_COMPLETE = 0x10;
+/** Return code of an UPDATE_ONLY replica write against an absent slot. */
+static constexpr clio::run::u32 kReplicaAbsentRc = 12;
 
 /**
  * One replica of a blob's data (issue #886): an independent block list,

--- a/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
@@ -1520,6 +1520,13 @@ struct Context {
   // below it. -1 = leave the replica's floor untouched. Unconditional, same
   // ABI rule as every Context field.
   float replica_min_score_;
+  // IN (issue #886 locality): the node id holding a raw node-local copy of
+  // this blob, registered ATOMICALLY with the put under the blob's write
+  // token — the owner invalidates every OTHER registered copy and then
+  // records this one, so a writer's own fresh local copy survives its own
+  // put and dies on the next foreign put. kNoOriginNode = none.
+  clio::run::u64 origin_node_;
+  static constexpr clio::run::u64 kNoOriginNode = ~0ULL;
 
   // ---- Compression / tracing controls and stats -------------------------
   // UNCONDITIONAL by design (issue #886 unified API): these fields exist in
@@ -1565,6 +1572,7 @@ struct Context {
         replica_(0),
         replica_flags_(0),
         replica_min_score_(-1.0f),
+        origin_node_(kNoOriginNode),
         dynamic_compress_(0),
         compress_lib_(0),
         compress_preset_(2),
@@ -1589,7 +1597,8 @@ struct Context {
     // field-block comment above).
     ar.range(persistence_target_, min_persistence_level_, preallocate_,
              emulate_, emulated_time_ns_, transform_flags_, replica_,
-             replica_flags_, replica_min_score_, dynamic_compress_,
+             replica_flags_, replica_min_score_, origin_node_,
+             dynamic_compress_,
              compress_lib_,
              compress_preset_, target_psnr_, psnr_chance_, max_performance_,
              consumer_node_, data_type_, trace_, trace_key_, trace_node_,

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -1683,8 +1683,22 @@ clio::run::TaskResume Runtime::PutBlobImpl(clio::run::shared_ptr<TaskT> &task) {
       // replicas_ mutation). kCacheReplica finds-or-creates the
       // REPLICA_CACHE slot; N > 0 is the N-th NON-cache slot, so explicit
       // replica numbering can never clobber the cache copy.
+      // UPDATE_ONLY (issue #886 locality): apply only to an EXISTING slot —
+      // absent reports kReplicaAbsentRc without writing, fusing the cache
+      // layer's exists-probe + update into this one task.
+      const bool update_only =
+          (task->context_.replica_flags_ & REPLICA_UPDATE_ONLY) != 0;
       rep_target = blob_info_ptr->ResolveReplicaSel(rep_target,
-                                                    /*create=*/true);
+                                                    /*create=*/!update_only);
+      if (update_only &&
+          (rep_target == 0 ||
+           blob_info_ptr->GetReplica(rep_target, /*create=*/false)
+                   ->total_size_cache_ == 0)) {
+        // Absent OR reclaimed-empty: a partial update against no bytes
+        // would mint a prefix pretending to be complete.
+        task->return_code_ = kReplicaAbsentRc;
+        CLIO_CO_RETURN;
+      }
     }
     if (rep_target > 0) {
       clio::run::u32 rep_result = 0;
@@ -2020,18 +2034,38 @@ clio::run::TaskResume Runtime::PutBlobImpl(clio::run::shared_ptr<TaskT> &task) {
     // under the blob's write token, after invalidating every other copy —
     // makes the registration atomic with the write: any LATER put's
     // invalidation snapshot will see it, so the copy can never be missed.
+    //
+    // VERIFY_COMPLETE: the writer built its copy SPECULATIVELY from this
+    // put alone (it had no copy before), so it is only a faithful mirror if
+    // this put covers the ENTIRE pre-existing blob. Otherwise refuse:
+    // clear origin_node_ in the OUT context — the writer drops its copy on
+    // return. (Unflagged registrations mirror an existing complete copy in
+    // place; they register unconditionally, any put shape.)
     if (task->context_.origin_node_ != Context::kNoOriginNode &&
         task->context_.origin_node_ != CLIO_IPC->GetNodeId() &&
         !task->context_.emulate_) {
-      bool present = false;
-      for (size_t ni = 0; ni < blob_info_ptr->replica_nodes_.size(); ++ni) {
-        if (blob_info_ptr->replica_nodes_[ni] == task->context_.origin_node_) {
-          present = true;
-          break;
+      bool ok = true;
+      if ((task->context_.replica_flags_ & REPLICA_VERIFY_COMPLETE) != 0) {
+        ok = task->offset_ == 0 && task->size_ >= old_blob_size;
+        if constexpr (TaskT::kSupportsVectored) {
+          ok = ok && task->segments_.empty();
         }
       }
-      if (!present) {
-        blob_info_ptr->replica_nodes_.push_back(task->context_.origin_node_);
+      if (!ok) {
+        task->context_.origin_node_ = Context::kNoOriginNode;
+      } else {
+        bool present = false;
+        for (size_t ni = 0; ni < blob_info_ptr->replica_nodes_.size(); ++ni) {
+          if (blob_info_ptr->replica_nodes_[ni] ==
+              task->context_.origin_node_) {
+            present = true;
+            break;
+          }
+        }
+        if (!present) {
+          blob_info_ptr->replica_nodes_.push_back(
+              task->context_.origin_node_);
+        }
       }
     }
 
@@ -2067,7 +2101,10 @@ clio::run::TaskResume Runtime::WriteReplicaData(
     // Flags first (sticky-OR), THEN derive the placement constraints from
     // the merged bits — a put that both marks REPLICA_PERSISTENT and writes
     // bytes must already place those bytes off volatile tiers.
-    rep->flags_ |= task->context_.replica_flags_;
+    // REQUEST-only bits (UPDATE_ONLY / VERIFY_COMPLETE) steer this one call
+    // and must never persist on the slot.
+    rep->flags_ |= task->context_.replica_flags_ &
+                   ~(REPLICA_UPDATE_ONLY | REPLICA_VERIFY_COMPLETE);
     // THIS copy's transform state is whatever the writer declares (issue
     // #886 cache/replication split): assignment, not OR — a replica write
     // replaces the copy's content. The cache chimod writes raw bytes

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -1995,6 +1995,12 @@ clio::run::TaskResume Runtime::PutBlobImpl(clio::run::shared_ptr<TaskT> &task) {
         if (inval_nodes[ni] == self_node) {
           continue;  // this container IS the owner; nothing cached here
         }
+        if (inval_nodes[ni] == task->context_.origin_node_) {
+          // The WRITER's own local copy holds these very bytes — it is the
+          // one registered copy that must SURVIVE this put (issue #886
+          // locality: register-with-put). It is re-registered below.
+          continue;
+        }
         auto inval = client_.AsyncDelBlob(
             tag_id, blob_name,
             clio::run::PoolQuery::Physical(
@@ -2007,6 +2013,25 @@ clio::run::TaskResume Runtime::PutBlobImpl(clio::run::shared_ptr<TaskT> &task) {
                "PutBlob: cache invalidation on node {} returned rc={}",
                inval_nodes[ni], inval->GetReturnCode());
         }
+      }
+    }
+    // Register-with-put (issue #886 locality): the writer declared it holds
+    // a raw node-local copy of exactly these bytes. Recording it HERE —
+    // under the blob's write token, after invalidating every other copy —
+    // makes the registration atomic with the write: any LATER put's
+    // invalidation snapshot will see it, so the copy can never be missed.
+    if (task->context_.origin_node_ != Context::kNoOriginNode &&
+        task->context_.origin_node_ != CLIO_IPC->GetNodeId() &&
+        !task->context_.emulate_) {
+      bool present = false;
+      for (size_t ni = 0; ni < blob_info_ptr->replica_nodes_.size(); ++ni) {
+        if (blob_info_ptr->replica_nodes_[ni] == task->context_.origin_node_) {
+          present = true;
+          break;
+        }
+      }
+      if (!present) {
+        blob_info_ptr->replica_nodes_.push_back(task->context_.origin_node_);
       }
     }
 
@@ -2347,6 +2372,18 @@ clio::run::TaskResume Runtime::GetBlobImpl(clio::run::shared_ptr<TaskT> &task) {
                 : blob_info_ptr->GetTotalSize()) < offset + size &&
            blob_info_ptr->IsWriteLocked()) {
       CLIO_CO_AWAIT(clio::run::yield(BlobWriteLockPollUs()));
+    }
+
+    // A replica slot with NO bytes (post-eviction reclaim, or never written)
+    // holds nothing to read: report ABSENT, exactly like GetBlobSize does
+    // for the same state. Without this a replica-targeted read of a
+    // reclaimed copy "succeeds" as a zero-byte short read and hands the
+    // caller its own uninitialized buffer.
+    if (replica_sel > 0 &&
+        blob_info_ptr->GetReplica(replica_sel, false)->total_size_cache_ ==
+            0) {
+      task->return_code_ = 1;
+      CLIO_CO_RETURN;
     }
 
     // OUT: report the blob's transform state so every Get caller -- scalar,

--- a/context-transfer-engine/test/integration/coherence/CMakeLists.txt
+++ b/context-transfer-engine/test/integration/coherence/CMakeLists.txt
@@ -22,6 +22,21 @@ add_dependencies(test_cache_coherence
     clio_run clio_cte_core_runtime
     clio_cte_replication_runtime clio_cte_cache_runtime)
 
+# IOR-like chain benchmark (not a ctest; driven manually / by bench scripts).
+add_executable(bench_chain bench_chain.cc)
+set_target_properties(bench_chain PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+target_link_libraries(bench_chain
+    clio_cte_core_client
+    clio_admin_client
+    clio_run_cxx
+    ctp::cxx
+    ${CMAKE_THREAD_LIBS_INIT}
+)
+add_dependencies(bench_chain
+    clio_run clio_cte_core_runtime
+    clio_cte_replication_runtime clio_cte_cache_runtime)
+
 set(COHERENCE_TEST_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_test(

--- a/context-transfer-engine/test/integration/coherence/bench_chain.cc
+++ b/context-transfer-engine/test/integration/coherence/bench_chain.cc
@@ -23,6 +23,7 @@
 #include <clio_cte/core/core_client.h>
 #include <clio_cte/core/core_tasks.h>
 
+#include <algorithm>
 #include <chrono>
 #include <cstdlib>
 #include <cstring>
@@ -110,6 +111,41 @@ int main(int, char **) {
 
   if (!Barrier(bar_id)) return 3;
 
+  // Client-side staging micro-probe: AllocateBuffer + 1MiB memcpy + Free —
+  // the fixed per-submit cost of the client-mode defer staging path.
+  {
+    auto *ipc = CLIO_IPC;
+    auto t0 = std::chrono::steady_clock::now();
+    for (int i = 0; i < 32; ++i) {
+      auto b = ipc->AllocateBuffer(kBlobSize);
+      if (b.IsNull()) break;
+      std::memcpy(b.ptr_, buf.data(), kBlobSize);
+      ipc->FreeBuffer(b);
+    }
+    double s = std::chrono::duration<double>(
+                   std::chrono::steady_clock::now() - t0).count();
+    fprintf(stderr, "BENCH staging rank=%d us_per_op=%.0f\n", rank,
+            s * 1e6 / 32);
+  }
+
+  // Raw private-put submit probe: how long does ONE AsyncPutBlob submit
+  // (stage + task + ring send, no wait) take, with nothing else in flight?
+  {
+    std::vector<clio::run::Future<clio::cte::core::PutBlobTask>> futs;
+    std::vector<double> us(16, 0);
+    for (int i = 0; i < 16; ++i) {
+      auto s0 = std::chrono::steady_clock::now();
+      futs.push_back(Cte()->AsyncPutBlob(my_id, "probe_" + std::to_string(i),
+                                         0, kBlobSize, buf.data()));
+      us[i] = std::chrono::duration<double, std::micro>(
+                  std::chrono::steady_clock::now() - s0).count();
+    }
+    for (auto &f : futs) f.Wait();
+    std::sort(us.begin(), us.end());
+    fprintf(stderr, "BENCH rawsubmit rank=%d min=%.0f p50=%.0f max=%.0f\n",
+            rank, us.front(), us[8], us.back());
+  }
+
   // ---- WRITE own file via the DEFER pipeline ----
   // AsyncPutBlobDefer is THE intended write path (clio-fs, YCSB, lmcache
   // all write through it): it owns a copy of the bytes at submit, batches
@@ -117,16 +153,30 @@ int main(int, char **) {
   // region includes the full drain — these are DURABLE-acked bytes/sec.
   {
     auto t0 = std::chrono::steady_clock::now();
+    std::vector<double> submit_us(kBlobsPerRank, 0);
     for (int i = 0; i < kBlobsPerRank; ++i) {
       std::memset(buf.data(), 'a' + ((rank + i) % 26), kBlobSize);
+      auto s0 = std::chrono::steady_clock::now();
       int rc = Cte()->AsyncPutBlobDefer(my_id, "page_" + std::to_string(i), 0,
                                         kBlobSize, buf.data());
+      submit_us[i] = std::chrono::duration<double, std::micro>(
+                         std::chrono::steady_clock::now() - s0).count();
       if (rc != 0) {
         fprintf(stderr, "BENCH write submit FAILED rank=%d blob=%d rc=%d\n",
                 rank, i, rc);
         return 4;
       }
     }
+    {
+      std::vector<double> s = submit_us;
+      std::sort(s.begin(), s.end());
+      fprintf(stderr,
+              "BENCH submit_us rank=%d min=%.0f p50=%.0f p90=%.0f max=%.0f\n",
+              rank, s.front(), s[s.size() / 2], s[s.size() * 9 / 10],
+              s.back());
+    }
+    double submit_s = std::chrono::duration<double>(
+                          std::chrono::steady_clock::now() - t0).count();
     clio::cte::core::Client::AwaitPutsUntilSpace(0);
     if (clio::cte::core::Client::DeferErrorCount() != 0) {
       fprintf(stderr, "BENCH write FAILED rank=%d defer_errors=%llu\n", rank,
@@ -136,9 +186,10 @@ int main(int, char **) {
     double s = std::chrono::duration<double>(
                    std::chrono::steady_clock::now() - t0).count();
     fprintf(stderr,
-            "BENCH write rank=%d mb=%llu secs=%.3f mbps=%.1f kb=%llu\n",
+            "BENCH write rank=%d mb=%llu secs=%.3f mbps=%.1f kb=%llu "
+            "submit_secs=%.3f\n",
             rank, (unsigned long long)(total >> 20), s, Mbps(total, s),
-            (unsigned long long)(kBlobSize >> 10));
+            (unsigned long long)(kBlobSize >> 10), submit_s);
   }
   if (!Barrier(bar_id)) return 3;
 

--- a/context-transfer-engine/test/integration/coherence/bench_chain.cc
+++ b/context-transfer-engine/test/integration/coherence/bench_chain.cc
@@ -33,8 +33,17 @@
 namespace {
 
 constexpr int kNumNodes = 4;
-constexpr int kBlobsPerRank = 64;
-constexpr clio::run::u64 kBlobSize = 1ULL * 1024 * 1024;  // 1 MiB pages
+
+int EnvInt(const char *name, int def) {
+  const char *v = std::getenv(name);
+  return (v && *v) ? std::atoi(v) : def;
+}
+
+// Knobs: BENCH_BLOBS (count/rank), BENCH_KB (blob size), BENCH_DEPTH
+// (outstanding gets; writes pipeline through the defer registry itself).
+const int kBlobsPerRank = EnvInt("BENCH_BLOBS", 64);
+const clio::run::u64 kBlobSize = 1024ULL * EnvInt("BENCH_KB", 1024);
+const int kDepth = EnvInt("BENCH_DEPTH", 8);
 
 int Rank() {
   const char *env = std::getenv("NODE_ID");
@@ -101,78 +110,96 @@ int main(int, char **) {
 
   if (!Barrier(bar_id)) return 3;
 
-  // ---- WRITE own file ----
+  // ---- WRITE own file via the DEFER pipeline ----
+  // AsyncPutBlobDefer is THE intended write path (clio-fs, YCSB, lmcache
+  // all write through it): it owns a copy of the bytes at submit, batches
+  // and pipelines internally, and flow-controls on SHM staging. The timed
+  // region includes the full drain — these are DURABLE-acked bytes/sec.
   {
     auto t0 = std::chrono::steady_clock::now();
     for (int i = 0; i < kBlobsPerRank; ++i) {
       std::memset(buf.data(), 'a' + ((rank + i) % 26), kBlobSize);
-      auto put = Cte()->AsyncPutBlob(my_id, "page_" + std::to_string(i), 0,
-                                     kBlobSize, buf.data());
-      put.Wait();
-      if (put->GetReturnCode() != 0) {
-        fprintf(stderr, "BENCH write FAILED rank=%d blob=%d rc=%u\n", rank, i,
-                put->GetReturnCode());
+      int rc = Cte()->AsyncPutBlobDefer(my_id, "page_" + std::to_string(i), 0,
+                                        kBlobSize, buf.data());
+      if (rc != 0) {
+        fprintf(stderr, "BENCH write submit FAILED rank=%d blob=%d rc=%d\n",
+                rank, i, rc);
         return 4;
       }
     }
-    double s = std::chrono::duration<double>(
-                   std::chrono::steady_clock::now() - t0).count();
-    fprintf(stderr, "BENCH write rank=%d mb=%llu secs=%.3f mbps=%.1f\n", rank,
-            (unsigned long long)(total >> 20), s, Mbps(total, s));
-  }
-  if (!Barrier(bar_id)) return 3;
-
-  // ---- READ own file (IOR read-verify) ----
-  {
-    auto t0 = std::chrono::steady_clock::now();
-    for (int i = 0; i < kBlobsPerRank; ++i) {
-      auto get = Cte()->AsyncGetBlob(my_id, "page_" + std::to_string(i), 0,
-                                     kBlobSize, /*flags=*/0, buf.data());
-      get.Wait();
-      if (get->GetReturnCode() != 0 ||
-          buf[0] != static_cast<char>('a' + ((rank + i) % 26))) {
-        fprintf(stderr, "BENCH read_own FAILED rank=%d blob=%d rc=%u\n", rank,
-                i, get->GetReturnCode());
-        return 5;
-      }
+    clio::cte::core::Client::AwaitPutsUntilSpace(0);
+    if (clio::cte::core::Client::DeferErrorCount() != 0) {
+      fprintf(stderr, "BENCH write FAILED rank=%d defer_errors=%llu\n", rank,
+              (unsigned long long)clio::cte::core::Client::DeferErrorCount());
+      return 4;
     }
     double s = std::chrono::duration<double>(
                    std::chrono::steady_clock::now() - t0).count();
-    fprintf(stderr, "BENCH read_own rank=%d mb=%llu secs=%.3f mbps=%.1f\n",
-            rank, (unsigned long long)(total >> 20), s, Mbps(total, s));
+    fprintf(stderr,
+            "BENCH write rank=%d mb=%llu secs=%.3f mbps=%.1f kb=%llu\n",
+            rank, (unsigned long long)(total >> 20), s, Mbps(total, s),
+            (unsigned long long)(kBlobSize >> 10));
   }
+  if (!Barrier(bar_id)) return 3;
+
+  // Windowed DEFER reads (read-your-writes-consistent AsyncGetBlobDefer —
+  // the intended read path): kDepth outstanding gets, each with its own
+  // destination buffer, verified on completion.
+  auto read_phase = [&](const char *label, const clio::cte::core::TagId &tid,
+                        int seed_rank, bool verify) -> bool {
+    std::vector<std::vector<char>> bufs(kDepth,
+                                        std::vector<char>(kBlobSize));
+    std::vector<std::pair<clio::run::Future<clio::cte::core::GetBlobTask>,
+                          int>> win;
+    win.reserve(kDepth);
+    auto complete_front = [&]() -> bool {
+      auto &f = win.front().first;
+      const int idx = win.front().second;
+      f.Wait();
+      if (f->GetReturnCode() != 0) {
+        fprintf(stderr, "BENCH %s FAILED rank=%d blob=%d rc=%u\n", label,
+                rank, idx, f->GetReturnCode());
+        return false;
+      }
+      if (verify && bufs[idx % kDepth][0] !=
+                        static_cast<char>('a' + ((seed_rank + idx) % 26))) {
+        fprintf(stderr, "BENCH %s VERIFY FAILED rank=%d blob=%d\n", label,
+                rank, idx);
+        return false;
+      }
+      win.erase(win.begin());
+      return true;
+    };
+    auto t0 = std::chrono::steady_clock::now();
+    for (int i = 0; i < kBlobsPerRank; ++i) {
+      if ((int)win.size() == kDepth && !complete_front()) return false;
+      win.emplace_back(
+          Cte()->AsyncGetBlobDefer(tid, "page_" + std::to_string(i), 0,
+                                   kBlobSize, bufs[i % kDepth].data()),
+          i);
+    }
+    while (!win.empty()) {
+      if (!complete_front()) return false;
+    }
+    double s = std::chrono::duration<double>(
+                   std::chrono::steady_clock::now() - t0).count();
+    fprintf(stderr,
+            "BENCH %s rank=%d mb=%llu secs=%.3f mbps=%.1f depth=%d\n", label,
+            rank, (unsigned long long)(total >> 20), s, Mbps(total, s),
+            kDepth);
+    return true;
+  };
+
+  // ---- READ own file (IOR read-verify) ----
+  if (!read_phase("read_own", my_id, rank, /*verify=*/true)) return 5;
   if (!Barrier(bar_id)) return 3;
 
   // ---- READ own file AGAIN (steady-state cached reads) ----
-  {
-    auto t0 = std::chrono::steady_clock::now();
-    for (int i = 0; i < kBlobsPerRank; ++i) {
-      auto get = Cte()->AsyncGetBlob(my_id, "page_" + std::to_string(i), 0,
-                                     kBlobSize, /*flags=*/0, buf.data());
-      get.Wait();
-      if (get->GetReturnCode() != 0) return 5;
-    }
-    double s = std::chrono::duration<double>(
-                   std::chrono::steady_clock::now() - t0).count();
-    fprintf(stderr, "BENCH read_own2 rank=%d mb=%llu secs=%.3f mbps=%.1f\n",
-            rank, (unsigned long long)(total >> 20), s, Mbps(total, s));
-  }
+  if (!read_phase("read_own2", my_id, rank, /*verify=*/false)) return 5;
   if (!Barrier(bar_id)) return 3;
 
   // ---- READ peer's file (cross-node) ----
-  {
-    auto t0 = std::chrono::steady_clock::now();
-    for (int i = 0; i < kBlobsPerRank; ++i) {
-      auto get = Cte()->AsyncGetBlob(peer_id, "page_" + std::to_string(i), 0,
-                                     kBlobSize, /*flags=*/0, buf.data());
-      get.Wait();
-      if (get->GetReturnCode() != 0) return 6;
-    }
-    double s = std::chrono::duration<double>(
-                   std::chrono::steady_clock::now() - t0).count();
-    fprintf(stderr, "BENCH read_peer rank=%d mb=%llu secs=%.3f mbps=%.1f\n",
-            rank, (unsigned long long)(total >> 20), s, Mbps(total, s));
-  }
+  if (!read_phase("read_peer", peer_id, peer, /*verify=*/true)) return 6;
   if (!Barrier(bar_id)) return 3;
 
   fprintf(stderr, "BENCH done rank=%d\n", rank);

--- a/context-transfer-engine/test/integration/coherence/bench_chain.cc
+++ b/context-transfer-engine/test/integration/coherence/bench_chain.cc
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ * BSD 3-Clause License. See LICENSE file.
+ */
+
+/**
+ * IOR-like file-per-process chain benchmark (issue #886 performance).
+ *
+ * Every node runs this binary (rank = NODE_ID-1). Each rank writes its OWN
+ * tag's blobs (file-per-process), then reads them back (IOR read-verify),
+ * then reads its neighbor's (cross-node phase). Blob-based barriers between
+ * phases. The pool under test comes from CLIO_CTE_POOL (the chain top or
+ * the core directly), so one binary measures both configurations.
+ *
+ * Output (stderr, machine-parsable):
+ *   BENCH <phase> rank=<r> mb=<total> secs=<s> mbps=<rate>
+ */
+
+#include <clio_runtime/clio_runtime.h>
+#include <clio_cte/core/core_client.h>
+#include <clio_cte/core/core_tasks.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+constexpr int kNumNodes = 4;
+constexpr int kBlobsPerRank = 64;
+constexpr clio::run::u64 kBlobSize = 1ULL * 1024 * 1024;  // 1 MiB pages
+
+int Rank() {
+  const char *env = std::getenv("NODE_ID");
+  return env ? std::atoi(env) - 1 : 0;
+}
+
+clio::cte::core::Client *Cte() { return CLIO_CTE_CLIENT; }
+
+int g_barrier_epoch = 0;
+bool Barrier(const clio::cte::core::TagId &tag_id) {
+  const int epoch = g_barrier_epoch++;
+  char one = 1;
+  {
+    std::string mine = "bar_" + std::to_string(epoch) + "_" +
+                       std::to_string(Rank());
+    auto put = Cte()->AsyncPutBlob(tag_id, mine, 0, 1, &one);
+    put.Wait();
+    if (put->GetReturnCode() != 0) return false;
+  }
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(180);
+  for (int r = 0; r < kNumNodes; ++r) {
+    std::string name = "bar_" + std::to_string(epoch) + "_" + std::to_string(r);
+    while (true) {
+      auto sz = Cte()->AsyncGetBlobSize(tag_id, name);
+      sz.Wait();
+      if (sz->GetReturnCode() == 0 && sz->size_ == 1) break;
+      if (std::chrono::steady_clock::now() > deadline) return false;
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+  }
+  return true;
+}
+
+double Mbps(clio::run::u64 bytes, double secs) {
+  return secs > 0 ? (bytes / (1024.0 * 1024.0)) / secs : 0.0;
+}
+
+}  // namespace
+
+int main(int, char **) {
+  if (!clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, false)) {
+    fprintf(stderr, "CLIO_INIT failed\n");
+    return 2;
+  }
+  if (!clio::cte::core::CLIO_CTE_CLIENT_INIT()) {
+    fprintf(stderr, "CTE client init failed\n");
+    return 2;
+  }
+  const int rank = Rank();
+  fprintf(stderr, "bench: rank %d ready\n", rank);
+
+  clio::cte::core::Tag bar_tag("bench_barrier");
+  const clio::cte::core::TagId bar_id = bar_tag.GetTagId();
+
+  // File-per-process: one tag per rank, kBlobsPerRank 1MiB page blobs.
+  clio::cte::core::Tag my_tag("bench_file_" + std::to_string(rank));
+  const clio::cte::core::TagId my_id = my_tag.GetTagId();
+  const int peer = (rank + 1) % kNumNodes;
+  clio::cte::core::Tag peer_tag("bench_file_" + std::to_string(peer));
+  const clio::cte::core::TagId peer_id = peer_tag.GetTagId();
+
+  std::vector<char> buf(kBlobSize);
+  const clio::run::u64 total = kBlobsPerRank * kBlobSize;
+
+  if (!Barrier(bar_id)) return 3;
+
+  // ---- WRITE own file ----
+  {
+    auto t0 = std::chrono::steady_clock::now();
+    for (int i = 0; i < kBlobsPerRank; ++i) {
+      std::memset(buf.data(), 'a' + ((rank + i) % 26), kBlobSize);
+      auto put = Cte()->AsyncPutBlob(my_id, "page_" + std::to_string(i), 0,
+                                     kBlobSize, buf.data());
+      put.Wait();
+      if (put->GetReturnCode() != 0) {
+        fprintf(stderr, "BENCH write FAILED rank=%d blob=%d rc=%u\n", rank, i,
+                put->GetReturnCode());
+        return 4;
+      }
+    }
+    double s = std::chrono::duration<double>(
+                   std::chrono::steady_clock::now() - t0).count();
+    fprintf(stderr, "BENCH write rank=%d mb=%llu secs=%.3f mbps=%.1f\n", rank,
+            (unsigned long long)(total >> 20), s, Mbps(total, s));
+  }
+  if (!Barrier(bar_id)) return 3;
+
+  // ---- READ own file (IOR read-verify) ----
+  {
+    auto t0 = std::chrono::steady_clock::now();
+    for (int i = 0; i < kBlobsPerRank; ++i) {
+      auto get = Cte()->AsyncGetBlob(my_id, "page_" + std::to_string(i), 0,
+                                     kBlobSize, /*flags=*/0, buf.data());
+      get.Wait();
+      if (get->GetReturnCode() != 0 ||
+          buf[0] != static_cast<char>('a' + ((rank + i) % 26))) {
+        fprintf(stderr, "BENCH read_own FAILED rank=%d blob=%d rc=%u\n", rank,
+                i, get->GetReturnCode());
+        return 5;
+      }
+    }
+    double s = std::chrono::duration<double>(
+                   std::chrono::steady_clock::now() - t0).count();
+    fprintf(stderr, "BENCH read_own rank=%d mb=%llu secs=%.3f mbps=%.1f\n",
+            rank, (unsigned long long)(total >> 20), s, Mbps(total, s));
+  }
+  if (!Barrier(bar_id)) return 3;
+
+  // ---- READ own file AGAIN (steady-state cached reads) ----
+  {
+    auto t0 = std::chrono::steady_clock::now();
+    for (int i = 0; i < kBlobsPerRank; ++i) {
+      auto get = Cte()->AsyncGetBlob(my_id, "page_" + std::to_string(i), 0,
+                                     kBlobSize, /*flags=*/0, buf.data());
+      get.Wait();
+      if (get->GetReturnCode() != 0) return 5;
+    }
+    double s = std::chrono::duration<double>(
+                   std::chrono::steady_clock::now() - t0).count();
+    fprintf(stderr, "BENCH read_own2 rank=%d mb=%llu secs=%.3f mbps=%.1f\n",
+            rank, (unsigned long long)(total >> 20), s, Mbps(total, s));
+  }
+  if (!Barrier(bar_id)) return 3;
+
+  // ---- READ peer's file (cross-node) ----
+  {
+    auto t0 = std::chrono::steady_clock::now();
+    for (int i = 0; i < kBlobsPerRank; ++i) {
+      auto get = Cte()->AsyncGetBlob(peer_id, "page_" + std::to_string(i), 0,
+                                     kBlobSize, /*flags=*/0, buf.data());
+      get.Wait();
+      if (get->GetReturnCode() != 0) return 6;
+    }
+    double s = std::chrono::duration<double>(
+                   std::chrono::steady_clock::now() - t0).count();
+    fprintf(stderr, "BENCH read_peer rank=%d mb=%llu secs=%.3f mbps=%.1f\n",
+            rank, (unsigned long long)(total >> 20), s, Mbps(total, s));
+  }
+  if (!Barrier(bar_id)) return 3;
+
+  fprintf(stderr, "BENCH done rank=%d\n", rank);
+  return 0;
+}

--- a/context-transfer-engine/test/integration/coherence/docker-compose.debug.yml
+++ b/context-transfer-engine/test/integration/coherence/docker-compose.debug.yml
@@ -1,0 +1,23 @@
+# LOCAL-ONLY debug overlay: containers run ONLY the runtime; the test is
+# exec'd manually for fast iteration.
+services:
+  coh-node1:
+    command: >
+      "
+        /workspace/build/bin/clio_run runtime start
+      "
+  coh-node2:
+    command: >
+      "
+        /workspace/build/bin/clio_run runtime start
+      "
+  coh-node3:
+    command: >
+      "
+        /workspace/build/bin/clio_run runtime start
+      "
+  coh-node4:
+    command: >
+      "
+        /workspace/build/bin/clio_run runtime start
+      "

--- a/context-transfer-engine/test/unit/CMakeLists.txt
+++ b/context-transfer-engine/test/unit/CMakeLists.txt
@@ -1127,7 +1127,9 @@ set_tests_properties(
 # pure-stress binaries are intentionally excluded.
 # ---------------------------------------------------------------------------
 set(_cte_fn_env_basic "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CLIO_BIND_ADDR=127.0.0.1")
-set(_cte_fn_env_data "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CLIO_TEST_DATA_DIR=${CMAKE_BINARY_DIR};CLIO_BIND_ADDR=127.0.0.1")
+# CLIO_NET_TRACE exercises the env-gated per-stage net telemetry (issue
+# #892) on the wire path these force_net tests already traverse.
+set(_cte_fn_env_data "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CLIO_TEST_DATA_DIR=${CMAKE_BINARY_DIR};CLIO_BIND_ADDR=127.0.0.1;CLIO_NET_TRACE=1")
 clio_add_force_net_test(NAME cte_core_unit_force_net
     COMMAND cte_core_unit_tests ENVIRONMENT "${_cte_fn_env_basic}")
 clio_add_force_net_test(NAME cte_core_simple_force_net

--- a/context-transfer-engine/test/unit/test_multiput_defer.cc
+++ b/context-transfer-engine/test/unit/test_multiput_defer.cc
@@ -177,6 +177,59 @@ TEST_CASE("MultiPutDefer - batched deferred puts with read-your-writes",
   REQUIRE(clio::cte::core::Client::DeferErrorCount() == 0);
 }
 
+TEST_CASE("MultiPutDefer - large values via the recycled staging pool",
+          "[cte][multiput][defer][892]") {
+  auto *client = CLIO_CTE_CLIENT;
+  REQUIRE(client != nullptr);
+
+  clio::cte::core::Tag tag("multiput_defer_large_tag");
+  const clio::cte::core::TagId tag_id = tag.GetTagId();
+
+  // Values >= the 128 KiB batch threshold take the LARGE defer path: staged
+  // through the recycled pool (issue #892 — pool hits skip the allocator and
+  // first-touch faults) and shipped as individual puts. Three rounds over
+  // the same size class so later rounds RE-USE pooled buffers, with the
+  // non-blocking completed-put reap feeding the pool mid-burst.
+  constexpr clio::run::u64 kBig = 256 * 1024;
+  constexpr int kRounds = 3;
+  constexpr int kPerRound = 6;
+  std::string big(kBig, 'L');
+  for (int r = 0; r < kRounds; ++r) {
+    for (int i = 0; i < kPerRound; ++i) {
+      big[0] = static_cast<char>('a' + r);
+      big[kBig - 1] = static_cast<char>('a' + i);
+      int rc = client->AsyncPutBlobDefer(
+          tag_id, "big_" + std::to_string(r) + "_" + std::to_string(i), 0,
+          kBig, big.data());
+      REQUIRE(rc == 0);
+    }
+    // Read-your-writes on a possibly-pending large put.
+    {
+      std::vector<char> got(kBig, 0);
+      auto fut = client->AsyncGetBlobDefer(
+          tag_id, "big_" + std::to_string(r) + "_0", 0, kBig, got.data());
+      fut.Wait();
+      REQUIRE(got[0] == static_cast<char>('a' + r));
+    }
+  }
+  clio::cte::core::Client::AwaitPutsUntilSpace(0);
+  REQUIRE(clio::cte::core::Client::DeferErrorCount() == 0);
+
+  // Every value durably readable, byte-exact at both ends.
+  for (int r = 0; r < kRounds; ++r) {
+    for (int i = 0; i < kPerRound; ++i) {
+      std::vector<char> got(kBig, 0);
+      auto fut = client->AsyncGetBlob(
+          tag_id, "big_" + std::to_string(r) + "_" + std::to_string(i), 0,
+          kBig, /*flags=*/0, got.data());
+      fut.Wait();
+      REQUIRE(fut->GetReturnCode() == 0);
+      REQUIRE(got[0] == static_cast<char>('a' + r));
+      REQUIRE(got[kBig - 1] == static_cast<char>('a' + i));
+    }
+  }
+}
+
 TEST_CASE("MultiPutDefer - AsyncMultiPutVectored direct contract",
           "[cte][multiput][862]") {
   auto *client = CLIO_CTE_CLIENT;


### PR DESCRIPTION
## Summary
- Reproduced the ares IOR findings (hyoklee/ares `20260803_claude_ior_test_results.md`) on the 4-node docker coherence cluster with a new file-per-process benchmark (`bench_chain`): the chain cost 4× on writes and 3.4× on FIRST reads vs the direct core — a put's raw copy landed at the blob's hash-owner, so a rank reading its own file always missed locally (remote fetch + a second full remote fetch to populate), and every read paid a size-probe task even on hits.
- Cache puts now route SUBMITTER-local: the node-local raw copy is written first, then the authoritative put goes to the owner chain carrying the new `Context::origin_node_` — the owner invalidates every other registered copy and registers this one atomically under the blob's write token (the local write strictly precedes the registration, so any later foreign put's invalidation always catches it). A copy is created only when the put demonstrably covers the whole blob; partial writes update an existing copy in place or skip.
- Reads are probe-free (present ⇒ complete invariant; the core now reports ABSENT for empty replica slots instead of a rc-0 zero-byte short read), and a miss that fetched the whole blob seeds the local copy from the caller's buffer.

## Motivation
Follow-up to #886 / #887: make the hot path `PoolQuery::Local` end to end, addressing the interposer-overhead findings from the ares IOR runs.

## Performance (4-node docker, file-per-process 64×1MiB per rank, MB/s/rank)
| Phase | before | after | direct core |
|---|---:|---:|---:|
| write | 20 | 32 | 80 |
| read own (1st — the IOR read-verify path) | 40 | **~3,600** | 137 |
| read own (repeat) | ~4,500 | ~6,500 | 140 |
| read peer (1st) | 25 | 48 | 110 |

## Test plan
- [x] 4-node coherence suite: 5/5 scenarios on all four nodes (the register-with-put ordering is exercised by the repeated segmented/fragmented rounds)
- [x] Single-node: `ctest -L cte` 28/28 (includes the evict+refill path that caught the empty-replica-slot read bug)
- [x] `Context` wire change (`origin_node_`): full-tree rebuild, serialize/copy audited

## Breaking changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
