### PR TITLE
Ship fuse adapter, chimods, and Windows exe across all package formats

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -82,12 +82,17 @@ jobs:
         # CLIO_CORE_ENABLE_PYTHON stays OFF (no nanobind C++ bindings), but the
         # pure-Python context visualizer ships as a standard feature via
         # CLIO_CORE_ENABLE_VISUALIZER (default ON, set explicitly for clarity).
+        # Cache + replication chimods already default ON (#886); pin them
+        # explicitly so a future default flip cannot silently drop them
+        # from published packages (#899).
         cmake -B build-deb \
           -DCLIO_CORE_ENABLE_DEB_PACKAGE=ON \
           -DCLIO_CORE_ENABLE_TESTS=OFF \
           -DCLIO_CORE_ENABLE_PYTHON=OFF \
           -DCLIO_CORE_ENABLE_VISUALIZER=ON \
           -DCLIO_CTE_ENABLE_FUSE_ADAPTER=ON \
+          -DCLIO_CTE_ENABLE_CACHE=ON \
+          -DCLIO_CTE_ENABLE_REPLICATION=ON \
           -G Ninja
 
     - name: Build with CMake
@@ -146,6 +151,7 @@ jobs:
         # CLIO_CORE_ENABLE_PYTHON stays OFF (no nanobind C++ bindings), but the
         # pure-Python context visualizer ships as a standard feature via
         # CLIO_CORE_ENABLE_VISUALIZER (default ON, set explicitly for clarity).
+        # Cache + replication pins: same rationale as build-deb (#899).
         cmake -B build-rpm \
           -DCLIO_CORE_ENABLE_RPM_PACKAGE=ON \
           -DCLIO_CORE_ENABLE_TESTS=OFF \
@@ -153,6 +159,8 @@ jobs:
           -DCLIO_CORE_ENABLE_VISUALIZER=ON \
           -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
           -DCLIO_CTE_ENABLE_FUSE_ADAPTER=ON \
+          -DCLIO_CTE_ENABLE_CACHE=ON \
+          -DCLIO_CTE_ENABLE_REPLICATION=ON \
           -G Ninja
 
     - name: Build with CMake
@@ -210,11 +218,14 @@ jobs:
 
     - name: Configure with CMake
       run: |
+        # Cache + replication pins: same rationale as build-deb (#899).
         cmake -B build-appimage \
           -DCLIO_CORE_ENABLE_APPIMAGE=ON \
           -DCLIO_CORE_ENABLE_TESTS=OFF \
           -DCLIO_CORE_ENABLE_PYTHON=OFF \
           -DCLIO_CTE_ENABLE_FUSE_ADAPTER=ON \
+          -DCLIO_CTE_ENABLE_CACHE=ON \
+          -DCLIO_CTE_ENABLE_REPLICATION=ON \
           -G Ninja
 
     - name: Build with CMake
@@ -291,10 +302,25 @@ jobs:
           exit 1
         fi
         python3 -c "import context_visualizer; print('context_visualizer import OK')"
+        echo "=== clio_cte_fuse (FUSE adapter, #899) ==="
+        # The .deb now declares libfuse3-dev + fuse3, so the apt install
+        # above must have pulled libfuse3.so.3 — a load failure here means
+        # the dependency declaration regressed.
+        rc=0; clio_cte_fuse --help || rc=$?
+        if [ "$rc" -ge 128 ] || [ "$rc" -lt 0 ]; then
+          echo "FAIL: clio_cte_fuse --help died with exit code $rc"
+          exit 1
+        fi
+        echo "=== cache + replication chimods present (#899) ==="
+        for mod in clio_cte_cache clio_cte_replication; do
+          dpkg -L iowarp-core | grep -q "$mod" || { echo "FAIL: $mod libs missing from package"; exit 1; }
+        done
         echo "=== dpkg -L iowarp-core (file manifest) ==="
         dpkg -L iowarp-core | head -40
         echo "=== ldd $(command -v clio_run) ==="
         ldd "$(command -v clio_run)" | grep -E "not found" && exit 1 || echo "All shared libraries resolve."
+        echo "=== ldd $(command -v clio_cte_fuse) ==="
+        ldd "$(command -v clio_cte_fuse)" | grep -E "not found" && exit 1 || echo "All shared libraries resolve."
 
   test-rpm:
     name: Test RPM install (${{ matrix.arch }})
@@ -339,10 +365,25 @@ jobs:
           exit 1
         fi
         python3 -c "import context_visualizer; print('context_visualizer import OK')"
