### PR TITLE
Serialize safe_bdev slot-allocator access across workers

### DIFF
--- a/context-runtime/modules/safe-bdev/include/clio_runtime/safe_bdev/safe_bdev_runtime.h
+++ b/context-runtime/modules/safe-bdev/include/clio_runtime/safe_bdev/safe_bdev_runtime.h
@@ -369,6 +369,26 @@ class Runtime : public clio::run::Container {
   std::set<clio::run::u64> written_slots_;
   mutable std::mutex slot_mu_;
 
+  // Slot-allocator lock. A container's methods are NOT serialized: client
+  // threads hash to different lanes (map_by_pid_tid), so several workers can
+  // be inside this container at once. data_alloc_ (per-member std::set + free
+  // list), rr_cursor_ and alloc_log_ are mutated by AllocateBlocks/FreeBlocks
+  // and read by GetStats, so every access takes this lock. Without it,
+  // concurrent Take()/Release() corrupt the heap (observed as
+  // "malloc(): unaligned tcache chunk detected" under >= 4 client threads,
+  // preceded by "block ... not live" warnings from lost set updates).
+  //
+  // Lock order is alloc_mu_ -> slot_mu_ (FreeBlocks marks slots dirty while
+  // holding it); never take alloc_mu_ while holding slot_mu_. Helpers that
+  // read data_alloc_ (StripeMembers, ForgetSlotIfEmpty) require the caller to
+  // hold alloc_mu_ and must not re-acquire it.
+  //
+  // NOT covered: the membership-change paths (AddBdev / RemoveBdev /
+  // RecoverBdev) push_back/pop_back on data_alloc_ across co_awaits, which can
+  // reallocate the vector under a concurrent data-plane task. Serializing
+  // those against I/O needs a suspension-aware lock (CoMutex), not this one.
+  mutable std::mutex alloc_mu_;
+
   /** Mark a slot as holding data and needing (re)parity. */
   void MarkSlotDirty(clio::run::u64 s) {
     std::lock_guard<std::mutex> g(slot_mu_);

--- a/context-runtime/modules/safe-bdev/src/safe_bdev_runtime.cc
+++ b/context-runtime/modules/safe-bdev/src/safe_bdev_runtime.cc
@@ -766,6 +766,10 @@ clio::run::TaskResume Runtime::AllocateBlocks(
     CLIO_CO_RETURN;
   }
 
+  // Guards data_alloc_/rr_cursor_/alloc_log_ against the other workers that can
+  // be executing this container concurrently. No co_await below, so a plain
+  // mutex is safe here.
+  std::lock_guard<std::mutex> alloc_g(alloc_mu_);
   const size_t nmembers = data_members_.size();
   clio::run::u64 remaining = size;
   while (remaining > 0) {
@@ -821,6 +825,9 @@ clio::run::TaskResume Runtime::FreeBlocks(clio::run::shared_ptr<FreeBlocksTask> 
   // Decode each block to (member d, slot s) and release the slot on that member.
   // The slot leaves the stripe -> if the stripe still has members, mark it dirty
   // so BuildParity re-derives the narrower parity; if it is now empty, forget it.
+  // Same allocator lock as AllocateBlocks (see alloc_mu_); StripeMembers and
+  // ForgetSlotIfEmpty read data_alloc_ under it and must not re-acquire it.
+  std::lock_guard<std::mutex> alloc_g(alloc_mu_);
   for (size_t i = 0; i < task->blocks_.size(); ++i) {
     const clio::run::bdev::Block &b = task->blocks_[i];
     clio::run::u32 d = 0;
@@ -1043,9 +1050,13 @@ clio::run::TaskResume Runtime::GetStats(clio::run::shared_ptr<GetStatsTask> &tas
   // Full aggregate capacity: every active data member contributes its own
   // remaining slots (bump headroom + reusable frees). No stranding.
   clio::run::u64 remaining = 0;
-  for (size_t d = 0; d < data_alloc_.size(); ++d) {
-    if (data_members_[d].state_ == ec::EcState::kActive) {
-      remaining += data_alloc_[d].RemainingSlots() * kChunkLen;
+  {
+    // data_alloc_ is mutated by concurrent AllocateBlocks/FreeBlocks.
+    std::lock_guard<std::mutex> alloc_g(alloc_mu_);
+    for (size_t d = 0; d < data_alloc_.size(); ++d) {
+      if (data_members_[d].state_ == ec::EcState::kActive) {
+        remaining += data_alloc_[d].RemainingSlots() * kChunkLen;
+      }
     }
   }
   task->remaining_size_ = remaining;

--- a/context-runtime/modules/safe-bdev/test/CMakeLists.txt
+++ b/context-runtime/modules/safe-bdev/test/CMakeLists.txt
@@ -33,6 +33,43 @@ set_target_properties(${SAFE_BDEV_TEST_TARGET} PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
 )
 
+# Concurrent data-plane regression test (issue #909). Its own binary because
+# reproducing the race needs more workers than the default 4: with 4, only two
+# are general-purpose and every data-plane task lands on the same one, so the
+# container is never entered concurrently. The ctest entry below raises
+# CLIO_NUM_THREADS for this binary alone, leaving the other suites untouched.
+set(SAFE_BDEV_CC_TEST_TARGET clio_safe_bdev_concurrency_tests)
+add_executable(${SAFE_BDEV_CC_TEST_TARGET} test_safe_bdev_concurrency.cc)
+
+target_include_directories(${SAFE_BDEV_CC_TEST_TARGET} PRIVATE
+  ${CLIO_RUN_ROOT}/include
+  ${CLIO_RUN_ROOT}/test  # For simple_test.h
+  ${CLIO_RUN_ROOT}/modules/admin/include
+  ${CLIO_RUN_ROOT}/modules/bdev/include
+  ${CLIO_RUN_ROOT}/modules/safe-bdev/include
+)
+
+target_link_libraries(${SAFE_BDEV_CC_TEST_TARGET}
+  clio_admin_runtime
+  clio_admin_client
+  clio_bdev_runtime
+  clio_bdev_client
+  clio_safe_bdev_runtime
+  clio_safe_bdev_client
+  ctp::cxx
+  ${CMAKE_THREAD_LIBS_INIT}
+)
+
+set_target_properties(${SAFE_BDEV_CC_TEST_TARGET} PROPERTIES
+  CXX_STANDARD 20
+  CXX_STANDARD_REQUIRED ON
+  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
+install(TARGETS ${SAFE_BDEV_CC_TEST_TARGET}
+  RUNTIME DESTINATION bin
+)
+
 # Erasure-coding core tests. These are daemon-independent: the EC core
 # (GF(2^8), Reed-Solomon, EcArray) is header-only and pulls in no Chimaera
 # runtime, so this target links nothing but the test harness. Keeping it
@@ -77,6 +114,20 @@ if(CLIO_CORE_ENABLE_TESTS)
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
   )
   set_tests_properties(cr_safe_bdev_ec_tests PROPERTIES TIMEOUT 60)
+
+  # CLIO_NUM_THREADS=16 is load-bearing: at the default 4 the scheduler places
+  # every data-plane task on the same general-purpose worker and the race can
+  # never occur. Distinct CLIO_PORT so it can run alongside the other suite.
+  add_test(
+    NAME cr_safe_bdev_concurrency_tests
+    COMMAND ${SAFE_BDEV_CC_TEST_TARGET}
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  )
+  set_tests_properties(cr_safe_bdev_concurrency_tests PROPERTIES
+    TIMEOUT 180
+    LABELS "msan_skip"
+    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CHIMAERA_TEST_MODE=1;CLIO_BIND_ADDR=127.0.0.1;CLIO_PORT=10501;CLIO_NUM_THREADS=16"
+  )
 endif()
 
 install(TARGETS ${SAFE_BDEV_TEST_TARGET}

--- a/context-runtime/modules/safe-bdev/test/test_safe_bdev_concurrency.cc
+++ b/context-runtime/modules/safe-bdev/test/test_safe_bdev_concurrency.cc
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Concurrent data-plane regression test for the safe_bdev ChiMod (issue #909).
+ *
+ * A container's methods are NOT serialized. Client threads submit independently
+ * and the scheduler places each task on the least-loaded worker, so several
+ * workers can execute inside the SAME safe_bdev container at once. This test
+ * drives Allocate -> Write -> Free from many threads and asserts that every
+ * slot handed out is returned.
+ *
+ * Without synchronization on data_alloc_/rr_cursor_, concurrent Take() and
+ * Release() lose std::set updates: FreeBlocks reports "block ... not live" and
+ * SKIPS the release (still returning rc=0), so slots leak and the post-run
+ * capacity comes back short. The same race corrupts the heap outright -- the
+ * unfixed module aborts with "malloc(): unaligned tcache chunk" inside
+ * safe_bdev::Runtime::Write. The capacity comparison is the assertion; a crash
+ * fails the test just as loudly.
+ *
+ * This lives in its own binary because reproducing the race needs more workers
+ * than the default 4 (with 4, only ~2 are general-purpose and every task lands
+ * on the same one). The ctest entry sets CLIO_NUM_THREADS accordingly.
+ */
+
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+
+#include <chrono>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "simple_test.h"
+
+using namespace std::chrono_literals;
+
+#include <clio_runtime/clio_runtime.h>
+#include <clio_runtime/pool_query.h>
+#include <clio_runtime/singletons.h>
+#include <clio_runtime/types.h>
+
+#include <clio_runtime/bdev/bdev_client.h>
+#include <clio_runtime/bdev/bdev_tasks.h>
+
+#include <clio_runtime/safe_bdev/safe_bdev_client.h>
+#include <clio_runtime/safe_bdev/safe_bdev_tasks.h>
+
+#include <clio_runtime/admin/admin_client.h>
+#include <clio_runtime/admin/admin_tasks.h>
+
+namespace {
+
+bool g_initialized = false;
+
+/** Per-member RAM size; 4 MiB holds many 64 KiB slots. */
+constexpr clio::run::u64 kMemberRamSize = 4 * 1024 * 1024;
+/** Mirrors Runtime::kChunkLen. */
+constexpr clio::run::u64 kChunkLen = 65536;
+
+/** Initialize Clio once for this test binary (runtime co-located). */
+void EnsureInit() {
+  if (!g_initialized) {
+    bool success = clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, true);
+    if (success) {
+      g_initialized = true;
+      SimpleTest::g_test_finalize = clio::run::CLIO_RUNTIME_FINALIZE;
+      std::this_thread::sleep_for(500ms);
+    }
+  }
+}
+
+/** Create a RAM-backed member bdev pool. */
+bool CreateRamMember(clio::run::bdev::Client &client,
+                     const std::string &pool_name,
+                     const clio::run::PoolId &pool_id) {
+  auto create_task =
+      client.AsyncCreate(clio::run::PoolQuery::Dynamic(), pool_name, pool_id,
+                         clio::run::bdev::BdevType::kRam, kMemberRamSize);
+  create_task.Wait();
+  client.pool_id_ = create_task->new_pool_id_;
+  client.return_code_ = create_task->return_code_;
+  return create_task->GetReturnCode() == 0;
+}
+
+/** A repeating, position-dependent byte pattern. */
+std::vector<ctp::u8> MakePattern(size_t size, ctp::u8 seed) {
+  std::vector<ctp::u8> v(size);
+  for (size_t i = 0; i < size; ++i) {
+    v[i] = static_cast<ctp::u8>((seed + i * 7 + (i >> 8)) & 0xFF);
+  }
+  return v;
+}
+
+}  // namespace
+
+TEST_CASE("safe_bdev_concurrent_data_plane",
+          "[safe_bdev][concurrency][regression]") {
+  EnsureInit();
+  REQUIRE(g_initialized);
+  std::this_thread::sleep_for(100ms);
+
+  const int pidsalt = static_cast<int>(getpid() & 0xFFF);
+  auto member_name = [&](int idx) {
+    return "cc_member_" + std::to_string(getpid()) + "_" + std::to_string(idx);
+  };
+
+  const int k = 4;
+  std::vector<clio::run::PoolId> data_ids;
+  for (int c = 0; c < k; ++c) {
+    clio::run::PoolId id(static_cast<clio::run::u32>(9500 + pidsalt + c), 0);
+    clio::run::bdev::Client client(id);
+    REQUIRE(CreateRamMember(client, member_name(c), id));
+    data_ids.push_back(client.pool_id_);
+  }
+
+  clio::run::PoolId safe_id(static_cast<clio::run::u32>(9550 + pidsalt), 0);
+  clio::run::safe_bdev::Client safe(safe_id);
+  std::vector<clio::run::safe_bdev::MemberBdevDesc> members;
+  for (int c = 0; c < k; ++c) {
+    members.emplace_back(member_name(c), /*node_id=*/0, data_ids[c]);
+  }
+  auto create_task = safe.AsyncCreate(clio::run::PoolQuery::Dynamic(),
+                                      "safe_bdev_cc_pool", safe_id,
+                                      /*max_failures=*/1, members);
+  create_task.Wait();
+  safe.pool_id_ = create_task->new_pool_id_;
+  REQUIRE(create_task->GetReturnCode() == 0);
+
+  // Baseline capacity: every slot this test allocates must be back in the
+  // per-member free lists by the end.
+  auto stats0 = safe.AsyncGetStats();
+  stats0.Wait();
+  REQUIRE(stats0->GetReturnCode() == 0);
+  const clio::run::u64 remaining_before = stats0->remaining_size_;
+  REQUIRE(remaining_before > 0);
+
+  // 16 threads keeps enough requests in flight that the scheduler spreads them
+  // over distinct workers; 4 MiB members leave ample slots for the working set.
+  constexpr size_t kThreads = 16;
+  constexpr size_t kItersPerThread = 300;
+  constexpr clio::run::u64 kIoLen = kChunkLen;
+
+  // REQUIRE throws, and an exception escaping a std::thread calls terminate --
+  // so worker threads only record; every assertion runs on the main thread.
+  std::vector<size_t> alloc_failures(kThreads, 0);
+  std::vector<size_t> write_failures(kThreads, 0);
+  std::vector<size_t> free_failures(kThreads, 0);
+  std::vector<size_t> completed(kThreads, 0);
+
+  auto worker = [&](size_t tid) {
+    const std::vector<ctp::u8> pattern =
+        MakePattern(static_cast<size_t>(kIoLen), static_cast<ctp::u8>(tid));
+    for (size_t i = 0; i < kItersPerThread; ++i) {
+      auto alloc =
+          safe.AsyncAllocateBlocks(clio::run::PoolQuery::Dynamic(), kIoLen);
+      alloc.Wait();
+      if (alloc->GetReturnCode() != 0 || alloc->blocks_.size() == 0) {
+        ++alloc_failures[tid];
+        continue;
+      }
+      clio::run::priv::vector<clio::run::bdev::Block> blocks(CTP_MALLOC);
+      for (size_t b = 0; b < alloc->blocks_.size(); ++b) {
+        blocks.push_back(alloc->blocks_[b]);
+      }
+
+      auto wbuf = CLIO_IPC->AllocateBuffer(kIoLen);
+      if (!wbuf.IsNull()) {
+        memcpy(wbuf.ptr_, pattern.data(), static_cast<size_t>(kIoLen));
+        auto wt = safe.AsyncWrite(clio::run::PoolQuery::Dynamic(), blocks,
+                                  wbuf.shm_.template Cast<void>(), kIoLen);
+        wt.Wait();
+        if (wt->GetReturnCode() != 0) {
+          ++write_failures[tid];
+        }
+        CLIO_IPC->FreeBuffer(wbuf);
+      } else {
+        ++write_failures[tid];
+      }
+
+      auto fr = safe.AsyncFreeBlocks(clio::run::PoolQuery::Dynamic(), blocks);
+      fr.Wait();
+      if (fr->GetReturnCode() != 0) {
+        ++free_failures[tid];
+      }
+      ++completed[tid];
+    }
+  };
+
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+  for (size_t t = 0; t < kThreads; ++t) {
+    threads.emplace_back(worker, t);
+  }
+  for (auto &t : threads) {
+    t.join();
+  }
+
+  size_t total_alloc_failures = 0, total_write_failures = 0;
+  size_t total_free_failures = 0, total_completed = 0;
+  for (size_t t = 0; t < kThreads; ++t) {
+    total_alloc_failures += alloc_failures[t];
+    total_write_failures += write_failures[t];
+    total_free_failures += free_failures[t];
+    total_completed += completed[t];
+  }
+
+  REQUIRE(total_alloc_failures == 0);
+  REQUIRE(total_write_failures == 0);
+  REQUIRE(total_free_failures == 0);
+  REQUIRE(total_completed == kThreads * kItersPerThread);
+
+  // The invariant: a lost Release() leaks its slot, so remaining capacity comes
+  // back short of the baseline.
+  auto stats1 = safe.AsyncGetStats();
+  stats1.Wait();
+  REQUIRE(stats1->GetReturnCode() == 0);
+  const clio::run::u64 remaining_after = stats1->remaining_size_;
+  HLOG(kInfo,
+       "safe_bdev concurrency: {} threads x {} iters, remaining {} -> {} "
+       "({} slots leaked)",
+       kThreads, kItersPerThread, remaining_before, remaining_after,
+       (remaining_before - remaining_after) / kChunkLen);
+  REQUIRE(remaining_after == remaining_before);
+
+  clio::run::admin::Client admin(clio::run::kAdminPoolId);
+  auto d =
+      admin.AsyncDestroyPool(clio::run::PoolQuery::Dynamic(), safe.pool_id_);
+  d.Wait();
+}
+
+SIMPLE_TEST_MAIN()


### PR DESCRIPTION
## Summary

- Guard `safe_bdev`'s slot-allocator state (`data_alloc_`, `rr_cursor_`, `alloc_log_`) with a new `alloc_mu_` in `AllocateBlocks` / `FreeBlocks` / `GetStats`. Lock order is `alloc_mu_ -> slot_mu_`; helpers that read `data_alloc_` (`StripeMembers`, `ForgetSlotIfEmpty`) run under it and must not re-acquire it.
- Add `cr_safe_bdev_concurrency_tests`, a regression test that drives Allocate -> Write -> Free from 16 threads and asserts every slot handed out comes back.

## Motivation

Fixes #909.

Container methods are not serialized — client threads submit independently and the scheduler places each task on the least-loaded worker, so several workers execute inside the same container at once. The allocator state was mutated with no synchronization, even though `dirty_slots_`/`written_slots_` right beside it are guarded by `slot_mu_`.

Concurrent `Take()`/`Release()` lose `std::set` updates — `FreeBlocks` then logs `block ... not live` and skips the release, leaking the slot — and corrupt the heap outright at higher thread counts:

```
malloc(): unaligned tcache chunk detected
Thread 20 "clio_run" received signal SIGABRT, Aborted.
#10 std::_Rb_tree<unsigned long, ...>::_M_insert_unique<unsigned long const&>()
   from libclio_safe_bdev_runtime.so
#11 clio::run::safe_bdev::Runtime::Write(...)
```

The daemon dies with no fatal log line; clients then fail with `shm_attach(chi_main_segment_...) failed`. `clio_bdev` is unaffected — its allocator is sharded per worker (`transport_->AllocateBlocks(size, worker_id, ...)`), which is also the natural follow-up for `safe_bdev` (see Performance note).

## Test plan

- [x] New regression test fails without the fix: `cr_safe_bdev_concurrency_tests ... (SEGFAULT)`
- [x] Passes with the fix, 5 consecutive runs: `ctest -R cr_safe_bdev_concurrency_tests --repeat until-fail:5`
- [x] Existing suites pass: `ctest -R "cr_all_safe_bdev_tests|cr_safe_bdev_ec_tests|cr_bdev"` — 9/9
- [x] No new compiler warnings
- [x] BSD 3-Clause header on the new file; new/changed lines within 80 columns
- [ ] `clang-format` not run — not installed on the machine used; please let CI confirm

The test needs `CLIO_NUM_THREADS=16` (set in its ctest `ENVIRONMENT`, hence a separate binary): at the default 4 workers only ~2 are general-purpose, every data-plane task lands on the same one, and the race cannot occur. Verified by instrumenting `AllocateBlocks` — 4 workers put all 2400 allocations on a single thread; 16 spread them across 9 and crashed.

## Follow-up (not covered here)

`AddBdev` / `RemoveBdev` / `RecoverBdev` `push_back`/`pop_back` on `data_alloc_` **across `co_await`s**, so the vector can reallocate under a concurrent data-plane task. A `std::mutex` cannot fix that — it needs a suspension-aware lock (CoMutex). Tracked in #909.

## Performance note

`alloc_mu_` is a single lock over all members, so the allocator now saturates where it previously scaled. Measured with a co-located runtime, alloc+free only: safe_bdev 38.8k ops/s (1 thread) -> 101k (4) -> 117k (16, saturated), against clio_bdev's per-worker-sharded 49.4k -> 199k -> 278k (still scaling). Correct but slower; sharding `data_alloc_` per member or per worker is the obvious next step.

## Breaking changes

None.