### PR TITLE
test(vol): probe the NULL-object file_specific ops (H5Fis_accessible / H5Fdelete)

### DIFF
--- a/benchmarks/hdf5-ingest/vol_c_isaccessible_test.c
+++ b/benchmarks/hdf5-ingest/vol_c_isaccessible_test.c
@@ -1,0 +1,101 @@
+/* Isolated C test for the filename-scoped file_specific ops through the clio VOL.
+ *
+ * H5VL_FILE_IS_ACCESSIBLE and H5VL_FILE_DELETE act on a *path*, not on an open
+ * file, so HDF5 invokes the connector's file_specific callback with obj == NULL.
+ * A connector that casts and dereferences that pointer segfaults; 3e8979cd
+ * fixed that, and this pins it so a future edit to clio_file_specific cannot
+ * quietly put the crash back.
+ *
+ * Two independent ways in, which is why the path is worth a dedicated probe:
+ *   - HDF5 itself, via H5VL__file_open_find_connector_cb, asks EVERY plugin on
+ *     HDF5_PLUGIN_PATH whether it can open a file -- so the connector did not
+ *     have to be selected for a plain H5Fopen to crash.
+ *   - Applications, directly: netCDF-C calls H5Fis_accessible from
+ *     NC_infermodel on every nc_create/nc_open, so every netCDF-4 program hit
+ *     it before any data moved.
+ *
+ * The h5py-based cases in this suite cannot reach either -- h5py never calls
+ * H5Fis_accessible -- which is why this lives here as a C probe.
+ *
+ * Checks, in order:
+ *   1. H5Fis_accessible on a real HDF5 file          -> true
+ *   2. H5Fis_accessible on a non-HDF5 file           -> false (not a crash)
+ *   3. H5Fis_accessible on a path that does not exist-> false/negative, no crash
+ *   4. H5Fdelete on the real file                    -> succeeds, file is gone
+ *
+ * Run with HDF5_VOL_CONNECTOR=clio (and a running clio_run). Exit 0 = pass.
+ * Build: h5cc -o vol_c_isaccessible_test vol_c_isaccessible_test.c
+ */
+#include <hdf5.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#define N 64
+
+/* Build a small, valid HDF5 file through whatever VOL is active. */
+static int make_file(const char *path) {
+  int vals[N];
+  for (int i = 0; i < N; ++i) vals[i] = i;
+
+  hid_t f = H5Fcreate(path, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+  if (f < 0) return 0;
+  hsize_t dims[1] = {N};
+  hid_t s = H5Screate_simple(1, dims, NULL);
+  hid_t d = H5Dcreate2(f, "vals", H5T_NATIVE_INT, s, H5P_DEFAULT, H5P_DEFAULT,
+                       H5P_DEFAULT);
+  int ok = (d >= 0) &&
+           (H5Dwrite(d, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, vals) >= 0);
+  if (d >= 0) H5Dclose(d);
+  H5Sclose(s);
+  H5Fclose(f);
+  return ok;
+}
+
+int main(void) {
+  const char *path = "/tmp/volc_isaccessible.h5";
+  const char *junk = "/tmp/volc_isaccessible_junk.bin";
+  const char *absent = "/tmp/volc_isaccessible_absent.h5";
+
+  unlink(path);
+  unlink(junk);
+  unlink(absent);
+
+  if (!make_file(path)) {
+    fprintf(stderr, "setup: could not create %s\n", path);
+    return 2;
+  }
+
+  FILE *fh = fopen(junk, "wb");
+  if (!fh) { fprintf(stderr, "setup: could not create %s\n", junk); return 2; }
+  fputs("this is not an HDF5 file", fh);
+  fclose(fh);
+
+  /* 1/2/3: the IS_ACCESSIBLE path, which is where obj == NULL arrives. */
+  htri_t real = H5Fis_accessible(path, H5P_DEFAULT);
+  htri_t not_hdf5 = H5Fis_accessible(junk, H5P_DEFAULT);
+  /* A missing path may report false or fail outright; both are fine. What is
+     not fine is crashing, so the value is only required to be "not true".
+     Wrapped in H5E_BEGIN_TRY because the expected failure would otherwise
+     print an error stack that reads like a test failure. */
+  htri_t missing;
+  H5E_BEGIN_TRY { missing = H5Fis_accessible(absent, H5P_DEFAULT); }
+  H5E_END_TRY;
+
+  int ok_real = (real > 0);
+  int ok_junk = (not_hdf5 == 0);
+  int ok_missing = (missing <= 0);
+
+  /* 4: the DELETE path, the other callback invoked with obj == NULL. */
+  herr_t del;
+  H5E_BEGIN_TRY { del = H5Fdelete(path, H5P_DEFAULT); }
+  H5E_END_TRY;
+  int ok_delete = (del >= 0) && (access(path, F_OK) != 0);
+
+  unlink(junk);
+
+  int ok = ok_real && ok_junk && ok_missing && ok_delete;
+  printf("is_accessible real=%d junk=%d missing=%d, delete=%d: %s\n",
+         (int)real, (int)not_hdf5, (int)missing, (int)del, ok ? "PASS" : "FAIL");
+  return ok ? 0 : 1;
+}

--- a/benchmarks/hdf5-ingest/vol_compat_suite.py
+++ b/benchmarks/hdf5-ingest/vol_compat_suite.py
@@ -485,6 +485,7 @@ C_PROBES = {
     "c_cache_identity":    "vol_c_cache_identity_test.c",
     "c_error_propagation": "vol_c_error_propagation_test.c",
     "c_passthrough_ops":   "vol_c_passthrough_ops_test.c",
+    "c_isaccessible":      "vol_c_isaccessible_test.c",
 }
 
 
@@ -540,7 +541,10 @@ def _run_c_tests():
     selection-aware read caching + partial-write invalidation (c_selection), and
     the cache-identity regressions (c_cache_identity): mem/file datatype
     mismatch, a cache surviving H5F_ACC_TRUNC of its file, and H5Dflush as a
-    barrier. Each of those three returned wrong data with a success status."""
+    barrier. Each of those three returned wrong data with a success status.
+    c_isaccessible covers the filename-scoped file_specific ops HDF5 invokes
+    with a NULL object; h5py never calls H5Fis_accessible, so no h5py case
+    reaches that callback."""
     src_dir = os.path.dirname(os.path.abspath(__file__))
     out = {}
     for name, src in C_PROBES.items():


### PR DESCRIPTION
Fixes #897.

## The bug

`H5VL_FILE_IS_ACCESSIBLE` and `H5VL_FILE_DELETE` act on a **filename**, not on
an open file, so HDF5 invokes the connector's `file_specific` callback with
`obj == NULL`. `clio_file_specific()` cast and dereferenced it unconditionally:

```cpp
auto *file = static_cast<clio_file_t *>(obj);
...
return H5VLfile_specific(file->obj.under_object, file->obj.under_vol_id, ...);
```

netCDF-C calls `H5Fis_accessible` from `NC_infermodel()` on every `nc_create`
and `nc_open`, so this killed **every** netCDF-4 application before any data
moved — `nc_create` → `NC_infermodel` → `H5Fis_accessible` → SIGSEGV.

## The fix

Mirror `H5VLpassthru`: for those two op types, shallow-copy the args, copy the
FAPL, point it at the under-VOL (always native for this connector, matching
`clio_file_create`), and forward with a NULL object.

## The test

`benchmarks/hdf5-ingest/vol_c_isaccessible_test.c`, added to the compat suite's
C-test set. It covers `H5Fis_accessible` on a real HDF5 file, a non-HDF5 file
and a missing path, plus `H5Fdelete` — the other callback HDF5 invokes with a
NULL object.

Every existing case in `vol_compat_suite.py` runs through h5py, and h5py never
calls `H5Fis_accessible`. The suite was green at 20/20 while this callback path
was unreachable from it, so the gap was structural rather than a missing case
in the existing style — hence a C test rather than another h5py case.

Verified both directions against a shared HDF5 `develop` build (VOL confirmed
linking the same `libhdf5`):

| connector | result |
| --- | --- |
| without the fix | `test exit=139` (SIGSEGV, core dumped) |
| with the fix | `is_accessible real=1 junk=0 missing=-1, delete=0: PASS` |

`H5Fdelete` returns 0 and the file is gone; the missing-path probe returns a
negative `htri_t`, which is a legitimate outcome — the test only requires "not
true, and not a crash", with the expected HDF5 error stack suppressed by
`H5E_BEGIN_TRY`.

## Beyond the crash

With this applied, netCDF-4 runs end to end through the connector.
`tst_chunks3` (netcdf-c `nc_perf`, 64³, deflate 6) completes all 18
write/read cases; the connector costs a fairly flat ~10–14 ms per timed
operation versus native — a median 13.4x with no pathological case. That
number is context, not a claim about tuned performance, and it is out of scope
for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