+        echo "=== clio_cte_fuse (FUSE adapter, #899) ==="
+        # The .rpm now requires fuse3-devel + fuse3, so dnf must have
+        # pulled libfuse3.so.3 — a load failure here means the dependency
+        # declaration regressed.
+        rc=0; clio_cte_fuse --help || rc=$?
+        if [ "$rc" -ge 128 ] || [ "$rc" -lt 0 ]; then
+          echo "FAIL: clio_cte_fuse --help died with exit code $rc"
+          exit 1
+        fi
+        echo "=== cache + replication chimods present (#899) ==="
+        for mod in clio_cte_cache clio_cte_replication; do
+          rpm -ql iowarp-core | grep -q "$mod" || { echo "FAIL: $mod libs missing from package"; exit 1; }
+        done
         echo "=== rpm -ql iowarp-core (file manifest) ==="
         rpm -ql iowarp-core | head -40
         echo "=== ldd $(command -v clio_run) ==="
         ldd "$(command -v clio_run)" | grep -E "not found" && exit 1 || echo "All shared libraries resolve."
+        echo "=== ldd $(command -v clio_cte_fuse) ==="
+        ldd "$(command -v clio_cte_fuse)" | grep -E "not found" && exit 1 || echo "All shared libraries resolve."
 
   test-appimage:
     name: Test AppImage (${{ matrix.arch }})
@@ -384,6 +425,146 @@ jobs:
           exit 1
         fi
         echo "AppImage launches and prints usage."
+        echo "=== Inspect payload: fuse adapter + chimods (#899) ==="
+        # --appimage-extract works without FUSE; inspect and smoke-test the
+        # extracted tree directly.
+        "$APPIMG" --appimage-extract >/dev/null
+        test -x squashfs-root/usr/bin/clio_cte_fuse || { echo "FAIL: clio_cte_fuse missing from AppImage"; exit 1; }
+        ls squashfs-root/usr/lib/libfuse3.so.3* >/dev/null 2>&1 || { echo "FAIL: libfuse3.so.3 not bundled"; exit 1; }
+        for mod in clio_cte_cache clio_cte_replication; do
+          ls squashfs-root/usr/lib/ | grep -q "$mod" || { echo "FAIL: $mod libs missing from AppImage"; exit 1; }
+        done
+        # Run the bundled adapter against the bundled libs — proves the
+        # AppImage is self-contained even where the host lacks libfuse3.
+        rc=0; LD_LIBRARY_PATH="$PWD/squashfs-root/usr/lib" squashfs-root/usr/bin/clio_cte_fuse --help || rc=$?
+        if [ "$rc" -ge 128 ]; then
+          echo "FAIL: bundled clio_cte_fuse --help died with exit code $rc"
+          exit 1
+        fi
+        echo "FUSE adapter present with bundled libfuse3."
+
+  #-----------------------------------------------------------------------
+  # Build native Windows package (ZIP + NSIS installer .exe)
+  #
+  # Windows users without Python get clio_run.exe & friends via a plain
+  # ZIP plus an NSIS installer (#899). Deps come from vcpkg exactly like
+  # the Windows wheel job in build-pip.yml; WinFsp provides the FUSE3-
+  # compatible SDK for clio_cte_fuse.exe. NSIS (makensis) is preinstalled
+  # on the windows-latest runner image.
+  #-----------------------------------------------------------------------
+  build-windows:
+    name: Build Windows package (x86_64)
+    runs-on: windows-latest
+    needs: [check-version]
+    if: always() && (needs.check-version.result == 'success' || needs.check-version.result == 'skipped')
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+        fetch-depth: 0
+
+    - name: Bootstrap vcpkg
+      run: |
+        cd $env:VCPKG_INSTALLATION_ROOT
+        git pull
+        .\bootstrap-vcpkg.bat
+
+    - name: Install vcpkg dependencies
+      run: |
+        C:/vcpkg/vcpkg install --triplet x64-windows zeromq yaml-cpp cereal msgpack-c
+
+    - name: Install WinFsp (FUSE adapter SDK)
+      run: choco install winfsp -y --no-progress
+
+    - name: Configure with CMake
+      run: |
+        # Cache + replication pins: same rationale as build-deb (#899).
+        cmake -B build-win `
+          -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake `
+          -DVCPKG_TARGET_TRIPLET=x64-windows `
+          -DCLIO_CORE_ENABLE_WINDOWS_PACKAGE=ON `
+          -DCLIO_CORE_ENABLE_TESTS=OFF `
+          -DCLIO_CORE_ENABLE_PYTHON=OFF `
+          -DCLIO_CTE_ENABLE_FUSE_ADAPTER=ON `
+          -DCLIO_CTE_ENABLE_CACHE=ON `
+          -DCLIO_CTE_ENABLE_REPLICATION=ON
+
+    - name: Build with CMake
+      run: cmake --build build-win --config Release --parallel 4
+
+    - name: Create ZIP + NSIS packages
+      run: |
+        cd build-win
+        cpack -G ZIP -C Release
+        cpack -G NSIS -C Release
+
+    - name: Upload Windows package artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: windows-package-x86_64
+        path: |
+          build-win/iowarp-core-*.zip
+          build-win/iowarp-core-*.exe
+
+  #-----------------------------------------------------------------------
+  # Install-and-smoke-test the Windows ZIP on a clean runner, mirroring
+  # test-deb / test-rpm. The NSIS .exe is asserted to exist but tested via
+  # the ZIP payload (identical file set; silent NSIS install would need UI
+  # automation for the PATH checkbox).
+  #-----------------------------------------------------------------------
+  test-windows:
+    name: Test Windows package (x86_64)
+    needs: [build-windows]
+    runs-on: windows-latest
+    if: always() && needs.build-windows.result == 'success'
+    steps:
+    - name: Download Windows package
+      uses: actions/download-artifact@v4
+      with:
+        name: windows-package-x86_64
+        path: pkg/
+
+    - name: Install WinFsp (FUSE adapter runtime)
+      run: choco install winfsp -y --no-progress
+
+    - name: Extract ZIP + smoke test
+      shell: pwsh
+      run: |
+        $zip = (Get-ChildItem pkg/iowarp-core-*.zip | Select-Object -First 1).FullName
+        Write-Host "Extracting $zip"
+        Expand-Archive $zip -DestinationPath extracted
+        # The archive wraps everything in one iowarp-core-<ver>-win64/ root.
+        $root = (Get-ChildItem extracted -Directory | Select-Object -First 1).FullName
+        $bin = Join-Path $root "bin"
+
+        Write-Host "=== clio_run.exe --help ==="
+        & "$bin\clio_run.exe" --help
+        # Same heuristic as build-pip.yml: negative exit codes are load-time
+        # crashes (missing DLL = 0xC0000135); small positive codes are the
+        # arg parser printing usage.
+        if ($LASTEXITCODE -lt 0 -or $LASTEXITCODE -gt 100) {
+          throw "clio_run --help died with exit code $LASTEXITCODE (likely missing DLL)"
+        }
+
+        Write-Host "=== clio_cte_fuse.exe (FUSE adapter, #899) ==="
+        if (-not (Test-Path "$bin\clio_cte_fuse.exe")) { throw "clio_cte_fuse.exe missing from package" }
+        $env:PATH = "${env:ProgramFiles(x86)}\WinFsp\bin;$env:PATH"
+        & "$bin\clio_cte_fuse.exe" --help
+        if ($LASTEXITCODE -lt 0 -or $LASTEXITCODE -gt 100) {
+          throw "clio_cte_fuse --help died with exit code $LASTEXITCODE"
+        }
+
+        Write-Host "=== cache + replication chimod DLLs present (#899) ==="
+        foreach ($mod in @('clio_cte_cache', 'clio_cte_replication')) {
+          if (-not (Get-ChildItem -Recurse $root -Filter "*$mod*")) { throw "$mod DLLs missing from package" }
+        }
+
+        Write-Host "=== NSIS installer artifact exists ==="
+        if (-not (Get-ChildItem pkg/iowarp-core-*.exe)) { throw "NSIS installer .exe missing" }
+
+        Write-Host "All Windows package tests passed."
+        exit 0
 
   #-----------------------------------------------------------------------
   # Publish all artifacts to GitHub Release on tag
