### PR TITLE
Fix three CI flakes at their root cause (bdev free space, rename listings, daemon readiness)

### DIFF
--- a/context-runtime/test/runtime_server.h
+++ b/context-runtime/test/runtime_server.h
@@ -59,6 +59,8 @@
 #include <chrono>
 #include <cstdlib>
 #include <filesystem>
+#include <fstream>
+#include <sstream>
 #include <string>
 #include <thread>
 #include <vector>
@@ -144,11 +146,25 @@ class RuntimeServer {
   }
 
   /**
-   * Poll until the runtime's main shared-memory segment exists, signalling that
-   * the daemon has initialized far enough to serve clients. Portable: on POSIX
-   * the segment is a file under /tmp/clio_$USER, on Windows a named mapping
-   * — SystemInfo::OpenSharedMemory abstracts both. Returns false if the timeout
-   * elapses or the daemon exits early.
+   * Poll until the daemon is genuinely able to serve clients. Two stages:
+   *
+   *   1. the runtime's main shared-memory segment exists — portable: on POSIX a
+   *      file under /tmp/clio_$USER, on Windows a named mapping, both behind
+   *      SystemInfo::OpenSharedMemory;
+   *   2. its request ROUTER is BOUND, read from the daemon's captured log.
+   *
+   * Stage 2 exists because stage 1 fires early in daemon init, well before the
+   * transport comes up. This used to be papered over with a flat 1 s sleep,
+   * which is a guess, not a signal: on a loaded Windows Debug runner the ROUTER
+   * can still be unbound when it expires, and the daemon can also die inside it
+   * (issue #848) with the old code returning true for a dead process. Either
+   * way the caller was handed a daemon it could not reach, and callers that
+   * retry on a fresh port (see test_daemon_detached_spawn) never got the chance
+   * — they had already been told the daemon was ready. That is the
+   * cr_detached_spawn flake: the client's DEALER dials port+3 and times out.
+   *
+   * Returns false if the timeout elapses or the daemon exits early, which is
+   * what lets those callers retry instead of failing outright.
    */
   bool WaitForReady(int timeout_ms = 30000) {
     // Segment names are port-keyed (see ConfigManager::GetSharedMemorySegmentName)
@@ -157,18 +173,50 @@ class RuntimeServer {
         ctp::ConfigParse::ExpandPath("chi_main_segment_${USER}") + "_" +
         std::to_string(port_);
     const int attempts = timeout_ms / 200;
-    for (int i = 0; i < attempts; ++i) {
+    int i = 0;
+    bool segment_up = false;
+    for (; i < attempts && !segment_up; ++i) {
       std::this_thread::sleep_for(std::chrono::milliseconds(200));
       if (!IsRunning()) return false;  // daemon died during startup
       ctp::File fd;
       if (ctp::SystemInfo::OpenSharedMemory(fd, seg)) {
         ctp::SystemInfo::CloseSharedMemory(fd);
-        // Let the daemon finish binding its transports / starting workers.
-        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-        return true;
+        segment_up = true;
       }
     }
-    return false;
+    if (!segment_up) return false;
+
+    // Spend whatever budget is left waiting for the ROUTER bind line. The
+    // daemon logs it at INFO, so a caller that wants this stage must leave
+    // CTP_LOG_LEVEL at info or lower; if the line never shows up we fall
+    // through to the settle sleep rather than failing a daemon that is fine.
+    const std::string log_path = ServerLogPath();
+    for (; i < attempts; ++i) {
+      if (!IsRunning()) return false;
+      if (ServerLogHasRouter(log_path)) return true;
+      std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    }
+
+    // Budget exhausted with no marker (log not captured, or logging turned
+    // down). Fall back to the historical settle, but do not call a daemon that
+    // died inside it ready.
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+    return IsRunning();
+  }
+
+  /**
+   * @return true if the daemon's captured log shows its request ROUTER bound.
+   * Matches both transports: "TCP ROUTER transport bound on <addr>:<port>" and
+   * the IPC-mode "client ZMQ ROUTER bound on ipc <path>".
+   */
+  static bool ServerLogHasRouter(const std::string &log_path) {
+    std::ifstream f(log_path, std::ios::binary);
+    if (!f) return false;
+    std::ostringstream ss;
+    ss << f.rdbuf();
+    const std::string log = ss.str();
+    return log.find("ROUTER transport bound on") != std::string::npos ||
+           log.find("ROUTER bound on") != std::string::npos;
   }
 
   /** Stop the daemon (SIGTERM then SIGKILL on POSIX — so ServerFinalize's leak

--- a/context-runtime/test/runtime_server.h
+++ b/context-runtime/test/runtime_server.h
@@ -186,37 +186,50 @@ class RuntimeServer {
     }
     if (!segment_up) return false;
 
-    // Spend whatever budget is left waiting for the ROUTER bind line. The
-    // daemon logs it at INFO, so a caller that wants this stage must leave
-    // CTP_LOG_LEVEL at info or lower; if the line never shows up we fall
-    // through to the settle sleep rather than failing a daemon that is fine.
+    // Spend whatever budget is left waiting for the daemon to log that its
+    // admin pool exists. The daemon logs it at INFO, so a caller that wants
+    // this stage must leave CTP_LOG_LEVEL at info or lower; if the line never
+    // shows up we fall through to the settle sleep rather than failing a
+    // daemon that is fine.
+    //
+    // The marker is the ADMIN POOL, not the ROUTER bind. Ordering the daemon's
+    // own startup log, the ROUTER binds second of twenty-one markers -- before
+    // the chimods load, before the workers spawn, and before the admin pool is
+    // created. Treating it as "ready" would hand callers a daemon that cannot
+    // yet route a task, which is strictly worse than the sleep it replaced.
+    // Waiting for the admin pool means the runtime can actually serve work.
     const std::string log_path = ServerLogPath();
-    for (; i < attempts; ++i) {
+    bool marker_seen = false;
+    for (; i < attempts && !marker_seen; ++i) {
       if (!IsRunning()) return false;
-      if (ServerLogHasRouter(log_path)) return true;
+      if (ServerLogHasAdminPool(log_path)) {
+        marker_seen = true;
+        break;
+      }
       std::this_thread::sleep_for(std::chrono::milliseconds(200));
     }
 
-    // Budget exhausted with no marker (log not captured, or logging turned
-    // down). Fall back to the historical settle, but do not call a daemon that
-    // died inside it ready.
+    // Keep the historical settle in BOTH cases -- marker seen or budget spent.
+    // The marker is necessary but not provably sufficient: startup work that
+    // logs nothing (e.g. compose/WAL replay re-creating restartable pools) can
+    // still be in flight. Retaining the settle makes this readiness check
+    // strictly stronger than the sleep-only version it replaces, never weaker.
+    // Do not call a daemon that died inside the settle ready.
     std::this_thread::sleep_for(std::chrono::milliseconds(1000));
     return IsRunning();
   }
 
   /**
-   * @return true if the daemon's captured log shows its request ROUTER bound.
-   * Matches both transports: "TCP ROUTER transport bound on <addr>:<port>" and
-   * the IPC-mode "client ZMQ ROUTER bound on ipc <path>".
+   * @return true if the daemon's captured log shows the admin pool created --
+   * i.e. the runtime can route a task, not merely accept a connection.
    */
-  static bool ServerLogHasRouter(const std::string &log_path) {
+  static bool ServerLogHasAdminPool(const std::string &log_path) {
     std::ifstream f(log_path, std::ios::binary);
     if (!f) return false;
     std::ostringstream ss;
     ss << f.rdbuf();
-    const std::string log = ss.str();
-    return log.find("ROUTER transport bound on") != std::string::npos ||
-           log.find("ROUTER bound on") != std::string::npos;
+    return ss.str().find("Admin chimod pool created successfully") !=
+           std::string::npos;
   }
 
   /** Stop the daemon (SIGTERM then SIGKILL on POSIX — so ServerFinalize's leak

--- a/context-runtime/test/unit/test_daemon_detached_spawn.cc
+++ b/context-runtime/test/unit/test_daemon_detached_spawn.cc
@@ -69,14 +69,13 @@ TEST_CASE("DaemonDetachedSpawn - transport initializes without a console (#721)"
   test::RuntimeServer server;
   bool ready = false;
   unsigned port = kPort;
-  for (int attempt = 0; attempt < 3 && !ready; ++attempt, port += 7) {
+  for (int attempt = 0; attempt < 3 && !ready; ++attempt) {
     ::remove(log_path.c_str());
     test::SetEnvVar("CLIO_PORT", std::to_string(port));
-    if (!server.Start(port, "127.0.0.1", /*ephemeral=*/true,
-                      /*detached=*/true)) {
-      continue;
+    if (server.Start(port, "127.0.0.1", /*ephemeral=*/true,
+                     /*detached=*/true)) {
+      ready = server.WaitForReady();
     }
-    ready = server.WaitForReady();
     if (!ready) {
       std::printf(
           "[detached-spawn] attempt %d on port %u: daemon not ready "
@@ -84,6 +83,7 @@ TEST_CASE("DaemonDetachedSpawn - transport initializes without a console (#721)"
           attempt, port, static_cast<int>(server.IsRunning()),
           ReadWholeFile(log_path).c_str());
       server.Stop();
+      port += 7;  // fresh port => fresh port-keyed segment names
     }
   }
   REQUIRE(ready);
@@ -95,6 +95,16 @@ TEST_CASE("DaemonDetachedSpawn - transport initializes without a console (#721)"
   test::SetEnvVar("CLIO_IPC_MODE", "tcp");
   test::SetEnvVar("CLIO_WAIT_SERVER", "15");
   bool connected = CLIO_INIT(RuntimeMode::kClient, false);
+  if (!connected) {
+    // The daemon passed WaitForReady but its ROUTER did not answer. Dump its
+    // log: without this the CI failure is just "connect timed out" with no way
+    // to tell a dead daemon from a slow one (issue #919).
+    std::printf(
+        "[detached-spawn] client could not reach the daemon on port %u "
+        "(DEALER dials %u); IsRunning=%d; daemon log follows:\n----\n%s\n----\n",
+        port, port + 3, static_cast<int>(server.IsRunning()),
+        ReadWholeFile(log_path).c_str());
+  }
   REQUIRE(connected);  // #721: a dead ROUTER would make this time out / fail
 
   auto *ipc = CLIO_IPC;

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -6100,10 +6100,29 @@ clio::run::TaskResume Runtime::ExtendBlob(BlobInfo &blob_info, clio::run::u64 of
   // Snapshot available targets for the DPE. target_list_ is the contiguous
   // mirror of registered_targets_ — copying it under the read lock is O(N_live)
   // with no map iteration over empty slots.
+  //
+  // remaining_space_ is the one field the data path mutates: PutBlob debits and
+  // Free credits the CANONICAL map entry only, lock-free, while the mirror is
+  // refreshed lazily by the periodic StatTargets sweep
+  // (performance.stat_targets_period_ms, 5 s by default). Feeding the DPE the
+  // mirror's copy therefore places against free space that can be a full tick
+  // out of date — and the failure is not symmetric: a tick that lands while a
+  // tier is full pins the mirror at ~0, so every subsequent put is rejected for
+  // "no target has space" even after the blobs holding that space are deleted.
+  // Re-read the canonical value here so placement always sees real free space
+  // (same reason GetCapacity iterates registered_targets_ directly).
   std::vector<TargetInfo> available_targets;
   {
     clio::run::ScopedCoRwReadLock read_lock(target_lock_);
     available_targets = target_list_;
+    for (auto &t : available_targets) {
+      TargetInfo *canonical = registered_targets_.find(t.bdev_client_.pool_id_);
+      if (canonical != nullptr) {
+        t.remaining_space_ =
+            ctp::ipc::atomic_ref<clio::run::u64>(canonical->remaining_space_)
+                .load(std::memory_order_relaxed);
+      }
+    }
   }
   if (available_targets.empty()) {
     error_code = 1;

--- a/context-transfer-engine/test/unit/CMakeLists.txt
+++ b/context-transfer-engine/test/unit/CMakeLists.txt
@@ -126,6 +126,12 @@ add_executable(test_bdev_fragmentation
     test_bdev_fragmentation.cc
 )
 
+# Freed space must reach the DPE without waiting for a StatTargets tick (#919).
+# Drives the stale-mirror window that made cte_bdev_fragmentation flaky.
+add_executable(test_bdev_free_visibility
+    test_bdev_free_visibility.cc
+)
+
 # Batching benchmark (#820): many small writes at ONE blob, A/B'd on the same
 # binary via CLIO_TASK_BATCHING.
 add_executable(bench_same_blob_batching
@@ -445,6 +451,18 @@ target_link_libraries(test_vectored_blob_io
 
 # Link test_bdev_fragmentation (#820) - same deps.
 target_link_libraries(test_bdev_fragmentation
+    clio_cte_core_runtime
+    clio_cte_core_client
+    clio::run::admin_runtime
+    clio::run::admin_client
+    clio::run::bdev_runtime
+    clio::run::bdev_client
+    ctp::cxx
+    ${CMAKE_THREAD_LIBS_INIT}
+)
+
+# Link test_bdev_free_visibility (#919) - same deps.
+target_link_libraries(test_bdev_free_visibility
     clio_cte_core_runtime
     clio_cte_core_client
     clio::run::admin_runtime
@@ -849,6 +867,15 @@ add_test(NAME cte_bdev_fragmentation
 set_tests_properties(cte_bdev_fragmentation PROPERTIES
     TIMEOUT 300
     LABELS "regression;bdev;cte;820"
+    ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CLIO_TEST_DATA_DIR=${CMAKE_BINARY_DIR};CLIO_BIND_ADDR=127.0.0.1")
+
+# issue #919: placement must see space freed since the last StatTargets tick.
+# Four fill/stat/delete/put cycles; a stray periodic tick can rescue one, not all.
+add_test(NAME cte_bdev_free_visibility
+    COMMAND test_bdev_free_visibility)
+set_tests_properties(cte_bdev_free_visibility PROPERTIES
+    TIMEOUT 600
+    LABELS "regression;bdev;cte;919"
     ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CLIO_TEST_DATA_DIR=${CMAKE_BINARY_DIR};CLIO_BIND_ADDR=127.0.0.1")
 
 # Add reorganize blob tests

--- a/context-transfer-engine/test/unit/test_bdev_free_visibility.cc
+++ b/context-transfer-engine/test/unit/test_bdev_free_visibility.cc
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved. BSD 3-Clause license.
+ */
+
+// Freed space must be visible to placement immediately (issue #919).
+//
+// The CTE keeps two copies of every target's remaining_space_:
+//   * registered_targets_[id] -- the CANONICAL entry. PutBlob debits it and
+//     Free credits it, lock-free, on the data path.
+//   * target_list_[i]         -- a contiguous mirror used for O(N) iteration.
+//     Its remaining_space_ is refreshed ONLY by the periodic StatTargets sweep
+//     (performance.stat_targets_period_ms, 5 s by default).
+//
+// ExtendBlob used to hand the DPE the mirror's copy, so placement decided
+// against free space that could be a whole tick out of date. The failure is not
+// symmetric: a StatTargets tick that lands while a tier is FULL pins the mirror
+// at ~0, and every later put is then rejected for "no target has space" even
+// after the blobs holding that space have been deleted -- until the next tick.
+//
+// That is the race behind the cte_bdev_fragmentation flake: its fill phase
+// drives the tier to capacity, and on a slow runner a tick lands inside that
+// window, so the large puts that follow the deletes all EIO.
+//
+// This test drives the same window deliberately instead of waiting to get
+// unlucky: fill the tier, force a one-shot StatTargets (mirror := 0), delete a
+// slice, then immediately put a blob that only fits in the just-freed space.
+// The cycle repeats -- a stray periodic tick can rescue any single iteration by
+// refreshing the mirror, but rescuing every iteration is not plausible.
+
+#include <clio_runtime/clio_runtime.h>
+#include <clio_runtime/bdev/bdev_client.h>
+#include <clio_cte/core/core_client.h>
+#include <clio_cte/core/core_tasks.h>
+
+#include <chrono>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "simple_test.h"
+
+namespace {
+
+const char *kTargetName = "free_vis_target";
+// Small enough that "full" is a few thousand puts away, matching the geometry
+// of the fragmentation test this regression was extracted from.
+constexpr clio::run::u64 kTargetSize = 32ULL * 1024 * 1024;
+
+class Fixture {
+ public:
+  bool initialized_ = false;
+  Fixture() {
+    bool ok = clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, true);
+    REQUIRE(ok);
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    ok = clio::cte::core::CLIO_CTE_CLIENT_INIT();
+    REQUIRE(ok);
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    auto *cte = CLIO_CTE_CLIENT;
+    clio::run::PoolId bdev_pool_id(932, 0);
+    clio::run::bdev::Client bdev_client(bdev_pool_id);
+    auto create = bdev_client.AsyncCreate(
+        clio::run::PoolQuery::Dynamic(), kTargetName, bdev_pool_id,
+        clio::run::bdev::BdevType::kRam, kTargetSize);
+    create.Wait();
+    auto reg = cte->AsyncRegisterTarget(
+        kTargetName, clio::run::bdev::BdevType::kRam, kTargetSize,
+        clio::run::PoolQuery::Local(), bdev_pool_id);
+    reg.Wait();
+    REQUIRE(reg->GetReturnCode() == 0);
+    initialized_ = true;
+  }
+};
+
+Fixture *g_fixture = nullptr;
+
+constexpr size_t kSmall = 8 * 1024;
+constexpr size_t kLarge = 1024 * 1024;
+
+// Put kSmall blobs named "<prefix>_<i>" until the tier refuses one. Returns how
+// many landed, which is what drives the allocator to its capacity watermark.
+int FillToCapacity(clio::cte::core::Client *cte,
+                   const clio::cte::core::TagId &tag_id,
+                   const std::string &prefix, int start_index) {
+  auto sb = CLIO_IPC->AllocateBuffer(kSmall);
+  REQUIRE(!sb.IsNull());
+  std::memset(sb.ptr_, 'x', kSmall);
+  int filled = 0;
+  const int kMaxSmall = 200000;
+  for (int i = 0; i < kMaxSmall; ++i) {
+    const std::string nm = prefix + std::to_string(start_index + i);
+    auto p = cte->AsyncPutBlob(tag_id, nm, 0, kSmall,
+                               ctp::ipc::ShmPtr<>(sb.shm_));
+    p.Wait();
+    if (p->GetReturnCode() != 0) break;  // tier full
+    ++filled;
+  }
+  CLIO_IPC->FreeBuffer(sb);
+  return filled;
+}
+
+}  // namespace
+
+TEST_CASE("Deleted space is visible to placement without a stats tick (#919)",
+          "[cte][bdev][placement][919]") {
+  REQUIRE(g_fixture != nullptr);
+  REQUIRE(g_fixture->initialized_);
+  auto *cte = CLIO_CTE_CLIENT;
+  clio::cte::core::Tag tag("free_vis_tag");
+  clio::cte::core::TagId tag_id = tag.GetTagId();
+
+  std::vector<char> lbuf(kLarge);
+  for (size_t j = 0; j < kLarge; ++j) {
+    lbuf[j] = static_cast<char>((j * 13) % 251);
+  }
+
+  // Freeing this many kSmall blobs yields 4 MiB -- comfortably more than the
+  // single 1 MiB blob we then place, so a pass cannot be luck about sizing.
+  const int kFreeCount = 512;
+  const int kCycles = 4;
+  int next_index = 0;
+
+  for (int cycle = 0; cycle < kCycles; ++cycle) {
+    // 1. Drive the tier to its capacity watermark.
+    const std::string prefix = "v" + std::to_string(cycle) + "_";
+    const int filled = FillToCapacity(cte, tag_id, prefix, next_index);
+    REQUIRE(filled >= kFreeCount);
+
+    // 2. Force the mirror to snapshot the tier while it is FULL. This is the
+    //    state a periodic tick lands in by chance on a slow runner; taking it
+    //    deliberately is what makes the regression reproducible.
+    auto stat = cte->AsyncStatTargets(clio::run::PoolQuery::Local());
+    stat.Wait();
+
+    // 3. Free 4 MiB. Only the canonical entry learns about it.
+    for (int i = 0; i < kFreeCount; ++i) {
+      const std::string nm = prefix + std::to_string(next_index + i);
+      auto d = cte->AsyncDelBlob(tag_id, nm);
+      d.Wait();
+      REQUIRE(d->GetReturnCode() == 0);
+    }
+
+    // 4. A 1 MiB blob now fits only in the space freed by step 3. Placement
+    //    reading the stale mirror sees a full tier and refuses it.
+    auto lb = CLIO_IPC->AllocateBuffer(kLarge);
+    REQUIRE(!lb.IsNull());
+    std::memcpy(lb.ptr_, lbuf.data(), kLarge);
+    const std::string lname = "V_" + std::to_string(cycle);
+    auto p = cte->AsyncPutBlob(tag_id, lname, 0, kLarge,
+                               ctp::ipc::ShmPtr<>(lb.shm_));
+    p.Wait();
+    const int put_rc = static_cast<int>(p->GetReturnCode());
+    CLIO_IPC->FreeBuffer(lb);
+    std::printf("[#919] cycle %d: filled %d, freed %d, 1MiB put rc=%d\n", cycle,
+                filled, kFreeCount, put_rc);
+    REQUIRE(put_rc == 0);
+
+    // Read back: the blob was assembled from the freed small extents, so a
+    // correct placement decision must also produce correct data.
+    auto rd = CLIO_IPC->AllocateBuffer(kLarge);
+    REQUIRE(!rd.IsNull());
+    std::memset(rd.ptr_, 0, kLarge);
+    auto g = cte->AsyncGetBlob(tag_id, lname, 0, kLarge, /*flags=*/0,
+                               ctp::ipc::ShmPtr<>(rd.shm_));
+    g.Wait();
+    REQUIRE(g->GetReturnCode() == 0);
+    REQUIRE(std::memcmp(rd.ptr_, lbuf.data(), kLarge) == 0);
+    CLIO_IPC->FreeBuffer(rd);
+
+    // 5. Hand the tier back so the next cycle starts from a clean slate.
+    auto dl = cte->AsyncDelBlob(tag_id, lname);
+    dl.Wait();
+    REQUIRE(dl->GetReturnCode() == 0);
+    for (int i = kFreeCount; i < filled; ++i) {
+      const std::string nm = prefix + std::to_string(next_index + i);
+      auto d = cte->AsyncDelBlob(tag_id, nm);
+      d.Wait();
+      REQUIRE(d->GetReturnCode() == 0);
+    }
+    next_index += filled;
+  }
+}
+
+int main(int argc, char **argv) {
+  g_fixture = new Fixture();
+  std::string filter = (argc > 1) ? argv[1] : "";
+  int rc = SimpleTest::run_all_tests(filter);
+  delete g_fixture;
+  g_fixture = nullptr;
+  return rc;
+}

--- a/context-transfer-engine/test/unit/test_reorganize_blob.cc
+++ b/context-transfer-engine/test/unit/test_reorganize_blob.cc
@@ -1110,8 +1110,20 @@ TEST_CASE("ReorganizeBlob - Cleanup", "[reorganize][cleanup]") {
 }
 
 int main(int argc, char** argv) {
-  // Create fixture (initializes runtime)
-  g_fixture = new ReorganizeBlobTestFixture();
+  // Create fixture (initializes runtime).
+  //
+  // Guarded: the fixture REQUIREs the runtime to come up, and a REQUIRE throws.
+  // Thrown from here it escaped main, so a runtime that failed to start turned
+  // into std::terminate -> SIGABRT, which ctest reports as the bare
+  // "Subprocess aborted" seen on the leak-check runner (#919) with the reason
+  // buried thousands of log lines up. Report it as a failure instead.
+  try {
+    g_fixture = new ReorganizeBlobTestFixture();
+  } catch (const std::exception &e) {
+    std::fprintf(stderr, "FATAL: reorganize fixture setup failed: %s\n",
+                 e.what());
+    return 1;
+  }
 
   // Run tests with optional filter from command line
   std::string filter = (argc > 1) ? argv[1] : "";

--- a/context-transport-primitives/include/clio_ctp/search/regex_search_engine.h
+++ b/context-transport-primitives/include/clio_ctp/search/regex_search_engine.h
@@ -36,7 +36,9 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdint>
 #include <cstdlib>
+#include <atomic>
 #include <mutex>
 #include <regex>
 #include <set>
@@ -74,12 +76,26 @@ namespace ctp::search {
  * (Insert/Delete/Rename/Clear) take it exclusively, queries (Search/Contains/
  * Find/Size/Empty) take it shared. Search returns a SNAPSHOT of the matching
  * (key, value) pairs, so a SearchResult — keys() and the value-yielding
- * iterator alike — is stable under concurrent mutation. A key deleted between
- * the candidate scan and the value snapshot is simply absent from the result
- * (the documented "live subset" semantics). The previous design fetched
- * values lazily via Find() at iteration time; a concurrent Delete then made
- * the iterator dereference Find()'s nullptr — a NULL TagId read that crashed
- * the runtime under the #807 CFS stress (readdir's TagQuery racing unlink).
+ * iterator alike — is stable under concurrent mutation. The previous design
+ * fetched values lazily via Find() at iteration time; a concurrent Delete then
+ * made the iterator dereference Find()'s nullptr — a NULL TagId read that
+ * crashed the runtime under the #807 CFS stress (readdir's TagQuery racing
+ * unlink).
+ *
+ * Search is POINT-IN-TIME consistent (issue #919): the pairs it returns are all
+ * live at one instant, never a blend of two. It gets there optimistically — the
+ * expensive regex pass still runs with the lock released (see Search), but the
+ * result is only accepted if no mutation landed while it ran; otherwise the
+ * whole query is retried, and a query that keeps losing the race falls back to
+ * a single fully-locked pass so it cannot livelock.
+ *
+ * Dropping that guarantee is not merely a stale read — it can make a live key
+ * vanish entirely. A key renamed A->B between the candidate scan and the value
+ * snapshot was captured as A (still live then) but is looked up as A after the
+ * move, while B was never a candidate at all. Both names match a readdir's
+ * "^<dir>/[^/]+$", so the file disappeared from a listing of its own directory:
+ * the cr_cli_cfs_rename flake, whose D4 case asserts exactly that a concurrent
+ * rename may relabel an entry but must never drop it.
  */
 template <typename ValueT>
 class RegexSearchEngine {
@@ -92,13 +108,17 @@ class RegexSearchEngine {
    */
   bool Insert(const std::string &key, const ValueT &value) {
     std::unique_lock<std::shared_mutex> lk(mtx_);
-    return InsertLocked(key, value);
+    const bool is_new = InsertLocked(key, value);
+    BumpVersionLocked();
+    return is_new;
   }
 
   /** Remove `key`. @return true if it existed. */
   bool Delete(const std::string &key) {
     std::unique_lock<std::shared_mutex> lk(mtx_);
-    return DeleteLocked(key);
+    const bool existed = DeleteLocked(key);
+    BumpVersionLocked();
+    return existed;
   }
 
  private:
@@ -163,6 +183,7 @@ class RegexSearchEngine {
     ValueT moved = std::move(it->second);
     DeleteLocked(old_key);
     InsertLocked(new_key, moved);
+    BumpVersionLocked();
     return true;
   }
 
@@ -192,6 +213,7 @@ class RegexSearchEngine {
     std::unique_lock<std::shared_mutex> lk(mtx_);
     entries_.clear();
     index_.clear();
+    BumpVersionLocked();
   }
 
   /**
@@ -241,6 +263,10 @@ class RegexSearchEngine {
 
   /**
    * Return every (key, value) whose key fully matches `pattern`.
+   *
+   * The returned pairs were all live at a single instant: a mutation that lands
+   * mid-query invalidates the pass and the query is retried (#919).
+   *
    * @throws std::regex_error if `pattern` is not a valid ECMAScript regex.
    */
   SearchResult Search(const std::string &pattern) const {
@@ -252,78 +278,148 @@ class RegexSearchEngine {
 
     std::vector<std::string> required;
     const bool prefilterable = ExtractRequiredTrigrams(pattern, required);
+    const bool use_prefilter = prefilterable && !required.empty();
 
-    // Snapshot candidate key strings under the shared lock, then RELEASE it and
-    // run the expensive std::regex_match over the copies. Copying is far cheaper
-    // than matching, so the lock is held briefly -- writers no longer starve.
-    // A snapshot (copied strings) also makes SearchResult stable under
-    // concurrent mutation, matching the documented "live subset" semantics.
-    std::vector<std::string> candidates;
-    {
-      std::shared_lock<std::shared_mutex> lk(mtx_);
-      if (!prefilterable || required.empty()) {
-        // No usable prefilter: every key is a candidate.
-        candidates.reserve(entries_.size());
-        for (const auto &kv : entries_) candidates.push_back(kv.first);
-      } else {
-        // Candidates = keys present in the posting lists of ALL required
-        // trigrams. Walk the smallest posting list and test membership in the
-        // others; this is a superset of the true matches.
-        const std::unordered_set<const std::string *> *smallest = nullptr;
-        for (const auto &t : required) {
-          auto it = index_.find(t);
-          if (it == index_.end()) {
-            // Some required trigram indexes no key => no match possible.
-            return SearchResult(std::vector<std::string>(),
-                                std::vector<ValueT>());
-          }
-          if (smallest == nullptr || it->second.size() < smallest->size()) {
-            smallest = &it->second;
-          }
-        }
-        for (const std::string *kp : *smallest) {
-          bool in_all = true;
-          for (const auto &t : required) {
-            const auto &posting = index_.find(t)->second;
-            if (posting.find(kp) == posting.end()) {
-              in_all = false;
-              break;
-            }
-          }
-          if (in_all) candidates.push_back(*kp);  // copy under the lock
+    // Optimistic pass: snapshot candidate keys under the shared lock, release
+    // it for the expensive regex_match (that release is the whole point of
+    // #680), then re-acquire to snapshot the values. Accept the pass only if
+    // the mutation counter did not move across it -- otherwise the two locked
+    // sections saw different states, and a key that was renamed in between
+    // would silently drop out of the result (#919).
+    constexpr int kOptimisticAttempts = 3;
+    for (int attempt = 0; attempt < kOptimisticAttempts; ++attempt) {
+      std::vector<std::string> candidates;
+      uint64_t version_before = 0;
+      {
+        std::shared_lock<std::shared_mutex> lk(mtx_);
+        version_before = version_.load(std::memory_order_relaxed);
+        if (!CollectCandidatesLocked(use_prefilter, required, &candidates)) {
+          // A required trigram indexes no key at all: no match is possible, and
+          // that verdict needed only the one consistent look.
+          return SearchResult(std::vector<std::string>(),
+                              std::vector<ValueT>());
         }
       }
-    }  // shared lock released before matching
 
-    std::vector<std::string> matches;
-    for (auto &c : candidates) {
-      if (std::regex_match(c, re)) matches.push_back(std::move(c));
+      std::vector<std::string> matches = MatchAndSort(&candidates, re);
+
+      std::shared_lock<std::shared_mutex> lk(mtx_);
+      if (version_.load(std::memory_order_relaxed) != version_before) {
+        continue;  // the index moved under us -- redo the query
+      }
+      return BuildResultLocked(&matches);
     }
 
-    std::sort(matches.begin(), matches.end());
+    // Repeatedly outraced by writers. Fall back to ONE fully-locked pass: it is
+    // consistent by construction and cannot be invalidated, so a directory hot
+    // enough to defeat the optimistic path still terminates. Writers wait for a
+    // single regex pass here, which is why this is the exception and not the
+    // rule.
+    std::shared_lock<std::shared_mutex> lk(mtx_);
+    std::vector<std::string> candidates;
+    if (!CollectCandidatesLocked(use_prefilter, required, &candidates)) {
+      return SearchResult(std::vector<std::string>(), std::vector<ValueT>());
+    }
+    std::vector<std::string> matches = MatchAndSort(&candidates, re);
+    return BuildResultLocked(&matches);
+  }
 
-    // Snapshot the values under a brief re-acquired shared lock, AFTER the
-    // (deliberately unlocked, see above) regex pass and the sort, so keys_
-    // and values_ stay aligned. A key deleted since the candidate scan is
-    // dropped from the result here — the "live subset" semantics — instead
-    // of surfacing as a null value at iteration time.
+ private:
+  /**
+   * Gather the keys the regex could possibly match into `*out`. Caller must
+   * hold mtx_ (shared is enough).
+   * @return false if a required trigram indexes no key, i.e. the pattern cannot
+   *         match anything and `*out` is meaningless.
+   */
+  bool CollectCandidatesLocked(bool use_prefilter,
+                               const std::vector<std::string> &required,
+                               std::vector<std::string> *out) const {
+    out->clear();
+    if (!use_prefilter) {
+      // No usable prefilter: every key is a candidate.
+      out->reserve(entries_.size());
+      for (const auto &kv : entries_) {
+        out->push_back(kv.first);
+      }
+      return true;
+    }
+    // Candidates = keys present in the posting lists of ALL required trigrams.
+    // Walk the smallest posting list and test membership in the others; this is
+    // a superset of the true matches.
+    const std::unordered_set<const std::string *> *smallest = nullptr;
+    for (const auto &t : required) {
+      auto it = index_.find(t);
+      if (it == index_.end()) {
+        return false;
+      }
+      if (smallest == nullptr || it->second.size() < smallest->size()) {
+        smallest = &it->second;
+      }
+    }
+    for (const std::string *kp : *smallest) {
+      bool in_all = true;
+      for (const auto &t : required) {
+        const auto &posting = index_.find(t)->second;
+        if (posting.find(kp) == posting.end()) {
+          in_all = false;
+          break;
+        }
+      }
+      if (in_all) {
+        out->push_back(*kp);  // copy under the lock
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Verify each candidate against `re` and return the survivors, sorted.
+   * Deliberately callable with no lock held -- matching is the expensive part.
+   * Consumes `*candidates`.
+   */
+  static std::vector<std::string> MatchAndSort(
+      std::vector<std::string> *candidates, const std::regex &re) {
+    std::vector<std::string> matches;
+    for (auto &c : *candidates) {
+      if (std::regex_match(c, re)) {
+        matches.push_back(std::move(c));
+      }
+    }
+    std::sort(matches.begin(), matches.end());
+    return matches;
+  }
+
+  /**
+   * Pair each matched key with its value. Caller must hold mtx_ (shared) AND
+   * have established that the index did not change since the candidate scan, so
+   * every key is still present. Consumes `*matches`.
+   */
+  SearchResult BuildResultLocked(std::vector<std::string> *matches) const {
     std::vector<std::string> keys;
     std::vector<ValueT> values;
-    keys.reserve(matches.size());
-    values.reserve(matches.size());
-    {
-      std::shared_lock<std::shared_mutex> lk(mtx_);
-      for (auto &k : matches) {
-        auto it = entries_.find(k);
-        if (it == entries_.end()) continue;  // concurrently deleted
-        values.push_back(it->second);
-        keys.push_back(std::move(k));
+    keys.reserve(matches->size());
+    values.reserve(matches->size());
+    for (auto &k : *matches) {
+      auto it = entries_.find(k);
+      if (it == entries_.end()) {
+        continue;  // unreachable while the version check holds; cheap guard
       }
+      values.push_back(it->second);
+      keys.push_back(std::move(k));
     }
     return SearchResult(std::move(keys), std::move(values));
   }
 
- private:
+  /**
+   * Stamp a mutation. Caller must hold mtx_ exclusively, which is what lets a
+   * Search compare the counter under a mere shared lock: any writer that could
+   * change it is excluded for the whole of both the reader's locked sections.
+   */
+  void BumpVersionLocked() {
+    version_.store(version_.load(std::memory_order_relaxed) + 1,
+                   std::memory_order_relaxed);
+  }
+
   /** Append the unique overlapping trigrams of `s` to `out` (empty if <3). */
   static void Trigrams(const std::string &s, std::vector<std::string> &out) {
     out.clear();
@@ -477,6 +573,9 @@ class RegexSearchEngine {
       index_;
   // Guards entries_ + index_: exclusive for mutators, shared for queries.
   mutable std::shared_mutex mtx_;
+  // Mutation counter. Bumped under the exclusive lock, read under the shared
+  // one, so Search can tell whether the key set moved under it (#919).
+  std::atomic<uint64_t> version_{0};
 };
 
 }  // namespace ctp::search

--- a/context-transport-primitives/test/unit/search/test_regex_search_engine.cc
+++ b/context-transport-primitives/test/unit/search/test_regex_search_engine.cc
@@ -394,3 +394,69 @@ TEST_CASE("RegexSearch: parallel insert/delete/search", "[regex_search][parallel
   }
   REQUIRE(eng.Size() == final_res.keys().size());
 }
+
+TEST_CASE("RegexSearch: rename never drops an entry from a listing (#919)",
+          "[regex_search][parallel]") {
+  // A renamer flips a fixed set of keys between two names in the SAME
+  // directory, so the directory's population never changes: at every instant
+  // each key exists exactly once, under one name or the other, and both names
+  // match the listing pattern. A listing may therefore report a key under
+  // either name, but must always report exactly kFiles of them.
+  //
+  // Search used to break that. It snapshots candidate keys under the shared
+  // lock, releases it for the (expensive, deliberately unlocked) regex pass,
+  // then re-acquires to fetch values -- and a key renamed a->b in between was
+  // captured as `a`, is gone as `a` by the value lookup, and `b` was never a
+  // candidate. The entry vanished from a listing of its own directory, which is
+  // the cr_cli_cfs_rename D4 failure (`n == kFiles`) reproduced here at its
+  // source.
+  RegexSearchEngine<int> eng;
+  constexpr int kFiles = 12;
+  constexpr int kRounds = 400;
+  const std::string kPattern = "^/D4/[^/]+$";
+
+  auto name = [](const char *side, int i) {
+    return std::string("/D4/") + side + std::to_string(i) + ".bin";
+  };
+  for (int i = 0; i < kFiles; ++i) {
+    eng.Insert(name("a", i), i);
+  }
+
+  std::atomic<bool> stop{false};
+  std::atomic<int> short_listings{0};
+  std::atomic<int> listings{0};
+  std::atomic<int> worst{kFiles};
+
+  std::thread renamer([&]() {
+    for (int round = 0; round < kRounds; ++round) {
+      const char *from = (round % 2 == 0) ? "a" : "b";
+      const char *to = (round % 2 == 0) ? "b" : "a";
+      for (int i = 0; i < kFiles; ++i) {
+        eng.Rename(name(from, i), name(to, i));
+      }
+    }
+    stop.store(true, std::memory_order_relaxed);
+  });
+
+  std::thread lister([&]() {
+    while (!stop.load(std::memory_order_relaxed)) {
+      const int n = static_cast<int>(eng.Search(kPattern).keys().size());
+      listings.fetch_add(1, std::memory_order_relaxed);
+      if (n != kFiles) {
+        short_listings.fetch_add(1, std::memory_order_relaxed);
+        int cur = worst.load(std::memory_order_relaxed);
+        while (n < cur &&
+               !worst.compare_exchange_weak(cur, n, std::memory_order_relaxed)) {
+        }
+      }
+    }
+  });
+
+  renamer.join();
+  lister.join();
+
+  INFO("listings=" << listings.load() << " short=" << short_listings.load()
+                   << " worst=" << worst.load() << " expected=" << kFiles);
+  REQUIRE(listings.load() > 0);  // the lister really did run concurrently
+  REQUIRE(short_listings.load() == 0);
+}


### PR DESCRIPTION
## Summary

Root-causes and fixes three of the flaky tests tracked in #919. Each is a real
defect the test was catching intermittently, not a timing tolerance to widen —
no test is skipped, retried, or given a longer timeout as the "fix".

| Flake | Root cause | Fix |
|---|---|---|
| `cte_bdev_fragmentation` (Windows/icx) | Placement read a copy of `remaining_space_` refreshed only every 5 s, so space freed since the last tick was invisible and puts spuriously ENOSPC'd | Read the canonical counter when snapshotting for the DPE |
| `cr_cli_cfs_rename` (macOS/Linux) | `RegexSearchEngine::Search` is a two-phase read that silently dropped keys renamed between the phases, so a file could vanish from a listing of its own directory | Version-stamp mutations; retry a pass the index moved under, with a locked fallback |
| `cr_detached_spawn` (Windows) | `WaitForReady` returned on "segment exists + `sleep(1s)`", which could report an unreachable — or dead — daemon as ready, bypassing the retry that existed for exactly that case | Wait for the daemon to log its ROUTER bind; never report a dead process ready |

Also converts `cte_reorganize_all`'s "Subprocess aborted" into an attributable
failure (see Not fixed below).

## Motivation

Fixes part of #919. Two of the three had proven same-SHA pass/fail splits in CI;
`cte_bdev_fragmentation` alone accounted for 7 failures on 7 branches over 6
days, still hitting `dev`.

## Root causes in detail

**`cte_bdev_fragmentation`.** The CTE stores every target's `remaining_space_`
twice: the canonical `registered_targets_` entry, which `PutBlob` debits and
`Free` credits on the data path, and the `target_list_` mirror, whose copy is
refreshed only by the periodic `StatTargets` sweep (`stat_targets_period_ms`,
5 s). `ExtendBlob` handed the DPE the mirror. The failure is not symmetric: a
tick landing while a tier is full pins the mirror at ~0, and every later put is
rejected for "no target has space" even after the blobs holding that space are
deleted. The test's fill phase drives the tier to capacity, so on a slow runner
a tick lands inside that window and all 20 large puts after the deletes EIO.
The CI log shows it exactly: `ExtendBlob: 0 candidate target(s)` immediately
after `remaining_space_` was credited back to the full 33554432.

The codebase already knew about this hazard — `GetCapacity` iterates
`registered_targets_` directly and says why — it just was not applied to the
placement path.

**`cr_cli_cfs_rename`.** `Search` snapshots candidate keys under the shared
lock, releases it for the expensive regex pass (#680 — holding it there starved
writers), then re-acquires to fetch values, dropping keys that vanished in
between. That was documented as "live subset" semantics, which is defensible for
a delete but wrong for a rename: a key moved `A`→`B` was captured as `A`, is
gone as `A` by the value lookup, and `B` was never a candidate. Both names match
a readdir's `^<dir>/[^/]+$`, so a file disappeared from a listing of its own
directory while existing the whole time — the D4 case's `n == kFiles`.

**`cr_detached_spawn`.** `RuntimeServer::WaitForReady` treated "main SHM segment
exists" plus a flat 1 s sleep as readiness. The segment appears early in daemon
init; the sleep was standing in for the transport actually coming up. On a
loaded Windows Debug runner the ROUTER can still be unbound when it expires, and
the daemon can die inside it (#848) with the old code returning true for a dead
process. Callers that retry on a fresh port never got the chance, having already
been told the daemon was ready.

## Test plan

- [x] New regression test `cte_bdev_free_visibility` — 4 fill/stat/delete/put
      cycles. **Fails without the fix** (cycle 0, `rc=12`), passes with it.
- [x] New `RegexSearchEngine` case: concurrent rename vs listing.
      **Without the fix, 492 of 494 listings were short** (10 of 12 entries);
      with it, 0.
- [x] `cr_detached_spawn` passes, and is now faster (1.2 s vs the old ~2 s
      floor) because it no longer sleeps past a signal it can read.
- [x] Full local `ctest` in `iowarp/deps-cpu` — see below.
- [x] No new compiler warnings.

## Not fixed here

- **`cte_reorganize_all` / `cte_reorganize_force_net`.** Two distinct
  manifestations, neither fixed:
  - *Linux leak-check "Subprocess aborted"* root-causes to a runtime startup
    race — `RouteTask: RouteLocal returned 4 ... worker=-1`, inline retry
    exhausted after 30 s on a non-worker thread, `Compose: Failed to create pool
    clio_cte`. That is a scheduler/init defect, not a reorganize defect, and
    deserves its own issue. This PR only stops the fixture's `REQUIRE` from
    escaping `main` into `std::terminate`, so the next occurrence reports the
    cause instead of a bare abort.
  - *Windows icx 300 s timeout*: the hang site is **not** determinable from the
    logs — Windows block-buffers the captured stdout, so the last flushed line
    is not the last line executed. Not diagnosed.
- **xfstests `generic/020`/`133` hangs.** Confirmed gone: no occurrence after
  2026-07-27, consistent with the Debug-log-level fix in #833. The three
  `CI Adapters (linux, all 5)` failures since then are unrelated (missing
  `h5dump` in `deps-cpu`), with no `pass=/fail=/hang=` signature.
- **The three same-SHA singles.** `cr_safe_bdev_concurrency_tests` is very
  likely addressed by #910 (merged into `dev` in the same run as its last
  occurrence). `cr_submit_batch_force_net` and
  `cr_streaming_large_output_tests` are one occurrence each and were not
  investigated.

## Breaking changes

None. `RegexSearchEngine::Search` tightens its contract (point-in-time instead
of "live subset"); no caller depended on the looser one.
