### PR TITLE
Bound the macOS FSKit mount probe and make it truly non-blocking

### DIFF
--- a/.github/workflows/ci-adapters.yml
+++ b/.github/workflows/ci-adapters.yml
@@ -215,7 +215,14 @@ jobs:
       # macOS 15.4+, mountpoint must live under /Volumes). NON-BLOCKING: FSKit
       # extension approval semantics on runner images are unproven — promote
       # to a hard gate once this step is observed green. See #903.
+      # timeout + continue-on-error: the first probe HUNG for 50+ minutes
+      # (fuse daemon stuck in an uninterruptible mount, the script's cleanup
+      # wait blocked behind it) — `|| echo` inside the script only survives
+      # failures, not hangs, so the non-blocking contract needs both a step
+      # bound and continue-on-error to hold.
       - name: FUSE mount smoke (FSKit backend, non-blocking probe)
+        timeout-minutes: 10
+        continue-on-error: true
         run: |
           if [ -f "$HOME/miniconda3/etc/profile.d/conda.sh" ]; then
             source "$HOME/miniconda3/etc/profile.d/conda.sh"


### PR DESCRIPTION
## Summary
Fast-follow to #904 (merged before this landed on the branch): the macOS FSKit mount probe **hung for 50+ minutes** on its first execution — the fuse daemon wedged in an uninterruptible mount and the smoke script's cleanup `wait` blocked behind it. The `|| echo` guard only survives failures, not hangs, so without this every dev adapters run's macOS job will wedge until the 120-minute job timeout. `timeout-minutes: 10` + `continue-on-error: true` restore the non-blocking contract (a bare step-timeout kill would otherwise fail the job).

Context: everything blocking in that first macOS run passed — macFUSE build, binary verify, and the full fuse unit + ops suites. The probe hang also suggests FSKit mounting is not viable on runner images (wedges rather than erroring); with this change it reports as a warning.

## Motivation
Fixes the #903 follow-up hang; the currently running dev adapters run will demonstrate it (its macOS job is heading into the unbounded probe).

## Test plan
- [ ] dev adapters macOS job completes within bounds after merge

## Breaking changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)