@@ -396,7 +577,7 @@ jobs:
   #-----------------------------------------------------------------------
   publish-release:
     name: Publish to GitHub Release
-    needs: [build-deb, build-rpm, build-appimage, test-deb, test-rpm, test-appimage]
+    needs: [build-deb, build-rpm, build-appimage, build-windows, test-deb, test-rpm, test-appimage, test-windows]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
@@ -420,6 +601,13 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         pattern: appimage-*
+        path: packages/
+        merge-multiple: true
+
+    - name: Download Windows packages
+      uses: actions/download-artifact@v4
+      with:
+        pattern: windows-package-*
         path: packages/
         merge-multiple: true
 

--- a/.github/workflows/build-pip.yml
+++ b/.github/workflows/build-pip.yml
@@ -88,8 +88,13 @@ jobs:
         CIBW_BUILD: ${{ matrix.cibw_build }}
         CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_image }}
         CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.cibw_image }}
+        # fuse3-devel: Linux wheels build the FUSE adapter by default
+        # (#899, see the platform override in installers/pip/pyproject.toml).
+        # Only the headers/import stub are needed at build time; the wheel
+        # does not bundle libfuse3.so.3 — end users get it from their
+        # distro's fuse3 packages.
         CIBW_BEFORE_ALL: >
-          yum install -y curl patchelf &&
+          yum install -y curl patchelf fuse3-devel &&
           bash {project}/installers/pip/build_deps_manylinux.sh
         CIBW_ENVIRONMENT: ${{ matrix.cibw_environment }}
         CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
@@ -134,6 +139,13 @@ jobs:
       run: |
         C:/vcpkg/vcpkg install --triplet x64-windows zeromq yaml-cpp cereal msgpack-c
 
+    # WinFsp provides the FUSE3-compatible SDK the Windows fuse adapter
+    # builds against (#899; see adapter/libfuse/CMakeLists.txt). The choco
+    # package installs to %ProgramFiles(x86)%\WinFsp, which is the CMake
+    # default search path.
+    - name: Install WinFsp (FUSE adapter SDK)
+      run: choco install winfsp -y --no-progress
+
     - name: Install cibuildwheel
       run: pip install cibuildwheel
 
