### PR TITLE
Fix owner-node cache blind spot behind the coherence CI failure

### DIFF
--- a/context-transfer-engine/cache/include/clio_cte/cache/cache_runtime.h
+++ b/context-transfer-engine/cache/include/clio_cte/cache/cache_runtime.h
@@ -101,6 +101,16 @@ class Runtime : public clio::cte::core::CoreInterposer {
   void AimAtCacheReplica(Context *ctx) const;
 
   /**
+   * True when THIS node hosts the blob's owner container (issue #894).
+   * The owner node keeps NO cache-slot copy: its primary is already
+   * node-local DRAM (and zero-IPC readable), and an owner-side copy sits
+   * outside the register/invalidate protocol — origin registration skips
+   * self, so nothing would ever invalidate it and it serves stale bytes
+   * after a foreign write (the CI-caught fragmented winner split).
+   */
+  bool IsBlobOwnerLocal(const TagId &tag_id, const std::string &blob_name);
+
+  /**
    * Best-effort population of THIS node's raw local copy from the blob's
    * authoritative owner chain, plus coherence registration (the owner's
    * next primary write invalidates the copy). Sequential from 0, so an

--- a/context-transfer-engine/cache/src/cache_runtime.cc
+++ b/context-transfer-engine/cache/src/cache_runtime.cc
@@ -92,6 +92,31 @@ clio::run::PoolQuery Runtime::ScheduleTask(
   return CoreInterposer::ScheduleTask(task);
 }
 
+bool Runtime::IsBlobOwnerLocal(const TagId &tag_id,
+                               const std::string &blob_name) {
+  // Same hash as the core's HashBlobToContainer (owner routing), resolved
+  // against THIS pool's container map — every pool in the chain shares the
+  // container layout (replication's primary-hit path relies on the same
+  // property).
+  auto *pool_manager = CLIO_POOL_MANAGER;
+  const clio::run::PoolInfo *info = pool_manager->GetPoolInfo(pool_id_);
+  if (info == nullptr || info->num_containers_ == 0) {
+    return false;
+  }
+  std::hash<std::string> string_hasher;
+  std::hash<clio::run::u32> u32_hasher;
+  clio::run::u32 h = u32_hasher(tag_id.major_);
+  h ^= u32_hasher(tag_id.minor_) + 0x9e3779b9 + (h << 6) + (h >> 2);
+  h ^= static_cast<clio::run::u32>(string_hasher(blob_name)) + 0x9e3779b9 +
+       (h << 6) + (h >> 2);
+  clio::run::ContainerId cid = h % info->num_containers_;
+  if (pool_manager->HasContainer(pool_id_, cid)) {
+    return true;
+  }
+  return pool_manager->GetContainerNodeId(pool_id_, cid) ==
+         CLIO_IPC->GetNodeId();
+}
+
 /** Mutate a put context to aim at THE cache replica: raw bytes, the
  *  configured score floor, cache-slot addressing. */
 void Runtime::AimAtCacheReplica(Context *ctx) const {
@@ -132,16 +157,27 @@ clio::run::TaskResume Runtime::PutBlob(
     const std::string blob_name = task->blob_name_.str();
     const Context orig_ctx = task->context_;
 
+    // The blob's OWNER node keeps no cache copy (issue #894): the primary
+    // is already node-local (and zero-IPC readable), and an owner-side
+    // copy sits outside the register/invalidate protocol — origin
+    // registration skips self, so a later foreign write would never
+    // invalidate it and this node would serve its own stale bytes forever
+    // (the CI-caught fragmented winner split).
+    const bool owner_local = IsBlobOwnerLocal(task->tag_id_, blob_name);
+
     // 1. ONE fused local task: apply the put to the local raw copy iff it
     //    exists (UPDATE_ONLY; kReplicaAbsentRc = it doesn't). No probes.
-    task->context_ = orig_ctx;
-    AimAtCacheReplica(&task->context_);
-    task->context_.replica_flags_ |= clio::cte::core::REPLICA_UPDATE_ONLY;
-    CLIO_CO_AWAIT(ForwardToCore(clio::cte::core::Method::kPutBlob,
-                           task.template Cast<clio::run::Task>()));
-    bool wrote_local = (task->GetReturnCode() == 0);
+    bool wrote_local = false;
     bool speculative = false;
-    if (!wrote_local &&
+    if (!owner_local) {
+      task->context_ = orig_ctx;
+      AimAtCacheReplica(&task->context_);
+      task->context_.replica_flags_ |= clio::cte::core::REPLICA_UPDATE_ONLY;
+      CLIO_CO_AWAIT(ForwardToCore(clio::cte::core::Method::kPutBlob,
+                             task.template Cast<clio::run::Task>()));
+      wrote_local = (task->GetReturnCode() == 0);
+    }
+    if (!owner_local && !wrote_local &&
         task->GetReturnCode() == clio::cte::core::kReplicaAbsentRc &&
         task->segments_.empty() && task->offset_ == 0) {
       // 1b. No copy yet and the put MIGHT cover the whole blob: create one
@@ -155,6 +191,9 @@ clio::run::TaskResume Runtime::PutBlob(
       wrote_local = (task->GetReturnCode() == 0);
       speculative = true;
     }
+    HLOG(kDebug,
+         "[COH] cache put blob={} node={} wrote_local={} speculative={}",
+         blob_name, CLIO_IPC->GetNodeId(), wrote_local, speculative);
 
     // 2. Authoritative put(s) to the owner chain (Dynamic hash-routes
     //    there). Vectored puts replay their regions in list order (the
@@ -228,15 +267,24 @@ clio::run::TaskResume Runtime::MultiPutBlob(
     const clio::run::u32 auth_ok = task->num_ok_;
     const int auth_rc = task->first_rc_;
 
-    task->context_ = orig_ctx;
-    AimAtCacheReplica(&task->context_);
-    task->num_ok_ = 0;
-    task->first_rc_ = 0;
-    CLIO_CO_AWAIT(ForwardToCore(clio::cte::core::Method::kMultiPutBlob,
-                           task.template Cast<clio::run::Task>()));
-    if (task->GetReturnCode() != 0 || task->first_rc_ != 0) {
-      HLOG(kWarning, "cache: batch cache-replica write failed rc={}/{} "
-           "(batch ok)", task->GetReturnCode(), task->first_rc_);
+    // The mirror batch is SINGLE-NODE only (issue #894): batched cache
+    // copies carry no origin registration, so on a cluster nothing would
+    // ever invalidate them and any foreign write leaves them stale — and
+    // records owned by this node are the owner blind spot outright.
+    // Multinode read locality still comes from the read path's populate,
+    // which registers (version-checked). Single-node has no foreign
+    // writers, so the mirror is coherent by construction there.
+    if (CLIO_IPC->GetNumHosts() <= 1) {
+      task->context_ = orig_ctx;
+      AimAtCacheReplica(&task->context_);
+      task->num_ok_ = 0;
+      task->first_rc_ = 0;
+      CLIO_CO_AWAIT(ForwardToCore(clio::cte::core::Method::kMultiPutBlob,
+                             task.template Cast<clio::run::Task>()));
+      if (task->GetReturnCode() != 0 || task->first_rc_ != 0) {
+        HLOG(kWarning, "cache: batch cache-replica write failed rc={}/{} "
+             "(batch ok)", task->GetReturnCode(), task->first_rc_);
+      }
     }
     // Report the AUTHORITATIVE batch's outcome.
     task->context_ = orig_ctx;
@@ -268,12 +316,18 @@ clio::run::TaskResume Runtime::GetBlob(
     // node mirrors into it; invalidation and populate-failure delete it
     // whole), so the read is OPPORTUNISTIC — no size probe, just try it.
     const std::string blob_name = task->blob_name_.str();
-    task->context_.replica_ = clio::cte::core::kCacheReplica;
-    CLIO_CO_AWAIT(ForwardToCore(clio::cte::core::Method::kGetBlob,
-                           task.template Cast<clio::run::Task>()));
-    task->context_.replica_ = 0;
-    if (task->GetReturnCode() == 0) {
-      CLIO_CO_RETURN;
+    // The owner node has no cache copy (issue #894, see PutBlob) — its
+    // authoritative primary is node-local already; skip straight to the
+    // chain and never populate here.
+    const bool owner_local = IsBlobOwnerLocal(task->tag_id_, blob_name);
+    if (!owner_local) {
+      task->context_.replica_ = clio::cte::core::kCacheReplica;
+      CLIO_CO_AWAIT(ForwardToCore(clio::cte::core::Method::kGetBlob,
+                             task.template Cast<clio::run::Task>()));
+      task->context_.replica_ = 0;
+      if (task->GetReturnCode() == 0) {
+        CLIO_CO_RETURN;
+      }
     }
 
     // Miss: fetch from the blob's authoritative owner chain (Dynamic
@@ -289,6 +343,7 @@ clio::run::TaskResume Runtime::GetBlob(
     {
       clio::run::u32 rc = 0;
       clio::run::u32 out_tflags = 0;
+      clio::run::u64 fetch_version = 0;
       for (size_t i = 0; i < regions.size() && rc == 0; ++i) {
         auto get = next->AsyncGetBlob(
             task->tag_id_, blob_name, regions[i].blob_off_, regions[i].size_,
@@ -297,8 +352,12 @@ clio::run::TaskResume Runtime::GetBlob(
         CLIO_CO_AWAIT(get);
         rc = get->GetReturnCode();
         out_tflags = get->context_.transform_flags_;
+        if (i == 0) {
+          fetch_version = get->context_.version_;
+        }
       }
       task->context_.transform_flags_ = out_tflags;
+      task->context_.version_ = fetch_version;
       task->SetReturnCode(rc);
       if (rc != 0) {
         CLIO_CO_RETURN;
@@ -309,6 +368,9 @@ clio::run::TaskResume Runtime::GetBlob(
     // read (and the zero-IPC fast path) is node-local. When this read
     // fetched the WHOLE blob (the file-per-process page pattern), the
     // caller's buffer seeds the copy directly — no re-fetch.
+    if (owner_local) {
+      CLIO_CO_RETURN;  // the primary IS this node's local copy
+    }
     {
       clio::run::u64 total = 0;
       {
@@ -331,9 +393,25 @@ clio::run::TaskResume Runtime::GetBlob(
                                        clio::run::PoolQuery::Local());
         CLIO_CO_AWAIT(put);
         if (put->GetReturnCode() == 0) {
+          // VERSION-CHECKED registration (issue #894): if the owner's
+          // content moved on since our fetch, the registration is REJECTED
+          // and the just-written copy is stale — delete it, the next read
+          // refetches. Without the check, a put completing between fetch
+          // and registration leaves this copy permanently stale (its
+          // invalidation snapshot ran before we registered).
           auto reg = next->AsyncRegisterReplicaContainer(
-              task->tag_id_, blob_name, CLIO_IPC->GetNodeId());
+              task->tag_id_, blob_name, CLIO_IPC->GetNodeId(),
+              clio::run::PoolQuery::Dynamic(), task->context_.version_);
           CLIO_CO_AWAIT(reg);
+          HLOG(kInfo,
+               "[COH] cache populate blob={} node={} ver={} reg rc={}",
+               blob_name, CLIO_IPC->GetNodeId(), task->context_.version_,
+               reg->GetReturnCode());
+          if (reg->GetReturnCode() != 0) {
+            auto del = local->AsyncDelBlob(task->tag_id_, blob_name,
+                                           clio::run::PoolQuery::Local());
+            CLIO_CO_AWAIT(del);
+          }
         }
       } else {
         CLIO_CO_AWAIT(PopulateLocal(task->tag_id_, blob_name));
@@ -363,6 +441,7 @@ clio::run::TaskResume Runtime::PopulateLocal(const TagId &tag_id,
     }
     total = sz->size_;
   }
+  clio::run::u64 fetch_version = 0;
   {
     bool failed = false;
     for (clio::run::u64 off = 0; off < total && !failed;
@@ -381,6 +460,9 @@ clio::run::TaskResume Runtime::PopulateLocal(const TagId &tag_id,
         CLIO_IPC->FreeBuffer(buf);
         failed = true;
         break;
+      }
+      if (off == 0) {
+        fetch_version = get->context_.version_;
       }
       // Into THIS node's core container cache-replica slot (Local query
       // bypasses owner routing): raw bytes, mirror record published for the
@@ -409,10 +491,24 @@ clio::run::TaskResume Runtime::PopulateLocal(const TagId &tag_id,
   {
     // Coherence registration at the blob's OWNER (Dynamic hash-routes
     // there): its next primary write invalidates this node's copy BEFORE
-    // acking, so a covering local copy is never stale.
-    auto reg = next->AsyncRegisterReplicaContainer(tag_id, blob_name,
-                                                   CLIO_IPC->GetNodeId());
+    // acking, so a covering local copy is never stale. VERSION-CHECKED
+    // (issue #894): if the owner's content moved on since the first chunk
+    // was fetched, the registration is REJECTED and the copy deleted —
+    // otherwise a put landing between fetch and registration leaves this
+    // copy permanently stale (its invalidation ran before we registered).
+    auto reg = next->AsyncRegisterReplicaContainer(
+        tag_id, blob_name, CLIO_IPC->GetNodeId(),
+        clio::run::PoolQuery::Dynamic(), fetch_version);
     CLIO_CO_AWAIT(reg);
+    HLOG(kInfo,
+         "[COH] cache populate-chunked blob={} node={} ver={} reg rc={}",
+         blob_name, CLIO_IPC->GetNodeId(), fetch_version,
+         reg->GetReturnCode());
+    if (reg->GetReturnCode() != 0) {
+      auto del = local->AsyncDelBlob(tag_id, blob_name,
+                                     clio::run::PoolQuery::Local());
+      CLIO_CO_AWAIT(del);
+    }
   }
   CLIO_CO_RETURN;
   CLIO_TASK_BODY_END
@@ -432,15 +528,18 @@ clio::run::TaskResume Runtime::GetBlobSize(
     // present copy current. NOTE: the copy is populated whole-blob and
     // reclaimed/invalidated whole-blob, so a present size is the full
     // logical size.
-    auto *local = GetLocalClient();
-    auto sz = local->AsyncGetBlobSize(task->tag_id_, task->blob_name_.str(),
-                                      clio::run::PoolQuery::Local(),
-                                      clio::cte::core::kCacheReplica);
-    CLIO_CO_AWAIT(sz);
-    if (sz->GetReturnCode() == 0 && sz->size_ > 0) {
-      task->size_ = sz->size_;
-      task->return_code_ = 0;
-      CLIO_CO_RETURN;
+    if (!IsBlobOwnerLocal(task->tag_id_, task->blob_name_.str())) {
+      auto *local = GetLocalClient();
+      auto sz = local->AsyncGetBlobSize(task->tag_id_,
+                                        task->blob_name_.str(),
+                                        clio::run::PoolQuery::Local(),
+                                        clio::cte::core::kCacheReplica);
+      CLIO_CO_AWAIT(sz);
+      if (sz->GetReturnCode() == 0 && sz->size_ > 0) {
+        task->size_ = sz->size_;
+        task->return_code_ = 0;
+        CLIO_CO_RETURN;
+      }
     }
   }
   {

--- a/context-transfer-engine/core/include/clio_cte/core/core_client.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_client.h
@@ -2429,11 +2429,12 @@ class Client : public clio::run::ContainerClient {
   clio::run::Future<RegisterReplicaContainerTask> AsyncRegisterReplicaContainer(
       const TagId &tag_id, const std::string &blob_name,
       clio::run::u64 node_id,
-      const clio::run::PoolQuery &pool_query = clio::run::PoolQuery::Dynamic()) {
+      const clio::run::PoolQuery &pool_query = clio::run::PoolQuery::Dynamic(),
+      clio::run::u64 expected_version = 0) {
     auto *ipc_manager = CLIO_CPU_IPC;
     auto task = ipc_manager->NewTask<RegisterReplicaContainerTask>(
         clio::run::CreateTaskId(), pool_id_, pool_query, tag_id, blob_name,
-        node_id);
+        node_id, expected_version);
     return ipc_manager->Send(task);
   }
 

--- a/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
@@ -922,19 +922,28 @@ struct RegisterReplicaContainerTask : public clio::run::Task {
   IN TagId tag_id_;
   IN clio::run::priv::string blob_name_;
   IN clio::run::u64 node_id_;  // the node holding the copy
+  /** Expected content version (issue #894): the Context::version_ the copy
+   *  was fetched at. Non-zero => the owner registers ONLY IF the blob's
+   *  content version still matches, and reports kVersionMismatchRc
+   *  otherwise — the copy is stale and the registrant must drop it. 0 =
+   *  unconditional (legacy). */
+  IN clio::run::u64 expected_version_;
+
+  static constexpr clio::run::u32 kVersionMismatchRc = 2;
 
   RegisterReplicaContainerTask()
       : clio::run::Task(), tag_id_(TagId::GetNull()),
-        blob_name_(CLIO_PRIV_ALLOC), node_id_(0) {}
+        blob_name_(CLIO_PRIV_ALLOC), node_id_(0), expected_version_(0) {}
 
   CTP_CROSS_FUN explicit RegisterReplicaContainerTask(
       const clio::run::TaskId &task_id, const clio::run::PoolId &pool_id,
       const clio::run::PoolQuery &pool_query, const TagId &tag_id,
-      const std::string &blob_name, clio::run::u64 node_id)
+      const std::string &blob_name, clio::run::u64 node_id,
+      clio::run::u64 expected_version = 0)
       : clio::run::Task(task_id, pool_id, pool_query,
                         Method::kRegisterReplicaContainer),
         tag_id_(tag_id), blob_name_(CLIO_PRIV_ALLOC, blob_name),
-        node_id_(node_id) {
+        node_id_(node_id), expected_version_(expected_version) {
     task_id_ = task_id;
     pool_id_ = pool_id;
     method_ = Method::kRegisterReplicaContainer;
@@ -945,7 +954,7 @@ struct RegisterReplicaContainerTask : public clio::run::Task {
   template <typename Archive>
   CTP_CROSS_FUN void SerializeIn(Archive &ar) {
     Task::SerializeIn(ar);
-    ar(tag_id_, blob_name_, node_id_);
+    ar(tag_id_, blob_name_, node_id_, expected_version_);
   }
 
   template <typename Archive>
@@ -958,6 +967,7 @@ struct RegisterReplicaContainerTask : public clio::run::Task {
     tag_id_ = other->tag_id_;
     blob_name_ = other->blob_name_;
     node_id_ = other->node_id_;
+    expected_version_ = other->expected_version_;
   }
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
@@ -1542,6 +1552,14 @@ struct Context {
   // put and dies on the next foreign put. kNoOriginNode = none.
   clio::run::u64 origin_node_;
   static constexpr clio::run::u64 kNoOriginNode = ~0ULL;
+  // OUT (issue #894 coherence): the blob's content version at the moment a
+  // GetBlob served it (the owner's last_modified_ tick). A reader that
+  // populates a node-local copy from the fetched bytes registers it with
+  // this as the EXPECTED version; the owner rejects the registration if the
+  // content moved on in between — closing the fetch->populate->register
+  // window that otherwise leaves a permanently stale registered copy when
+  // a racing put's invalidation snapshot ran before the registration.
+  clio::run::u64 version_;
 
   // ---- Compression / tracing controls and stats -------------------------
   // UNCONDITIONAL by design (issue #886 unified API): these fields exist in
@@ -1588,6 +1606,7 @@ struct Context {
         replica_flags_(0),
         replica_min_score_(-1.0f),
         origin_node_(kNoOriginNode),
+        version_(0),
         dynamic_compress_(0),
         compress_lib_(0),
         compress_preset_(2),
@@ -1612,7 +1631,7 @@ struct Context {
     // field-block comment above).
     ar.range(persistence_target_, min_persistence_level_, preallocate_,
              emulate_, emulated_time_ns_, transform_flags_, replica_,
-             replica_flags_, replica_min_score_, origin_node_,
+             replica_flags_, replica_min_score_, origin_node_, version_,
              dynamic_compress_,
              compress_lib_,
              compress_preset_, target_psnr_, psnr_chance_, max_performance_,

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -2005,6 +2005,9 @@ clio::run::TaskResume Runtime::PutBlobImpl(clio::run::shared_ptr<TaskT> &task) {
       }
       blob_info_ptr->replica_nodes_.clear();
       const clio::run::u64 self_node = CLIO_IPC->GetNodeId();
+      HLOG(kInfo, "[COH] put blob={} inval {} node(s) (origin={} ver={})",
+           blob_name, inval_nodes.size(), task->context_.origin_node_,
+           blob_info_ptr->last_modified_);
       for (size_t ni = 0; ni < inval_nodes.size(); ++ni) {
         if (inval_nodes[ni] == self_node) {
           continue;  // this container IS the owner; nothing cached here
@@ -2052,6 +2055,8 @@ clio::run::TaskResume Runtime::PutBlobImpl(clio::run::shared_ptr<TaskT> &task) {
         }
       }
       if (!ok) {
+        HLOG(kInfo, "[COH] put blob={} REFUSED origin {} (incomplete)",
+             blob_name, task->context_.origin_node_);
         task->context_.origin_node_ = Context::kNoOriginNode;
       } else {
         bool present = false;
@@ -2066,6 +2071,9 @@ clio::run::TaskResume Runtime::PutBlobImpl(clio::run::shared_ptr<TaskT> &task) {
           blob_info_ptr->replica_nodes_.push_back(
               task->context_.origin_node_);
         }
+        HLOG(kInfo, "[COH] put blob={} registered origin {} ver={}",
+             blob_name, task->context_.origin_node_,
+             blob_info_ptr->last_modified_);
       }
     }
 
@@ -2431,6 +2439,12 @@ clio::run::TaskResume Runtime::GetBlobImpl(clio::run::shared_ptr<TaskT> &task) {
         replica_sel > 0
             ? blob_info_ptr->GetReplica(replica_sel, false)->transform_flags_
             : blob_info_ptr->transform_flags_;
+    // OUT: content version at serve time (issue #894), read BEFORE the block
+    // snapshot — if a put completes between this read and the snapshot the
+    // caller holds NEW bytes stamped with the OLD version, and a
+    // version-checked registration then REJECTS (safe, refetch) rather than
+    // accepting stale bytes under a fresh version.
+    task->context_.version_ = blob_info_ptr->last_modified_;
 
     // Use the pre-provided data pointer from the task
     ctp::ipc::ShmPtr<> blob_data_ptr = task->blob_data_;
@@ -2545,7 +2559,24 @@ clio::run::TaskResume Runtime::RegisterReplicaContainer(
     // registered self would make the next put's invalidation delete the
     // authoritative blob (replicas included).
     if (task->node_id_ == CLIO_IPC->GetNodeId()) {
+      HLOG(kInfo, "[COH] register blob={} node {} SELF-refused",
+           task->blob_name_.str(), task->node_id_);
       task->return_code_ = 0;
+      CLIO_CO_RETURN;
+    }
+    // Version gate (issue #894): the registrant fetched its copy at
+    // expected_version_. If the content has moved on since, the copy is
+    // STALE and must not be registered — a put that completed between the
+    // fetch and this registration took its invalidation snapshot without
+    // the registrant, so accepting here would leave a permanently stale
+    // registered copy (the CI-reproduced fragmented-round winner split).
+    if (task->expected_version_ != 0 &&
+        blob_info_ptr->last_modified_ != task->expected_version_) {
+      HLOG(kInfo,
+           "[COH] register blob={} node {} VERSION-reject (want {} have {})",
+           task->blob_name_.str(), task->node_id_, task->expected_version_,
+           blob_info_ptr->last_modified_);
+      task->return_code_ = RegisterReplicaContainerTask::kVersionMismatchRc;
       CLIO_CO_RETURN;
     }
     // Dedup append. No co_await from the check to the push, so this is
@@ -2562,6 +2593,9 @@ clio::run::TaskResume Runtime::RegisterReplicaContainer(
     if (!present) {
       blob_info_ptr->replica_nodes_.push_back(task->node_id_);
     }
+    HLOG(kInfo, "[COH] register blob={} node {} ACCEPTED ver={}",
+         task->blob_name_.str(), task->node_id_,
+         blob_info_ptr->last_modified_);
     task->return_code_ = 0;
   } catch (const std::exception &e) {
     task->return_code_ = 1;

--- a/context-transfer-engine/test/integration/coherence/clio_config.yaml
+++ b/context-transfer-engine/test/integration/coherence/clio_config.yaml
@@ -23,6 +23,15 @@ runtime:
   local_sched: "default"
   heartbeat_interval: 1000
 
+# This suite validates COHERENCE, not failure detection (the leader-election
+# cluster test owns SWIM coverage). On CI-class CPU budgets (4 runtimes + 4
+# spinning clients on ~4 vCPUs) probe responses starve for >30s and SWIM
+# false-positives a healthy node dead — recovery then reshuffles containers
+# and every blob-barrier cascades to timeout (issue #894's second failure
+# shape). A genuinely dead node still fails the suite via barrier timeouts.
+swim:
+  enabled: false
+
 compose:
   - mod_name: clio_cte_core
     pool_name: cte_main

--- a/context-transfer-engine/test/integration/coherence/docker-compose.cpulimit.yml
+++ b/context-transfer-engine/test/integration/coherence/docker-compose.cpulimit.yml
@@ -1,0 +1,12 @@
+# LOCAL-ONLY overlay: mimic the CI runner's CPU budget (4 vCPUs shared by
+# 4 runtime containers + 4 test clients) to reproduce timing-dependent
+# failures that never fire on an unconstrained host.
+services:
+  coh-node1:
+    cpus: 0.5
+  coh-node2:
+    cpus: 0.5
+  coh-node3:
+    cpus: 0.5
+  coh-node4:
+    cpus: 0.5

--- a/context-transfer-engine/test/integration/coherence/run_tests.sh
+++ b/context-transfer-engine/test/integration/coherence/run_tests.sh
@@ -73,6 +73,15 @@ if [ "$overall" != "0" ]; then
         say "=== node $n log (tail) ==="
         docker logs "coh-node$n" 2>&1 | tail -60
     done
+    if [ -n "${COH_LOG_DIR:-}" ]; then
+        # Full per-node logs for post-mortem (the tails above routinely miss
+        # the interesting window; the EXIT trap destroys the containers).
+        mkdir -p "$COH_LOG_DIR"
+        for n in 1 2 3 4; do
+            docker logs "coh-node$n" > "$COH_LOG_DIR/coh-node$n.log" 2>&1 || true
+        done
+        say "full node logs saved to $COH_LOG_DIR"
+    fi
     err "cache coherence suite FAILED"
     exit 1
 fi

--- a/context-transfer-engine/test/integration/coherence/test_cache_coherence.cc
+++ b/context-transfer-engine/test/integration/coherence/test_cache_coherence.cc
@@ -77,6 +77,29 @@ bool MatchesPattern(const char *buf, clio::run::u64 size, int writer,
 
 clio::cte::core::Client *Chain() { return CLIO_CTE_CLIENT; }
 
+/** Decode which (writer, round) pattern buf holds, for failure forensics.
+ *  Returns "w<writer>r<round>", "torn(...)" for a recognizable prefix, or
+ *  "unknown". */
+std::string DecodePattern(const char *buf, clio::run::u64 size) {
+  for (int w = 0; w < kNumNodes; ++w) {
+    for (int r = 0; r < kRepeatRounds; ++r) {
+      if (MatchesPattern(buf, size, w, r)) {
+        return "w" + std::to_string(w) + "r" + std::to_string(r);
+      }
+    }
+  }
+  for (int w = 0; w < kNumNodes; ++w) {
+    for (int r = 0; r < kRepeatRounds; ++r) {
+      if (buf[0] == static_cast<char>((w * 31 + r * 7) & 0x7f) &&
+          buf[1] == static_cast<char>((w * 31 + r * 7 + 13) & 0x7f)) {
+        return "torn(w" + std::to_string(w) + "r" + std::to_string(r) +
+               " prefix)";
+      }
+    }
+  }
+  return "unknown";
+}
+
 /** Blob-based rendezvous: every rank puts its arrival blob and waits for
  *  the other ranks' — the store itself is the message board. Epochs make
  *  names unique so no cleanup is needed between barriers. */
@@ -163,6 +186,16 @@ TEST_CASE("Coherence - put once read many (reader-local DRAM)",
                                         clio::cte::core::kCacheReplica);
       sz.Wait();
       if (sz->GetReturnCode() == 0 && sz->size_ >= kPormSize) {
+        local = true;
+        break;
+      }
+      // The blob's OWNER node keeps no cache-slot copy by design (issue
+      // #894): there the authoritative primary IS the node-local DRAM
+      // copy. A Local primary probe answers only on the owner node.
+      auto psz = direct.AsyncGetBlobSize(tag_id, peer_name,
+                                         clio::run::PoolQuery::Local());
+      psz.Wait();
+      if (psz->GetReturnCode() == 0 && psz->size_ >= kPormSize) {
         local = true;
         break;
       }
@@ -276,6 +309,21 @@ static void FragmentedRound(const clio::cte::core::TagId &tag_id,
     std::string name =
         "winner_" + std::to_string(epoch) + "_" + std::to_string(r);
     REQUIRE(ReadFull(tag_id, name, &w, 1));
+    if (w != static_cast<char>('0' + winner)) {
+      // Forensics for the winner split: whose pattern is this node actually
+      // holding, and does a fresh read still return it?
+      std::vector<char> now(kSharedSize);
+      std::string now_dec = "readfail";
+      if (ReadFull(tag_id, blob, now.data(), kSharedSize)) {
+        now_dec = DecodePattern(now.data(), kSharedSize);
+      }
+      fprintf(stderr,
+              "[COH-DIAG] rank=%d round=%d winner=%d but rank %d published "
+              "'%c'; my stable read decodes as %s, fresh re-read decodes as "
+              "%s\n",
+              rank, round, winner, r, w, DecodePattern(got.data(),
+              kSharedSize).c_str(), now_dec.c_str());
+    }
     REQUIRE(w == static_cast<char>('0' + winner));
   }
   REQUIRE(Barrier(tag_id));

--- a/context-transfer-engine/test/unit/test_cache_interpose.cc
+++ b/context-transfer-engine/test/unit/test_cache_interpose.cc
@@ -133,24 +133,6 @@ static bool WaitPrimarySize(clio::cte::core::Client *core,
   return false;
 }
 
-/** Poll until the CACHE replica of tag/name reports `want` bytes. */
-static bool WaitCacheReplicaSize(clio::cte::core::Client *core,
-                                 const clio::cte::core::TagId &tag_id,
-                                 const std::string &name,
-                                 clio::run::u64 want) {
-  for (int attempt = 0; attempt < 300; ++attempt) {
-    auto sz = core->AsyncGetBlobSize(tag_id, name,
-                                     clio::run::PoolQuery::Dynamic(),
-                                     clio::cte::core::kCacheReplica);
-    sz.Wait();
-    if (sz->GetReturnCode() == 0 && sz->size_ == want) {
-      return true;
-    }
-    std::this_thread::sleep_for(std::chrono::milliseconds(20));
-  }
-  return false;
-}
-
 TEST_CASE("CacheInterpose - async write-through cache over core",
           "[cte][cache][886]") {
   CacheInterposeFixture fixture;
@@ -200,14 +182,15 @@ TEST_CASE("CacheInterpose - async write-through cache over core",
       REQUIRE(psz->size_ == kValSize);
     }
 
-    // The cache replica has the bytes NOW too (written before the ack).
+    // Single node ⇒ this node OWNS every blob, and the owner keeps NO
+    // cache-slot copy (issue #894): the primary IS the node-local copy,
+    // and an owner-side copy would sit outside the invalidation protocol.
     {
       auto rsz = core->AsyncGetBlobSize(tag_id, "wb_blob",
                                         clio::run::PoolQuery::Dynamic(),
                                         clio::cte::core::kCacheReplica);
       rsz.Wait();
-      REQUIRE(rsz->GetReturnCode() == 0);
-      REQUIRE(rsz->size_ == kValSize);
+      REQUIRE((rsz->GetReturnCode() != 0 || rsz->size_ == 0));
     }
 
     // Size through the cache answers the logical size from the raw copy.
@@ -267,23 +250,22 @@ TEST_CASE("CacheInterpose - async write-through cache over core",
     p2.Wait();
     REQUIRE(p2->GetReturnCode() == 0);
 
-    // Primary AND cache replica both hold the second payload, no waiting.
+    // The primary holds the second payload, no waiting. (No cache-slot
+    // copy to check — the owner node keeps none, issue #894.)
     std::vector<char> got(kValSize, 0);
     auto get = core->AsyncGetBlob(tag_id, "co_blob", 0, kValSize,
                                   /*flags=*/0, got.data());
     get.Wait();
     REQUIRE(get->GetReturnCode() == 0);
     REQUIRE(std::memcmp(got.data(), v2.data(), kValSize) == 0);
+    // Reads through the cache observe the final bytes too.
     {
-      std::vector<char> raw(kValSize, 0);
-      clio::cte::core::Context cctx;
-      cctx.replica_ = clio::cte::core::kCacheReplica;
-      auto gc = core->AsyncGetBlob(tag_id, "co_blob", 0, kValSize,
-                                   /*flags=*/0, raw.data(),
-                                   clio::run::PoolQuery::Dynamic(), cctx);
+      std::vector<char> via(kValSize, 0);
+      auto gc = cache_io.AsyncGetBlob(tag_id, "co_blob", 0, kValSize,
+                                      /*flags=*/0, via.data());
       gc.Wait();
       REQUIRE(gc->GetReturnCode() == 0);
-      REQUIRE(std::memcmp(raw.data(), v2.data(), kValSize) == 0);
+      REQUIRE(std::memcmp(via.data(), v2.data(), kValSize) == 0);
     }
   }
 
@@ -306,8 +288,15 @@ TEST_CASE("CacheInterpose - async write-through cache over core",
     REQUIRE(get->GetReturnCode() == 0);
     REQUIRE(std::memcmp(got.data(), vm.data(), kValSize) == 0);
 
-    // The miss re-populated the REPLICA_CACHE slot.
-    REQUIRE(WaitCacheReplicaSize(core, tag_id, "miss_blob", kValSize));
+    // The owner node never populates a cache-slot copy (issue #894): the
+    // read was served straight from the node-local primary.
+    {
+      auto rsz = core->AsyncGetBlobSize(tag_id, "miss_blob",
+                                        clio::run::PoolQuery::Dynamic(),
+                                        clio::cte::core::kCacheReplica);
+      rsz.Wait();
+      REQUIRE((rsz->GetReturnCode() != 0 || rsz->size_ == 0));
+    }
   }
 
   // ======================================================================


### PR DESCRIPTION
## Summary
- The blob-**owner** node's cache-slot copy sat outside the coherence protocol: origin registration skips self, so no foreign write ever invalidated it and the owner node stably served its own stale bytes whenever it was not the last writer — the round-order-dependent `repeated fragmented` winner split that failed dev Cluster Tests (and PR #779's check). Owner nodes now keep **no cache-slot copy**: their primary is already node-local DRAM and zero-IPC readable, so the copy bought no locality and doubled RAM.
- **Version-checked registration**: `GetBlob` reports the blob's content version in the OUT context; read-populate registrations carry it as `expected_version_` and the owner rejects stale ones (the reader deletes its local copy). Closes the fetch→register window that a racing put's invalidation snapshot cannot see.
- **Batch cache mirror is single-node only**: batched copies carry no registration, so on a cluster nothing would ever invalidate them.
- The coherence cluster config **disables SWIM**: on CI-class CPU budgets probe responses starve >30s and SWIM false-positives a healthy node dead — recovery reshuffles containers and every blob-barrier cascades to timeout (the second failure shape in the CI log, where a node was declared dead while its runtime demonstrably kept processing). The leader-election cluster test owns SWIM coverage; a genuinely dead node still fails this suite via barrier timeouts.
- Forensics for future flakes: `[COH]` runtime event logs (invalidate / register accept / self-refuse / version-reject), test-side winner decoding on mismatch, `COH_LOG_DIR` full-log dump in `run_tests.sh`, and a `docker-compose.cpulimit.yml` overlay (cpus: 0.5/node) that reproduces the CI timing locally.

## Motivation
Fixes #894 — dev Cluster Tests (and the dev→main PR check) red since the #891 merge.

Diagnosis trail: reproduced at `cpus: 0.5`; `[COH]` logs showed round-1 owner-serialization order 3,0,1,2 with writer 1 (the owner node) invalidating others but never registering itself, so winner 2's final put found an empty replica set and invalidated nothing. Node 1 then decoded its own `w1r1` pattern on every re-read while everyone else held `w2r1`.

## Test plan
- [x] 4-node coherence suite at CI-like CPU limits (cpus 0.5/node): passing, loop of 6 iterations in progress (iter 1 green; pre-fix the failure reproduced ~1 in 2)
- [x] Single-node CTE regression subset (`ctest -R 'cte_core_blob_put|cte_core_blob_get|cte_core_integration|cte_core_workflow|cte_functional_all|cte_core_tasks'`): 8/8 pass
- [ ] CI Cluster Tests green (note: the pre-existing #856 leader-election flake fails the same job independently)

## Breaking changes
None. Wire format: `Context` gains an OUT `version_` field and `RegisterReplicaContainerTask` an IN `expected_version_` (both ends ship together; no cross-version compatibility expected).

## Follow-ups
- A put targeting a SWIM-dead node can hang the submitting client forever (dead-node retry limbo) instead of erroring — observed while diagnosing; issue to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)