### PR TITLE
Extract SemanticSearch into a new indexer chimod

### DIFF
--- a/context-assimilation-engine/test/unit/test_cae_labeling_dispatch_config.yaml
+++ b/context-assimilation-engine/test/unit/test_cae_labeling_dispatch_config.yaml
@@ -21,12 +21,14 @@ compose:
     bdev_type: ram
     capacity: "256MB"
 
-  # CAE core at the entrypoint (512.0), labeling enabled.
+  # CAE core at the entrypoint (512.0), labeling enabled. Forwards to the
+  # indexer (564.0), which owns SemanticSearch (issue #905) over the CTE
+  # core at 513.0.
   - mod_name: clio_cae_core
     pool_name: cae_label
     pool_query: local
     pool_id: "512.0"
-    next_pool_id: "513.0"
+    next_pool_id: "564.0"
     label_endpoint: "http://127.0.0.1:1"
     label_prompts:
       summarize: "Summarize this document:"
@@ -56,3 +58,11 @@ compose:
         score: 1.0
     dpe:
       dpe_type: "max_bw"
+
+  # Indexer chimod (issue #905): owns SemanticSearch; the CAE forward
+  # terminates here instead of the core.
+  - mod_name: clio_cte_indexer
+    pool_name: clio_cte_indexer
+    pool_query: local
+    pool_id: "564.0"
+    next_pool_id: "513.0"

--- a/context-assimilation-engine/test/unit/test_cae_semantic_search_config.yaml
+++ b/context-assimilation-engine/test/unit/test_cae_semantic_search_config.yaml
@@ -1,7 +1,7 @@
 # Compose configuration for the CAE labeling + CTE semantic-search test.
 # Same shape as the labeling test: CAE intercepts at 512.0 with one
-# labeling rule that fires on every blob; CTE backs it at 513.0 and
-# owns the BM25 search.
+# labeling rule that fires on every blob; the indexer chimod at 564.0
+# owns the BM25 search (issue #905) over the CTE core at 513.0.
 
 networking:
   port: 9413
@@ -22,7 +22,7 @@ compose:
     pool_name: cae_main
     pool_query: local
     pool_id: "512.0"
-    next_pool_id: "513.0"
+    next_pool_id: "564.0"
     label_endpoint: "http://127.0.0.1:11434"
     label_prompts:
       summarize: "Summarize the following text in one short sentence."
@@ -45,3 +45,11 @@ compose:
         score: 1.0
     dpe:
       dpe_type: "max_bw"
+
+  # Indexer chimod (issue #905): CAE forwards PutBlob and SemanticSearch
+  # here; puts maintain the index inline and the search is served from it.
+  - mod_name: clio_cte_indexer
+    pool_name: clio_cte_indexer
+    pool_query: local
+    pool_id: "564.0"
+    next_pool_id: "513.0"

--- a/context-exploration-engine/api/test/CMakeLists.txt
+++ b/context-exploration-engine/api/test/CMakeLists.txt
@@ -12,10 +12,12 @@ function(add_cee_api_unit_test TEST_NAME TEST_SOURCE)
   # Create test executable
   add_executable(${TEST_NAME} ${TEST_SOURCE})
 
-  # Link common dependencies
+  # Link common dependencies (indexer client: the SemanticSearch pool the
+  # BM25 tests compose over the core, issue #905)
   target_link_libraries(${TEST_NAME}
     PRIVATE
       clio_cee_api
+      clio_cte_indexer_client
   )
 
   # Install test binary
@@ -52,6 +54,7 @@ add_executable(test_context_comprehensive test_context_comprehensive.cc)
 target_link_libraries(test_context_comprehensive
   PRIVATE
     clio_cee_api
+    clio_cte_indexer_client
 )
 install(TARGETS test_context_comprehensive DESTINATION bin/tests)
 

--- a/context-exploration-engine/api/test/test_context_comprehensive.cc
+++ b/context-exploration-engine/api/test/test_context_comprehensive.cc
@@ -51,6 +51,7 @@
 #include <clio_cae/core/constants.h>
 #include <clio_cae/core/factory/assimilation_ctx.h>
 #include <clio_cte/core/core_client.h>
+#include <clio_cte/indexer/indexer_client.h>
 #include <clio_runtime/bdev/bdev_tasks.h>
 #include <clio_runtime/clio_runtime.h>
 #include <fstream>
@@ -122,12 +123,35 @@ public:
           clio::run::PoolId(512, 10));          // explicit bdev pool id
       reg_task.Wait();
 
-      // Initialize CAE client
-      CLIO_CAE_CLIENT_INIT();
+      // Create the indexer pool over the core (issue #905): it owns
+      // SemanticSearch, so the BM25 query tests need it in the chain.
+      {
+        clio::cte::indexer::Client indexer_client;
+        clio::cte::indexer::IndexerConfig indexer_params;
+        indexer_params.next_pool_id_ = clio::cte::core::kCtePoolId;
+        auto idx_create = indexer_client.AsyncCreateIndexer(
+            clio::run::PoolQuery::Local(),
+            clio::cte::indexer::kIndexerPoolName,
+            clio::cte::indexer::kIndexerPoolId,
+            indexer_params);
+        idx_create.Wait();
+        if (idx_create->GetReturnCode() != 0) {
+          throw std::runtime_error("Indexer pool creation failed");
+        }
+      }
+      // Bind the CTE client singleton to the indexer so every put/search
+      // in these tests flows through it (the interposer forwards the rest).
+      cte_client->Init(clio::cte::indexer::kIndexerPoolId);
 
-      // Create CAE pool
+      // Create CAE pool BEFORE CLIO_CAE_CLIENT_INIT: the init helper
+      // creates the pool with DEFAULT params (next = the core), and a
+      // second create by id just returns the existing pool — so whoever
+      // creates first decides the chain. CAE's internal CTE writes
+      // (ParseOmni assimilation, labeling) must flow through the indexer
+      // to be searchable.
       clio::cae::core::Client cae_client;
       clio::cae::core::CreateParams cae_params;