@@ -154,8 +166,12 @@ jobs:
         # --ignore-existing tells delvewheel to treat DLLs already in the
         # wheel as satisfied, so it can traverse the dep graph without
         # trying to locate them externally.
+        # --exclude winfsp-x64.dll: clio_cte_fuse.exe links the WinFsp
+        # system DLL, which ships with the user's WinFsp install (a signed
+        # driver package) and must never be vendored into the wheel.
         CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >-
-          delvewheel repair -w {dest_dir} -v --ignore-existing {wheel}
+          delvewheel repair -w {dest_dir} -v --ignore-existing
+          --exclude winfsp-x64.dll {wheel}
       run: cibuildwheel --output-dir installers/pip/wheelhouse
 
     - name: Upload Windows wheels
@@ -383,9 +399,37 @@ jobs:
               unset rc
             done
 
+            echo "=== FUSE adapter entry point (Linux standard feature) ==="
+            # The wheel ships clio_cte_fuse but deliberately not
+            # libfuse3.so.3 (a system dep, see #899). Install the distro
+            # fuse3 runtime like an end user would, then apply the same
+            # signal-level heuristic as the benchmarks above.
+            if command -v apt-get &>/dev/null; then
+              apt-get install -y -qq fuse3 libfuse3-3 >/dev/null 2>&1
+            elif command -v dnf &>/dev/null; then
+              dnf install -y -q fuse3 fuse3-libs >/dev/null 2>&1
+            fi
+            clio_cte_fuse --help || rc=$?
+            rc=${rc:-0}
+            if [ "$rc" -ge 128 ]; then
+              echo "FAIL: clio_cte_fuse --help died with signal (exit $rc)"
+              exit 1
+            fi
+            unset rc
+
             echo "=== Symbol resolution check ==="
             LIB_DIR=$(python -c "import iowarp_core; print(iowarp_core.get_lib_dir())")
             export LD_LIBRARY_PATH="$LIB_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
+            echo "=== Cache + replication chimods present ==="
+            # Both chimods ship by default (#886/#899); a missing lib means
+            # the pip_package component lost them.
+            for mod in cache replication; do
+              if ! ls "$LIB_DIR"/libclio_cte_${mod}_* >/dev/null 2>&1; then
+                echo "FAIL: libclio_cte_${mod}_* missing from wheel lib dir"
+                exit 1
+              fi
+            done
             MISSING=0
             for so in "$LIB_DIR"/*.so "$LIB_DIR"/*.so.*; do
               [ -f "$so" ] || continue
@@ -533,6 +577,12 @@ jobs:
         name: wheels-win_amd64
         path: wheels/
 
+    # WinFsp runtime for the fuse adapter smoke test (#899) — end users
+    # install this from winfsp.dev. The DLL lives under
+    # %ProgramFiles(x86)%\WinFsp\bin, which is not on PATH by default.
+    - name: Install WinFsp (FUSE adapter runtime)
+      run: choco install winfsp -y --no-progress
+
     - name: Test wheel in clean venv
       shell: pwsh
       run: |
@@ -583,6 +633,26 @@ jobs:
             throw "$bench --help died with exit code $LASTEXITCODE"
           }
         }
+
+        Write-Host "=== FUSE adapter (WinFsp standard feature, #899) ==="
+        # The exe must ship in the wheel; delvewheel excludes winfsp-x64.dll
+        # (system DLL), so put the WinFsp bin dir on PATH like an installed
+        # WinFsp app launcher would before exercising the binary.
+        $binDir = python -c "import iowarp_core; print(iowarp_core.get_bin_dir())"
+        if (-not (Test-Path "$binDir\clio_cte_fuse.exe")) {
+          throw "clio_cte_fuse.exe missing from wheel bin dir ($binDir)"
+        }
+        $env:PATH = "${env:ProgramFiles(x86)}\WinFsp\bin;$env:PATH"
+        clio_cte_fuse --help
+        if ($LASTEXITCODE -lt 0 -or $LASTEXITCODE -gt 100) {
+          throw "clio_cte_fuse --help died with exit code $LASTEXITCODE"
+        }
+
+        Write-Host "=== Cache + replication chimods present (#899) ==="
+        # DLLs are RUNTIME artifacts on Windows, so they land in bin/ (import
+        # .lib archives go to lib/) — search both.
+        python -c "import iowarp_core, glob, os, sys; dirs = [iowarp_core.get_lib_dir(), iowarp_core.get_bin_dir()]; missing = [m for m in ('cache', 'replication') if not any(glob.glob(os.path.join(d, f'*clio_cte_{m}_*')) for d in dirs)]; sys.exit(f'missing chimods: {missing}' if missing else 0)"
+        if ($LASTEXITCODE -ne 0) { throw "cache/replication chimod DLLs missing from wheel" }
 
         Write-Host "=== All Windows tests passed ==="
         # The bench --help calls above leave $LASTEXITCODE = 1 (they print

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ option(CLIO_CORE_ENABLE_CPACK "Enable CPack for package generation" OFF)
 option(CLIO_CORE_ENABLE_DEB_PACKAGE "Build Debian .deb package via CPack" OFF)
 option(CLIO_CORE_ENABLE_RPM_PACKAGE "Build RPM .rpm package via CPack" OFF)
 option(CLIO_CORE_ENABLE_APPIMAGE "Build portable AppImage via appimagetool" OFF)
+option(CLIO_CORE_ENABLE_WINDOWS_PACKAGE "Build Windows ZIP archive + NSIS installer .exe via CPack" OFF)
 option(CLIO_CORE_ENABLE_CONDA "Enable Conda environment configuration (adds Conda paths to include/link directories)" OFF)
 option(CLIO_CORE_ENABLE_DOCKER_CI "Enable Docker-based integration tests (requires Docker)" OFF)
 option(BUILD_SHARED_LIBS "Build shared libraries (.dll/.so) instead of static ones (.lib/.a)" ON)
@@ -1779,6 +1780,21 @@ endif()
 if(CLIO_CORE_ENABLE_CTE AND TARGET clio_cte_core_client)
   list(APPEND PIP_LIB_TARGETS clio_cte_core_client clio_cte_core_runtime)
 endif()
+# Cache + replication chimods (#886) build ON by default and ship in the
+# deb/rpm/AppImage via the module macros' default-component installs — but
+# the wheel filters to COMPONENT pip_package, so without these entries
+# `pip install iowarp-core` silently lacks both modules (#899).
+if(TARGET clio_cte_cache_client)
+  list(APPEND PIP_LIB_TARGETS clio_cte_cache_client clio_cte_cache_runtime)
+endif()
+if(TARGET clio_cte_replication_client)
+  list(APPEND PIP_LIB_TARGETS clio_cte_replication_client clio_cte_replication_runtime)
+endif()
+# Filesystem chimod: NEEDED by the clio_cte_fuse adapter binary that ships
+# in the wheel when CLIO_CTE_ENABLE_FUSE_ADAPTER is ON (#899).
+if(TARGET clio_cte_filesystem_client)
+  list(APPEND PIP_LIB_TARGETS clio_cte_filesystem_client clio_cte_filesystem_runtime)
+endif()
 if(CLIO_CORE_ENABLE_CAE AND TARGET clio_cae_core_client)
   list(APPEND PIP_LIB_TARGETS clio_cae_core_client clio_cae_core_runtime)
 endif()
@@ -1917,6 +1933,11 @@ if(WIN32 AND DEFINED VCPKG_INSTALLED_DIR AND DEFINED VCPKG_TARGET_TRIPLET)
     if(_vcpkg_dlls)
       install(FILES ${_vcpkg_dlls}
         COMPONENT pip_package
+        DESTINATION bin)
+      # Mirror into the default component so the native Windows package
+      # (CPack ZIP/NSIS filters to Unspecified, like DEB/RPM) also ships
+      # the third-party DLLs its exes need (#899).
+      install(FILES ${_vcpkg_dlls}
         DESTINATION bin)
     endif()
   endif()

--- a/cmake/packaging/CPackConfig.cmake
+++ b/cmake/packaging/CPackConfig.cmake
@@ -74,6 +74,15 @@ if(CLIO_CORE_ENABLE_DEB_PACKAGE OR CLIO_CORE_ENABLE_CPACK)
         set(CPACK_DEBIAN_PACKAGE_DEPENDS
             "${CPACK_DEBIAN_PACKAGE_DEPENDS}, python3, python3-flask, python3-yaml, python3-msgpack")
     endif()
+    # The FUSE adapter binary (clio_cte_fuse) links libfuse3.so.3 and
+    # mounting needs the setuid fusermount3 helper from the fuse3 package.
+    # Without these the shipped binary dies at exec with a dynamic-linker
+    # error on any host that never installed fuse (#899). libfuse3-dev is
+    # the -dev-name convention used for every other dep above.
+    if(CLIO_CTE_ENABLE_FUSE_ADAPTER)
+        set(CPACK_DEBIAN_PACKAGE_DEPENDS
+            "${CPACK_DEBIAN_PACKAGE_DEPENDS}, libfuse3-dev, fuse3")
+    endif()
 
     # Use Debian-standard filename: <pkg>_<ver>-<rel>_<arch>.deb. Without this,
     # CPack defaults to "iowarp-core-<ver>-Linux.deb" with no arch suffix, so
@@ -110,6 +119,13 @@ if(CLIO_CORE_ENABLE_RPM_PACKAGE OR CLIO_CORE_ENABLE_CPACK)
         set(CPACK_RPM_PACKAGE_REQUIRES
             "${CPACK_RPM_PACKAGE_REQUIRES}, python3, python3-flask, python3-pyyaml, python3-msgpack")
     endif()
+    # FUSE runtime deps for clio_cte_fuse — same rationale as the DEB
+    # branch above (#899): fuse3-devel pulls libfuse3.so.3, fuse3 provides
+    # fusermount3 for actually mounting.
+    if(CLIO_CTE_ENABLE_FUSE_ADAPTER)
+        set(CPACK_RPM_PACKAGE_REQUIRES
+            "${CPACK_RPM_PACKAGE_REQUIRES}, fuse3-devel, fuse3")
+    endif()
     # Disable auto-generated Requires on internal libraries. With AUTOREQ
     # default-on, rpmbuild scans every installed .so and adds a
     # Requires: lib<x>.so()(64bit) for each one — including our OWN
@@ -144,6 +160,37 @@ if(CLIO_CORE_ENABLE_RPM_PACKAGE OR CLIO_CORE_ENABLE_CPACK)
     set(CPACK_RPM_FILE_NAME "RPM-DEFAULT")
 
     message(STATUS "CPack: RPM generator enabled")
+endif()
+
+# Windows Package Configuration (ZIP archive + NSIS installer .exe)
+if(CLIO_CORE_ENABLE_WINDOWS_PACKAGE)
+    list(APPEND CPACK_GENERATOR "ZIP" "NSIS")
+    set(CPACK_GENERATORS_ENABLED ON)
+
+    # Same component filter as DEB/RPM: package the default (Unspecified)
+    # component only, in one artifact. Without the *_COMPONENT_INSTALL
+    # switches CPack falls back to monolithic mode and drags wheel-only
+    # pip_package files (iowarp_core.pth, ...) into the archive/installer.
+    set(CPACK_ARCHIVE_COMPONENT_INSTALL ON)
+    set(CPACK_NSIS_COMPONENT_INSTALL ON)
+
+    set(CPACK_PACKAGE_INSTALL_DIRECTORY "iowarp-core")
+    set(CPACK_NSIS_PACKAGE_NAME "IOWarp Core ${PROJECT_VERSION}")
+    set(CPACK_NSIS_DISPLAY_NAME "IOWarp Core")
+    # Offer the "add bin/ to PATH" checkbox so `clio_run` works from any
+    # terminal after install.
+    set(CPACK_NSIS_MODIFY_PATH ON)
+    set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL ON)
+
+    # Arch-suffixed filenames, matching the DEB/RPM rationale above.
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+        set(_win_arch "win64")
+    else()
+        set(_win_arch "win32")
+    endif()
+    set(CPACK_PACKAGE_FILE_NAME "iowarp-core-${PROJECT_VERSION}-${_win_arch}")
+
+    message(STATUS "CPack: ZIP + NSIS generators enabled (${_win_arch})")
 endif()
 
 # Legacy TGZ support (from CLIO_CORE_ENABLE_CPACK)

--- a/cmake/packaging/build_appimage.sh.in
+++ b/cmake/packaging/build_appimage.sh.in
@@ -54,12 +54,36 @@ cp '@APPIMAGE_STAGING_DIR@/clio_run.png' \
 # final AppImage assembly to appimagetool below so we control the output
 # filename (iowarp-core-<ver>-<arch>.AppImage to match our release naming).
 echo "Bundling runtime libs into AppDir..."
+# clio_cte_fuse (the FUSE adapter, staged when CLIO_CTE_ENABLE_FUSE_ADAPTER
+# is ON) has NEEDED entries clio_run doesn't — most importantly
+# libfuse3.so.3 — so linuxdeploy must walk it too or the shipped adapter
+# only works on hosts that already installed libfuse3 (#899).
+EXTRA_EXEC_ARGS=""
+if [ -x '@APPIMAGE_STAGING_DIR@/usr/bin/clio_cte_fuse' ]; then
+    EXTRA_EXEC_ARGS="--executable @APPIMAGE_STAGING_DIR@/usr/bin/clio_cte_fuse"
+fi
 "./$LINUXDEPLOY" \
     --appdir '@APPIMAGE_STAGING_DIR@' \
     --executable '@APPIMAGE_STAGING_DIR@/usr/bin/clio_run' \
+    $EXTRA_EXEC_ARGS \
     --desktop-file '@APPIMAGE_STAGING_DIR@/clio_run.desktop' \
     --icon-file '@APPIMAGE_STAGING_DIR@/clio_run.png' \
     || { echo "linuxdeploy failed"; exit 1; }
+
+# linuxdeploy consults the AppImage excludelist, which skips libfuse.so.2
+# (the AppImage *runtime's* own dependency) and on some versions also
+# libfuse3. Our clio_cte_fuse needs libfuse3.so.3 at exec time regardless,
+# so copy it in explicitly if linuxdeploy declined to.
+if [ -x '@APPIMAGE_STAGING_DIR@/usr/bin/clio_cte_fuse' ] && \
+   ! ls '@APPIMAGE_STAGING_DIR@'/usr/lib/libfuse3.so.3* >/dev/null 2>&1; then
+    FUSE3_LIB=$(ldconfig -p | awk '/libfuse3\.so\.3 /{print $NF; exit}')
+    if [ -n "$FUSE3_LIB" ]; then
+        echo "Bundling $FUSE3_LIB (skipped by linuxdeploy excludelist)..."
+        cp -L "$FUSE3_LIB" '@APPIMAGE_STAGING_DIR@/usr/lib/'
+    else
+        echo "WARNING: libfuse3.so.3 not found on build host; clio_cte_fuse will need system libfuse3" >&2
+    fi
+fi
 
 # ---- appimagetool ----
 # Resolve to an absolute or ./-prefixed path so we don't have to rely on

--- a/context-transfer-engine/adapter/libfuse/CMakeLists.txt
+++ b/context-transfer-engine/adapter/libfuse/CMakeLists.txt
@@ -68,3 +68,9 @@ target_link_libraries(clio_cte_fuse
 
 install(TARGETS clio_cte_fuse
     RUNTIME DESTINATION bin)
+# Also ship in the pip wheel: scikit-build-core installs only COMPONENT
+# pip_package, so without this second rule the wheel's clio_cte_fuse
+# console script points at a binary that is not there (#899).
+install(TARGETS clio_cte_fuse
+    COMPONENT pip_package
+    RUNTIME DESTINATION bin)

--- a/context-transfer-engine/benchmark/CMakeLists.txt
+++ b/context-transfer-engine/benchmark/CMakeLists.txt
@@ -91,7 +91,13 @@ endif()
 # its own symbols at System.loadLibrary time.
 find_path(CLIO_JNI_INCLUDE_DIR jni.h
   HINTS $ENV{JAVA_HOME}/include /usr/lib/jvm/default-java/include)
-if(CLIO_JNI_INCLUDE_DIR)
+# NOT WIN32: InitOnce() installs a no-op SIGUSR1 sigaction to survive the
+# Linux SHM transport's tgkill wakeups — POSIX-signal machinery with no
+# Windows counterpart (and no Windows SHM-wake path to survive). Windows
+# runners ship a JDK, so without this gate every Windows build that finds
+# jni.h dies compiling sigaction/SIGUSR1 (first seen when the packaging
+# workflows ran against dev content in #899).
+if(CLIO_JNI_INCLUDE_DIR AND NOT WIN32)
   message(STATUS "YCSB JNI binding enabled (jni.h at ${CLIO_JNI_INCLUDE_DIR})")
   add_library(clio_ycsb_jni SHARED
     ycsb/clio_ycsb_jni.cc

--- a/installers/pip/iowarp_core/_cli.py
+++ b/installers/pip/iowarp_core/_cli.py
@@ -105,9 +105,29 @@ def cte_bench_main():
 def cte_fuse_main():
     """Entry point for the ``clio_cte_fuse`` console script.
 
-    Requires libfuse3 to be installed on the system (e.g. ``apt install fuse3``).
-    If libfuse3 is absent the binary will exit with a dynamic-linker error.
+    Linux: requires libfuse3 from the system (e.g. ``apt install fuse3``).
+    If libfuse3 is absent the binary exits with a dynamic-linker error.
+    Windows: requires WinFsp (https://winfsp.dev); its bin dir is added to
+    PATH below so ``winfsp-x64.dll`` resolves without a system-wide PATH
+    edit. macOS wheels do not ship this binary (no FUSE3 API on macOS).
     """
+    if sys.platform == "win32":
+        winfsp_bin = os.path.join(
+            os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)"),
+            "WinFsp",
+            "bin",
+        )
+        if os.path.isdir(winfsp_bin):
+            os.environ["PATH"] = (
+                winfsp_bin + os.pathsep + os.environ.get("PATH", "")
+            )
+        else:
+            print(
+                "Error: WinFsp not found (looked in %s). Install it from "
+                "https://winfsp.dev to use the FUSE adapter." % winfsp_bin,
+                file=sys.stderr,
+            )
+            sys.exit(1)
     _exec_iowarp_bin("clio_cte_fuse")
 
 

--- a/installers/pip/pyproject.toml
+++ b/installers/pip/pyproject.toml
@@ -81,7 +81,14 @@ CLIO_CORE_ENABLE_MPI = "OFF"
 CLIO_CORE_ENABLE_HDF5 = "OFF"
 CLIO_CORE_ENABLE_ELF = "OFF"
 CLIO_CTE_ENABLE_COMPRESS = "OFF"
+# FUSE adapter: OFF here is the macOS value; Linux and Windows wheels turn
+# it ON via the per-OS overrides at the bottom of this file (#899).
 CLIO_CTE_ENABLE_FUSE_ADAPTER = "OFF"
+# Cache + replication chimods ship by default (#886/#899). They already
+# default ON in CMake; pin them here so a future default flip cannot
+# silently drop them from published wheels.
+CLIO_CTE_ENABLE_CACHE = "ON"
+CLIO_CTE_ENABLE_REPLICATION = "ON"
 CLIO_CORE_ENABLE_ENCRYPT = "OFF"
 CLIO_CORE_ENABLE_CUDA = "OFF"
 CLIO_CORE_ENABLE_ROCM = "OFF"
@@ -92,3 +99,31 @@ CTP_LOG_LEVEL = "1"
 provider = "scikit_build_core.metadata.regex"
 input = "../../CMakeLists.txt"
 regex = 'project\(iowarp-core VERSION (?P<value>[\d.]+)'
+
+# ---------------------------------------------------------------------------
+# Per-OS overrides (#899): ship the OS-specific FUSE adapter by default.
+# `if.platform-system` regex-matches sys.platform ("linux", "win32",
+# "darwin").
+#   - Linux: libfuse3. The binary links libfuse3.so.3, which the wheel does
+#     NOT bundle (see repair_wheel.sh — external system libs stay external);
+#     users need their distro's fuse3/libfuse3 packages at mount time, as
+#     documented in iowarp_core._cli.cte_fuse_main.
+#   - Windows: WinFsp (https://winfsp.dev). The build finds WinFsp's
+#     FUSE3-compatible SDK (adapter/libfuse/CMakeLists.txt); end users need
+#     the WinFsp runtime installed.
+#   - macOS: stays OFF — there is no fuse3 pkg-config on macOS (macFUSE
+#     exposes the FUSE2 API), so the base define above applies.
+# ---------------------------------------------------------------------------
+# inherit.cmake.define = "append" is load-bearing: without it an override's
+# cmake.define table REPLACES the whole base table (verified against
+# scikit-build-core 0.12), silently dropping STATIC_DEPS and every other
+# base define from the wheel build.
+[[tool.scikit-build.overrides]]
+if.platform-system = "linux"
+inherit.cmake.define = "append"
+cmake.define.CLIO_CTE_ENABLE_FUSE_ADAPTER = "ON"
+
+[[tool.scikit-build.overrides]]
+if.platform-system = "win32"
+inherit.cmake.define = "append"
+cmake.define.CLIO_CTE_ENABLE_FUSE_ADAPTER = "ON"


### PR DESCRIPTION
## Summary
- **deb/rpm**: declare `libfuse3-dev, fuse3` / `fuse3-devel, fuse3` runtime deps (conditional on `CLIO_CTE_ENABLE_FUSE_ADAPTER`) — the packages shipped `clio_cte_fuse` but it died with a dynamic-linker error on any clean host
- **AppImage**: linuxdeploy now walks `clio_cte_fuse` too (plus an explicit `libfuse3.so.3` copy fallback for excludelist versions that skip it), so the bundled adapter is self-contained
- **pip wheels**: the `clio_cte_fuse` console script finally points at a real binary — the adapter builds ON for Linux (libfuse3) and Windows (WinFsp) via per-OS scikit-build overrides, and the binary + the cache/replication/filesystem chimod libs now install into the `pip_package` component. macOS stays off (no FUSE3 API there)
- **Windows exe**: new `build-windows`/`test-windows` jobs in `build-packages.yml` produce a CPack ZIP + NSIS installer (`iowarp-core-<ver>-win64.exe`) with `clio_run.exe`, vcpkg DLLs, and the WinFsp fuse adapter; release publish includes them
- **Cache + replication on by default**: pinned explicitly in every package build + wheel defines, with new smoke-test assertions (manifest greps, wheel lib checks) in all test jobs so a default flip can't silently drop them
- The context visualizer already shipped by default everywhere; test jobs keep covering it

## Motivation
Fixes #899

## Landmine fixed
A scikit-build-core override with `cmake.define.X` **replaces the whole base define table** (verified on 0.12.2: 22 defines → 1, silently dropping `CLIO_CORE_STATIC_DEPS`). The per-OS overrides carry `inherit.cmake.define = "append"`, verified with `SettingsReader` resolving all 24 defines.

## Test plan
- [x] Local: full Ninja build + `cpack -G DEB` → `.deb` declares `..., libfuse3-dev, fuse3`; payload contains `clio_cte_fuse`, `libclio_cte_{cache,replication,filesystem}_*.so`, `context-visualizer`
- [x] Local: `cmake --install --component pip_package` contains `bin/clio_cte_fuse` + all chimod libs
- [x] Local: `clio_cte_fuse --help` exits 0 (smoke tests rely on this)
- [x] Local: scikit-build-core settings resolution (Linux) = 24 defines, FUSE ON
- [ ] `build-packages.yml` workflow_dispatch on this branch (deb/rpm/AppImage/Windows jobs; dispatched, see PR comments)
- [ ] `build-pip.yml` workflow_dispatch on this branch (Linux/macOS/Windows wheels + clean-container tests)

Note: both packaging workflows trigger only on push-to-main and `workflow_dispatch` — regular PR CI does not exercise them, hence the manual dispatches above.

## Breaking changes
None. The deb/rpm gain two dependency entries; wheels gain one binary + six libs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)