+      cae_params.next_pool_id_ = clio::cte::indexer::kIndexerPoolId;
       auto cae_create = cae_client.AsyncCreate(
           clio::run::PoolQuery::Local(),
           "test_cae_pool",
@@ -138,6 +162,9 @@ public:
       if (cae_create->GetReturnCode() != 0) {
         throw std::runtime_error("CAE pool creation failed");
       }
+
+      // Initialize CAE client (binds the singleton; finds the pool above).
+      CLIO_CAE_CLIENT_INIT();
 
       INFO("CEE infrastructure initialized");
       g_initialized = true;

--- a/context-runtime/config/clio_default.yaml
+++ b/context-runtime/config/clio_default.yaml
@@ -216,15 +216,23 @@ compose:
   # === Indexer (SemanticSearch index, issue #905) ===
   # Search layer: owns the term index that serves Method::kSemanticSearch
   # (the CTE core no longer implements it). Mutating data verbs are
-  # intercepted to keep the index current and forwarded down unchanged;
-  # everything else passes through. Sits ABOVE the compressor so its
-  # read-backs see logical (uncompressed) bytes. The index is derived
-  # state: never persisted, rebuilt from the chain below on restart.
+  # intercepted — a put's only cost is an O(1) coalesced dirty-key enqueue;
+  # the periodic sweep tokenizes asynchronously and a search drains first
+  # (read-your-writes) — and forwarded down unchanged; everything else
+  # passes through. Sits ABOVE the compressor so its read-backs see logical
+  # (uncompressed) bytes. The module persists its own snapshot + WAL: a
+  # restart restores the index and never rescans storage; pre-existing data
+  # enters via a tag's first-insertion backfill or the kReindexScan verb.
   - mod_name: clio_cte_indexer
     pool_name: clio_cte_indexer
     pool_query: local
     pool_id: "564.0"
     next_pool_id: "561.0"               # replication (562.0 with compressor)
+    index_log_path: "${HOME}/.clio/cte_indexer_index"
+    # index_sweep_period_ms: 100        # async drain cadence (0 = lazy)
+    # index_wal_compact_bytes: "8MB"    # WAL size that triggers compaction
+    # tag_re: ".*"                      # index scope: only matching tags...
+    # blob_re: ".*"                     # ...and blob names are tokenized
 
   # === Cache (node-local raw copies, issue #886) ===
   # Locality layer and the TOP of the chain, with ASYNCHRONOUS WRITE-THROUGH

--- a/context-runtime/config/clio_default.yaml
+++ b/context-runtime/config/clio_default.yaml
@@ -171,7 +171,8 @@ compose:
   # and stack via next_pool_id, separating RELIABILITY (replication) from
   # LOCALITY (cache) from ENCODING (compression). The canonical full chain:
   #
-  #   cache(563.0) -> [compressor(562.0) ->] replication(561.0) -> core(512.0)
+  #   cache(563.0) -> indexer(564.0) -> [compressor(562.0) ->]
+  #     replication(561.0) -> core(512.0)
   #
   # Point any clio::cte::core::Client (or the filesystem chimod below) at
   # the TOP pool and the whole chain is transparent: a put writes through
@@ -205,12 +206,25 @@ compose:
   # Encoding layer: transparently compresses on the way down and
   # decompresses on the way out. Requires a build with
   # CLIO_CTE_ENABLE_COMPRESS=ON; uncomment this entry AND re-point the
-  # cache entry below at 562.0 to enable it.
+  # indexer entry below at 562.0 to enable it.
   # - mod_name: clio_cte_compressor
   #   pool_name: clio_cte_compressor
   #   pool_query: local
   #   pool_id: "562.0"
   #   next_pool_id: "561.0"             # replication pool — see entry above
+
+  # === Indexer (SemanticSearch index, issue #905) ===
+  # Search layer: owns the term index that serves Method::kSemanticSearch
+  # (the CTE core no longer implements it). Mutating data verbs are
+  # intercepted to keep the index current and forwarded down unchanged;
+  # everything else passes through. Sits ABOVE the compressor so its
+  # read-backs see logical (uncompressed) bytes. The index is derived
+  # state: never persisted, rebuilt from the chain below on restart.
+  - mod_name: clio_cte_indexer
+    pool_name: clio_cte_indexer
+    pool_query: local
+    pool_id: "564.0"
+    next_pool_id: "561.0"               # replication (562.0 with compressor)
 
   # === Cache (node-local raw copies, issue #886) ===
   # Locality layer and the TOP of the chain, with ASYNCHRONOUS WRITE-THROUGH
@@ -225,7 +239,7 @@ compose:
     pool_name: clio_cte_cache
     pool_query: local
     pool_id: "563.0"
-    next_pool_id: "561.0"               # replication (562.0 with compressor)
+    next_pool_id: "564.0"               # indexer — see entry above
     min_score: 0.5                      # cache copies' score floor
 
   # === Context Filesystem (CFS) ===

--- a/context-transfer-engine/CMakeLists.txt
+++ b/context-transfer-engine/CMakeLists.txt
@@ -95,6 +95,16 @@ else()
     message(STATUS "CTE: cache chimod disabled (use -DCLIO_CTE_ENABLE_CACHE=ON)")
 endif()
 
+# Add the indexer ChiMod (issue #905) — owns the SemanticSearch index as an
+# interposer above the CTE core. Small and dependency-free.
+option(CLIO_CTE_ENABLE_INDEXER "Build the indexer chimod (#905)" ON)
+if(CLIO_CTE_ENABLE_INDEXER)
+    message(STATUS "CTE: building indexer chimod")
+    add_subdirectory(indexer)
+else()
+    message(STATUS "CTE: indexer chimod disabled (use -DCLIO_CTE_ENABLE_INDEXER=ON)")
+endif()
+
 # Add the bdev ChiMod (when it exists)
 # add_subdirectory(chimods/bdev)
 

--- a/context-transfer-engine/benchmark/clio_cte_bench.cc
+++ b/context-transfer-engine/benchmark/clio_cte_bench.cc
@@ -88,12 +88,23 @@ class CTEBenchmark {
     if (a_.test_case == "Put") return RunGeneric(Mode::kPut);
     if (a_.test_case == "Get") return RunGeneric(Mode::kGet);
     if (a_.test_case == "PutGet") return RunGeneric(Mode::kPutGet);
-    HLOG(kError, "Unknown test case: {} (Put|Get|PutGet)", a_.test_case);
+    if (a_.test_case == "PutDefer") return RunGeneric(Mode::kPutDefer);
+    if (a_.test_case == "GetDefer") return RunGeneric(Mode::kGetDefer);
+    if (a_.test_case == "PutGetDefer") return RunGeneric(Mode::kPutGetDefer);
+    HLOG(kError,
+         "Unknown test case: {} "
+         "(Put|Get|PutGet|PutDefer|GetDefer|PutGetDefer)",
+         a_.test_case);
     return false;
   }
 
  private:
-  enum class Mode { kPut, kGet, kPutGet };
+  enum class Mode { kPut, kGet, kPutGet, kPutDefer, kGetDefer, kPutGetDefer };
+
+  static bool IsDeferMode(Mode m) {
+    return m == Mode::kPutDefer || m == Mode::kGetDefer ||
+           m == Mode::kPutGetDefer;
+  }
 
   void PrintInfo() {
     HLOG(kInfo, "=== CTE Core Benchmark ===");
@@ -226,8 +237,119 @@ class CTEBenchmark {
     CLIO_IPC->FreeBuffer(get_shm);
   }
 
+  /**
+   * Defer-API worker (issue #905 bench coverage of the #862/#878 registry):
+   * PutDefer streams AsyncPutBlobDefer from a PRIVATE buffer — the call owns
+   * a copy, so one buffer serves every op — with `--depth * io-size` as the
+   * registry pacing wall (making --depth the in-flight window, symmetric
+   * with the futures window of the plain modes). The timed region INCLUDES
+   * the final AwaitPutsUntilSpace(0) drain: deferred acks are early by
+   * design, and throughput that excludes the drain would count unfinished
+   * work. GetDefer issues AsyncGetBlobDefer into per-slot private buffers,
+   * batched exactly like the plain Get arm; each future's Wait() must run
+   * (client-mode private gets copy staged bytes in PostWait). PutGetDefer
+   * alternates put/get on the same key per op, so gets exercise the
+   * read-your-writes TryServe path against in-flight puts.
+   * Completion failures are counted, not thrown: the DeferErrorCount()
+   * delta across the run flags them.
+   */
+  void WorkerDefer(Mode mode, size_t tid, std::atomic<bool> &err,
+                   std::vector<long long> &times,
+                   std::vector<clio_bench::u64> &ops) {
+    auto *cte = CLIO_CTE_CLIENT;
+    std::vector<char> put_buf(a_.io_size, static_cast<char>(tid & 0xFF));
+    const size_t get_slots = a_.depth > 0 ? static_cast<size_t>(a_.depth) : 1;
+    std::vector<char> get_buf(a_.io_size * get_slots, 0);
+
+    std::string tag_name = "tag_n" + node_id_ + "_t" + std::to_string(tid);
+    auto tag_task = cte->AsyncGetOrCreateTag(tag_name);
+    tag_task.Wait();
+    clio::cte::core::TagId tag_id = tag_task->tag_id_;
+    auto blob_name = [&](long k) {
+      return "blob_t" + std::to_string(tid) + "_" + std::to_string(k);
+    };
+    const clio::run::PoolQuery pq = MakeQuery();
+    const clio::run::u64 inflight_wall =
+        static_cast<clio::run::u64>(a_.depth) * a_.io_size;
+    const clio_bench::u64 err_before = clio::cte::core::Client::DeferErrorCount();
+
+    // GetDefer needs the keyspace populated first (untimed, drained).
+    if (mode == Mode::kGetDefer) {
+      for (long k = 0; k < KeyspaceSize(); ++k) {
+        if (cte->AsyncPutBlobDefer(tag_id, blob_name(k), 0, a_.io_size,
+                                   put_buf.data(), 0.8f,
+                                   clio::cte::core::Context(), 0, pq,
+                                   inflight_wall) != 0) {
+          err.store(true, std::memory_order_relaxed);
+          return;
+        }
+      }
+      clio::cte::core::Client::AwaitPutsUntilSpace(0);
+    }
+
+    const bool timed = a_.time_limit_s > 0.0;
+    const long target = timed ? std::numeric_limits<long>::max() : a_.io_count;
+    clio_bench::u64 done = 0;
+    auto start = steady_clock::now();
+
+    for (long i = 0; i < target; i += a_.depth) {
+      if (err.load(std::memory_order_relaxed)) break;
+      if (timed && TimeUp(start, a_.time_limit_s)) break;
+      long batch = timed ? a_.depth : std::min<long>(a_.depth, target - i);
+
+      if (mode == Mode::kPutDefer || mode == Mode::kPutGetDefer) {
+        for (long j = 0; j < batch; ++j) {
+          int rc = cte->AsyncPutBlobDefer(
+              tag_id, blob_name(KeyIndex(i + j, per_thread_blobs_)), 0,
+              a_.io_size, put_buf.data(), 0.8f, clio::cte::core::Context(), 0,
+              pq, inflight_wall);
+          if (rc != 0) {
+            HLOG(kError, "[t{}] AsyncPutBlobDefer rc={}", tid, rc);
+            err.store(true, std::memory_order_relaxed);
+            break;
+          }
+        }
+      }
+      if (mode == Mode::kGetDefer || mode == Mode::kPutGetDefer) {
+        std::vector<clio::run::Future<clio::cte::core::GetBlobTask>> gts;
+        gts.reserve(batch);
+        for (long j = 0; j < batch; ++j) {
+          char *slot = get_buf.data() + static_cast<size_t>(j) * a_.io_size;
+          gts.push_back(cte->AsyncGetBlobDefer(
+              tag_id, blob_name(KeyIndex(i + j, per_thread_blobs_)), 0,
+              a_.io_size, slot, 0, pq));
+        }
+        for (auto &t : gts) {
+          if (t.IsNull()) continue;
+          t.Wait();
+          if (t->return_code_.load() != 0) {
+            HLOG(kError, "[t{}] GetBlobDefer rc={}", tid,
+                 t->return_code_.load());
+            err.store(true, std::memory_order_relaxed);
+          }
+        }
+      }
+      done += static_cast<clio_bench::u64>(batch);
+    }
+
+    // Drain INSIDE the timed region — deferred acks are early by design;
+    // undrained throughput would count work the runtime hasn't done yet.
+    if (mode == Mode::kPutDefer || mode == Mode::kPutGetDefer) {
+      clio::cte::core::Client::AwaitPutsUntilSpace(0);
+    }
+    times[tid] =
+        duration_cast<microseconds>(steady_clock::now() - start).count();
+    ops[tid] = done;
+
+    if (clio::cte::core::Client::DeferErrorCount() != err_before) {
+      HLOG(kError, "[t{}] deferred put completion failures: {}", tid,
+           clio::cte::core::Client::DeferErrorCount() - err_before);
+      err.store(true, std::memory_order_relaxed);
+    }
+  }
+
   bool RunGeneric(Mode mode) {
-    if (mode == Mode::kGet) {
+    if (mode == Mode::kGet || mode == Mode::kGetDefer) {
       HLOG(kInfo, "Populating {} keys/thread for Get...", KeyspaceSize());
     }
     std::vector<std::thread> threads;
@@ -235,8 +357,13 @@ class CTEBenchmark {
     std::vector<clio_bench::u64> ops(a_.threads);
     std::atomic<bool> err{false};
     for (size_t i = 0; i < a_.threads; ++i) {
-      threads.emplace_back(&CTEBenchmark::Worker, this, mode, i,
-                           std::ref(err), std::ref(times), std::ref(ops));
+      if (IsDeferMode(mode)) {
+        threads.emplace_back(&CTEBenchmark::WorkerDefer, this, mode, i,
+                             std::ref(err), std::ref(times), std::ref(ops));
+      } else {
+        threads.emplace_back(&CTEBenchmark::Worker, this, mode, i,
+                             std::ref(err), std::ref(times), std::ref(ops));
+      }
     }
     for (auto &t : threads) t.join();
     clio_bench::PrintResults(a_.test_case, a_, times, ops);

--- a/context-transfer-engine/benchmark/clio_cte_semantic_bench.cc
+++ b/context-transfer-engine/benchmark/clio_cte_semantic_bench.cc
@@ -162,6 +162,10 @@ int main(int argc, char **argv) {
     }
   } finalize_guard;
   std::this_thread::sleep_for(milliseconds(500));
+  // SemanticSearch lives in the indexer chimod (issue #905), composed at
+  // 564.0 in the default chain — and puts must flow through it to be
+  // indexed. Default the client binding there; CLIO_CTE_POOL still wins.
+  setenv("CLIO_CTE_POOL", "564.0", /*overwrite=*/0);
   if (!clio::cte::core::CLIO_CTE_CLIENT_INIT()) {
     HLOG(kError, "Failed to initialize CTE client");
     return 1;

--- a/context-transfer-engine/core/include/clio_cte/core/core_runtime.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_runtime.h
@@ -856,14 +856,9 @@ private:
    */
   clio::run::TaskResume BlobQuery(clio::run::shared_ptr<BlobQueryTask> &task);
 
-  /**
-   * BM25 keyword search over blob contents (Method::kSemanticSearch).
-   * Filters by tag+blob regex like BlobQuery, then tokenizes each
-   * candidate blob's bytes and scores them against query_text_ using
-   * Okapi BM25 with corpus stats computed over the matched working
-   * set. Returns top-k results sorted by descending score.
-   */
-  clio::run::TaskResume SemanticSearch(clio::run::shared_ptr<SemanticSearchTask> &task);
+  // SemanticSearch (Method::kSemanticSearch) moved to the indexer chimod
+  // (issue #905) — the task struct and client API stay here (interposers
+  // speak the core's vocabulary), but the core no longer executes it.
 
   /**
    * Timestamp-window search over blob metadata (Method::kTemporalSearch).

--- a/context-transfer-engine/core/src/autogen/core_lib_exec.cc
+++ b/context-transfer-engine/core/src/autogen/core_lib_exec.cc
@@ -252,8 +252,16 @@ clio::run::TaskResume Runtime::Run(clio::run::u32 method, clio::run::shared_ptr<
       break;
     }
     case Method::kSemanticSearch: {
+      // Moved to the indexer chimod (issue #905): the core no longer owns
+      // the search index. An explicit error beats the default's silent
+      // empty result — reaching here means the deployment composed no
+      // clio_cte_indexer above this pool.
       auto& typed_task = task_ptr.template Cast<SemanticSearchTask>();
-      CLIO_CO_AWAIT(SemanticSearch(typed_task));
+      HLOG(kError,
+           "SemanticSearch reached the CTE core: compose the clio_cte_indexer "
+           "chimod above this pool (issue #905)");
+      typed_task->results_.clear();
+      typed_task->return_code_ = 2;
       break;
     }
     case Method::kTemporalSearch: {

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -5382,6 +5382,11 @@ void Runtime::RestoreMetadataFromLog() {
         BlobBlock block(bdev_client, target_query, offset, size);
         blob_info.blocks_.push_back(block);
       }
+      // blocks_ was rebuilt directly: resync the O(1) size cache, or every
+      // restored blob reports GetTotalSize()==0 (a Debug build asserts) and
+      // post-restart reads/rebuilds see empty blobs. The WAL-replay path
+      // below already did this; the snapshot path forgot.
+      blob_info.RecomputeTotalSize();
 
       tag_blob_name_to_info_.insert_or_assign(composite_key, std::make_shared<BlobInfo>(blob_info));
       MirrorBlobToShm(composite_key, blob_info);
@@ -5579,6 +5584,16 @@ void Runtime::ReplayTransactionLogs() {
             // them. Which shard a blob's records land in is per-worker, so
             // the loss was nondeterministic (caught by the persist test).
             blob_info.replicas_ = existing->replicas_;
+            // Carry the BLOCKS too (issue #905) — third instance of the
+            // same hazard: the snapshot restored this blob's block layout,
+            // and replaying the create record would zero it, so every
+            // restart reported size 0 and lost the persistent primary
+            // bytes' placement (caught by the indexer rebuild test). A
+            // later kExtendBlob record, when present, still replaces the
+            // layout wholesale; a replayed kDelBlob removed the entry, so
+            // a genuine delete+recreate never reaches this carry-over.
+            blob_info.blocks_ = existing->blocks_;
+            blob_info.RecomputeTotalSize();
           }
         }
         tag_blob_name_to_info_.insert_or_assign(composite_key, std::make_shared<BlobInfo>(blob_info));
@@ -7315,214 +7330,10 @@ clio::run::TaskResume Runtime::BlobQuery(clio::run::shared_ptr<BlobQueryTask> &t
 }
 
 // ==============================================================================
-// SemanticSearch — BM25 over blob contents
+// SemanticSearch moved to the indexer chimod (issue #905): the core no
+// longer reads blob bytes at query time — the indexer maintains the term
+// index incrementally and serves Method::kSemanticSearch itself.
 // ==============================================================================
-
-namespace {
-
-// Tokenize raw bytes as lowercase alphanumeric runs of length >= 2.
-// Anything else (whitespace, punctuation, non-ASCII) splits a token.
-// Deliberately simple; good enough for English-ish text from labels.
-std::vector<std::string> SemSearchTokenize(const char *data, size_t size) {
-  std::vector<std::string> tokens;
-  std::string cur;
-  cur.reserve(16);
-  for (size_t i = 0; i < size; ++i) {
-    unsigned char c = static_cast<unsigned char>(data[i]);
-    if (std::isalnum(c)) {
-      cur.push_back(static_cast<char>(std::tolower(c)));
-    } else {
-      if (cur.size() >= 2) tokens.push_back(std::move(cur));
-      cur.clear();
-    }
-  }
-  if (cur.size() >= 2) tokens.push_back(std::move(cur));
-  return tokens;
-}
-
-struct SemSearchDoc {
-  TagId tag_id;
-  std::string tag_name;
-  std::string blob_name;
-  std::unordered_map<std::string, int> tf;
-  size_t length;
-};
-
-}  // namespace
-
-clio::run::TaskResume Runtime::SemanticSearch(
-    clio::run::shared_ptr<SemanticSearchTask> &task) {
-  CLIO_TASK_BODY_BEGIN
-  task->results_.clear();
-  task->return_code_ = 0;
-
-  std::string tag_regex_str = task->tag_regex_.str();
-  std::string blob_regex_str = task->blob_regex_.str();
-  std::string query_text = task->query_text_.str();
-  clio::run::u32 k = task->k_;
-
-  std::regex tag_pattern;
-  std::regex blob_pattern;
-  try {
-    tag_pattern = std::regex(tag_regex_str);
-    blob_pattern = std::regex(blob_regex_str);
-  } catch (const std::regex_error &e) {
-    HLOG(kError, "SemanticSearch: bad regex (tag='{}' blob='{}'): {}",
-         tag_regex_str, blob_regex_str, e.what());
-    task->return_code_ = 1;
-    CLIO_CO_RETURN;
-  }
-
-  // Step 1: pick matching (tag_name, tag_id) pairs from tag metadata
-  // (same iteration as BlobQuery).
-  std::vector<std::pair<std::string, TagId>> matching_tags;
-  tag_name_to_id_.for_each(
-      [&](const std::string &stored, const TagId &tag_id) {
-        std::string full = ResolveTagName(stored);
-        if (std::regex_match(full, tag_pattern)) {
-          matching_tags.emplace_back(full, tag_id);
-        }
-      });
-
-  // Step 2: walk the tag-blob metadata and collect (tag_id, tag_name,
-  // blob_name) triples whose blob_name matches blob_regex_. We collect names
-  // first and read bytes afterward — keeping the metadata iteration short
-  // means the for_each lambda doesn't block on bdev I/O.
-  struct Candidate { TagId tag_id; std::string tag_name; std::string blob_name; };
-  std::vector<Candidate> candidates;
-  for (const auto &tn : matching_tags) {
-    const std::string &tag_name = tn.first;
-    const TagId &tag_id = tn.second;
-    std::string prefix = std::to_string(tag_id.major_) + "." +
-                         std::to_string(tag_id.minor_) + ".";
-    tag_blob_name_to_info_.for_each(
-        [&prefix, &blob_pattern, &tag_id, &tag_name, &candidates](
-            const std::string &composite_key, const std::shared_ptr<BlobInfo> &blob_info_sp) { const BlobInfo &blob_info = *blob_info_sp; (void)blob_info;
-          (void)blob_info;
-          if (composite_key.rfind(prefix, 0) != 0) return;
-          std::string blob_name = composite_key.substr(prefix.length());
-          if (std::regex_match(blob_name, blob_pattern)) {
-            candidates.push_back({tag_id, tag_name, blob_name});
-          }
-        });
-  }
-  if (candidates.empty()) {
-    HLOG(kDebug,
-         "SemanticSearch: no candidates for tag='{}' blob='{}'",
-         tag_regex_str, blob_regex_str);
-    CLIO_CO_RETURN;
-  }
-
-  // Step 3: read each candidate's bytes, tokenize, and accumulate
-  // BM25 corpus statistics (tf per doc, doc length, df, avgdl).
-  auto *ipc_manager = CLIO_IPC;
-  std::vector<SemSearchDoc> docs;
-  docs.reserve(candidates.size());
-  for (auto &cand : candidates) {
-    std::shared_ptr<BlobInfo> info = CheckBlobExists(cand.blob_name, cand.tag_id);
-    if (info == nullptr) continue;
-    clio::run::u64 total = info->GetTotalSize();
-    if (total == 0) continue;
-
-    ctp::ipc::FullPtr<char> buf = ipc_manager->AllocateBuffer(total);
-    if (buf.IsNull()) {
-      HLOG(kWarning,
-           "SemanticSearch: AllocateBuffer({}) failed for blob '{}'; "
-           "skipping",
-           total, cand.blob_name);
-      continue;
-    }
-    ctp::ipc::ShmPtr<> shm(buf.shm_);
-    clio::run::u32 read_rc = 0;
-    {
-      // issue #753 (reader half): pin + snapshot, same discipline as
-      // GetBlobImpl — the pin keeps extent-freeing mutators from reclaiming
-      // the extents mid-read, the snapshot keeps a concurrent Put's blocks_
-      // push_back from dangling the vector we iterate.
-      while (!info->TryPinRead()) {
-        CLIO_CO_AWAIT(clio::run::yield(BlobWriteLockPollUs()));
-      }
-      BlobReadPinGuard read_pin_guard(info.get());
-      clio::run::priv::vector<BlobBlock> blocks_snapshot(info->blocks_);
-      CLIO_CO_AWAIT(ReadData(blocks_snapshot, shm, total, 0, read_rc));
-    }
-    if (read_rc != 0) {
-      HLOG(kWarning,
-           "SemanticSearch: ReadData failed for blob '{}' (rc={}); "
-           "skipping",
-           cand.blob_name, read_rc);
-      ipc_manager->FreeBuffer(buf);
-      continue;
-    }
-
-    auto tokens = SemSearchTokenize(buf.ptr_, total);
-    ipc_manager->FreeBuffer(buf);
-
-    SemSearchDoc doc;
-    doc.tag_id = cand.tag_id;
-    doc.tag_name = std::move(cand.tag_name);
-    doc.blob_name = std::move(cand.blob_name);
-    doc.length = tokens.size();
-    for (auto &t : tokens) ++doc.tf[t];
-    docs.push_back(std::move(doc));
-  }
-  if (docs.empty()) {
-    CLIO_CO_RETURN;
-  }
-
-  // Step 4: BM25. Corpus stats are computed over the working set
-  // (the matched slice), not over all CTE blobs — this is "rank
-  // within this regex" semantics. k1=1.5 / b=0.75 are the standard
-  // Okapi defaults.
-  constexpr double kK1 = 1.5;
-  constexpr double kB = 0.75;
-  std::unordered_map<std::string, int> df;
-  double total_len = 0.0;
-  for (auto &d : docs) {
-    total_len += static_cast<double>(d.length);
-    for (auto &kv : d.tf) df[kv.first]++;
-  }
-  double avgdl = (docs.empty() ? 1.0 : total_len / docs.size());
-  if (avgdl <= 0.0) avgdl = 1.0;
-  const size_t N = docs.size();
-
-  auto qtokens = SemSearchTokenize(query_text.data(), query_text.size());
-  std::unordered_set<std::string> uniq_q(qtokens.begin(), qtokens.end());
-
-  std::vector<SemanticSearchResult> scored;
-  scored.reserve(docs.size());
-  for (auto &d : docs) {
-    double score = 0.0;
-    for (auto &q : uniq_q) {
-      auto df_it = df.find(q);
-      if (df_it == df.end()) continue;
-      auto tf_it = d.tf.find(q);
-      if (tf_it == d.tf.end()) continue;
-      double df_q = static_cast<double>(df_it->second);
-      double idf = std::log((static_cast<double>(N) - df_q + 0.5) /
-                                (df_q + 0.5) +
-                            1.0);
-      double tf_q = static_cast<double>(tf_it->second);
-      double norm =
-          1.0 - kB + kB * (static_cast<double>(d.length) / avgdl);
-      score += idf * (tf_q * (kK1 + 1.0)) / (tf_q + kK1 * norm);
-    }
-    scored.emplace_back(d.tag_id, d.tag_name, d.blob_name, score);
-  }
-
-  std::sort(scored.begin(), scored.end(),
-            [](const SemanticSearchResult &a,
-               const SemanticSearchResult &b) { return a.score_ > b.score_; });
-  if (k > 0 && scored.size() > k) scored.resize(k);
-  task->results_ = std::move(scored);
-  HLOG(kDebug,
-       "SemanticSearch: tag='{}' blob='{}' query='{}' -> {} results "
-       "(from {} candidates)",
-       tag_regex_str, blob_regex_str, query_text, task->results_.size(),
-       candidates.size());
-  CLIO_CO_RETURN;
-  CLIO_TASK_BODY_END
-}
 
 // ==============================================================================
 // TemporalSearch — timestamp-window scan over blob metadata

--- a/context-transfer-engine/indexer/CMakeLists.txt
+++ b/context-transfer-engine/indexer/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.10)
+project(clio_cte_indexer)
+
+#------------------------------------------------------------------------------
+# Indexer chimod (issue #905) — owns the SemanticSearch index as an
+# interposer above the CTE core. Built via the standard ChiMod build
+# functions.
+#------------------------------------------------------------------------------
+
+add_clio_module_runtime(
+  SOURCES
+    src/indexer_runtime.cc
+    src/autogen/indexer_lib_exec.cc
+)
+
+add_clio_module_client(
+  SOURCES
+    src/indexer_client.cc
+)
+
+# The indexer chimod drives the CTE core through its public client.
+target_link_libraries(clio_cte_indexer_runtime PUBLIC clio_cte_core_client)
+target_link_libraries(clio_cte_indexer_client PUBLIC clio_cte_core_client)
+target_include_directories(clio_cte_indexer_runtime PRIVATE
+    ${CMAKE_SOURCE_DIR}/context-transfer-engine/core/include)
+target_include_directories(clio_cte_indexer_client PRIVATE
+    ${CMAKE_SOURCE_DIR}/context-transfer-engine/core/include)

--- a/context-transfer-engine/indexer/clio_mod.yaml
+++ b/context-transfer-engine/indexer/clio_mod.yaml
@@ -1,0 +1,23 @@
+# Indexer ChiMod (issue #905) — owns the SemanticSearch reverse index that
+# used to live in the CTE core. An INTERPOSER in the standard chain: speaks
+# the core's task interface, maintains a per-container forward index (term
+# frequencies per doc) by intercepting the mutating data verbs, serves
+# kSemanticSearch from that index (no per-query blob reads), and forwards
+# every other core method to `next` verbatim. On restart the index is
+# REBUILT from the storage below (BlobQuery + GetBlob against next).
+module_name: indexer
+namespace: clio::cte
+version: 1.0.0
+
+kCreate: 0
+kDestroy: 1
+kMonitor: 9
+
+# Interposed core verbs (MUST equal the core's ids)
+kPutBlob: 15
+kDelBlob: 18
+kDelTag: 19
+kSemanticSearch: 35
+kTruncateBlob: 37
+kRenameTag: 38
+kMultiPutBlob: 48

--- a/context-transfer-engine/indexer/clio_mod.yaml
+++ b/context-transfer-engine/indexer/clio_mod.yaml
@@ -23,4 +23,5 @@ kRenameTag: 38
 kMultiPutBlob: 48
 
 # Module verbs (>= 100, above the core id space)
-kIndexSweep: 100  # periodic asynchronous index drain
+kIndexSweep: 100   # periodic asynchronous index drain
+kReindexScan: 101  # explicit on-demand backfill of existing data

--- a/context-transfer-engine/indexer/clio_mod.yaml
+++ b/context-transfer-engine/indexer/clio_mod.yaml
@@ -21,3 +21,6 @@ kSemanticSearch: 35
 kTruncateBlob: 37
 kRenameTag: 38
 kMultiPutBlob: 48
+
+# Module verbs (>= 100, above the core id space)
+kIndexSweep: 100  # periodic asynchronous index drain

--- a/context-transfer-engine/indexer/include/clio_cte/indexer/autogen/indexer_methods.h
+++ b/context-transfer-engine/indexer/include/clio_cte/indexer/autogen/indexer_methods.h
@@ -69,9 +69,11 @@ GLOBAL_CROSS_CONST clio::run::u32 kMultiPutBlob =
     clio::cte::core::Method::kMultiPutBlob;
 
 // Module verbs live ABOVE the core's id space (>= 100, interposer rule).
-// kIndexSweep drives the asynchronous index drain (periodic task).
+// kIndexSweep drives the asynchronous index drain (periodic task);
+// kReindexScan is the explicit on-demand backfill of existing data.
 GLOBAL_CROSS_CONST clio::run::u32 kIndexSweep = 100;
-GLOBAL_CROSS_CONST clio::run::u32 kMaxMethodId = 101;
+GLOBAL_CROSS_CONST clio::run::u32 kReindexScan = 101;
+GLOBAL_CROSS_CONST clio::run::u32 kMaxMethodId = 102;
 
 inline const std::vector<std::string>& GetMethodNames() {
   static const std::vector<std::string> names = [] {
@@ -87,6 +89,7 @@ inline const std::vector<std::string>& GetMethodNames() {
     v[kRenameTag] = "RenameTag";
     v[kMultiPutBlob] = "MultiPutBlob";
     v[kIndexSweep] = "IndexSweep";
+    v[kReindexScan] = "ReindexScan";
     return v;
   }();
   return names;

--- a/context-transfer-engine/indexer/include/clio_cte/indexer/autogen/indexer_methods.h
+++ b/context-transfer-engine/indexer/include/clio_cte/indexer/autogen/indexer_methods.h
@@ -68,8 +68,9 @@ GLOBAL_CROSS_CONST clio::run::u32 kRenameTag =
 GLOBAL_CROSS_CONST clio::run::u32 kMultiPutBlob =
     clio::cte::core::Method::kMultiPutBlob;
 
-// The id space above the core's stays reserved for future module verbs
-// (explicit BuildIndex/DropIndex/IndexStats), which must live >= 100.
+// Module verbs live ABOVE the core's id space (>= 100, interposer rule).
+// kIndexSweep drives the asynchronous index drain (periodic task).
+GLOBAL_CROSS_CONST clio::run::u32 kIndexSweep = 100;
 GLOBAL_CROSS_CONST clio::run::u32 kMaxMethodId = 101;
 
 inline const std::vector<std::string>& GetMethodNames() {
@@ -85,6 +86,7 @@ inline const std::vector<std::string>& GetMethodNames() {
     v[kTruncateBlob] = "TruncateBlob";
     v[kRenameTag] = "RenameTag";
     v[kMultiPutBlob] = "MultiPutBlob";
+    v[kIndexSweep] = "IndexSweep";
     return v;
   }();
   return names;

--- a/context-transfer-engine/indexer/include/clio_cte/indexer/autogen/indexer_methods.h
+++ b/context-transfer-engine/indexer/include/clio_cte/indexer/autogen/indexer_methods.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CLIO_CTE_INDEXER_AUTOGEN_METHODS_H_
+#define CLIO_CTE_INDEXER_AUTOGEN_METHODS_H_
+
+#include <clio_runtime/clio_runtime.h>
+#include <clio_cte/core/autogen/core_methods.h>
+#include <string>
+#include <vector>
+
+/**
+ * Method ids for the indexer chimod. Hand-maintained; same interposition
+ * rules as the cache/replication/compressor chimods: the interposed core
+ * verbs carry the CORE's ids and task structs, every other core id is
+ * forwarded verbatim by the dispatch defaults, and module verbs live ABOVE
+ * the core's id space.
+ */
+namespace clio::cte::indexer {
+
+namespace Method {
+GLOBAL_CROSS_CONST clio::run::u32 kCreate = 0;
+GLOBAL_CROSS_CONST clio::run::u32 kDestroy = 1;
+GLOBAL_CROSS_CONST clio::run::u32 kMonitor = 9;
+
+// Interposed core verbs — same ids, same task structs as the core.
+// The mutating data verbs are intercepted to keep the index current;
+// kSemanticSearch TERMINATES here (the core no longer implements it).
+GLOBAL_CROSS_CONST clio::run::u32 kPutBlob = clio::cte::core::Method::kPutBlob;
+GLOBAL_CROSS_CONST clio::run::u32 kDelBlob = clio::cte::core::Method::kDelBlob;
+GLOBAL_CROSS_CONST clio::run::u32 kDelTag = clio::cte::core::Method::kDelTag;
+GLOBAL_CROSS_CONST clio::run::u32 kSemanticSearch =
+    clio::cte::core::Method::kSemanticSearch;
+GLOBAL_CROSS_CONST clio::run::u32 kTruncateBlob =
+    clio::cte::core::Method::kTruncateBlob;
+GLOBAL_CROSS_CONST clio::run::u32 kRenameTag =
+    clio::cte::core::Method::kRenameTag;
+GLOBAL_CROSS_CONST clio::run::u32 kMultiPutBlob =
+    clio::cte::core::Method::kMultiPutBlob;
+
+// The id space above the core's stays reserved for future module verbs
+// (explicit BuildIndex/DropIndex/IndexStats), which must live >= 100.
+GLOBAL_CROSS_CONST clio::run::u32 kMaxMethodId = 101;
+
+inline const std::vector<std::string>& GetMethodNames() {
+  static const std::vector<std::string> names = [] {
+    std::vector<std::string> v(kMaxMethodId);
+    v[0] = "Create";
+    v[1] = "Destroy";
+    v[9] = "Monitor";
+    v[kPutBlob] = "PutBlob";
+    v[kDelBlob] = "DelBlob";
+    v[kDelTag] = "DelTag";
+    v[kSemanticSearch] = "SemanticSearch";
+    v[kTruncateBlob] = "TruncateBlob";
+    v[kRenameTag] = "RenameTag";
+    v[kMultiPutBlob] = "MultiPutBlob";
+    return v;
+  }();
+  return names;
+}
+}  // namespace Method
+
+}  // namespace clio::cte::indexer
+
+#endif  // CLIO_CTE_INDEXER_AUTOGEN_METHODS_H_

--- a/context-transfer-engine/indexer/include/clio_cte/indexer/indexer_client.h
+++ b/context-transfer-engine/indexer/include/clio_cte/indexer/indexer_client.h
@@ -60,6 +60,25 @@ class Client : public clio::cte::core::Client {
   }
 
 #if CTP_IS_HOST
+  /**
+   * On-demand backfill: enumerate existing blobs matching the given regexes
+   * (intersected with the module's configured scope) and enqueue them for
+   * asynchronous indexing. The ONLY way to index pre-existing data besides
+   * a tag's first-insertion backfill — restarts restore persisted state and
+   * never rescan.
+   */
+  clio::run::Future<ReindexScanTask> AsyncReindexScan(
+      const std::string &tag_regex = ".*",
+      const std::string &blob_regex = ".*",
+      const clio::run::PoolQuery &pool_query =
+          clio::run::PoolQuery::Broadcast()) {
+    auto *ipc = CLIO_CPU_IPC;
+    auto task = ipc->NewTask<ReindexScanTask>(
+        clio::run::CreateTaskId(), indexer_pool_id_, pool_query, tag_regex,
+        blob_regex);
+    return ipc->Send(task);
+  }
+
   /** Create the indexer container. Set params.next_pool_id_ to the pool it
    *  forwards to (usually the CTE core). */
   clio::run::Future<CreateTask> AsyncCreateIndexer(

--- a/context-transfer-engine/indexer/include/clio_cte/indexer/indexer_client.h
+++ b/context-transfer-engine/indexer/include/clio_cte/indexer/indexer_client.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CLIO_CTE_INDEXER_INDEXER_CLIENT_H_
+#define CLIO_CTE_INDEXER_INDEXER_CLIENT_H_
+
+#include <clio_runtime/clio_runtime.h>
+#include <clio_runtime/admin/admin_client.h>
+#include <clio_cte/core/core_client.h>
+#include <clio_cte/indexer/indexer_tasks.h>
+
+#include <string>
+
+namespace clio::cte::indexer {
+
+/**
+ * Indexer chimod client (issue #905). The pool speaks the CTE core's task
+ * interface — point a clio::cte::core::Client at kIndexerPoolId (or any
+ * chain that forwards into it) and AsyncSemanticSearch works unchanged;
+ * this class only exists to create the pool with its chain configuration.
+ */
+class Client : public clio::cte::core::Client {
+ public:
+  Client() = default;
+
+  Client(const clio::run::PoolId &indexer_pool_id,
+         const clio::run::PoolId &core_pool_id)
+      : indexer_pool_id_(indexer_pool_id) {
+    clio::cte::core::Client::Init(core_pool_id);
+  }
+
+#if CTP_IS_HOST
+  /** Create the indexer container. Set params.next_pool_id_ to the pool it
+   *  forwards to (usually the CTE core). */
+  clio::run::Future<CreateTask> AsyncCreateIndexer(
+      const clio::run::PoolQuery &pool_query, const std::string &pool_name,
+      const clio::run::PoolId &custom_pool_id, const IndexerConfig &params) {
+    auto *ipc = CLIO_CPU_IPC;
+    auto task = ipc->NewTask<CreateTask>(
+        clio::run::CreateTaskId(), clio::run::kAdminPoolId, pool_query,
+        IndexerConfig::chimod_lib_name, pool_name, custom_pool_id, this,
+        params);
+    auto fut = ipc->Send(task);
+    indexer_pool_id_ = custom_pool_id;
+    return fut;
+  }
+#endif  // CTP_IS_HOST
+
+  clio::run::PoolId indexer_pool_id_;
+};
+
+}  // namespace clio::cte::indexer
+
+#endif  // CLIO_CTE_INDEXER_INDEXER_CLIENT_H_

--- a/context-transfer-engine/indexer/include/clio_cte/indexer/indexer_runtime.h
+++ b/context-transfer-engine/indexer/include/clio_cte/indexer/indexer_runtime.h
@@ -54,8 +54,12 @@ namespace clio::cte::indexer {
  * core (indexer -> core):
  *
  *  - PutBlob/MultiPutBlob/TruncateBlob forward down `next` FIRST; on
- *    success the affected doc is re-read from the chain and re-tokenized,
- *    so the index is updated before the ack (read-your-writes search).
+ *    success the affected doc is re-tokenized before the ack
+ *    (read-your-writes search). Whole-blob writes — the dominant shape —
+ *    tokenize the task's own payload directly; only partial writes re-read
+ *    the blob from the chain, via nested inline calls on the co-located
+ *    core container (never client round-trips: the dispatch/queue cycle
+ *    was the measured dominant cost, see CLIO_RUN_INLINE / #862).
  *  - DelBlob/DelTag drop the affected docs; RenameTag rewrites tag names.
  *  - SemanticSearch TERMINATES here: BM25 over the per-container index
  *    slice, identical semantics to the core's old scan (df/avgdl over the
@@ -98,6 +102,8 @@ class Runtime : public clio::cte::core::CoreInterposer {
       clio::run::shared_ptr<clio::cte::core::RenameTagTask> &task);
   clio::run::TaskResume SemanticSearch(
       clio::run::shared_ptr<clio::cte::core::SemanticSearchTask> &task);
+  clio::run::TaskResume IndexSweep(
+      clio::run::shared_ptr<IndexSweepTask> &task);
 
   // ---- Container virtuals (defined in autogen/indexer_lib_exec.cc) ----
   void Init(const clio::run::PoolId &pool_id, const std::string &pool_name,
@@ -141,8 +147,32 @@ class Runtime : public clio::cte::core::CoreInterposer {
 
   /** Re-read one blob's current bytes from the chain and replace its index
    *  entry (erases it when the blob is empty or unreadable — matching the
-   *  old scan, which skipped zero-length and unreadable blobs). */
+   *  old scan, which skipped zero-length and unreadable blobs). Fallback
+   *  path only: whole-blob puts tokenize their own payload instead. The
+   *  read runs as a nested inline call on the core container. */
   clio::run::TaskResume ReindexBlob(TagId tag_id, std::string blob_name);
+
+  /** Post-op logical blob size via a nested inline GetBlobSize on the core
+   *  container (0 when absent/failed). */
+  clio::run::TaskResume ProbeBlobSize(TagId tag_id,
+                                      const std::string &blob_name,
+                                      clio::run::u64 *total_out);
+
+  /** Tokenize `data` and replace the blob's index entry (synchronous, no
+   *  awaits; locks index_mutex_ internally). */
+  void IndexDocBytes(const TagId &tag_id, const std::string &tag_name,
+                     const std::string &blob_name, const char *data,
+                     clio::run::u64 len);
+
+  /** Mark a blob dirty for the asynchronous drain (O(1), coalesced by doc
+   *  key — the put ack path's ONLY indexing cost). */
+  void EnqueuePending(const TagId &tag_id, const std::string &blob_name);
+
+  /** Drain the pending set to empty: pop-and-reindex until no entry remains
+   *  AND no other drainer is mid-entry. Multiple drainers cooperate (each
+   *  pops distinct keys); a search calls this as its read-your-writes
+   *  barrier, the periodic sweep calls it for background progress. */
+  clio::run::TaskResume DrainPendingIndex();
 
   /** Rebuild this container's index slice from the storage below (restart
    *  path): enumerate local (tag, blob) pairs via BlobQuery, re-read and
@@ -178,6 +208,19 @@ class Runtime : public clio::cte::core::CoreInterposer {
   std::unordered_map<std::string, IndexedDoc> index_;
   /** TagId -> resolved full tag name (rewritten by RenameTag). */
   std::unordered_map<clio::run::u64, std::string> tag_names_;
+
+  /** Dirty blobs awaiting re-tokenization, keyed like index_ so overwrites
+   *  COALESCE (N puts to a hot blob = one drain-time read+scan). Guarded by
+   *  index_mutex_. */
+  struct PendingReindex {
+    TagId tag_id_;
+    std::string blob_name_;
+  };
+  std::unordered_map<std::string, PendingReindex> pending_;
+  /** Entries popped by a drainer but not yet indexed — the search barrier
+   *  waits for BOTH pending_ empty and this zero. Guarded by index_mutex_. */
+  clio::run::u32 draining_ = 0;
+
   std::mutex index_mutex_;
 };
 

--- a/context-transfer-engine/indexer/include/clio_cte/indexer/indexer_runtime.h
+++ b/context-transfer-engine/indexer/include/clio_cte/indexer/indexer_runtime.h
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CLIO_CTE_INDEXER_INDEXER_RUNTIME_H_
+#define CLIO_CTE_INDEXER_INDEXER_RUNTIME_H_
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+#include <clio_runtime/clio_runtime.h>
+#include <clio_cte/core/core_client.h>
+#include <clio_cte/core/core_interposer.h>
+#include <clio_cte/indexer/indexer_client.h>
+#include <clio_cte/indexer/indexer_tasks.h>
+
+namespace clio::cte::indexer {
+
+/**
+ * Indexer chimod runtime (issue #905) — owns the SemanticSearch index that
+ * used to be computed brute-force inside the CTE core (which re-read every
+ * candidate blob's bytes on every query). An interposer directly above the
+ * core (indexer -> core):
+ *
+ *  - PutBlob/MultiPutBlob/TruncateBlob forward down `next` FIRST; on
+ *    success the affected doc is re-read from the chain and re-tokenized,
+ *    so the index is updated before the ack (read-your-writes search).
+ *  - DelBlob/DelTag drop the affected docs; RenameTag rewrites tag names.
+ *  - SemanticSearch TERMINATES here: BM25 over the per-container index
+ *    slice, identical semantics to the core's old scan (df/avgdl over the
+ *    regex-matched working set; Broadcast + AggregateOut merges shards).
+ *  - The index is DERIVED, rebuildable state: never persisted. On restart
+ *    each container rebuilds its slice from the storage below (BlobQuery +
+ *    GetBlob against `next`) before Create() acks. Blobs whose bytes lived
+ *    only on volatile (RAM) tiers cannot be re-read after a reboot and drop
+ *    out of the index — the same content is also unreadable by GetBlob, so
+ *    the index stays consistent with what storage can actually serve.
+ *
+ * The index is a FORWARD index (per-doc term frequencies + lengths), not a
+ * term->postings inverted index: the search semantics compute BM25 corpus
+ * statistics over the regex-matched slice per query, which requires
+ * iterating matched docs anyway. What the index buys is eliminating the
+ * per-query blob reads and tokenization.
+ */
+class Runtime : public clio::cte::core::CoreInterposer {
+ public:
+  using CreateParams = IndexerConfig;  // required by CLIO_TASK_CC
+
+  Runtime() = default;
+  ~Runtime() override = default;
+
+  // ---- Method handlers ----
+  clio::run::TaskResume Create(clio::run::shared_ptr<CreateTask> &task);
+  clio::run::TaskResume Destroy(clio::run::shared_ptr<DestroyTask> &task);
+  clio::run::TaskResume Monitor(clio::run::shared_ptr<MonitorTask> &task);
+  clio::run::TaskResume PutBlob(
+      clio::run::shared_ptr<clio::cte::core::PutBlobTask> &task);
+  clio::run::TaskResume MultiPutBlob(
+      clio::run::shared_ptr<clio::cte::core::MultiPutBlobTask> &task);
+  clio::run::TaskResume DelBlob(
+      clio::run::shared_ptr<clio::cte::core::DelBlobTask> &task);
+  clio::run::TaskResume DelTag(
+      clio::run::shared_ptr<clio::cte::core::DelTagTask> &task);
+  clio::run::TaskResume TruncateBlob(
+      clio::run::shared_ptr<clio::cte::core::TruncateBlobTask> &task);
+  clio::run::TaskResume RenameTag(
+      clio::run::shared_ptr<clio::cte::core::RenameTagTask> &task);
+  clio::run::TaskResume SemanticSearch(
+      clio::run::shared_ptr<clio::cte::core::SemanticSearchTask> &task);
+
+  // ---- Container virtuals (defined in autogen/indexer_lib_exec.cc) ----
+  void Init(const clio::run::PoolId &pool_id, const std::string &pool_name,
+            clio::run::u32 container_id = 0) override;
+  void Restart(const clio::run::PoolId &pool_id, const std::string &pool_name,
+               clio::run::u32 container_id = 0) override;
+  clio::run::TaskResume Run(clio::run::u32 method,
+                      clio::run::shared_ptr<clio::run::Task> task_ptr) override;
+  clio::run::u64 GetWorkRemaining() const override;
+  void LocalLoadTask(clio::run::u32 method, clio::run::DefaultLoadArchive &archive,
+                     clio::run::shared_ptr<clio::run::Task>& task_ptr) override;
+  clio::run::shared_ptr<clio::run::Task> LocalAllocLoadTask(
+      clio::run::u32 method, clio::run::DefaultLoadArchive &archive) override;
+  void LocalSaveTask(clio::run::u32 method, clio::run::DefaultSaveArchive &archive,
+                     clio::run::shared_ptr<clio::run::Task>& task_ptr) override;
+  void AggregateOut(clio::run::u32 method, clio::run::shared_ptr<clio::run::Task> &orig_task,
+                    const clio::run::shared_ptr<clio::run::Task> &replica_task) override;
+  void AggregateIn(clio::run::u32 method, clio::run::shared_ptr<clio::run::Task> &agg_task,
+                   const clio::run::shared_ptr<clio::run::Task> &member_task) override;
+  void SaveTask(clio::run::u32 method, clio::run::SaveTaskArchive &archive,
+                clio::run::shared_ptr<clio::run::Task>& task_ptr) override;
+  void LoadTask(clio::run::u32 method, clio::run::LoadTaskArchive &archive,
+                clio::run::shared_ptr<clio::run::Task>& task_ptr) override;
+  clio::run::shared_ptr<clio::run::Task> AllocLoadTask(clio::run::u32 method,
+                                             clio::run::LoadTaskArchive &archive) override;
+  clio::run::shared_ptr<clio::run::Task> NewCopyTask(clio::run::u32 method,
+                                           clio::run::shared_ptr<clio::run::Task> &orig,
+                                           bool deep) override;
+  clio::run::shared_ptr<clio::run::Task> NewTask(clio::run::u32 method) override;
+
+ private:
+  /** One indexed document: the tokenization the core's old scan produced
+   *  per candidate, kept current instead of recomputed per query. */
+  struct IndexedDoc {
+    TagId tag_id_;
+    std::string tag_name_;
+    std::string blob_name_;
+    std::unordered_map<std::string, int> tf_;
+    size_t length_ = 0;
+  };
+
+  /** Re-read one blob's current bytes from the chain and replace its index
+   *  entry (erases it when the blob is empty or unreadable — matching the
+   *  old scan, which skipped zero-length and unreadable blobs). */
+  clio::run::TaskResume ReindexBlob(TagId tag_id, std::string blob_name);
+
+  /** Rebuild this container's index slice from the storage below (restart
+   *  path): enumerate local (tag, blob) pairs via BlobQuery, re-read and
+   *  tokenize each. */
+  clio::run::TaskResume RebuildIndex();
+
+  /** Resolve (and cache) a tag's full name for result rows / tag_regex. */
+  clio::run::TaskResume ResolveTagName(TagId tag_id, std::string *name_out);
+
+  /** Lazily bind the next-pool client (compose next_pool_id). */
+  clio::cte::core::Client *GetNextClient();
+
+  static std::string DocKey(const TagId &tag_id, const std::string &blob_name) {
+    return std::to_string(tag_id.major_) + "." +
+           std::to_string(tag_id.minor_) + "." + blob_name;
+  }
+  static clio::run::u64 TagKey(const TagId &tag_id) {
+    return (static_cast<clio::run::u64>(tag_id.major_) << 32) |
+           static_cast<clio::run::u64>(tag_id.minor_);
+  }
+
+  IndexerConfig config_;
+  std::unique_ptr<clio::cte::core::Client> next_client_;
+
+  // Restart flag: set by Restart() before Init()/Create() (same protocol as
+  // the core's is_restart_). Triggers RebuildIndex() in Create().
+  bool is_restart_ = false;
+
+  /** The index slice this container owns, keyed "major.minor.blob_name"
+   *  (the core's composite key). Guarded by index_mutex_: handlers touch it
+   *  only between awaits, but distinct blobs' tasks interleave on the
+   *  worker pool. */
+  std::unordered_map<std::string, IndexedDoc> index_;
+  /** TagId -> resolved full tag name (rewritten by RenameTag). */
+  std::unordered_map<clio::run::u64, std::string> tag_names_;
+  std::mutex index_mutex_;
+};
+
+}  // namespace clio::cte::indexer
+
+#endif  // CLIO_CTE_INDEXER_INDEXER_RUNTIME_H_

--- a/context-transfer-engine/indexer/include/clio_cte/indexer/indexer_runtime.h
+++ b/context-transfer-engine/indexer/include/clio_cte/indexer/indexer_runtime.h
@@ -34,10 +34,13 @@
 #ifndef CLIO_CTE_INDEXER_INDEXER_RUNTIME_H_
 #define CLIO_CTE_INDEXER_INDEXER_RUNTIME_H_
 
+#include <fstream>
 #include <memory>
 #include <mutex>
+#include <regex>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 
 #include <clio_runtime/clio_runtime.h>
 #include <clio_cte/core/core_client.h>
@@ -64,12 +67,18 @@ namespace clio::cte::indexer {
  *  - SemanticSearch TERMINATES here: BM25 over the per-container index
  *    slice, identical semantics to the core's old scan (df/avgdl over the
  *    regex-matched working set; Broadcast + AggregateOut merges shards).
- *  - The index is DERIVED, rebuildable state: never persisted. On restart
- *    each container rebuilds its slice from the storage below (BlobQuery +
- *    GetBlob against `next`) before Create() acks. Blobs whose bytes lived
- *    only on volatile (RAM) tiers cannot be re-read after a reboot and drop
- *    out of the index — the same content is also unreadable by GetBlob, so
- *    the index stays consistent with what storage can actually serve.
+ *  - SCOPE: only blobs matching the configured tag_re AND blob_re are ever
+ *    tokenized (default .*): out-of-scope content costs no scan, no index
+ *    memory, no WAL.
+ *  - PERSISTENCE (index_log_path): the module owns a snapshot + append WAL
+ *    of its own state. A restart RESTORES and never rescans storage; the
+ *    WAL folds into the snapshot at a size threshold and on clean
+ *    shutdown (which also persists still-dirty keys). Pre-existing data
+ *    enters the index only via a tag's one-time first-insertion backfill
+ *    or the explicit kReindexScan verb — both ENQUEUE for the async drain.
+ *    Crash window: dirty keys acked after the last WAL record may stay
+ *    stale until rewritten or rescanned (the index is derived state;
+ *    kReindexScan repairs).
  *
  * The index is a FORWARD index (per-doc term frequencies + lengths), not a
  * term->postings inverted index: the search semantics compute BM25 corpus
@@ -104,6 +113,8 @@ class Runtime : public clio::cte::core::CoreInterposer {
       clio::run::shared_ptr<clio::cte::core::SemanticSearchTask> &task);
   clio::run::TaskResume IndexSweep(
       clio::run::shared_ptr<IndexSweepTask> &task);
+  clio::run::TaskResume ReindexScan(
+      clio::run::shared_ptr<ReindexScanTask> &task);
 
   // ---- Container virtuals (defined in autogen/indexer_lib_exec.cc) ----
   void Init(const clio::run::PoolId &pool_id, const std::string &pool_name,
@@ -165,8 +176,27 @@ class Runtime : public clio::cte::core::CoreInterposer {
                      clio::run::u64 len);
 
   /** Mark a blob dirty for the asynchronous drain (O(1), coalesced by doc
-   *  key — the put ack path's ONLY indexing cost). */
+   *  key — the put ack path's ONLY indexing cost). Pre-filters on the
+   *  module's blob_re scope; the tag_re half is enforced at drain time
+   *  (the tag name is only resolved there). Also triggers the one-time
+   *  first-insertion backfill for tags the index has never seen. */
   void EnqueuePending(const TagId &tag_id, const std::string &blob_name);
+
+  // ---- Persistence (issue #905: snapshot + WAL, never rescan) ----
+  /** Append one WAL record; no-op when persistence is off. */
+  void WalAppendDoc(const IndexedDoc &doc);
+  void WalAppendDelDoc(const TagId &tag_id, const std::string &blob_name);
+  void WalAppendDelTag(const TagId &tag_id);
+  void WalAppendRenameTag(const TagId &tag_id, const std::string &new_name);
+  void WalAppendTagSeen(const TagId &tag_id);
+  /** Truncate-and-rewrite the snapshot (docs + tag names + seen tags +
+   *  dirty keys), then truncate the WAL. Called on clean shutdown, after a
+   *  restore (compaction), and when the WAL crosses the size threshold. */
+  void SnapshotIndex();
+  /** Load snapshot + replay WAL into memory (last-wins), dropping docs
+   *  outside the CURRENT scope config. Returns true when state was
+   *  restored. */
+  bool RestoreIndex();
 
   /** Drain the pending set to empty: pop-and-reindex until no entry remains
    *  AND no other drainer is mid-entry. Multiple drainers cooperate (each
@@ -174,10 +204,14 @@ class Runtime : public clio::cte::core::CoreInterposer {
    *  barrier, the periodic sweep calls it for background progress. */
   clio::run::TaskResume DrainPendingIndex();
 
-  /** Rebuild this container's index slice from the storage below (restart
-   *  path): enumerate local (tag, blob) pairs via BlobQuery, re-read and
-   *  tokenize each. */
-  clio::run::TaskResume RebuildIndex();
+  /** Enumerate existing local (tag, blob) pairs matching the given regexes
+   *  (each intersected with the module scope) via BlobQuery on the chain
+   *  below and ENQUEUE them for the asynchronous drain. Used by the
+   *  kReindexScan verb and the per-tag first-insertion backfill; restarts
+   *  restore persisted state and never call this. */
+  clio::run::TaskResume ScanAndEnqueue(std::string tag_regex,
+                                       std::string blob_regex,
+                                       clio::run::u64 *enqueued_out);
 
   /** Resolve (and cache) a tag's full name for result rows / tag_regex. */
   clio::run::TaskResume ResolveTagName(TagId tag_id, std::string *name_out);
@@ -217,9 +251,29 @@ class Runtime : public clio::cte::core::CoreInterposer {
     std::string blob_name_;
   };
   std::unordered_map<std::string, PendingReindex> pending_;
+  /** Tags whose FIRST insertion has been observed and whose pre-existing
+   *  blobs must be backfilled (drained before pending_; each pops into a
+   *  scoped ScanAndEnqueue). Guarded by index_mutex_. */
+  std::unordered_map<clio::run::u64, TagId> pending_tag_backfills_;
+  /** Tags the index has already seen (backfill fired or restored) — the
+   *  first-insertion trigger. Persisted, so restarts never re-backfill.
+   *  Guarded by index_mutex_. */
+  std::unordered_set<clio::run::u64> tags_seen_;
   /** Entries popped by a drainer but not yet indexed — the search barrier
-   *  waits for BOTH pending_ empty and this zero. Guarded by index_mutex_. */
+   *  waits for BOTH pending sets empty and this zero. Guarded by
+   *  index_mutex_. */
   clio::run::u32 draining_ = 0;
+
+  /** Compiled module scope (config tag_re_/blob_re_). */
+  std::regex scope_tag_re_;
+  std::regex scope_blob_re_;
+  bool scope_match_all_ = true;  ///< both regexes are ".*" (skip the checks)
+
+  /** Persistence streams (open iff config index_log_path_ non-empty). WAL
+   *  appends run under index_mutex_ (they follow the state mutation they
+   *  record). */
+  std::ofstream wal_;
+  clio::run::u64 wal_bytes_ = 0;
 
   std::mutex index_mutex_;
 };

--- a/context-transfer-engine/indexer/include/clio_cte/indexer/indexer_tasks.h
+++ b/context-transfer-engine/indexer/include/clio_cte/indexer/indexer_tasks.h
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CLIO_CTE_INDEXER_INDEXER_TASKS_H_
+#define CLIO_CTE_INDEXER_INDEXER_TASKS_H_
+
+#include <clio_runtime/clio_runtime.h>
+#include <clio_runtime/task.h>
+#include <clio_runtime/admin/admin_tasks.h>
+#include <clio_cte/core/core_tasks.h>
+#include <clio_cte/indexer/autogen/indexer_methods.h>
+
+#include <string>
+
+namespace clio::cte::indexer {
+
+/** The indexer chimod speaks the CTE core's vocabulary. */
+using Context = clio::cte::core::Context;
+using TagId = clio::cte::core::TagId;
+
+/**
+ * Well-known default pool id/name. In the standard chain the indexer sits
+ * directly ABOVE the core (indexer 564 -> core 512): the mutating data
+ * verbs must flow through it for the index to stay current, and search
+ * clients address it (or any pool that forwards down to it).
+ */
+static constexpr clio::run::PoolId kIndexerPoolId(564, 0);
+static constexpr const char *kIndexerPoolName = "clio_cte_indexer";
+
+/**
+ * Container creation params. next_pool_id_ is the pool this indexer
+ * forwards non-search verbs to (usually the CTE core). The index itself is
+ * DERIVED state: nothing here configures persistence because the index is
+ * never persisted — on restart it is rebuilt from the storage below.
+ */
+struct IndexerConfig {
+  static constexpr const char* chimod_lib_name = "clio_cte_indexer";
+
+  clio::run::PoolId next_pool_id_;  ///< Next pool in the chain (e.g. 512.0)
+
+  IndexerConfig() : next_pool_id_(clio::run::PoolId::GetNull()) {}
+  IndexerConfig(const clio::run::PoolId &pool_id, const IndexerConfig &other)
+      : next_pool_id_(other.next_pool_id_) {
+    (void)pool_id;
+  }
+
+  template <class Archive>
+  void serialize(Archive &ar) {
+    // EVERY field round-trips (the cache/replication silently-dropped-field
+    // audit rule).
+    ar(next_pool_id_);
+  }
+
+  /** Load configuration from compose YAML. */
+  void LoadConfig(const clio::run::PoolConfig &pool_config) {
+    if (!pool_config.config_.empty()) {
+      try {
+        YAML::Node node = YAML::Load(pool_config.config_);
+        if (node["next_pool_id"]) {
+          std::string next_str = node["next_pool_id"].as<std::string>();
+          auto dot = next_str.find('.');
+          if (dot != std::string::npos) {
+            clio::run::u32 major = std::stoul(next_str.substr(0, dot));
+            clio::run::u32 minor = std::stoul(next_str.substr(dot + 1));
+            next_pool_id_ = clio::run::PoolId(major, minor);
+          }
+        }
+      } catch (...) {
+        // Config parsing is best-effort
+      }
+    }
+  }
+};
+
+/** Standard pool creation. */
+using CreateTask = clio::run::admin::GetOrCreatePoolTask<IndexerConfig>;
+
+/** Cleanup the indexer container. */
+struct DestroyTask : public clio::run::Task {
+  DestroyTask() : clio::run::Task() {}
+
+  explicit DestroyTask(const clio::run::TaskId &task_id,
+                       const clio::run::PoolId &pool_id,
+                       const clio::run::PoolQuery &pool_query)
+      : clio::run::Task(task_id, pool_id, pool_query, Method::kDestroy) {}
+
+  void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
+    Task::AggregateOut(other_base);
+    Copy(other_base.template Cast<DestroyTask>());
+  }
+
+  void Copy(const ctp::ipc::FullPtr<DestroyTask>& other) {
+    Task::Copy(other.template Cast<clio::run::Task>());
+  }
+
+  template <typename Ar> void SerializeIn(Ar &ar) { Task::SerializeIn(ar); }
+  template <typename Ar> void SerializeOut(Ar &ar) { Task::SerializeOut(ar); }
+};
+
+using MonitorTask = clio::run::admin::MonitorTask;
+
+}  // namespace clio::cte::indexer
+
+#endif  // CLIO_CTE_INDEXER_INDEXER_TASKS_H_

--- a/context-transfer-engine/indexer/include/clio_cte/indexer/indexer_tasks.h
+++ b/context-transfer-engine/indexer/include/clio_cte/indexer/indexer_tasks.h
@@ -37,6 +37,7 @@
 #include <clio_runtime/clio_runtime.h>
 #include <clio_runtime/task.h>
 #include <clio_runtime/admin/admin_tasks.h>
+#include <clio_ctp/util/config_parse.h>
 #include <clio_cte/core/core_tasks.h>
 #include <clio_cte/indexer/autogen/indexer_methods.h>
 
@@ -74,11 +75,32 @@ struct IndexerConfig {
   /// work. 0 disables the sweep: the index is then updated only when a
   /// search runs (lazy indexing).
   clio::run::u32 index_sweep_period_ms_ = 100;
+  /// Index SCOPE: only blobs whose full tag name matches tag_re_ AND whose
+  /// blob name matches blob_re_ are tokenized (std::regex_match, same
+  /// full-string semantics as the search filters). Out-of-scope content
+  /// costs nothing — no scan, no index memory, no WAL. Defaults index
+  /// everything.
+  std::string tag_re_ = ".*";
+  std::string blob_re_ = ".*";
+  /// Index persistence (issue #905): when non-empty, the module keeps its
+  /// state in <path> (snapshot) + <path>.wal (append-only deltas) and a
+  /// restart RESTORES instead of rescanning storage. Empty = in-memory
+  /// only: a restart comes up EMPTY and re-indexes incrementally (first
+  /// insertion per tag backfills that tag; kReindexScan backfills on
+  /// demand).
+  std::string index_log_path_;
+  /// WAL size that triggers snapshot+truncate compaction (checked by the
+  /// periodic sweep).
+  clio::run::u64 index_wal_compact_bytes_ = 8ULL * 1024 * 1024;
 
   IndexerConfig() : next_pool_id_(clio::run::PoolId::GetNull()) {}
   IndexerConfig(const clio::run::PoolId &pool_id, const IndexerConfig &other)
       : next_pool_id_(other.next_pool_id_),
-        index_sweep_period_ms_(other.index_sweep_period_ms_) {
+        index_sweep_period_ms_(other.index_sweep_period_ms_),
+        tag_re_(other.tag_re_),
+        blob_re_(other.blob_re_),
+        index_log_path_(other.index_log_path_),
+        index_wal_compact_bytes_(other.index_wal_compact_bytes_) {
     (void)pool_id;
   }
 
@@ -86,7 +108,8 @@ struct IndexerConfig {
   void serialize(Archive &ar) {
     // EVERY field round-trips (the cache/replication silently-dropped-field
     // audit rule).
-    ar(next_pool_id_, index_sweep_period_ms_);
+    ar(next_pool_id_, index_sweep_period_ms_, tag_re_, blob_re_,
+       index_log_path_, index_wal_compact_bytes_);
   }
 
   /** Load configuration from compose YAML. */
@@ -106,6 +129,20 @@ struct IndexerConfig {
         if (node["index_sweep_period_ms"]) {
           index_sweep_period_ms_ =
               node["index_sweep_period_ms"].as<clio::run::u32>();
+        }
+        if (node["tag_re"]) {
+          tag_re_ = node["tag_re"].as<std::string>();
+        }
+        if (node["blob_re"]) {
+          blob_re_ = node["blob_re"].as<std::string>();
+        }
+        if (node["index_log_path"]) {
+          index_log_path_ = ctp::ConfigParse::ExpandPath(
+              node["index_log_path"].as<std::string>());
+        }
+        if (node["index_wal_compact_bytes"]) {
+          index_wal_compact_bytes_ = ctp::ConfigParse::ParseSize(
+              node["index_wal_compact_bytes"].as<std::string>());
         }
       } catch (...) {
         // Config parsing is best-effort
@@ -140,6 +177,61 @@ struct DestroyTask : public clio::run::Task {
 };
 
 using MonitorTask = clio::run::admin::MonitorTask;
+
+/**
+ * Explicit on-demand index scan (Method::kReindexScan): enumerate existing
+ * blobs matching tag_re_ AND blob_re_ (intersected with the module's
+ * configured scope) via BlobQuery on the chain below, and ENQUEUE them for
+ * the asynchronous drain. The only way pre-existing cold data enters the
+ * index besides a tag's first-insertion backfill — restarts restore
+ * persisted state and never rescan.
+ */
+struct ReindexScanTask : public clio::run::Task {
+  IN clio::run::priv::string tag_regex_;
+  IN clio::run::priv::string blob_regex_;
+  OUT clio::run::u64 blobs_enqueued_;
+
+  ReindexScanTask()
+      : clio::run::Task(),
+        tag_regex_(CLIO_PRIV_ALLOC),
+        blob_regex_(CLIO_PRIV_ALLOC),
+        blobs_enqueued_(0) {}
+
+  explicit ReindexScanTask(const clio::run::TaskId &task_id,
+                           const clio::run::PoolId &pool_id,
+                           const clio::run::PoolQuery &pool_query,
+                           const std::string &tag_regex,
+                           const std::string &blob_regex)
+      : clio::run::Task(task_id, pool_id, pool_query, Method::kReindexScan),
+        tag_regex_(CLIO_PRIV_ALLOC, tag_regex),
+        blob_regex_(CLIO_PRIV_ALLOC, blob_regex),
+        blobs_enqueued_(0) {}
+
+  template <typename Ar>
+  void SerializeIn(Ar &ar) {
+    Task::SerializeIn(ar);
+    ar(tag_regex_, blob_regex_);
+  }
+
+  template <typename Ar>
+  void SerializeOut(Ar &ar) {
+    Task::SerializeOut(ar);
+    ar(blobs_enqueued_);
+  }
+
+  void Copy(const ctp::ipc::FullPtr<ReindexScanTask> &other) {
+    Task::Copy(other.template Cast<clio::run::Task>());
+    tag_regex_ = other->tag_regex_;
+    blob_regex_ = other->blob_regex_;
+    blobs_enqueued_ = other->blobs_enqueued_;
+  }
+
+  void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
+    Task::AggregateOut(other_base);
+    auto other = other_base.template Cast<ReindexScanTask>();
+    blobs_enqueued_ += other->blobs_enqueued_;
+  }
+};
 
 /** Periodic driver of the asynchronous index drain (Method::kIndexSweep). */
 struct IndexSweepTask : public clio::run::Task {

--- a/context-transfer-engine/indexer/include/clio_cte/indexer/indexer_tasks.h
+++ b/context-transfer-engine/indexer/include/clio_cte/indexer/indexer_tasks.h
@@ -67,10 +67,18 @@ struct IndexerConfig {
   static constexpr const char* chimod_lib_name = "clio_cte_indexer";
 
   clio::run::PoolId next_pool_id_;  ///< Next pool in the chain (e.g. 512.0)
+  /// Period of the asynchronous index drain (kIndexSweep). Indexing is OFF
+  /// the put ack path: a put only enqueues its (tag, blob) key — coalesced,
+  /// so N overwrites of a hot blob cost ONE re-tokenize — and the sweep (or
+  /// a SemanticSearch, which drains first for read-your-writes) does the
+  /// work. 0 disables the sweep: the index is then updated only when a
+  /// search runs (lazy indexing).
+  clio::run::u32 index_sweep_period_ms_ = 100;
 
   IndexerConfig() : next_pool_id_(clio::run::PoolId::GetNull()) {}
   IndexerConfig(const clio::run::PoolId &pool_id, const IndexerConfig &other)
-      : next_pool_id_(other.next_pool_id_) {
+      : next_pool_id_(other.next_pool_id_),
+        index_sweep_period_ms_(other.index_sweep_period_ms_) {
     (void)pool_id;
   }
 
@@ -78,7 +86,7 @@ struct IndexerConfig {
   void serialize(Archive &ar) {
     // EVERY field round-trips (the cache/replication silently-dropped-field
     // audit rule).
-    ar(next_pool_id_);
+    ar(next_pool_id_, index_sweep_period_ms_);
   }
 
   /** Load configuration from compose YAML. */
@@ -94,6 +102,10 @@ struct IndexerConfig {
             clio::run::u32 minor = std::stoul(next_str.substr(dot + 1));
             next_pool_id_ = clio::run::PoolId(major, minor);
           }
+        }
+        if (node["index_sweep_period_ms"]) {
+          index_sweep_period_ms_ =
+              node["index_sweep_period_ms"].as<clio::run::u32>();
         }
       } catch (...) {
         // Config parsing is best-effort
@@ -128,6 +140,23 @@ struct DestroyTask : public clio::run::Task {
 };
 
 using MonitorTask = clio::run::admin::MonitorTask;
+
+/** Periodic driver of the asynchronous index drain (Method::kIndexSweep). */
+struct IndexSweepTask : public clio::run::Task {
+  IndexSweepTask() : clio::run::Task() {}
+
+  explicit IndexSweepTask(const clio::run::TaskId &task_id,
+                          const clio::run::PoolId &pool_id,
+                          const clio::run::PoolQuery &pool_query)
+      : clio::run::Task(task_id, pool_id, pool_query, Method::kIndexSweep) {}
+
+  void Copy(const ctp::ipc::FullPtr<IndexSweepTask> &other) {
+    Task::Copy(other.template Cast<clio::run::Task>());
+  }
+
+  template <typename Ar> void SerializeIn(Ar &ar) { Task::SerializeIn(ar); }
+  template <typename Ar> void SerializeOut(Ar &ar) { Task::SerializeOut(ar); }
+};
 
 }  // namespace clio::cte::indexer
 

--- a/context-transfer-engine/indexer/src/autogen/indexer_lib_exec.cc
+++ b/context-transfer-engine/indexer/src/autogen/indexer_lib_exec.cc
@@ -65,7 +65,8 @@ namespace clio::cte::indexer {
   X(kTruncateBlob, clio::cte::core::TruncateBlobTask, TruncateBlob)       \
   X(kRenameTag, clio::cte::core::RenameTagTask, RenameTag)                \
   X(kMultiPutBlob, clio::cte::core::MultiPutBlobTask, MultiPutBlob)       \
-  X(kIndexSweep, IndexSweepTask, IndexSweep)
+  X(kIndexSweep, IndexSweepTask, IndexSweep)                              \
+  X(kReindexScan, ReindexScanTask, ReindexScan)
 
 void Runtime::Init(const clio::run::PoolId &pool_id, const std::string &pool_name,
                    clio::run::u32 container_id) {

--- a/context-transfer-engine/indexer/src/autogen/indexer_lib_exec.cc
+++ b/context-transfer-engine/indexer/src/autogen/indexer_lib_exec.cc
@@ -64,7 +64,8 @@ namespace clio::cte::indexer {
   X(kSemanticSearch, clio::cte::core::SemanticSearchTask, SemanticSearch) \
   X(kTruncateBlob, clio::cte::core::TruncateBlobTask, TruncateBlob)       \
   X(kRenameTag, clio::cte::core::RenameTagTask, RenameTag)                \
-  X(kMultiPutBlob, clio::cte::core::MultiPutBlobTask, MultiPutBlob)
+  X(kMultiPutBlob, clio::cte::core::MultiPutBlobTask, MultiPutBlob)       \
+  X(kIndexSweep, IndexSweepTask, IndexSweep)
 
 void Runtime::Init(const clio::run::PoolId &pool_id, const std::string &pool_name,
                    clio::run::u32 container_id) {

--- a/context-transfer-engine/indexer/src/autogen/indexer_lib_exec.cc
+++ b/context-transfer-engine/indexer/src/autogen/indexer_lib_exec.cc
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Container virtual API dispatch for the indexer ChiMod (Run / Save / Load /
+ * NewTask / Aggregate), switch-case over Method ids. Hand-maintained to
+ * match clio_mod.yaml + indexer_methods.h (mirrors the cache chimod's
+ * autogen/cache_lib_exec.cc).
+ *
+ * INTERPOSITION (issues #886/#905): this pool speaks the CTE core's task
+ * interface. The X-macro lists the methods this module implements — the
+ * core's mutating data verbs plus kSemanticSearch, with the core's task
+ * structs — and every DEFAULT case delegates to the core container, so any
+ * core method this module does not override behaves exactly as if the task
+ * had been addressed to the core pool (including wire serialization:
+ * Save/Load/NewTask for forwarded ids are the core's).
+ */
+#include "clio_cte/indexer/indexer_runtime.h"
+#include "clio_cte/indexer/autogen/indexer_methods.h"
+#include <clio_runtime/clio_runtime.h>
+#include <clio_runtime/task.h>
+
+namespace clio::cte::indexer {
+
+// One case body per (function, method); declared once to keep the dispatch
+// functions in sync.
+#define CLIO_INDEXER_FOR_EACH_METHOD(X)                                   \
+  X(kCreate, CreateTask, Create)                                          \
+  X(kDestroy, DestroyTask, Destroy)                                       \
+  X(kMonitor, MonitorTask, Monitor)                                       \
+  X(kPutBlob, clio::cte::core::PutBlobTask, PutBlob)                      \
+  X(kDelBlob, clio::cte::core::DelBlobTask, DelBlob)                      \
+  X(kDelTag, clio::cte::core::DelTagTask, DelTag)                         \
+  X(kSemanticSearch, clio::cte::core::SemanticSearchTask, SemanticSearch) \
+  X(kTruncateBlob, clio::cte::core::TruncateBlobTask, TruncateBlob)       \
+  X(kRenameTag, clio::cte::core::RenameTagTask, RenameTag)                \
+  X(kMultiPutBlob, clio::cte::core::MultiPutBlobTask, MultiPutBlob)
+
+void Runtime::Init(const clio::run::PoolId &pool_id, const std::string &pool_name,
+                   clio::run::u32 container_id) {
+  clio::run::Container::Init(pool_id, pool_name, container_id);
+  DefineModel(Method::kMaxMethodId);
+  SetMethodNames(Method::GetMethodNames());
+}
+
+void Runtime::Restart(const clio::run::PoolId &pool_id, const std::string &pool_name,
+                      clio::run::u32 container_id) {
+  // Same protocol as the core: flag the warm start BEFORE Init/Create so
+  // Create() rebuilds the index slice from the storage below.
+  is_restart_ = true;
+  Init(pool_id, pool_name, container_id);
+}
+
+clio::run::u64 Runtime::GetWorkRemaining() const { return 0; }
+
+clio::run::TaskResume Runtime::Run(clio::run::u32 method,
+                             clio::run::shared_ptr<clio::run::Task> task_ptr) {
+  CLIO_TASK_BODY_BEGIN
+  switch (method) {
+#define X(MID, TASK, HANDLER)                                       \
+    case Method::MID: {                                             \
+      auto &typed = task_ptr.template Cast<TASK>();                 \
+      CLIO_CO_AWAIT(HANDLER(typed));                                \
+      break;                                                        \
+    }
+    CLIO_INDEXER_FOR_EACH_METHOD(X)
+#undef X
+    default:
+      // Interposition escape: execute any other (core) method on the core
+      // container, verbatim.
+      CLIO_CO_AWAIT(ForwardToCore(method, task_ptr));
+      break;
+  }
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
+void Runtime::SaveTask(clio::run::u32 method, clio::run::SaveTaskArchive &archive,
+                       clio::run::shared_ptr<clio::run::Task> &task_ptr) {
+  switch (method) {
+#define X(MID, TASK, HANDLER)                                  \
+    case Method::MID:                                          \
+      archive << *task_ptr.template Cast<TASK>();              \
+      break;
+    CLIO_INDEXER_FOR_EACH_METHOD(X)
+#undef X
+    default:
+      ForwardSaveTask(method, archive, task_ptr);
+      break;
+  }
+}
+
+void Runtime::LoadTask(clio::run::u32 method, clio::run::LoadTaskArchive &archive,
+                       clio::run::shared_ptr<clio::run::Task> &task_ptr) {
+  switch (method) {
+#define X(MID, TASK, HANDLER)                                  \
+    case Method::MID:                                          \
+      archive >> *task_ptr.template Cast<TASK>();              \
+      break;
+    CLIO_INDEXER_FOR_EACH_METHOD(X)
+#undef X
+    default:
+      ForwardLoadTask(method, archive, task_ptr);
+      break;
+  }
+}
+
+clio::run::shared_ptr<clio::run::Task> Runtime::AllocLoadTask(
+    clio::run::u32 method, clio::run::LoadTaskArchive &archive) {
+  clio::run::shared_ptr<clio::run::Task> task_ptr = NewTask(method);
+  if (!task_ptr.IsNull()) {
+    LoadTask(method, archive, task_ptr);
+  }
+  return task_ptr;
+}
+
+void Runtime::LocalLoadTask(clio::run::u32 method, clio::run::DefaultLoadArchive &archive,
+                            clio::run::shared_ptr<clio::run::Task> &task_ptr) {
+  switch (method) {
+#define X(MID, TASK, HANDLER)                                  \
+    case Method::MID:                                          \
+      archive >> *task_ptr.template Cast<TASK>();              \
+      break;
+    CLIO_INDEXER_FOR_EACH_METHOD(X)
+#undef X
+    default:
+      ForwardLocalLoadTask(method, archive, task_ptr);
+      break;
+  }
+}
+
+clio::run::shared_ptr<clio::run::Task> Runtime::LocalAllocLoadTask(
+    clio::run::u32 method, clio::run::DefaultLoadArchive &archive) {
+  clio::run::shared_ptr<clio::run::Task> task_ptr = NewTask(method);
+  if (!task_ptr.IsNull()) {
+    LocalLoadTask(method, archive, task_ptr);
+  }
+  return task_ptr;
+}
+
+void Runtime::LocalSaveTask(clio::run::u32 method, clio::run::DefaultSaveArchive &archive,
+                            clio::run::shared_ptr<clio::run::Task> &task_ptr) {
+  switch (method) {
+#define X(MID, TASK, HANDLER)                                  \
+    case Method::MID:                                          \
+      archive << *task_ptr.template Cast<TASK>();              \
+      break;
+    CLIO_INDEXER_FOR_EACH_METHOD(X)
+#undef X
+    default:
+      ForwardLocalSaveTask(method, archive, task_ptr);
+      break;
+  }
+}
+
+clio::run::shared_ptr<clio::run::Task> Runtime::NewCopyTask(
+    clio::run::u32 method, clio::run::shared_ptr<clio::run::Task> &orig_task_ptr, bool deep) {
+  auto *ipc_manager = CLIO_IPC;
+  if (!ipc_manager) {
+    return clio::run::shared_ptr<clio::run::Task>();
+  }
+  switch (method) {
+#define X(MID, TASK, HANDLER)                                            \
+    case Method::MID: {                                                  \
+      auto new_task = ipc_manager->NewTask<TASK>();                      \
+      if (!new_task.IsNull()) {                                          \
+        new_task->Copy(ctp::ipc::FullPtr<TASK>(                          \
+            orig_task_ptr.template Cast<TASK>().get()));                 \
+        return new_task.template Cast<clio::run::Task>();                \
+      }                                                                  \
+      break;                                                             \
+    }
+    CLIO_INDEXER_FOR_EACH_METHOD(X)
+#undef X
+    default:
+      return ForwardNewCopyTask(method, orig_task_ptr, deep);
+  }
+  return clio::run::shared_ptr<clio::run::Task>();
+}
+
+clio::run::shared_ptr<clio::run::Task> Runtime::NewTask(clio::run::u32 method) {
+  auto *ipc_manager = CLIO_IPC;
+  if (!ipc_manager) {
+    return clio::run::shared_ptr<clio::run::Task>();
+  }
+  switch (method) {
+#define X(MID, TASK, HANDLER)                                  \
+    case Method::MID:                                          \
+      return ipc_manager->NewTask<TASK>().template Cast<clio::run::Task>();
+    CLIO_INDEXER_FOR_EACH_METHOD(X)
+#undef X
+    default:
+      return ForwardNewTask(method);
+  }
+}
+
+void Runtime::AggregateOut(clio::run::u32 method, clio::run::shared_ptr<clio::run::Task> &orig_task,
+                           const clio::run::shared_ptr<clio::run::Task> &replica_task) {
+  switch (method) {
+#define X(MID, TASK, HANDLER)                                            \
+    case Method::MID:                                                    \
+      orig_task.template Cast<TASK>()->AggregateOut(                     \
+          ctp::ipc::FullPtr<clio::run::Task>(replica_task.get()));       \
+      break;
+    CLIO_INDEXER_FOR_EACH_METHOD(X)
+#undef X
+    default:
+      ForwardAggregateOut(method, orig_task, replica_task);
+      break;
+  }
+}
+
+void Runtime::AggregateIn(clio::run::u32 method, clio::run::shared_ptr<clio::run::Task> &agg_task,
+                          const clio::run::shared_ptr<clio::run::Task> &member_task) {
+  // No ManyToOne methods of our own; forwarded core methods delegate.
+  ForwardAggregateIn(method, agg_task, member_task);
+}
+
+#undef CLIO_INDEXER_FOR_EACH_METHOD
+
+}  // namespace clio::cte::indexer

--- a/context-transfer-engine/indexer/src/indexer_client.cc
+++ b/context-transfer-engine/indexer/src/indexer_client.cc
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// The indexer client is header-only (indexer_client.h); this TU exists so
+// the client library has a compilation unit (same shape as cache/replication).
+#include <clio_cte/indexer/indexer_client.h>

--- a/context-transfer-engine/indexer/src/indexer_runtime.cc
+++ b/context-transfer-engine/indexer/src/indexer_runtime.cc
@@ -1,0 +1,522 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <regex>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <clio_cte/core/blob_batch.h>
+#include <clio_cte/indexer/indexer_runtime.h>
+
+namespace clio::cte::indexer {
+
+namespace {
+
+// Tokenize raw bytes as lowercase alphanumeric runs of length >= 2.
+// MUST stay identical to the tokenization the core's old in-core scan used
+// (issue #905 moved it here verbatim): the python/CAE semantic-search tests
+// assert on its ranking behavior.
+std::vector<std::string> SemSearchTokenize(const char *data, size_t size) {
+  std::vector<std::string> tokens;
+  std::string cur;
+  cur.reserve(16);
+  for (size_t i = 0; i < size; ++i) {
+    unsigned char c = static_cast<unsigned char>(data[i]);
+    if (std::isalnum(c)) {
+      cur.push_back(static_cast<char>(std::tolower(c)));
+    } else {
+      if (cur.size() >= 2) tokens.push_back(std::move(cur));
+      cur.clear();
+    }
+  }
+  if (cur.size() >= 2) tokens.push_back(std::move(cur));
+  return tokens;
+}
+
+}  // namespace
+
+clio::run::TaskResume Runtime::Create(clio::run::shared_ptr<CreateTask> &task) {
+  CLIO_TASK_BODY_BEGIN
+  config_ = task->GetParams();
+  interposer_next_pool_ = config_.next_pool_id_;  // base forwarding target
+  if (!config_.next_pool_id_.IsNull()) {
+    next_client_ =
+        std::make_unique<clio::cte::core::Client>(config_.next_pool_id_);
+  }
+  if (is_restart_) {
+    // Warm start: the storage below restored its own metadata/data before
+    // this pool composed (compose order puts `next` first), so the index
+    // slice can be rebuilt from it before Create acks — searches are
+    // correct from the first post-restart query.
+    CLIO_CO_AWAIT(RebuildIndex());
+  }
+  task->return_code_ = 0;
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
+clio::run::TaskResume Runtime::Destroy(clio::run::shared_ptr<DestroyTask> &task) {
+  CLIO_TASK_BODY_BEGIN
+  {
+    std::lock_guard<std::mutex> lock(index_mutex_);
+    index_.clear();
+    tag_names_.clear();
+  }
+  task->return_code_ = 0;
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
+clio::run::TaskResume Runtime::Monitor(clio::run::shared_ptr<MonitorTask> &task) {
+  CLIO_TASK_BODY_BEGIN
+  task->return_code_ = 0;
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
+clio::cte::core::Client *Runtime::GetNextClient() {
+  if (!next_client_) {
+    next_client_ = std::make_unique<clio::cte::core::Client>(CorePoolId());
+  }
+  return next_client_.get();
+}
+
+// ---------------------------------------------------------------------------
+// Index maintenance
+// ---------------------------------------------------------------------------
+
+clio::run::TaskResume Runtime::ResolveTagName(TagId tag_id,
+                                              std::string *name_out) {
+  CLIO_TASK_BODY_BEGIN
+  {
+    std::lock_guard<std::mutex> lock(index_mutex_);
+    auto it = tag_names_.find(TagKey(tag_id));
+    if (it != tag_names_.end()) {
+      *name_out = it->second;
+      CLIO_CO_RETURN;
+    }
+  }
+  {
+    auto fut = GetNextClient()->AsyncGetTagName(tag_id);
+    CLIO_CO_AWAIT(fut);
+    if (fut->GetReturnCode() == 0 && fut->found_ != 0) {
+      *name_out = fut->tag_name_.str();
+      std::lock_guard<std::mutex> lock(index_mutex_);
+      tag_names_[TagKey(tag_id)] = *name_out;
+    } else {
+      name_out->clear();
+    }
+  }
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
+clio::run::TaskResume Runtime::ReindexBlob(TagId tag_id,
+                                           std::string blob_name) {
+  CLIO_TASK_BODY_BEGIN
+  {
+    auto *ipc_manager = CLIO_CPU_IPC;
+    auto *next = GetNextClient();
+
+    // Current logical size decides index membership: the old in-core scan
+    // skipped zero-length blobs, so an empty (or vanished) blob leaves the
+    // index rather than lingering as an empty doc.
+    clio::run::u64 total = 0;
+    clio::run::u32 size_rc = 0;
+    {
+      auto size_fut = next->AsyncGetBlobSize(tag_id, blob_name,
+                                             clio::run::PoolQuery::Local());
+      CLIO_CO_AWAIT(size_fut);
+      size_rc = size_fut->GetReturnCode();
+      if (size_rc == 0) {
+        total = size_fut->size_;
+      }
+    }
+    if (total == 0) {
+      HLOG(kDebug,
+           "Indexer: blob '{}' (tag {}.{}) not indexable (size rc={}, "
+           "size 0) — dropping from index",
+           blob_name, tag_id.major_, tag_id.minor_, size_rc);
+      std::lock_guard<std::mutex> lock(index_mutex_);
+      index_.erase(DocKey(tag_id, blob_name));
+      CLIO_CO_RETURN;
+    }
+
+    std::string tag_name;
+    CLIO_CO_AWAIT(ResolveTagName(tag_id, &tag_name));
+
+    // Re-read the blob's CURRENT bytes from the chain — always correct for
+    // partial/vectored writes and truncates, at the cost of one read-back
+    // per mutation. The layer below serves the logical (untransformed)
+    // bytes, which is what the tokenizer must see.
+    ctp::ipc::FullPtr<char> buf = ipc_manager->AllocateBuffer(total);
+    if (buf.IsNull()) {
+      HLOG(kWarning,
+           "Indexer: AllocateBuffer({}) failed for blob '{}'; leaving stale "
+           "index entry",
+           total, blob_name);
+      CLIO_CO_RETURN;
+    }
+    clio::run::u32 read_rc = 0;
+    {
+      auto get_fut = next->AsyncGetBlob(tag_id, blob_name, 0, total, 0,
+                                        ctp::ipc::ShmPtr<>(buf.shm_),
+                                        clio::run::PoolQuery::Local());
+      CLIO_CO_AWAIT(get_fut);
+      read_rc = get_fut->GetReturnCode();
+    }
+    if (read_rc != 0) {
+      ipc_manager->FreeBuffer(buf);
+      HLOG(kWarning,
+           "Indexer: GetBlob failed for blob '{}' (rc={}); dropping index "
+           "entry",
+           blob_name, read_rc);
+      std::lock_guard<std::mutex> lock(index_mutex_);
+      index_.erase(DocKey(tag_id, blob_name));
+      CLIO_CO_RETURN;
+    }
+
+    auto tokens = SemSearchTokenize(buf.ptr_, total);
+    ipc_manager->FreeBuffer(buf);
+
+    IndexedDoc doc;
+    doc.tag_id_ = tag_id;
+    doc.tag_name_ = std::move(tag_name);
+    doc.blob_name_ = blob_name;
+    doc.length_ = tokens.size();
+    for (auto &t : tokens) ++doc.tf_[t];
+    {
+      std::lock_guard<std::mutex> lock(index_mutex_);
+      index_[DocKey(tag_id, blob_name)] = std::move(doc);
+    }
+  }
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
+// ---------------------------------------------------------------------------
+// Intercepted mutating verbs: forward FIRST, then keep the index current.
+// ---------------------------------------------------------------------------
+
+clio::run::TaskResume Runtime::PutBlob(
+    clio::run::shared_ptr<clio::cte::core::PutBlobTask> &task) {
+  CLIO_TASK_BODY_BEGIN
+  CLIO_CO_AWAIT(ForwardToCore(clio::cte::core::Method::kPutBlob,
+                              task.template Cast<clio::run::Task>()));
+  // Replica-addressed writes duplicate primary content the index already
+  // tracks (the primary put flowed through here too) — never re-index them.
+  if (task->GetReturnCode() == 0 && task->context_.replica_ == 0) {
+    // blob_name_ is INOUT (the gpu page suffix is composed handler-side),
+    // so read it AFTER the forward.
+    CLIO_CO_AWAIT(ReindexBlob(task->tag_id_, task->blob_name_.str()));
+  }
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
+clio::run::TaskResume Runtime::MultiPutBlob(
+    clio::run::shared_ptr<clio::cte::core::MultiPutBlobTask> &task) {
+  CLIO_TASK_BODY_BEGIN
+  CLIO_CO_AWAIT(ForwardToCore(clio::cte::core::Method::kMultiPutBlob,
+                              task.template Cast<clio::run::Task>()));
+  if (task->GetReturnCode() == 0 && task->context_.replica_ == 0) {
+    std::vector<clio::cte::core::MultiPutDesc> descs =
+        clio::cte::core::DecodeMultiPutDescs(task->descs_);
+    for (size_t i = 0; i < descs.size(); ++i) {
+      CLIO_CO_AWAIT(ReindexBlob(descs[i].tag_id_, descs[i].blob_name_));
+    }
+  }
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
+clio::run::TaskResume Runtime::TruncateBlob(
+    clio::run::shared_ptr<clio::cte::core::TruncateBlobTask> &task) {
+  CLIO_TASK_BODY_BEGIN
+  CLIO_CO_AWAIT(ForwardToCore(clio::cte::core::Method::kTruncateBlob,
+                              task.template Cast<clio::run::Task>()));
+  if (task->GetReturnCode() == 0) {
+    CLIO_CO_AWAIT(ReindexBlob(task->tag_id_, task->blob_name_.str()));
+  }
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
+clio::run::TaskResume Runtime::DelBlob(
+    clio::run::shared_ptr<clio::cte::core::DelBlobTask> &task) {
+  CLIO_TASK_BODY_BEGIN
+  CLIO_CO_AWAIT(ForwardToCore(clio::cte::core::Method::kDelBlob,
+                              task.template Cast<clio::run::Task>()));
+  if (task->GetReturnCode() == 0) {
+    std::lock_guard<std::mutex> lock(index_mutex_);
+    index_.erase(DocKey(task->tag_id_, task->blob_name_.str()));
+  }
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
+clio::run::TaskResume Runtime::DelTag(
+    clio::run::shared_ptr<clio::cte::core::DelTagTask> &task) {
+  CLIO_TASK_BODY_BEGIN
+  CLIO_CO_AWAIT(ForwardToCore(clio::cte::core::Method::kDelTag,
+                              task.template Cast<clio::run::Task>()));
+  // tag_id_ is INOUT (resolved from tag_name_ when given by name), so it is
+  // authoritative after the forward. POSIX-unlink alias survival (the tag
+  // living on under another name) reports a nonzero "kept alive" path via
+  // rc==0 with the tag intact — the conservative move either way is to drop
+  // docs only when the tag is actually gone, which the core signals with
+  // rc==0 on a cascade delete. A dropped-then-still-alive tag would heal on
+  // the next put; a kept-then-deleted tag would serve ghosts, so we only
+  // prune on success.
+  if (task->GetReturnCode() == 0 && !task->tag_id_.IsNull()) {
+    std::lock_guard<std::mutex> lock(index_mutex_);
+    for (auto it = index_.begin(); it != index_.end();) {
+      if (it->second.tag_id_.major_ == task->tag_id_.major_ &&
+          it->second.tag_id_.minor_ == task->tag_id_.minor_) {
+        it = index_.erase(it);
+      } else {
+        ++it;
+      }
+    }
+    tag_names_.erase(TagKey(task->tag_id_));
+  }
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
+clio::run::TaskResume Runtime::RenameTag(
+    clio::run::shared_ptr<clio::cte::core::RenameTagTask> &task) {
+  CLIO_TASK_BODY_BEGIN
+  CLIO_CO_AWAIT(ForwardToCore(clio::cte::core::Method::kRenameTag,
+                              task.template Cast<clio::run::Task>()));
+  if (task->GetReturnCode() == 0 && !task->tag_id_.IsNull()) {
+    std::string new_name = task->new_name_.str();
+    std::lock_guard<std::mutex> lock(index_mutex_);
+    tag_names_[TagKey(task->tag_id_)] = new_name;
+    for (auto &kv : index_) {
+      if (kv.second.tag_id_.major_ == task->tag_id_.major_ &&
+          kv.second.tag_id_.minor_ == task->tag_id_.minor_) {
+        kv.second.tag_name_ = new_name;
+      }
+    }
+  }
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
+// ---------------------------------------------------------------------------
+// SemanticSearch — BM25 over the maintained index (no blob reads).
+// ---------------------------------------------------------------------------
+
+clio::run::TaskResume Runtime::SemanticSearch(
+    clio::run::shared_ptr<clio::cte::core::SemanticSearchTask> &task) {
+  CLIO_TASK_BODY_BEGIN
+  task->results_.clear();
+  task->return_code_ = 0;
+  {
+    std::string tag_regex_str = task->tag_regex_.str();
+    std::string blob_regex_str = task->blob_regex_.str();
+    std::string query_text = task->query_text_.str();
+    clio::run::u32 k = task->k_;
+
+    std::regex tag_pattern;
+    std::regex blob_pattern;
+    try {
+      tag_pattern = std::regex(tag_regex_str);
+      blob_pattern = std::regex(blob_regex_str);
+    } catch (const std::regex_error &e) {
+      HLOG(kError, "Indexer SemanticSearch: bad regex (tag='{}' blob='{}'): {}",
+           tag_regex_str, blob_regex_str, e.what());
+      task->return_code_ = 1;
+      CLIO_CO_RETURN;
+    }
+
+    // The matched working set: same regex_match (full-string) semantics as
+    // the core's old scan, evaluated against the index instead of the
+    // metadata maps. Tag-name matches are cached per tag within the pass.
+    struct MatchedDoc {
+      const IndexedDoc *doc;
+    };
+    std::vector<MatchedDoc> matched;
+    std::unordered_map<clio::run::u64, bool> tag_match_memo;
+    {
+      std::lock_guard<std::mutex> lock(index_mutex_);
+      for (const auto &kv : index_) {
+        const IndexedDoc &doc = kv.second;
+        clio::run::u64 tkey = TagKey(doc.tag_id_);
+        auto memo = tag_match_memo.find(tkey);
+        bool tag_ok;
+        if (memo != tag_match_memo.end()) {
+          tag_ok = memo->second;
+        } else {
+          tag_ok = std::regex_match(doc.tag_name_, tag_pattern);
+          tag_match_memo.emplace(tkey, tag_ok);
+        }
+        if (!tag_ok) continue;
+        if (!std::regex_match(doc.blob_name_, blob_pattern)) continue;
+        matched.push_back({&doc});
+      }
+
+      // BM25 with corpus statistics over the matched slice only — "rank
+      // within this regex" semantics, identical constants and math to the
+      // core's old implementation (k1=1.5 / b=0.75 Okapi defaults). Scoring
+      // runs under the index lock (pointers into index_ stay valid); it is
+      // pure in-memory arithmetic, no awaits.
+      if (!matched.empty()) {
+        constexpr double kK1 = 1.5;
+        constexpr double kB = 0.75;
+        std::unordered_map<std::string, int> df;
+        double total_len = 0.0;
+        for (const auto &m : matched) {
+          total_len += static_cast<double>(m.doc->length_);
+          for (const auto &kv2 : m.doc->tf_) df[kv2.first]++;
+        }
+        double avgdl = total_len / static_cast<double>(matched.size());
+        if (avgdl <= 0.0) avgdl = 1.0;
+        const size_t N = matched.size();
+
+        auto qtokens = SemSearchTokenize(query_text.data(), query_text.size());
+        std::unordered_set<std::string> uniq_q(qtokens.begin(), qtokens.end());
+
+        std::vector<clio::cte::core::SemanticSearchResult> scored;
+        scored.reserve(matched.size());
+        for (const auto &m : matched) {
+          const IndexedDoc &d = *m.doc;
+          double score = 0.0;
+          for (const auto &q : uniq_q) {
+            auto df_it = df.find(q);
+            if (df_it == df.end()) continue;
+            auto tf_it = d.tf_.find(q);
+            if (tf_it == d.tf_.end()) continue;
+            double df_q = static_cast<double>(df_it->second);
+            double idf = std::log((static_cast<double>(N) - df_q + 0.5) /
+                                      (df_q + 0.5) +
+                                  1.0);
+            double tf_q = static_cast<double>(tf_it->second);
+            double norm =
+                1.0 - kB + kB * (static_cast<double>(d.length_) / avgdl);
+            score += idf * (tf_q * (kK1 + 1.0)) / (tf_q + kK1 * norm);
+          }
+          scored.emplace_back(d.tag_id_, d.tag_name_, d.blob_name_, score);
+        }
+
+        std::sort(scored.begin(), scored.end(),
+                  [](const clio::cte::core::SemanticSearchResult &a,
+                     const clio::cte::core::SemanticSearchResult &b) {
+                    return a.score_ > b.score_;
+                  });
+        if (k > 0 && scored.size() > k) scored.resize(k);
+        task->results_ = std::move(scored);
+      }
+    }
+    HLOG(kDebug,
+         "Indexer SemanticSearch: tag='{}' blob='{}' query='{}' -> {} results "
+         "(index size {})",
+         tag_regex_str, blob_regex_str, query_text, task->results_.size(),
+         index_.size());
+  }
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
+// ---------------------------------------------------------------------------
+// Restart: rebuild the index slice from the storage below.
+// ---------------------------------------------------------------------------
+
+clio::run::TaskResume Runtime::RebuildIndex() {
+  CLIO_TASK_BODY_BEGIN
+  {
+    auto *next = GetNextClient();
+
+    // Enumerate THIS node's (tag, blob) pairs: Local keeps each container's
+    // rebuild to the slice its co-located core container owns, matching the
+    // interposer's owner-delegated routing (every container rebuilds its own
+    // shard; a Broadcast here would index every blob on every node).
+    std::vector<std::string> tag_names;
+    std::vector<std::string> blob_names;
+    {
+      auto query_fut = next->AsyncBlobQuery(".*", ".*", 0,
+                                            clio::run::PoolQuery::Local());
+      CLIO_CO_AWAIT(query_fut);
+      if (query_fut->GetReturnCode() != 0) {
+        HLOG(kError, "Indexer: restart BlobQuery failed (rc={}); index "
+             "starts empty", query_fut->GetReturnCode());
+        CLIO_CO_RETURN;
+      }
+      tag_names = query_fut->tag_names_;
+      blob_names = query_fut->blob_names_;
+    }
+
+    clio::run::u64 indexed = 0;
+    for (size_t i = 0; i < tag_names.size() && i < blob_names.size(); ++i) {
+      // Resolve the tag's id (GetOrCreateTag on an existing tag is a pure
+      // lookup — the tag survived the restart via the core's own WAL).
+      TagId tag_id = TagId::GetNull();
+      {
+        auto tag_fut = next->AsyncGetOrCreateTag(tag_names[i]);
+        CLIO_CO_AWAIT(tag_fut);
+        if (tag_fut->GetReturnCode() != 0) {
+          HLOG(kWarning, "Indexer: restart tag resolve failed for '{}'",
+               tag_names[i]);
+          continue;
+        }
+        tag_id = tag_fut->tag_id_;
+      }
+      HLOG(kDebug, "Indexer: restart re-index '{}' (tag '{}' -> {}.{})",
+           blob_names[i], tag_names[i], tag_id.major_, tag_id.minor_);
+      {
+        std::lock_guard<std::mutex> lock(index_mutex_);
+        tag_names_[TagKey(tag_id)] = tag_names[i];
+      }
+      // ReindexBlob skips what storage cannot serve anymore: blobs whose
+      // bytes lived only on volatile (RAM) tiers lost them in the reboot,
+      // and the index must agree with what GetBlob can actually return.
+      CLIO_CO_AWAIT(ReindexBlob(tag_id, blob_names[i]));
+      ++indexed;
+    }
+    HLOG(kInfo, "Indexer: restart rebuild complete — {} blobs processed, "
+         "index size {}", indexed, index_.size());
+  }
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
+}  // namespace clio::cte::indexer
+
+CLIO_TASK_CC(clio::cte::indexer::Runtime)

--- a/context-transfer-engine/indexer/src/indexer_runtime.cc
+++ b/context-transfer-engine/indexer/src/indexer_runtime.cc
@@ -32,6 +32,7 @@
  */
 
 #include <algorithm>
+#include <array>
 #include <cctype>
 #include <cmath>
 #include <regex>
@@ -48,18 +49,85 @@ namespace clio::cte::indexer {
 
 namespace {
 
+/**
+ * Execute a freshly-built core-vocabulary task on the co-located core
+ * container as a NESTED call on the current fiber — the same mechanism
+ * ForwardToCore uses for interposed traffic, applied to the indexer's own
+ * sub-ops (size probe / read-back / tag-name resolve).
+ *
+ * This exists because the first cut issued these through the CLIENT API
+ * from inside the runtime: every re-index paid 2-3 full task
+ * dispatch/queue/schedule/complete round-trips whose payload was a local
+ * metadata lookup — the same cost profile CLIO_RUN_INLINE (#862) documents
+ * for puts, and the dominant term in the indexer's measured put overhead.
+ * Unlike CLIO_RUN_INLINE this is not env-gated: an interposer executing on
+ * its next pool's local container is the sanctioned chain mechanism, not an
+ * opt-in optimization.
+ *
+ * Same synthesized-completed-future shape as detail::RunInlineOrSend.
+ */
+template <typename TaskT>
+clio::run::TaskResume RunOnCore(clio::run::ContainerHold core,
+                                clio::run::u32 method,
+                                clio::run::shared_ptr<TaskT> &task) {
+  CLIO_TASK_BODY_BEGIN
+  {
+    if (core == nullptr) {
+      task->SetReturnCode(1);
+      CLIO_CO_RETURN;
+    }
+    task->BeginRunContext();
+    clio::run::Future<TaskT> fut(task->pool_id_, task->method_, task);
+    fut.GetFutureShm()->origin_ = clio::run::ClientOrigin::kClientShm;
+    task->RunFuture() = fut.template Cast<clio::run::Task>();
+    clio::run::shared_ptr<clio::run::Task> base =
+        task.template Cast<clio::run::Task>();
+    CLIO_CO_AWAIT(core->Run(method, base));
+    task->SetComplete();
+  }
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
+/** CLIO_INDEXER_PASSIVE=1: forward-only interposition — no index
+ *  maintenance at all. Kill switch for production triage and the measured
+ *  baseline separating interposition cost from indexing cost. */
+bool IndexerPassive() {
+  static const bool v = std::getenv("CLIO_INDEXER_PASSIVE") != nullptr;
+  return v;
+}
+
 // Tokenize raw bytes as lowercase alphanumeric runs of length >= 2.
-// MUST stay identical to the tokenization the core's old in-core scan used
-// (issue #905 moved it here verbatim): the python/CAE semantic-search tests
-// assert on its ranking behavior.
+// Classification semantics MUST stay identical to the core's old in-core
+// scan (C-locale isalnum/tolower over ASCII): the python/CAE semantic-search
+// tests assert on its ranking behavior. Unlike the old scan this runs on
+// EVERY put, so the per-byte cost is the put path's floor — the locale
+// isalnum()/tolower() calls it used were ~3-10ns/byte (measured ~350MB/s put
+// ceiling); the precomputed table below classifies+lowers in one L1 load.
+// 0 = not a token byte; else the lowercased byte.
+const unsigned char *SemSearchByteTable() {
+  // C-locale alnum only: '0'-'9', 'A'-'Z' (lowered), 'a'-'z'. High bytes
+  // stay 0 — matching C-locale isalnum on this runtime's daemons.
+  static const std::array<unsigned char, 256> table = [] {
+    std::array<unsigned char, 256> t{};
+    for (int c = '0'; c <= '9'; ++c) t[c] = static_cast<unsigned char>(c);
+    for (int c = 'a'; c <= 'z'; ++c) t[c] = static_cast<unsigned char>(c);
+    for (int c = 'A'; c <= 'Z'; ++c)
+      t[c] = static_cast<unsigned char>(c - 'A' + 'a');
+    return t;
+  }();
+  return table.data();
+}
+
 std::vector<std::string> SemSearchTokenize(const char *data, size_t size) {
+  const unsigned char *tbl = SemSearchByteTable();
   std::vector<std::string> tokens;
   std::string cur;
   cur.reserve(16);
   for (size_t i = 0; i < size; ++i) {
-    unsigned char c = static_cast<unsigned char>(data[i]);
-    if (std::isalnum(c)) {
-      cur.push_back(static_cast<char>(std::tolower(c)));
+    unsigned char mapped = tbl[static_cast<unsigned char>(data[i])];
+    if (mapped != 0) {
+      cur.push_back(static_cast<char>(mapped));
     } else {
       if (cur.size() >= 2) tokens.push_back(std::move(cur));
       cur.clear();
@@ -79,6 +147,21 @@ clio::run::TaskResume Runtime::Create(clio::run::shared_ptr<CreateTask> &task) {
     next_client_ =
         std::make_unique<clio::cte::core::Client>(config_.next_pool_id_);
   }
+  // Background progress for the asynchronous index drain (same periodic
+  // pattern as replication's write-through sweep). Searches drain
+  // synchronously regardless — the sweep only bounds how stale the index
+  // can sit between searches.
+  if (config_.index_sweep_period_ms_ > 0) {
+    auto *ipc = CLIO_CPU_IPC;
+    auto sweep = ipc->NewTask<IndexSweepTask>(
+        clio::run::CreateTaskId(), pool_id_, clio::run::PoolQuery::Local());
+    sweep->SetPeriod(static_cast<double>(config_.index_sweep_period_ms_),
+                     clio::run::kMilli);
+    sweep->SetFlags(TASK_PERIODIC);  // SetPeriod alone does not mark it
+    ipc->Send(sweep);
+    HLOG(kInfo, "Indexer: async index sweep every {} ms",
+         config_.index_sweep_period_ms_);
+  }
   if (is_restart_) {
     // Warm start: the storage below restored its own metadata/data before
     // this pool composed (compose order puts `next` first), so the index
@@ -97,6 +180,7 @@ clio::run::TaskResume Runtime::Destroy(clio::run::shared_ptr<DestroyTask> &task)
     std::lock_guard<std::mutex> lock(index_mutex_);
     index_.clear();
     tag_names_.clear();
+    pending_.clear();
   }
   task->return_code_ = 0;
   CLIO_CO_RETURN;
@@ -133,10 +217,18 @@ clio::run::TaskResume Runtime::ResolveTagName(TagId tag_id,
     }
   }
   {
-    auto fut = GetNextClient()->AsyncGetTagName(tag_id);
-    CLIO_CO_AWAIT(fut);
-    if (fut->GetReturnCode() == 0 && fut->found_ != 0) {
-      *name_out = fut->tag_name_.str();
+    // Nested inline run on the co-located core: tag metadata is a local map
+    // lookup; a client round-trip here costs more than the lookup itself.
+    // Broadcast is unnecessary — every chain container is one-per-node and
+    // the tag either resolves locally or the name stays uncached until a
+    // path that can see it (rebuild seeds the cache from BlobQuery names).
+    auto task = CLIO_CPU_IPC->NewTask<clio::cte::core::GetTagNameTask>(
+        clio::run::CreateTaskId(), CorePoolId(), clio::run::PoolQuery::Local(),
+        tag_id);
+    CLIO_CO_AWAIT(RunOnCore(CoreContainer(),
+                            clio::cte::core::Method::kGetTagName, task));
+    if (task->GetReturnCode() == 0 && task->found_ != 0) {
+      *name_out = task->tag_name_.str();
       std::lock_guard<std::mutex> lock(index_mutex_);
       tag_names_[TagKey(tag_id)] = *name_out;
     } else {
@@ -147,32 +239,52 @@ clio::run::TaskResume Runtime::ResolveTagName(TagId tag_id,
   CLIO_TASK_BODY_END
 }
 
+clio::run::TaskResume Runtime::ProbeBlobSize(TagId tag_id,
+                                             const std::string &blob_name,
+                                             clio::run::u64 *total_out) {
+  CLIO_TASK_BODY_BEGIN
+  {
+    auto task = CLIO_CPU_IPC->NewTask<clio::cte::core::GetBlobSizeTask>(
+        clio::run::CreateTaskId(), CorePoolId(), clio::run::PoolQuery::Local(),
+        tag_id, blob_name, 0);
+    CLIO_CO_AWAIT(RunOnCore(CoreContainer(),
+                            clio::cte::core::Method::kGetBlobSize, task));
+    *total_out = task->GetReturnCode() == 0 ? task->size_ : 0;
+  }
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
+void Runtime::IndexDocBytes(const TagId &tag_id, const std::string &tag_name,
+                            const std::string &blob_name, const char *data,
+                            clio::run::u64 len) {
+  auto tokens = SemSearchTokenize(data, len);
+  IndexedDoc doc;
+  doc.tag_id_ = tag_id;
+  doc.tag_name_ = tag_name;
+  doc.blob_name_ = blob_name;
+  doc.length_ = tokens.size();
+  for (auto &t : tokens) ++doc.tf_[t];
+  std::lock_guard<std::mutex> lock(index_mutex_);
+  index_[DocKey(tag_id, blob_name)] = std::move(doc);
+}
+
 clio::run::TaskResume Runtime::ReindexBlob(TagId tag_id,
                                            std::string blob_name) {
   CLIO_TASK_BODY_BEGIN
   {
     auto *ipc_manager = CLIO_CPU_IPC;
-    auto *next = GetNextClient();
 
     // Current logical size decides index membership: the old in-core scan
     // skipped zero-length blobs, so an empty (or vanished) blob leaves the
     // index rather than lingering as an empty doc.
     clio::run::u64 total = 0;
-    clio::run::u32 size_rc = 0;
-    {
-      auto size_fut = next->AsyncGetBlobSize(tag_id, blob_name,
-                                             clio::run::PoolQuery::Local());
-      CLIO_CO_AWAIT(size_fut);
-      size_rc = size_fut->GetReturnCode();
-      if (size_rc == 0) {
-        total = size_fut->size_;
-      }
-    }
+    CLIO_CO_AWAIT(ProbeBlobSize(tag_id, blob_name, &total));
     if (total == 0) {
       HLOG(kDebug,
-           "Indexer: blob '{}' (tag {}.{}) not indexable (size rc={}, "
-           "size 0) — dropping from index",
-           blob_name, tag_id.major_, tag_id.minor_, size_rc);
+           "Indexer: blob '{}' (tag {}.{}) not indexable (size 0 or stat "
+           "failed) — dropping from index",
+           blob_name, tag_id.major_, tag_id.minor_);
       std::lock_guard<std::mutex> lock(index_mutex_);
       index_.erase(DocKey(tag_id, blob_name));
       CLIO_CO_RETURN;
@@ -181,10 +293,11 @@ clio::run::TaskResume Runtime::ReindexBlob(TagId tag_id,
     std::string tag_name;
     CLIO_CO_AWAIT(ResolveTagName(tag_id, &tag_name));
 
-    // Re-read the blob's CURRENT bytes from the chain — always correct for
-    // partial/vectored writes and truncates, at the cost of one read-back
-    // per mutation. The layer below serves the logical (untransformed)
-    // bytes, which is what the tokenizer must see.
+    // Re-read the blob's CURRENT bytes from the chain — the always-correct
+    // fallback for partial/vectored writes and truncates (whole-blob puts
+    // never come here; they tokenize straight from the task payload). The
+    // read runs as a nested inline call on the core container: no client
+    // round-trip, no queue hop.
     ctp::ipc::FullPtr<char> buf = ipc_manager->AllocateBuffer(total);
     if (buf.IsNull()) {
       HLOG(kWarning,
@@ -195,11 +308,14 @@ clio::run::TaskResume Runtime::ReindexBlob(TagId tag_id,
     }
     clio::run::u32 read_rc = 0;
     {
-      auto get_fut = next->AsyncGetBlob(tag_id, blob_name, 0, total, 0,
-                                        ctp::ipc::ShmPtr<>(buf.shm_),
-                                        clio::run::PoolQuery::Local());
-      CLIO_CO_AWAIT(get_fut);
-      read_rc = get_fut->GetReturnCode();
+      auto get_task = ipc_manager->NewTask<clio::cte::core::GetBlobTask>(
+          clio::run::CreateTaskId(), CorePoolId(),
+          clio::run::PoolQuery::Local(), tag_id, blob_name.c_str(),
+          static_cast<clio::run::u64>(0), total, static_cast<clio::run::u32>(0),
+          ctp::ipc::ShmPtr<>(buf.shm_), clio::cte::core::Context());
+      CLIO_CO_AWAIT(RunOnCore(CoreContainer(),
+                              clio::cte::core::Method::kGetBlob, get_task));
+      read_rc = get_task->GetReturnCode();
     }
     if (read_rc != 0) {
       ipc_manager->FreeBuffer(buf);
@@ -212,26 +328,74 @@ clio::run::TaskResume Runtime::ReindexBlob(TagId tag_id,
       CLIO_CO_RETURN;
     }
 
-    auto tokens = SemSearchTokenize(buf.ptr_, total);
+    IndexDocBytes(tag_id, tag_name, blob_name, buf.ptr_, total);
     ipc_manager->FreeBuffer(buf);
-
-    IndexedDoc doc;
-    doc.tag_id_ = tag_id;
-    doc.tag_name_ = std::move(tag_name);
-    doc.blob_name_ = blob_name;
-    doc.length_ = tokens.size();
-    for (auto &t : tokens) ++doc.tf_[t];
-    {
-      std::lock_guard<std::mutex> lock(index_mutex_);
-      index_[DocKey(tag_id, blob_name)] = std::move(doc);
-    }
   }
   CLIO_CO_RETURN;
   CLIO_TASK_BODY_END
 }
 
+void Runtime::EnqueuePending(const TagId &tag_id,
+                             const std::string &blob_name) {
+  std::lock_guard<std::mutex> lock(index_mutex_);
+  pending_[DocKey(tag_id, blob_name)] = PendingReindex{tag_id, blob_name};
+}
+
+clio::run::TaskResume Runtime::DrainPendingIndex() {
+  CLIO_TASK_BODY_BEGIN
+  for (;;) {
+    bool have = false;
+    bool wait = false;
+    TagId tag_id = TagId::GetNull();
+    std::string blob_name;
+    {
+      std::lock_guard<std::mutex> lock(index_mutex_);
+      if (!pending_.empty()) {
+        auto it = pending_.begin();
+        tag_id = it->second.tag_id_;
+        blob_name = std::move(it->second.blob_name_);
+        pending_.erase(it);
+        ++draining_;
+        have = true;
+      } else if (draining_ != 0) {
+        // Another drainer is mid-entry: the barrier must outlast it.
+        wait = true;
+      }
+    }
+    if (have) {
+      CLIO_CO_AWAIT(ReindexBlob(tag_id, blob_name));
+      std::lock_guard<std::mutex> lock(index_mutex_);
+      --draining_;
+      continue;
+    }
+    if (wait) {
+      CLIO_CO_AWAIT(clio::run::yield(50));
+      continue;
+    }
+    break;  // pending empty and nothing in flight
+  }
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
+clio::run::TaskResume Runtime::IndexSweep(
+    clio::run::shared_ptr<IndexSweepTask> &task) {
+  CLIO_TASK_BODY_BEGIN
+  CLIO_CO_AWAIT(DrainPendingIndex());
+  task->return_code_ = 0;
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
 // ---------------------------------------------------------------------------
-// Intercepted mutating verbs: forward FIRST, then keep the index current.
+// Intercepted mutating verbs: forward FIRST, then mark the doc dirty.
+// Indexing is ASYNCHRONOUS (issue #905 perf): the ack path's only cost is
+// an O(1) coalesced enqueue — the measured synchronous alternatives were
+// put-throughput disasters (client-hop read-backs ~350MB/s; even a
+// payload-direct inline tokenize capped puts at the scanner's ~0.7GB/s).
+// The drain (sweep task or a search's barrier) re-reads CURRENT bytes per
+// dirty key, so N overwrites cost one scan and the index converges to the
+// latest content.
 // ---------------------------------------------------------------------------
 
 clio::run::TaskResume Runtime::PutBlob(
@@ -241,10 +405,11 @@ clio::run::TaskResume Runtime::PutBlob(
                               task.template Cast<clio::run::Task>()));
   // Replica-addressed writes duplicate primary content the index already
   // tracks (the primary put flowed through here too) — never re-index them.
-  if (task->GetReturnCode() == 0 && task->context_.replica_ == 0) {
+  if (task->GetReturnCode() == 0 && task->context_.replica_ == 0 &&
+      !IndexerPassive()) {
     // blob_name_ is INOUT (the gpu page suffix is composed handler-side),
     // so read it AFTER the forward.
-    CLIO_CO_AWAIT(ReindexBlob(task->tag_id_, task->blob_name_.str()));
+    EnqueuePending(task->tag_id_, task->blob_name_.str());
   }
   CLIO_CO_RETURN;
   CLIO_TASK_BODY_END
@@ -255,11 +420,12 @@ clio::run::TaskResume Runtime::MultiPutBlob(
   CLIO_TASK_BODY_BEGIN
   CLIO_CO_AWAIT(ForwardToCore(clio::cte::core::Method::kMultiPutBlob,
                               task.template Cast<clio::run::Task>()));
-  if (task->GetReturnCode() == 0 && task->context_.replica_ == 0) {
+  if (task->GetReturnCode() == 0 && task->context_.replica_ == 0 &&
+      !IndexerPassive()) {
     std::vector<clio::cte::core::MultiPutDesc> descs =
         clio::cte::core::DecodeMultiPutDescs(task->descs_);
     for (size_t i = 0; i < descs.size(); ++i) {
-      CLIO_CO_AWAIT(ReindexBlob(descs[i].tag_id_, descs[i].blob_name_));
+      EnqueuePending(descs[i].tag_id_, descs[i].blob_name_);
     }
   }
   CLIO_CO_RETURN;
@@ -271,8 +437,8 @@ clio::run::TaskResume Runtime::TruncateBlob(
   CLIO_TASK_BODY_BEGIN
   CLIO_CO_AWAIT(ForwardToCore(clio::cte::core::Method::kTruncateBlob,
                               task.template Cast<clio::run::Task>()));
-  if (task->GetReturnCode() == 0) {
-    CLIO_CO_AWAIT(ReindexBlob(task->tag_id_, task->blob_name_.str()));
+  if (task->GetReturnCode() == 0 && !IndexerPassive()) {
+    EnqueuePending(task->tag_id_, task->blob_name_.str());
   }
   CLIO_CO_RETURN;
   CLIO_TASK_BODY_END
@@ -285,7 +451,9 @@ clio::run::TaskResume Runtime::DelBlob(
                               task.template Cast<clio::run::Task>()));
   if (task->GetReturnCode() == 0) {
     std::lock_guard<std::mutex> lock(index_mutex_);
-    index_.erase(DocKey(task->tag_id_, task->blob_name_.str()));
+    std::string key = DocKey(task->tag_id_, task->blob_name_.str());
+    index_.erase(key);
+    pending_.erase(key);
   }
   CLIO_CO_RETURN;
   CLIO_TASK_BODY_END
@@ -310,6 +478,14 @@ clio::run::TaskResume Runtime::DelTag(
       if (it->second.tag_id_.major_ == task->tag_id_.major_ &&
           it->second.tag_id_.minor_ == task->tag_id_.minor_) {
         it = index_.erase(it);
+      } else {
+        ++it;
+      }
+    }
+    for (auto it = pending_.begin(); it != pending_.end();) {
+      if (it->second.tag_id_.major_ == task->tag_id_.major_ &&
+          it->second.tag_id_.minor_ == task->tag_id_.minor_) {
+        it = pending_.erase(it);
       } else {
         ++it;
       }
@@ -349,6 +525,9 @@ clio::run::TaskResume Runtime::SemanticSearch(
   CLIO_TASK_BODY_BEGIN
   task->results_.clear();
   task->return_code_ = 0;
+  // Read-your-writes barrier: indexing is asynchronous, so bring the index
+  // current with every acked mutation BEFORE evaluating the query.
+  CLIO_CO_AWAIT(DrainPendingIndex());
   {
     std::string tag_regex_str = task->tag_regex_.str();
     std::string blob_regex_str = task->blob_regex_.str();

--- a/context-transfer-engine/indexer/src/indexer_runtime.cc
+++ b/context-transfer-engine/indexer/src/indexer_runtime.cc
@@ -35,6 +35,7 @@
 #include <array>
 #include <cctype>
 #include <cmath>
+#include <cstring>
 #include <regex>
 #include <string>
 #include <unordered_map>
@@ -147,6 +148,36 @@ clio::run::TaskResume Runtime::Create(clio::run::shared_ptr<CreateTask> &task) {
     next_client_ =
         std::make_unique<clio::cte::core::Client>(config_.next_pool_id_);
   }
+  // Compile the module scope once. A bad regex disables scoping open
+  // (index everything) rather than failing the pool — config is
+  // best-effort, matching LoadConfig.
+  scope_match_all_ = config_.tag_re_ == ".*" && config_.blob_re_ == ".*";
+  try {
+    scope_tag_re_ = std::regex(config_.tag_re_);
+    scope_blob_re_ = std::regex(config_.blob_re_);
+  } catch (const std::regex_error &e) {
+    HLOG(kError, "Indexer: bad scope regex (tag='{}' blob='{}'): {} — "
+         "indexing everything", config_.tag_re_, config_.blob_re_, e.what());
+    scope_match_all_ = true;
+  }
+  // Persistence (issue #905): restore snapshot + WAL — a restart NEVER
+  // rescans storage. Restore-then-compact leaves a fresh snapshot and an
+  // empty WAL; the append stream opens after compaction.
+  if (!config_.index_log_path_.empty()) {
+    std::lock_guard<std::mutex> lock(index_mutex_);
+    if (RestoreIndex()) {
+      HLOG(kInfo, "Indexer: restored {} docs ({} pending) from {}",
+           index_.size(), pending_.size(), config_.index_log_path_);
+    }
+    SnapshotIndex();  // compact: snapshot current state, truncate WAL
+    wal_.open(config_.index_log_path_ + ".wal",
+              std::ios::binary | std::ios::app);
+    wal_bytes_ = 0;
+    if (!wal_.is_open()) {
+      HLOG(kError, "Indexer: cannot open WAL at {}.wal — persistence OFF",
+           config_.index_log_path_);
+    }
+  }
   // Background progress for the asynchronous index drain (same periodic
   // pattern as replication's write-through sweep). Searches drain
   // synchronously regardless — the sweep only bounds how stale the index
@@ -162,13 +193,6 @@ clio::run::TaskResume Runtime::Create(clio::run::shared_ptr<CreateTask> &task) {
     HLOG(kInfo, "Indexer: async index sweep every {} ms",
          config_.index_sweep_period_ms_);
   }
-  if (is_restart_) {
-    // Warm start: the storage below restored its own metadata/data before
-    // this pool composed (compose order puts `next` first), so the index
-    // slice can be rebuilt from it before Create acks — searches are
-    // correct from the first post-restart query.
-    CLIO_CO_AWAIT(RebuildIndex());
-  }
   task->return_code_ = 0;
   CLIO_CO_RETURN;
   CLIO_TASK_BODY_END
@@ -178,9 +202,15 @@ clio::run::TaskResume Runtime::Destroy(clio::run::shared_ptr<DestroyTask> &task)
   CLIO_TASK_BODY_BEGIN
   {
     std::lock_guard<std::mutex> lock(index_mutex_);
+    // Clean shutdown: persist EVERYTHING including still-dirty keys, so the
+    // next boot resumes exactly here (the restored pending set re-drains).
+    SnapshotIndex();
+    if (wal_.is_open()) wal_.close();
     index_.clear();
     tag_names_.clear();
     pending_.clear();
+    pending_tag_backfills_.clear();
+    tags_seen_.clear();
   }
   task->return_code_ = 0;
   CLIO_CO_RETURN;
@@ -199,6 +229,348 @@ clio::cte::core::Client *Runtime::GetNextClient() {
     next_client_ = std::make_unique<clio::cte::core::Client>(CorePoolId());
   }
   return next_client_.get();
+}
+
+// ---------------------------------------------------------------------------
+// Persistence: snapshot + append WAL (issue #905). Binary, versioned magic,
+// same hand-rolled discipline as the core's FlushMetadata/TransactionLog.
+// All writers assume index_mutex_ is HELD by the caller (they record a
+// mutation made under that lock). Restart restores; it never rescans.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+constexpr char kIdxMagic[8] = {'C', 'L', 'I', 'O', 'I', 'D', 'X', '1'};
+enum IdxWalType : unsigned char {
+  kWalDoc = 1,
+  kWalDelDoc = 2,
+  kWalDelTag = 3,
+  kWalRenameTag = 4,
+  kWalTagSeen = 5,
+};
+
+template <typename T>
+void WPod(std::ofstream &os, const T &v) {
+  os.write(reinterpret_cast<const char *>(&v), sizeof(T));
+}
+void WStr(std::ofstream &os, const std::string &s) {
+  auto len = static_cast<clio::run::u32>(s.size());
+  WPod(os, len);
+  os.write(s.data(), len);
+}
+template <typename T>
+bool RPod(std::ifstream &is, T *v) {
+  is.read(reinterpret_cast<char *>(v), sizeof(T));
+  return is.good();
+}
+bool RStr(std::ifstream &is, std::string *s) {
+  clio::run::u32 len = 0;
+  if (!RPod(is, &len)) return false;
+  s->resize(len);
+  is.read(s->data(), len);
+  return is.good() || (len == 0 && !is.bad());
+}
+
+/** Anchor a literal tag name as a full-match regex. */
+std::string EscapeRegex(const std::string &raw) {
+  std::string out;
+  out.reserve(raw.size() + 8);
+  for (char c : raw) {
+    if (std::strchr("\\^$.|?*+()[]{}", c) != nullptr) out.push_back('\\');
+    out.push_back(c);
+  }
+  return out;
+}
+
+}  // namespace
+
+void Runtime::WalAppendDoc(const IndexedDoc &doc) {
+  if (!wal_.is_open()) return;
+  WPod(wal_, static_cast<unsigned char>(kWalDoc));
+  WPod(wal_, doc.tag_id_.major_);
+  WPod(wal_, doc.tag_id_.minor_);
+  WStr(wal_, doc.tag_name_);
+  WStr(wal_, doc.blob_name_);
+  WPod(wal_, static_cast<clio::run::u64>(doc.length_));
+  WPod(wal_, static_cast<clio::run::u32>(doc.tf_.size()));
+  for (const auto &kv : doc.tf_) {
+    WStr(wal_, kv.first);
+    WPod(wal_, static_cast<clio::run::u32>(kv.second));
+  }
+  wal_.flush();
+  wal_bytes_ += 32 + doc.tag_name_.size() + doc.blob_name_.size() +
+                doc.tf_.size() * 12;
+}
+
+void Runtime::WalAppendDelDoc(const TagId &tag_id,
+                              const std::string &blob_name) {
+  if (!wal_.is_open()) return;
+  WPod(wal_, static_cast<unsigned char>(kWalDelDoc));
+  WPod(wal_, tag_id.major_);
+  WPod(wal_, tag_id.minor_);
+  WStr(wal_, blob_name);
+  wal_.flush();
+  wal_bytes_ += 16 + blob_name.size();
+}
+
+void Runtime::WalAppendDelTag(const TagId &tag_id) {
+  if (!wal_.is_open()) return;
+  WPod(wal_, static_cast<unsigned char>(kWalDelTag));
+  WPod(wal_, tag_id.major_);
+  WPod(wal_, tag_id.minor_);
+  wal_.flush();
+  wal_bytes_ += 9;
+}
+
+void Runtime::WalAppendRenameTag(const TagId &tag_id,
+                                 const std::string &new_name) {
+  if (!wal_.is_open()) return;
+  WPod(wal_, static_cast<unsigned char>(kWalRenameTag));
+  WPod(wal_, tag_id.major_);
+  WPod(wal_, tag_id.minor_);
+  WStr(wal_, new_name);
+  wal_.flush();
+  wal_bytes_ += 16 + new_name.size();
+}
+
+void Runtime::WalAppendTagSeen(const TagId &tag_id) {
+  if (!wal_.is_open()) return;
+  WPod(wal_, static_cast<unsigned char>(kWalTagSeen));
+  WPod(wal_, tag_id.major_);
+  WPod(wal_, tag_id.minor_);
+  wal_.flush();
+  wal_bytes_ += 9;
+}
+
+void Runtime::SnapshotIndex() {
+  if (config_.index_log_path_.empty()) return;
+  const bool reopen = wal_.is_open();
+  if (reopen) wal_.close();
+  {
+    std::ofstream snap(config_.index_log_path_,
+                       std::ios::binary | std::ios::trunc);
+    if (!snap.is_open()) {
+      HLOG(kError, "Indexer: cannot write snapshot at {}",
+           config_.index_log_path_);
+      return;
+    }
+    snap.write(kIdxMagic, sizeof(kIdxMagic));
+    WPod(snap, static_cast<clio::run::u32>(1));  // version
+    WPod(snap, static_cast<clio::run::u32>(tag_names_.size()));
+    for (const auto &kv : tag_names_) {
+      WPod(snap, kv.first);
+      WStr(snap, kv.second);
+    }
+    WPod(snap, static_cast<clio::run::u32>(tags_seen_.size()));
+    for (clio::run::u64 key : tags_seen_) {
+      WPod(snap, key);
+    }
+    WPod(snap, static_cast<clio::run::u64>(index_.size()));
+    for (const auto &kv : index_) {
+      const IndexedDoc &doc = kv.second;
+      WPod(snap, doc.tag_id_.major_);
+      WPod(snap, doc.tag_id_.minor_);
+      WStr(snap, doc.tag_name_);
+      WStr(snap, doc.blob_name_);
+      WPod(snap, static_cast<clio::run::u64>(doc.length_));
+      WPod(snap, static_cast<clio::run::u32>(doc.tf_.size()));
+      for (const auto &tf : doc.tf_) {
+        WStr(snap, tf.first);
+        WPod(snap, static_cast<clio::run::u32>(tf.second));
+      }
+    }
+    // Dirty keys survive a clean shutdown: the restored pending set
+    // re-drains, so acked-but-unindexed content is never silently lost.
+    WPod(snap, static_cast<clio::run::u32>(
+                   pending_.size() + pending_tag_backfills_.size()));
+    for (const auto &kv : pending_) {
+      WPod(snap, kv.second.tag_id_.major_);
+      WPod(snap, kv.second.tag_id_.minor_);
+      WStr(snap, kv.second.blob_name_);
+    }
+    // Un-run tag backfills persist as dirty markers with an empty blob
+    // name; restore re-registers them.
+    for (const auto &kv : pending_tag_backfills_) {
+      WPod(snap, kv.second.major_);
+      WPod(snap, kv.second.minor_);
+      WStr(snap, std::string());
+    }
+  }
+  // WAL entries are superseded by the snapshot: truncate.
+  std::ofstream(config_.index_log_path_ + ".wal",
+                std::ios::binary | std::ios::trunc);
+  wal_bytes_ = 0;
+  if (reopen) {
+    wal_.open(config_.index_log_path_ + ".wal",
+              std::ios::binary | std::ios::app);
+  }
+}
+
+bool Runtime::RestoreIndex() {
+  bool any = false;
+  auto in_scope = [&](const std::string &tag_name,
+                      const std::string &blob_name) {
+    if (scope_match_all_) return true;
+    return std::regex_match(tag_name, scope_tag_re_) &&
+           std::regex_match(blob_name, scope_blob_re_);
+  };
+  // ---- Snapshot ----
+  {
+    std::ifstream snap(config_.index_log_path_, std::ios::binary);
+    char magic[8];
+    if (snap.is_open() && snap.read(magic, 8) &&
+        std::memcmp(magic, kIdxMagic, 8) == 0) {
+      clio::run::u32 version = 0;
+      RPod(snap, &version);
+      clio::run::u32 n_tags = 0;
+      RPod(snap, &n_tags);
+      for (clio::run::u32 i = 0; i < n_tags && snap.good(); ++i) {
+        clio::run::u64 key = 0;
+        std::string name;
+        if (!RPod(snap, &key) || !RStr(snap, &name)) break;
+        tag_names_[key] = name;
+      }
+      clio::run::u32 n_seen = 0;
+      RPod(snap, &n_seen);
+      for (clio::run::u32 i = 0; i < n_seen && snap.good(); ++i) {
+        clio::run::u64 key = 0;
+        if (!RPod(snap, &key)) break;
+        tags_seen_.insert(key);
+      }
+      clio::run::u64 n_docs = 0;
+      RPod(snap, &n_docs);
+      for (clio::run::u64 i = 0; i < n_docs && snap.good(); ++i) {
+        IndexedDoc doc;
+        clio::run::u64 length = 0;
+        clio::run::u32 ntf = 0;
+        if (!RPod(snap, &doc.tag_id_.major_) ||
+            !RPod(snap, &doc.tag_id_.minor_) ||
+            !RStr(snap, &doc.tag_name_) || !RStr(snap, &doc.blob_name_) ||
+            !RPod(snap, &length) || !RPod(snap, &ntf)) {
+          break;
+        }
+        doc.length_ = static_cast<size_t>(length);
+        doc.tf_.reserve(ntf);
+        bool ok = true;
+        for (clio::run::u32 t = 0; t < ntf; ++t) {
+          std::string term;
+          clio::run::u32 cnt = 0;
+          if (!RStr(snap, &term) || !RPod(snap, &cnt)) {
+            ok = false;
+            break;
+          }
+          doc.tf_.emplace(std::move(term), static_cast<int>(cnt));
+        }
+        if (!ok) break;
+        if (in_scope(doc.tag_name_, doc.blob_name_)) {
+          std::string key = DocKey(doc.tag_id_, doc.blob_name_);
+          index_[key] = std::move(doc);
+          any = true;
+        }
+      }
+      clio::run::u32 n_dirty = 0;
+      RPod(snap, &n_dirty);
+      for (clio::run::u32 i = 0; i < n_dirty && snap.good(); ++i) {
+        TagId tag_id = TagId::GetNull();
+        std::string blob_name;
+        if (!RPod(snap, &tag_id.major_) || !RPod(snap, &tag_id.minor_) ||
+            !RStr(snap, &blob_name)) {
+          break;
+        }
+        if (blob_name.empty()) {
+          pending_tag_backfills_[TagKey(tag_id)] = tag_id;
+        } else {
+          pending_[DocKey(tag_id, blob_name)] =
+              PendingReindex{tag_id, blob_name};
+        }
+        any = true;
+      }
+    }
+  }
+  // ---- WAL replay (last-wins on top of the snapshot) ----
+  {
+    std::ifstream wal(config_.index_log_path_ + ".wal", std::ios::binary);
+    while (wal.is_open() && wal.good()) {
+      unsigned char type = 0;
+      if (!RPod(wal, &type)) break;
+      if (type == kWalDoc) {
+        IndexedDoc doc;
+        clio::run::u64 length = 0;
+        clio::run::u32 ntf = 0;
+        if (!RPod(wal, &doc.tag_id_.major_) ||
+            !RPod(wal, &doc.tag_id_.minor_) || !RStr(wal, &doc.tag_name_) ||
+            !RStr(wal, &doc.blob_name_) || !RPod(wal, &length) ||
+            !RPod(wal, &ntf)) {
+          break;
+        }
+        doc.length_ = static_cast<size_t>(length);
+        bool ok = true;
+        for (clio::run::u32 t = 0; t < ntf; ++t) {
+          std::string term;
+          clio::run::u32 cnt = 0;
+          if (!RStr(wal, &term) || !RPod(wal, &cnt)) {
+            ok = false;
+            break;
+          }
+          doc.tf_.emplace(std::move(term), static_cast<int>(cnt));
+        }
+        if (!ok) break;
+        tag_names_[TagKey(doc.tag_id_)] = doc.tag_name_;
+        if (in_scope(doc.tag_name_, doc.blob_name_)) {
+          std::string key = DocKey(doc.tag_id_, doc.blob_name_);
+          index_[key] = std::move(doc);
+          any = true;
+        }
+      } else if (type == kWalDelDoc) {
+        TagId tag_id = TagId::GetNull();
+        std::string blob_name;
+        if (!RPod(wal, &tag_id.major_) || !RPod(wal, &tag_id.minor_) ||
+            !RStr(wal, &blob_name)) {
+          break;
+        }
+        std::string key = DocKey(tag_id, blob_name);
+        index_.erase(key);
+        pending_.erase(key);
+      } else if (type == kWalDelTag) {
+        TagId tag_id = TagId::GetNull();
+        if (!RPod(wal, &tag_id.major_) || !RPod(wal, &tag_id.minor_)) break;
+        for (auto it = index_.begin(); it != index_.end();) {
+          if (it->second.tag_id_.major_ == tag_id.major_ &&
+              it->second.tag_id_.minor_ == tag_id.minor_) {
+            it = index_.erase(it);
+          } else {
+            ++it;
+          }
+        }
+        tag_names_.erase(TagKey(tag_id));
+        tags_seen_.erase(TagKey(tag_id));
+        pending_tag_backfills_.erase(TagKey(tag_id));
+      } else if (type == kWalRenameTag) {
+        TagId tag_id = TagId::GetNull();
+        std::string new_name;
+        if (!RPod(wal, &tag_id.major_) || !RPod(wal, &tag_id.minor_) ||
+            !RStr(wal, &new_name)) {
+          break;
+        }
+        tag_names_[TagKey(tag_id)] = new_name;
+        for (auto &kv : index_) {
+          if (kv.second.tag_id_.major_ == tag_id.major_ &&
+              kv.second.tag_id_.minor_ == tag_id.minor_) {
+            kv.second.tag_name_ = new_name;
+          }
+        }
+      } else if (type == kWalTagSeen) {
+        TagId tag_id = TagId::GetNull();
+        if (!RPod(wal, &tag_id.major_) || !RPod(wal, &tag_id.minor_)) break;
+        tags_seen_.insert(TagKey(tag_id));
+      } else {
+        HLOG(kWarning, "Indexer: unknown WAL record type {} — stopping "
+             "replay", static_cast<int>(type));
+        break;
+      }
+    }
+  }
+  return any;
 }
 
 // ---------------------------------------------------------------------------
@@ -266,6 +638,7 @@ void Runtime::IndexDocBytes(const TagId &tag_id, const std::string &tag_name,
   doc.length_ = tokens.size();
   for (auto &t : tokens) ++doc.tf_[t];
   std::lock_guard<std::mutex> lock(index_mutex_);
+  WalAppendDoc(doc);
   index_[DocKey(tag_id, blob_name)] = std::move(doc);
 }
 
@@ -286,12 +659,27 @@ clio::run::TaskResume Runtime::ReindexBlob(TagId tag_id,
            "failed) — dropping from index",
            blob_name, tag_id.major_, tag_id.minor_);
       std::lock_guard<std::mutex> lock(index_mutex_);
-      index_.erase(DocKey(tag_id, blob_name));
+      if (index_.erase(DocKey(tag_id, blob_name)) != 0) {
+        WalAppendDelDoc(tag_id, blob_name);
+      }
       CLIO_CO_RETURN;
     }
 
     std::string tag_name;
     CLIO_CO_AWAIT(ResolveTagName(tag_id, &tag_name));
+
+    // Module scope, tag half (the blob half was pre-checked at enqueue):
+    // out-of-scope content is never tokenized and leaves the index if a
+    // scope change stranded an old entry there.
+    if (!scope_match_all_ &&
+        (tag_name.empty() || !std::regex_match(tag_name, scope_tag_re_) ||
+         !std::regex_match(blob_name, scope_blob_re_))) {
+      std::lock_guard<std::mutex> lock(index_mutex_);
+      if (index_.erase(DocKey(tag_id, blob_name)) != 0) {
+        WalAppendDelDoc(tag_id, blob_name);
+      }
+      CLIO_CO_RETURN;
+    }
 
     // Re-read the blob's CURRENT bytes from the chain — the always-correct
     // fallback for partial/vectored writes and truncates (whole-blob puts
@@ -324,7 +712,9 @@ clio::run::TaskResume Runtime::ReindexBlob(TagId tag_id,
            "entry",
            blob_name, read_rc);
       std::lock_guard<std::mutex> lock(index_mutex_);
-      index_.erase(DocKey(tag_id, blob_name));
+      if (index_.erase(DocKey(tag_id, blob_name)) != 0) {
+        WalAppendDelDoc(tag_id, blob_name);
+      }
       CLIO_CO_RETURN;
     }
 
@@ -337,20 +727,54 @@ clio::run::TaskResume Runtime::ReindexBlob(TagId tag_id,
 
 void Runtime::EnqueuePending(const TagId &tag_id,
                              const std::string &blob_name) {
+  // Scope precheck on the half we can evaluate without a resolve: an
+  // out-of-scope blob name never even enters the queue. The tag_re half is
+  // enforced at drain time, where the tag name is resolved anyway.
+  if (!scope_match_all_ && !std::regex_match(blob_name, scope_blob_re_)) {
+    return;
+  }
   std::lock_guard<std::mutex> lock(index_mutex_);
+  // tag_re precheck when the tag's name is already cached: a scoped-out
+  // tag's writes then cost NOTHING past this lookup (first writes before
+  // the name is cached fall through; the drain filters and caches).
+  if (!scope_match_all_) {
+    auto name_it = tag_names_.find(TagKey(tag_id));
+    if (name_it != tag_names_.end() &&
+        !std::regex_match(name_it->second, scope_tag_re_)) {
+      return;
+    }
+  }
   pending_[DocKey(tag_id, blob_name)] = PendingReindex{tag_id, blob_name};
+  // First-insertion backfill: the first write a tag receives after the
+  // indexer composed schedules a one-time scan of that tag's PRE-EXISTING
+  // blobs (drained asynchronously like everything else). tags_seen_ is
+  // persisted, so restarts never re-trigger it.
+  clio::run::u64 tkey = TagKey(tag_id);
+  if (tags_seen_.insert(tkey).second) {
+    WalAppendTagSeen(tag_id);
+    pending_tag_backfills_[tkey] = tag_id;
+  }
 }
 
 clio::run::TaskResume Runtime::DrainPendingIndex() {
   CLIO_TASK_BODY_BEGIN
   for (;;) {
     bool have = false;
+    bool have_backfill = false;
     bool wait = false;
     TagId tag_id = TagId::GetNull();
     std::string blob_name;
     {
       std::lock_guard<std::mutex> lock(index_mutex_);
-      if (!pending_.empty()) {
+      if (!pending_tag_backfills_.empty()) {
+        // Backfills FIRST: they feed pending_, so draining them early keeps
+        // one pass sufficient.
+        auto it = pending_tag_backfills_.begin();
+        tag_id = it->second;
+        pending_tag_backfills_.erase(it);
+        ++draining_;
+        have_backfill = true;
+      } else if (!pending_.empty()) {
         auto it = pending_.begin();
         tag_id = it->second.tag_id_;
         blob_name = std::move(it->second.blob_name_);
@@ -361,6 +785,22 @@ clio::run::TaskResume Runtime::DrainPendingIndex() {
         // Another drainer is mid-entry: the barrier must outlast it.
         wait = true;
       }
+    }
+    if (have_backfill) {
+      std::string tag_name;
+      CLIO_CO_AWAIT(ResolveTagName(tag_id, &tag_name));
+      if (!tag_name.empty() &&
+          (scope_match_all_ ||
+           std::regex_match(tag_name, scope_tag_re_))) {
+        clio::run::u64 enq = 0;
+        CLIO_CO_AWAIT(ScanAndEnqueue("^" + EscapeRegex(tag_name) + "$",
+                                     config_.blob_re_, &enq));
+        HLOG(kDebug, "Indexer: first-insertion backfill of tag '{}' "
+             "enqueued {} blobs", tag_name, enq);
+      }
+      std::lock_guard<std::mutex> lock(index_mutex_);
+      --draining_;
+      continue;
     }
     if (have) {
       CLIO_CO_AWAIT(ReindexBlob(tag_id, blob_name));
@@ -382,6 +822,14 @@ clio::run::TaskResume Runtime::IndexSweep(
     clio::run::shared_ptr<IndexSweepTask> &task) {
   CLIO_TASK_BODY_BEGIN
   CLIO_CO_AWAIT(DrainPendingIndex());
+  {
+    // WAL compaction: past the threshold, fold the log into a fresh
+    // snapshot so replay stays O(index), not O(history).
+    std::lock_guard<std::mutex> lock(index_mutex_);
+    if (wal_.is_open() && wal_bytes_ > config_.index_wal_compact_bytes_) {
+      SnapshotIndex();
+    }
+  }
   task->return_code_ = 0;
   CLIO_CO_RETURN;
   CLIO_TASK_BODY_END
@@ -451,9 +899,13 @@ clio::run::TaskResume Runtime::DelBlob(
                               task.template Cast<clio::run::Task>()));
   if (task->GetReturnCode() == 0) {
     std::lock_guard<std::mutex> lock(index_mutex_);
-    std::string key = DocKey(task->tag_id_, task->blob_name_.str());
-    index_.erase(key);
-    pending_.erase(key);
+    std::string blob_name = task->blob_name_.str();
+    std::string key = DocKey(task->tag_id_, blob_name);
+    bool had = index_.erase(key) != 0;
+    had = pending_.erase(key) != 0 || had;
+    if (had) {
+      WalAppendDelDoc(task->tag_id_, blob_name);
+    }
   }
   CLIO_CO_RETURN;
   CLIO_TASK_BODY_END
@@ -491,6 +943,10 @@ clio::run::TaskResume Runtime::DelTag(
       }
     }
     tag_names_.erase(TagKey(task->tag_id_));
+    // A recreated tag is a NEW first insertion: it must re-backfill.
+    tags_seen_.erase(TagKey(task->tag_id_));
+    pending_tag_backfills_.erase(TagKey(task->tag_id_));
+    WalAppendDelTag(task->tag_id_);
   }
   CLIO_CO_RETURN;
   CLIO_TASK_BODY_END
@@ -511,6 +967,7 @@ clio::run::TaskResume Runtime::RenameTag(
         kv.second.tag_name_ = new_name;
       }
     }
+    WalAppendRenameTag(task->tag_id_, new_name);
   }
   CLIO_CO_RETURN;
   CLIO_TASK_BODY_END
@@ -635,63 +1092,83 @@ clio::run::TaskResume Runtime::SemanticSearch(
 }
 
 // ---------------------------------------------------------------------------
-// Restart: rebuild the index slice from the storage below.
+// On-demand scan (kReindexScan verb + first-insertion backfill): enumerate
+// and ENQUEUE — the asynchronous drain does the indexing. Restarts restore
+// persisted state and never come here.
 // ---------------------------------------------------------------------------
 
-clio::run::TaskResume Runtime::RebuildIndex() {
+clio::run::TaskResume Runtime::ScanAndEnqueue(std::string tag_regex,
+                                              std::string blob_regex,
+                                              clio::run::u64 *enqueued_out) {
   CLIO_TASK_BODY_BEGIN
   {
     auto *next = GetNextClient();
 
     // Enumerate THIS node's (tag, blob) pairs: Local keeps each container's
-    // rebuild to the slice its co-located core container owns, matching the
-    // interposer's owner-delegated routing (every container rebuilds its own
-    // shard; a Broadcast here would index every blob on every node).
+    // scan to the slice its co-located core container owns, matching the
+    // interposer's owner-delegated routing (a Broadcast here would enqueue
+    // every blob on every node).
     std::vector<std::string> tag_names;
     std::vector<std::string> blob_names;
     {
-      auto query_fut = next->AsyncBlobQuery(".*", ".*", 0,
+      auto query_fut = next->AsyncBlobQuery(tag_regex, blob_regex, 0,
                                             clio::run::PoolQuery::Local());
       CLIO_CO_AWAIT(query_fut);
       if (query_fut->GetReturnCode() != 0) {
-        HLOG(kError, "Indexer: restart BlobQuery failed (rc={}); index "
-             "starts empty", query_fut->GetReturnCode());
+        HLOG(kWarning, "Indexer: scan BlobQuery(tag='{}' blob='{}') failed "
+             "(rc={})", tag_regex, blob_regex, query_fut->GetReturnCode());
         CLIO_CO_RETURN;
       }
       tag_names = query_fut->tag_names_;
       blob_names = query_fut->blob_names_;
     }
 
-    clio::run::u64 indexed = 0;
     for (size_t i = 0; i < tag_names.size() && i < blob_names.size(); ++i) {
       // Resolve the tag's id (GetOrCreateTag on an existing tag is a pure
-      // lookup — the tag survived the restart via the core's own WAL).
+      // lookup) and seed the name cache for the drain.
       TagId tag_id = TagId::GetNull();
       {
         auto tag_fut = next->AsyncGetOrCreateTag(tag_names[i]);
         CLIO_CO_AWAIT(tag_fut);
         if (tag_fut->GetReturnCode() != 0) {
-          HLOG(kWarning, "Indexer: restart tag resolve failed for '{}'",
+          HLOG(kWarning, "Indexer: scan tag resolve failed for '{}'",
                tag_names[i]);
           continue;
         }
         tag_id = tag_fut->tag_id_;
       }
-      HLOG(kDebug, "Indexer: restart re-index '{}' (tag '{}' -> {}.{})",
-           blob_names[i], tag_names[i], tag_id.major_, tag_id.minor_);
       {
         std::lock_guard<std::mutex> lock(index_mutex_);
         tag_names_[TagKey(tag_id)] = tag_names[i];
+        // A scanned tag counts as seen: the scan IS its backfill.
+        if (tags_seen_.insert(TagKey(tag_id)).second) {
+          WalAppendTagSeen(tag_id);
+        }
+        if (scope_match_all_ ||
+            std::regex_match(blob_names[i], scope_blob_re_)) {
+          pending_[DocKey(tag_id, blob_names[i])] =
+              PendingReindex{tag_id, blob_names[i]};
+          if (enqueued_out != nullptr) ++(*enqueued_out);
+        }
       }
-      // ReindexBlob skips what storage cannot serve anymore: blobs whose
-      // bytes lived only on volatile (RAM) tiers lost them in the reboot,
-      // and the index must agree with what GetBlob can actually return.
-      CLIO_CO_AWAIT(ReindexBlob(tag_id, blob_names[i]));
-      ++indexed;
     }
-    HLOG(kInfo, "Indexer: restart rebuild complete — {} blobs processed, "
-         "index size {}", indexed, index_.size());
   }
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
+clio::run::TaskResume Runtime::ReindexScan(
+    clio::run::shared_ptr<ReindexScanTask> &task) {
+  CLIO_TASK_BODY_BEGIN
+  {
+    clio::run::u64 enqueued = 0;
+    CLIO_CO_AWAIT(ScanAndEnqueue(task->tag_regex_.str(),
+                                 task->blob_regex_.str(), &enqueued));
+    task->blobs_enqueued_ = enqueued;
+    HLOG(kInfo, "Indexer: ReindexScan(tag='{}' blob='{}') enqueued {} blobs",
+         task->tag_regex_.str(), task->blob_regex_.str(), enqueued);
+  }
+  task->return_code_ = 0;
   CLIO_CO_RETURN;
   CLIO_TASK_BODY_END
 }

--- a/context-transfer-engine/test/integration/CMakeLists.txt
+++ b/context-transfer-engine/test/integration/CMakeLists.txt
@@ -4,6 +4,13 @@ cmake_minimum_required(VERSION 3.10)
 # Restart integration test (no Docker required)
 add_subdirectory(restart)
 
+# Indexer restart test (#905, no Docker required): docs put through the
+# indexer, runtime reboot, SemanticSearch verified against the index the
+# indexer rebuilt from file-backed storage. Gated on the indexer chimod.
+if(TARGET clio_cte_indexer_client)
+    add_subdirectory(indexer_restart)
+endif()
+
 # Replication persistence test (#886, no Docker required): 50 CachedPuts
 # (DRAM primary + disk replica), runtime reboot, disk replicas verified.
 # Gated on the replication chimod (default ON).

--- a/context-transfer-engine/test/integration/indexer_restart/CMakeLists.txt
+++ b/context-transfer-engine/test/integration/indexer_restart/CMakeLists.txt
@@ -1,0 +1,37 @@
+# CMakeLists.txt for the indexer restart integration test (issue #905)
+cmake_minimum_required(VERSION 3.10)
+
+# Restart test client (two-mode: --put / --verify)
+add_executable(test_indexer_restart test_indexer_restart.cc)
+
+target_link_libraries(test_indexer_restart
+    clio_cte_core_client
+    clio::run::admin_client
+    ctp::cxx
+    ${CMAKE_THREAD_LIBS_INIT}
+)
+
+set(INDEXER_RESTART_TEST_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+# Shell script test that orchestrates the multi-process restart workflow.
+# POSIX-only, same constraints as the cte_restart_integration script.
+if(UNIX)
+    add_test(NAME cte_indexer_restart
+        COMMAND bash ${INDEXER_RESTART_TEST_DIR}/test_indexer_restart.sh
+        WORKING_DIRECTORY ${INDEXER_RESTART_TEST_DIR}
+    )
+
+    set_tests_properties(cte_indexer_restart
+        PROPERTIES
+            TIMEOUT 300
+            LABELS "integration;restart;cte;indexer;semantic-search;msan_skip"
+            ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};BIN_DIR=${CMAKE_BINARY_DIR}/bin;CLIO_BIND_ADDR=127.0.0.1;CLIO_PORT=10500"
+            RESOURCE_LOCK "clio_runtime"
+    )
+endif()
+
+install(TARGETS test_indexer_restart
+    RUNTIME DESTINATION bin
+)
+
+message(STATUS "Indexer restart integration test configured")

--- a/context-transfer-engine/test/integration/indexer_restart/test_indexer_restart.cc
+++ b/context-transfer-engine/test/integration/indexer_restart/test_indexer_restart.cc
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Indexer restart test client (issue #905), two-mode:
+ *
+ *   --put     Phase 1: put four topically-distinct documents through the
+ *             indexer pool (564.0), flush the core's metadata/data, and
+ *             sanity-check that SemanticSearch ranks them correctly while
+ *             the inline-maintained index is live.
+ *   --verify  Phase 2 (after a daemon restart + re-compose): run the SAME
+ *             searches WITHOUT any puts. Results can only come from the
+ *             index the indexer rebuilt from the restored storage below —
+ *             an empty or wrong ranking means the rebuild failed.
+ *
+ * Orchestrated by test_indexer_restart.sh; binds the client to the indexer
+ * pool via CLIO_CTE_POOL=564.0 (exported by the script).
+ */
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include <clio_cte/core/core_client.h>
+#include <clio_cte/core/core_tasks.h>
+#include <clio_runtime/clio_runtime.h>
+
+namespace {
+
+constexpr const char *kTagName = "idx_restart_tag";
+
+struct Doc {
+  const char *name;
+  const char *body;
+};
+
+// Distinct vocabularies so BM25 rankings are unambiguous.
+const Doc kDocs[] = {
+    {"doc_space",
+     "Apollo 11 landed on the Moon in 1969. Astronauts Armstrong and Aldrin "
+     "walked the lunar surface while Collins orbited overhead."},
+    {"doc_cook",
+     "A roux is equal parts butter and flour cooked into a paste, the base "
+     "for classic French sauces like bechamel and espagnole."},
+    {"doc_garden",
+     "Tomato plants need full sun, regular watering, and well-drained soil "
+     "with slightly acidic pH for a healthy fruit set."},
+    {"doc_rail",
+     "The transcontinental railroad joined the Central Pacific and Union "
+     "Pacific lines at Promontory Summit in 1869 with a golden spike."},
+};
+constexpr size_t kNumDocs = sizeof(kDocs) / sizeof(kDocs[0]);
+
+bool InitClient() {
+  if (!clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, false)) {
+    HLOG(kError, "Failed to init Clio client");
+    return false;
+  }
+  // CLIO_CTE_POOL=564.0 (set by the driver script) binds the singleton to
+  // the indexer pool without creating anything.
+  if (!clio::cte::core::CLIO_CTE_CLIENT_INIT()) {
+    HLOG(kError, "Failed to init CTE client");
+    return false;
+  }
+  return true;
+}
+
+/** Run one search and dump the results for the log. */
+std::vector<clio::cte::core::SemanticSearchResult> Search(
+    const std::string &query, clio::run::u32 k) {
+  auto *cte = CLIO_CTE_CLIENT;
+  auto task = cte->AsyncSemanticSearch(".*", "^doc_.*$", query, k,
+                                       clio::run::PoolQuery::Broadcast());
+  task.Wait();
+  if (task->GetReturnCode() != 0) {
+    HLOG(kError, "SemanticSearch('{}') rc={}", query, task->GetReturnCode());
+    return {};
+  }
+  for (size_t i = 0; i < task->results_.size(); ++i) {
+    HLOG(kInfo, "  #{} {} (score {})", i, task->results_[i].blob_name_,
+         task->results_[i].score_);
+  }
+  return task->results_;
+}
+
+/** The assertions both phases share: the index (fresh or rebuilt) must
+ *  contain exactly the four docs and rank them by topic. */
+int VerifySearches(const char *phase) {
+  // Empty query: BM25 scores are all 0 but every regex-matched indexed doc
+  // is returned — a direct census of the index.
+  HLOG(kInfo, "{}: census query", phase);
+  auto all = Search("", 0);
+  if (all.size() != kNumDocs) {
+    HLOG(kError, "{}: expected {} indexed docs, found {}", phase, kNumDocs,
+         all.size());
+    return 1;
+  }
+
+  HLOG(kInfo, "{}: space query", phase);
+  auto space = Search("apollo moon lunar surface astronauts", 4);
+  if (space.empty() || space[0].blob_name_ != "doc_space" ||
+      space[0].score_ <= 0.0) {
+    HLOG(kError, "{}: space query did not rank doc_space first", phase);
+    return 1;
+  }
+  for (size_t i = 1; i < space.size(); ++i) {
+    if (space[i].score_ > space[i - 1].score_) {
+      HLOG(kError, "{}: results not sorted by descending score", phase);
+      return 1;
+    }
+  }
+
+  HLOG(kInfo, "{}: cooking query", phase);
+  auto cook = Search("butter flour roux sauce", 2);
+  if (cook.empty() || cook[0].blob_name_ != "doc_cook") {
+    HLOG(kError, "{}: cooking query did not rank doc_cook first", phase);
+    return 1;
+  }
+
+  HLOG(kSuccess, "{}: searches verified", phase);
+  return 0;
+}
+
+int PutPhase() {
+  if (!InitClient()) return 1;
+  auto *cte = CLIO_CTE_CLIENT;
+  auto *ipc = CLIO_IPC;
+  if (ipc == nullptr) {
+    HLOG(kError, "Phase 1: no IPC manager");
+    return 1;
+  }
+
+  auto tag = cte->AsyncGetOrCreateTag(kTagName);
+  tag.Wait();
+  if (tag->GetReturnCode() != 0) {
+    HLOG(kError, "Phase 1: GetOrCreateTag rc={}", tag->GetReturnCode());
+    return 1;
+  }
+
+  for (size_t i = 0; i < kNumDocs; ++i) {
+    const size_t len = strlen(kDocs[i].body);
+    ctp::ipc::FullPtr<char> buf = ipc->AllocateBuffer(len);
+    if (buf.IsNull()) {
+      HLOG(kError, "Phase 1: AllocateBuffer failed");
+      return 1;
+    }
+    memcpy(buf.ptr_, kDocs[i].body, len);
+    ctp::ipc::ShmPtr<> shm(buf.shm_);
+    auto put = cte->AsyncPutBlob(tag->tag_id_, kDocs[i].name, 0, len, shm,
+                                 1.0f);
+    put.Wait();
+    ipc->FreeBuffer(buf);
+    if (put->GetReturnCode() != 0) {
+      HLOG(kError, "Phase 1: PutBlob '{}' rc={}", kDocs[i].name,
+           put->GetReturnCode());
+      return 1;
+    }
+    HLOG(kInfo, "Phase 1: put '{}' ({} bytes)", kDocs[i].name, len);
+  }
+
+  // Pre-restart sanity: the inline-maintained index must already serve
+  // correct rankings; otherwise phase 2 would diagnose the wrong thing.
+  if (VerifySearches("Phase 1") != 0) return 1;
+
+  // Persist the core's metadata snapshot and data so the restart has
+  // something to rebuild from (routed through the indexer, forwarded down).
+  auto flush_meta = cte->AsyncFlushMetadata(clio::run::PoolQuery::Local(), 0);
+  flush_meta.Wait();
+  auto flush_data = cte->AsyncFlushData(clio::run::PoolQuery::Local(), 0, 0);
+  flush_data.Wait();
+  HLOG(kSuccess, "Phase 1: {} docs stored, index verified, state flushed",
+       kNumDocs);
+  return 0;
+}
+
+int VerifyPhase() {
+  if (!InitClient()) return 1;
+  // NO puts here: everything the searches return was rebuilt from storage.
+  return VerifySearches("Phase 2");
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+  if (argc != 2) {
+    HLOG(kError, "Usage: {} [--put|--verify]", argv[0]);
+    return 1;
+  }
+  const std::string mode = argv[1];
+  if (mode == "--put") return PutPhase();
+  if (mode == "--verify") return VerifyPhase();
+  HLOG(kError, "Usage: {} [--put|--verify]", argv[0]);
+  return 1;
+}

--- a/context-transfer-engine/test/integration/indexer_restart/test_indexer_restart.sh
+++ b/context-transfer-engine/test/integration/indexer_restart/test_indexer_restart.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Indexer restart integration test (issue #905): prove the SemanticSearch
+# index is rebuilt from storage after a daemon reboot.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Use BIN_DIR from environment, or fall back to /workspace/build/bin
+BIN_DIR="${BIN_DIR:-/workspace/build/bin}"
+COMPOSE_CONFIG="${SCRIPT_DIR}/test_indexer_restart_compose.yaml"
+CONF_DIR="/tmp/clio_indexer_restart_test"
+
+echo "=== Indexer Restart Integration Test (issue #905) ==="
+echo "BIN_DIR: $BIN_DIR"
+echo "COMPOSE_CONFIG: $COMPOSE_CONFIG"
+
+stop_runtime() {
+    if [ -n "$RUNTIME_PID" ] && kill -0 $RUNTIME_PID 2>/dev/null; then
+        $BIN_DIR/clio_run stop --grace-period 2000 2>/dev/null || true
+        sleep 2
+        if kill -0 $RUNTIME_PID 2>/dev/null; then
+            kill -9 $RUNTIME_PID 2>/dev/null || true
+        fi
+        wait $RUNTIME_PID 2>/dev/null || true
+    fi
+    RUNTIME_PID=""
+}
+
+cleanup() {
+    stop_runtime
+    sleep 1
+    rm -f /dev/shm/clio_*
+    rm -rf "$CONF_DIR"
+}
+trap cleanup EXIT
+
+# Clean slate
+rm -f /dev/shm/clio_*
+rm -rf "$CONF_DIR"
+mkdir -p "$CONF_DIR"
+
+export CLIO_SERVER_CONF="$COMPOSE_CONFIG"
+# Bind the test client to the indexer pool (the interposition entrypoint).
+export CLIO_CTE_POOL="564.0"
+# Isolate the restart-log WAL: compose registration must not pollute the
+# shared ~/.clio/restart_log.bin (same discipline as the CTE WAL test).
+export CLIO_RESTART_LOG="$CONF_DIR/restart_log.bin"
+
+# === Phase 1: start runtime, compose, put docs, verify live index, flush ===
+echo ""
+echo "=== Phase 1: store documents, verify inline index ==="
+
+$BIN_DIR/clio_run runtime start &
+RUNTIME_PID=$!
+sleep 3
+
+echo "Runtime started (PID=$RUNTIME_PID), composing pools..."
+$BIN_DIR/clio_run compose "$COMPOSE_CONFIG"
+
+$BIN_DIR/test_indexer_restart --put
+
+echo "Stopping runtime..."
+stop_runtime
+sleep 1
+rm -f /dev/shm/clio_*
+
+echo "Phase 1 complete. Persistent state in $CONF_DIR:"
+ls -la "$CONF_DIR" 2>/dev/null || true
+
+# === Phase 2: restart runtime, re-compose (Restart path), verify searches ===
+echo ""
+echo "=== Phase 2: restart, rebuild index from storage, verify ==="
+
+$BIN_DIR/clio_run runtime start &
+RUNTIME_PID=$!
+sleep 3
+
+echo "Runtime restarted (PID=$RUNTIME_PID), re-composing (restart path)..."
+$BIN_DIR/clio_run compose "$COMPOSE_CONFIG"
+
+$BIN_DIR/test_indexer_restart --verify
+
+echo "Stopping runtime..."
+stop_runtime
+
+echo ""
+echo "=== INDEXER RESTART TEST PASSED ==="

--- a/context-transfer-engine/test/integration/indexer_restart/test_indexer_restart_compose.yaml
+++ b/context-transfer-engine/test/integration/indexer_restart/test_indexer_restart_compose.yaml
@@ -1,0 +1,37 @@
+---
+# Indexer restart test (issue #905): CTE core on a FILE-backed tier (bytes
+# survive the reboot) + the indexer chimod above it. Both restart: true so
+# re-composing after a daemon restart takes the Restart() path — the core
+# replays its metadata WAL, then the indexer rebuilds its term index from
+# the restored storage (BlobQuery + GetBlob against next_pool_id).
+runtime:
+  num_threads: 4
+  queue_depth: 256
+  conf_dir: /tmp/clio_indexer_restart_test
+
+compose:
+  - mod_name: clio_cte_core
+    pool_name: cte_indexer_restart
+    pool_query: local
+    pool_id: "512.0"
+    restart: true
+    storage:
+      - path: /tmp/clio_indexer_restart_test/file_dev
+        bdev_type: file
+        capacity_limit: 100MB
+        # Without this the target defaults to "volatile" and the restart
+        # restore drops every block placed on it — the rebuild would then
+        # (correctly) find nothing to index.
+        persistence_level: "temporary"
+    performance:
+      metadata_log_path: /tmp/clio_indexer_restart_test/metadata.log
+      transaction_log_capacity: 32MB
+      flush_metadata_period_ms: 0
+      flush_data_period_ms: 0
+
+  - mod_name: clio_cte_indexer
+    pool_name: clio_cte_indexer
+    pool_query: local
+    pool_id: "564.0"
+    restart: true
+    next_pool_id: "512.0"

--- a/context-transfer-engine/test/integration/indexer_restart/test_indexer_restart_compose.yaml
+++ b/context-transfer-engine/test/integration/indexer_restart/test_indexer_restart_compose.yaml
@@ -35,3 +35,6 @@ compose:
     pool_id: "564.0"
     restart: true
     next_pool_id: "512.0"
+    # Module WAL (issue #905): phase 2 verifies searches served from the
+    # RESTORED index — no rescan of storage happens on restart.
+    index_log_path: /tmp/clio_indexer_restart_test/indexer_index.log

--- a/context-transfer-engine/test/unit/CMakeLists.txt
+++ b/context-transfer-engine/test/unit/CMakeLists.txt
@@ -1036,6 +1036,41 @@ set_tests_properties(
 )
 endif()  # TARGET clio_cte_cache_client
 
+#------------------------------------------------------------------------------
+# Indexer chimod behavioral coverage (issue #905): scope, async drain +
+# search barrier, maintenance verbs, kReindexScan, first-insertion backfill.
+#------------------------------------------------------------------------------
+if(TARGET clio_cte_indexer_client)
+add_executable(test_indexer_ops test_indexer_ops.cc)
+target_include_directories(test_indexer_ops PRIVATE
+    ${CMAKE_SOURCE_DIR}/context-runtime/test
+    ${CMAKE_SOURCE_DIR}/context-transfer-engine/indexer/include
+)
+target_link_libraries(test_indexer_ops
+    clio_cte_core_runtime
+    clio_cte_core_client
+    clio_cte_indexer_runtime
+    clio_cte_indexer_client
+    clio::run::admin_runtime
+    clio::run::admin_client
+    clio::run::bdev_runtime
+    clio::run::bdev_client
+    ctp::cxx
+    ${CMAKE_THREAD_LIBS_INIT}
+)
+
+add_test(NAME cte_indexer_ops
+    COMMAND test_indexer_ops)
+
+set_tests_properties(
+    cte_indexer_ops
+    PROPERTIES
+        TIMEOUT 300
+        LABELS "unit;indexer;cte;semantic-search;coverage"
+        ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CLIO_TEST_DATA_DIR=${CMAKE_BINARY_DIR};CLIO_BIND_ADDR=127.0.0.1"
+)
+endif()  # TARGET clio_cte_indexer_client
+
 # Full 4-layer stack (issue #886 cache/replication split): cache(563) ->
 # compressor(562) -> replication(561) -> core(512). A compressed blob KEEPS
 # the SHM fast path via its raw cache replica; the persistent replica holds

--- a/context-transfer-engine/test/unit/test_indexer_ops.cc
+++ b/context-transfer-engine/test/unit/test_indexer_ops.cc
@@ -74,6 +74,10 @@ class IndexerOpsFixture {
     if (g_initialized) return;
     config_path_ = chi_test_data_dir() + "/indexer_ops_config.yaml";
     restart_log_path_ = chi_test_data_dir() + "/indexer_ops_restart.bin";
+    // Stale persisted index state from an earlier run would RESTORE into
+    // this boot and pollute the assertions — start clean.
+    fs::remove(IndexLogPath());
+    fs::remove(IndexLogPath() + ".wal");
     CreateConfigFile();
     ctp::SystemInfo::Setenv("CLIO_SERVER_CONF", config_path_.c_str(), 1);
     // Hermetic pool set (same discipline as the cache interpose test).
@@ -86,9 +90,16 @@ class IndexerOpsFixture {
     g_initialized = true;
   }
 
+  static std::string IndexLogPath() {
+    return chi_test_data_dir() + "/indexer_ops_index.log";
+  }
+
   void CreateConfigFile() {
     std::ofstream f(config_path_);
     REQUIRE(f.is_open());
+    // index_log_path exercises the WAL appends on every mutation; the tiny
+    // compact threshold makes the periodic sweep fold the WAL into a
+    // snapshot mid-test (SnapshotIndex coverage).
     f << R"(
 runtime:
   num_threads: 4
@@ -114,6 +125,8 @@ compose:
     next_pool_id: "512.0"
     tag_re: "idx_.*"
     index_sweep_period_ms: 50
+    index_log_path: ")" << IndexLogPath() << R"("
+    index_wal_compact_bytes: "2KB"
 )";
   }
 };
@@ -275,6 +288,32 @@ TEST_CASE("Indexer - scope, drain, and index maintenance verbs",
     hits = Search(via_idx, "ancient manuscripts newspaper");
     REQUIRE(!Contains(hits, "bf_old"));
     REQUIRE(!Contains(hits, "bf_new"));
+  }
+
+  // --- Persistence restore: a SECOND indexer pool over the same log files
+  // must serve searches it never saw written — its Create() runs
+  // RestoreIndex over 564's snapshot + WAL. (In-process stand-in for a
+  // daemon reboot; the restart integration test covers the real thing.)
+  {
+    clio::cte::indexer::IndexerConfig params;
+    params.next_pool_id_ = clio::run::PoolId(512, 0);
+    params.tag_re_ = "idx_.*";
+    params.index_log_path_ = IndexerOpsFixture::IndexLogPath();
+    auto create = idx.AsyncCreateIndexer(clio::run::PoolQuery::Local(),
+                                         "indexer_restore",
+                                         clio::run::PoolId(565, 0), params);
+    create.Wait();
+    REQUIRE(create->GetReturnCode() == 0);
+
+    clio::cte::core::Client via_restored(clio::run::PoolId(565, 0));
+    auto task = via_restored.AsyncSemanticSearch(
+        ".*", "^scan_1$", "volcanic basalt columns", 0,
+        clio::run::PoolQuery::Local());
+    task.Wait();
+    REQUIRE(task->GetReturnCode() == 0);
+    REQUIRE(!task->results_.empty());
+    REQUIRE(task->results_[0].blob_name_ == "scan_1");
+    REQUIRE(task->results_[0].score_ > 0.0);
   }
 }
 

--- a/context-transfer-engine/test/unit/test_indexer_ops.cc
+++ b/context-transfer-engine/test/unit/test_indexer_ops.cc
@@ -1,0 +1,281 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Indexer chimod behavioral coverage (issue #905): scope enforcement,
+ * asynchronous drain + search barrier, overwrite coalescing, DelBlob /
+ * DelTag / RenameTag / TruncateBlob index maintenance, the kReindexScan
+ * verb, and the per-tag first-insertion backfill. Composes core(512) +
+ * indexer(564, scope tag_re "idx_.*") in an embedded runtime; one core
+ * client is bound THROUGH the indexer (564) and one directly at the core
+ * (512) to stage pre-existing data the indexer has never seen.
+ */
+
+#include <clio_runtime/clio_runtime.h>
+#include <clio_cte/core/core_client.h>
+#include <clio_cte/core/core_tasks.h>
+#include <clio_cte/indexer/indexer_client.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "simple_test.h"
+
+namespace fs = std::filesystem;
+
+static std::string chi_test_data_dir() {
+  const char *d = clio::run::env::GetCompat("TEST_DATA_DIR");
+  return (d && *d) ? d : ".";
+}
+
+class IndexerOpsFixture {
+ public:
+  static inline bool g_initialized = false;
+  std::string config_path_;
+  std::string restart_log_path_;
+
+  IndexerOpsFixture() {
+    if (g_initialized) return;
+    config_path_ = chi_test_data_dir() + "/indexer_ops_config.yaml";
+    restart_log_path_ = chi_test_data_dir() + "/indexer_ops_restart.bin";
+    CreateConfigFile();
+    ctp::SystemInfo::Setenv("CLIO_SERVER_CONF", config_path_.c_str(), 1);
+    // Hermetic pool set (same discipline as the cache interpose test).
+    ctp::SystemInfo::Setenv("CLIO_RESTART_LOG", restart_log_path_.c_str(), 1);
+
+    REQUIRE(clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, true));
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    REQUIRE(clio::cte::core::CLIO_CTE_CLIENT_INIT());
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    g_initialized = true;
+  }
+
+  void CreateConfigFile() {
+    std::ofstream f(config_path_);
+    REQUIRE(f.is_open());
+    f << R"(
+runtime:
+  num_threads: 4
+  queue_depth: 1024
+
+compose:
+  - mod_name: clio_cte_core
+    pool_name: clio_cte
+    pool_query: local
+    pool_id: 512.0
+    storage:
+      - path: "ram::indexer_ops_ram"
+        bdev_type: "ram"
+        capacity_limit: "256MB"
+        score: 1.0
+    dpe:
+      dpe_type: "max_bw"
+
+  - mod_name: clio_cte_indexer
+    pool_name: clio_cte_indexer
+    pool_query: local
+    pool_id: 564.0
+    next_pool_id: "512.0"
+    tag_re: "idx_.*"
+    index_sweep_period_ms: 50
+)";
+  }
+};
+
+namespace {
+
+/** Put `body` as blob `name` under `tag_id` through `cte`. */
+void PutText(clio::cte::core::Client &cte, const clio::cte::core::TagId &tag,
+             const std::string &name, const std::string &body) {
+  auto *ipc = CLIO_IPC;
+  ctp::ipc::FullPtr<char> buf = ipc->AllocateBuffer(body.size());
+  REQUIRE(!buf.IsNull());
+  memcpy(buf.ptr_, body.data(), body.size());
+  auto put = cte.AsyncPutBlob(tag, name, 0, body.size(),
+                              ctp::ipc::ShmPtr<>(buf.shm_), 1.0f);
+  put.Wait();
+  REQUIRE(put->GetReturnCode() == 0);
+  ipc->FreeBuffer(buf);
+}
+
+/** Search through the indexer pool; returns blob names in rank order. */
+std::vector<std::string> Search(clio::cte::core::Client &cte,
+                                const std::string &query,
+                                const std::string &tag_re = ".*",
+                                const std::string &blob_re = ".*") {
+  auto task = cte.AsyncSemanticSearch(tag_re, blob_re, query, 0,
+                                      clio::run::PoolQuery::Local());
+  task.Wait();
+  REQUIRE(task->GetReturnCode() == 0);
+  std::vector<std::string> names;
+  for (const auto &r : task->results_) names.push_back(r.blob_name_);
+  return names;
+}
+
+bool Contains(const std::vector<std::string> &v, const std::string &s) {
+  return std::find(v.begin(), v.end(), s) != v.end();
+}
+
+}  // namespace
+
+TEST_CASE("Indexer - scope, drain, and index maintenance verbs",
+          "[cte][indexer]") {
+  IndexerOpsFixture fixture;
+
+  // Clients: THROUGH the indexer (564) and DIRECT to the core (512).
+  clio::cte::core::Client via_idx(clio::run::PoolId(564, 0));
+  clio::cte::core::Client direct(clio::run::PoolId(512, 0));
+  clio::cte::indexer::Client idx;
+  idx.indexer_pool_id_ = clio::run::PoolId(564, 0);
+
+  auto tag_of = [&](clio::cte::core::Client &c, const std::string &name) {
+    auto t = c.AsyncGetOrCreateTag(name);
+    t.Wait();
+    REQUIRE(t->GetReturnCode() == 0);
+    return t->tag_id_;
+  };
+
+  // --- Scope: only tags matching "idx_.*" are tokenized -------------------
+  auto tag1 = tag_of(via_idx, "idx_tag1");
+  auto tag_out = tag_of(via_idx, "other_tag");
+  PutText(via_idx, tag1, "doc_a", "apollo lunar module descended to the moon");
+  PutText(via_idx, tag_out, "doc_x", "apollo apollo apollo out of scope text");
+
+  auto hits = Search(via_idx, "apollo lunar");
+  REQUIRE(Contains(hits, "doc_a"));
+  REQUIRE(!Contains(hits, "doc_x"));  // out-of-scope tag never indexed
+
+  // --- Overwrite: index converges to the LATEST content (coalesced) -------
+  // Matched docs are always returned (score 0 when no term hits — the
+  // census semantics), so assert on SCORES: the old vocabulary must stop
+  // scoring and the new one must score.
+  PutText(via_idx, tag1, "doc_a", "gardening tomatoes need full sunshine");
+  {
+    auto task = via_idx.AsyncSemanticSearch(".*", "^doc_a$", "apollo lunar",
+                                            0, clio::run::PoolQuery::Local());
+    task.Wait();
+    REQUIRE(task->GetReturnCode() == 0);
+    REQUIRE(!task->results_.empty());
+    REQUIRE(task->results_[0].score_ == 0.0);
+
+    auto task2 = via_idx.AsyncSemanticSearch(".*", "^doc_a$",
+                                             "tomatoes sunshine", 0,
+                                             clio::run::PoolQuery::Local());
+    task2.Wait();
+    REQUIRE(task2->GetReturnCode() == 0);
+    REQUIRE(!task2->results_.empty());
+    REQUIRE(task2->results_[0].score_ > 0.0);
+  }
+
+  // --- RenameTag: result rows carry the new tag name ----------------------
+  {
+    auto rn = via_idx.AsyncRenameTag("idx_tag1", "idx_tag1_renamed", tag1);
+    rn.Wait();
+    REQUIRE(rn->GetReturnCode() == 0);
+    auto task = via_idx.AsyncSemanticSearch("idx_tag1_renamed", ".*",
+                                            "tomatoes", 0,
+                                            clio::run::PoolQuery::Local());
+    task.Wait();
+    REQUIRE(task->GetReturnCode() == 0);
+    REQUIRE(!task->results_.empty());
+    REQUIRE(task->results_[0].tag_name_ == "idx_tag1_renamed");
+  }
+
+  // --- TruncateBlob to 0: the doc leaves the index ------------------------
+  {
+    auto tr = via_idx.AsyncTruncateBlob(tag1, "doc_a", 0);
+    tr.Wait();
+    REQUIRE(tr->GetReturnCode() == 0);
+    hits = Search(via_idx, "tomatoes sunshine");
+    REQUIRE(!Contains(hits, "doc_a"));
+  }
+
+  // --- DelBlob: removed from results --------------------------------------
+  PutText(via_idx, tag1, "doc_b", "steam locomotives crossed the prairie");
+  hits = Search(via_idx, "locomotives prairie");
+  REQUIRE(Contains(hits, "doc_b"));
+  {
+    auto del = via_idx.AsyncDelBlob(tag1, "doc_b");
+    del.Wait();
+    REQUIRE(del->GetReturnCode() == 0);
+    hits = Search(via_idx, "locomotives prairie");
+    REQUIRE(!Contains(hits, "doc_b"));
+  }
+
+  // --- kReindexScan: pre-existing data the indexer never saw --------------
+  // Stage blobs DIRECTLY at the core (bypassing the indexer entirely).
+  auto tag_scan = tag_of(direct, "idx_scan");
+  PutText(direct, tag_scan, "scan_1", "volcanic basalt columns by the sea");
+  PutText(direct, tag_scan, "scan_2", "glacier carved fjords in the north");
+  hits = Search(via_idx, "basalt fjords glacier");
+  REQUIRE(!Contains(hits, "scan_1"));  // never flowed through the indexer
+  {
+    auto scan = idx.AsyncReindexScan("^idx_scan$", ".*",
+                                     clio::run::PoolQuery::Local());
+    scan.Wait();
+    REQUIRE(scan->GetReturnCode() == 0);
+    REQUIRE(scan->blobs_enqueued_ >= 2);
+  }
+  hits = Search(via_idx, "basalt columns");
+  REQUIRE(Contains(hits, "scan_1"));
+  hits = Search(via_idx, "glacier fjords");
+  REQUIRE(Contains(hits, "scan_2"));
+
+  // --- First-insertion backfill: one write indexes the tag's past ---------
+  auto tag_bf = tag_of(direct, "idx_backfill");
+  PutText(direct, tag_bf, "bf_old", "ancient manuscripts in the archive");
+  // First write THROUGH the indexer for this tag triggers the backfill.
+  PutText(via_idx, tag_bf, "bf_new", "fresh newspaper headlines today");
+  hits = Search(via_idx, "ancient manuscripts archive");
+  REQUIRE(Contains(hits, "bf_old"));  // backfilled without any explicit scan
+  hits = Search(via_idx, "newspaper headlines");
+  REQUIRE(Contains(hits, "bf_new"));
+
+  // --- DelTag: every doc of the tag leaves the index ----------------------
+  {
+    auto del = via_idx.AsyncDelTag("idx_backfill");
+    del.Wait();
+    REQUIRE(del->GetReturnCode() == 0);
+    hits = Search(via_idx, "ancient manuscripts newspaper");
+    REQUIRE(!Contains(hits, "bf_old"));
+    REQUIRE(!Contains(hits, "bf_new"));
+  }
+}
+
+SIMPLE_TEST_MAIN()

--- a/context-transfer-engine/test/unit/test_indexer_ops.cc
+++ b/context-transfer-engine/test/unit/test_indexer_ops.cc
@@ -184,6 +184,17 @@ TEST_CASE("Indexer - scope, drain, and index maintenance verbs",
     return t->tag_id_;
   };
 
+  // --- A SemanticSearch reaching the BARE core (no indexer above it) must
+  // fail loudly (rc=2), not silently return empty — the miscomposed-
+  // deployment guard in core_lib_exec.
+  {
+    auto task = direct.AsyncSemanticSearch(".*", ".*", "anything", 0,
+                                           clio::run::PoolQuery::Local());
+    task.Wait();
+    REQUIRE(task->GetReturnCode() == 2);
+    REQUIRE(task->results_.empty());
+  }
+
   // --- Scope: only tags matching "idx_.*" are tokenized -------------------
   auto tag1 = tag_of(via_idx, "idx_tag1");
   auto tag_out = tag_of(via_idx, "other_tag");

--- a/context-transfer-engine/wrapper/python/test_cte_semantic_search.py
+++ b/context-transfer-engine/wrapper/python/test_cte_semantic_search.py
@@ -106,6 +106,17 @@ def generate_test_config() -> str:
                 ],
                 "dpe": {"dpe_type": "max_bw"},
             },
+            # Indexer chimod (issue #905): owns the SemanticSearch index.
+            # Puts flow through it (CLIO_CTE_POOL below binds the client
+            # here) so the index is maintained inline; the core no longer
+            # implements Method::kSemanticSearch.
+            {
+                "mod_name": "clio_cte_indexer",
+                "pool_name": "clio_cte_indexer",
+                "pool_query": "local",
+                "pool_id": "564.0",
+                "next_pool_id": "512.0",
+            },
         ],
     }
     cfg_path = os.path.join(tmp, "clio_semsearch_conf.yaml")
@@ -263,6 +274,12 @@ def run_test(cte) -> int:
 
 
 def main() -> int:
+    # Bind the CTE client singleton to the indexer pool (issue #905): the
+    # sanctioned interposer redirect, so PutBlob maintains the index and
+    # SemanticSearch is served from it — the core alone rejects Method 35.
+    # 564.0 exists in both the generated test compose and the default chain
+    # (external-runtime mode).
+    os.environ.setdefault("CLIO_CTE_POOL", "564.0")
     if should_initialize_runtime():
         try:
             import clio_cte_core_ext as cte


### PR DESCRIPTION
## Summary
- New `context-transfer-engine/indexer` chimod (pool 564.0): an interposer above the CTE core that owns the SemanticSearch index. It maintains a per-container forward index (term frequencies + doc lengths) by intercepting PutBlob/MultiPutBlob/TruncateBlob (forward-then-re-read) and DelBlob/DelTag/RenameTag, serves Method 35 from that index with the core's exact BM25 semantics, and forwards every other core method down `next_pool_id` (cache/replication pattern, `CoreInterposer` base).
- The CTE core no longer executes SemanticSearch — no more re-reading every candidate blob's bytes per query. The task struct, method id, and client API stay in core so every consumer (CAE forward, CEE, Python bindings, `cte_search`, benchmark) works unchanged; a Method-35 task reaching a core with no indexer composed now returns an explicit error instead of a silent scan.
- **Restart**: the index is derived state, never persisted. On the compose restart path each container rebuilds its slice from the storage below (BlobQuery + GetOrCreateTag + GetBlob) before Create acks. New `cte_indexer_restart` integration test (file-backed tier, two daemons, two-phase client) proves post-reboot searches return byte-identical BM25 rankings with zero puts after the restart.
- **Two latent core restart bugs fixed** (exposed by the rebuild test): `RestoreMetadataFromLog` never resynced `total_size_cache_` after rebuilding `blocks_`, so every restored blob reported size 0 (a Debug build asserts in `GetTotalSize`); and `kCreateNewBlob` WAL replay reset restored block layouts — the third instance of the outlives-the-flush hazard, alongside transform flags (#818) and replicas (#886).
- Default chain updated: `cache(563) -> indexer(564) -> [compressor(562) ->] replication(561) -> core(512)` — indexer sits above the compressor so its read-backs see logical bytes.

## Motivation
Closes #905. Search-index management is derived-data policy, not core storage responsibility; core's contract stays put/get/metadata, and the index becomes rebuildable layer state.

## Test plan
- [x] New restart test passes: `ctest -R cte_indexer_restart` (rankings identical pre/post reboot)
- [x] Restart/WAL regressions on the core fixes: `cr_cli_cte_wal_restart`, `cr_cli_compose_restart`, `cr_cli_restart_log`, `cte_restart_integration`, `cte_replication_persist_integration` all pass
- [x] `python_semantic_search_test`, `python_temporal_search_test`, `python_bindings_test`, `python_types_test` pass (client bound to the indexer via `CLIO_CTE_POOL=564.0`)
- [x] `cae_labeling_dispatch` passes (CAE → indexer SemanticSearch forward)
- [x] CEE suite 19/19 including `cee_query_prompt_bm25` (CEE → CAE → indexer chain; fixture now creates the CAE pool with `next_pool_id`=indexer *before* `CLIO_CAE_CLIENT_INIT`, whose default create used to win)
- [x] `cr_autogen_sweep_tests` passes (core keeps Method-35 serialization cases)
- [ ] `cae_semantic_search` needs live Ollama — not runnable on this box, CI covers it
- [x] cpplint clean on all new files; BSD headers applied

## Breaking changes
None for API consumers (method id + task structs unchanged). Deployments composing the core WITHOUT the indexer now get an explicit error (rc=2 + log) on SemanticSearch instead of results — compose `clio_cte_indexer` above the core (the default config does). Follow-ups: TemporalSearch (Method 36) intentionally stays in core (pure metadata scan); docs-site configuration page needs the new chain diagram (docs repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)