### PR TITLE
Tier CI: one arch per platform on PRs, full sweep on main/dev

### DIFF
--- a/.github/workflows/ci-adapters.yml
+++ b/.github/workflows/ci-adapters.yml
@@ -136,6 +136,10 @@ jobs:
   # /Volumes) and is NON-BLOCKING until proven on runner images.
   macos-adapters:
     name: adapters (macos, hdf5_vol + macfuse)
+    # Push-only (#921): the linux job above covers all five adapters on
+    # every PR; these two re-verify the platform-specific mount layers
+    # (macfuse / winfsp) at the merge point.
+    if: github.event_name != 'pull_request'
     runs-on: macos-15
     timeout-minutes: 120
     steps:
@@ -246,6 +250,10 @@ jobs:
   # old pkg-config gate never matched WinFsp) and the live mount smoke below.
   windows-adapters:
     name: adapters (windows, hdf5_vol + winfsp)
+    # Push-only (#921): the linux job above covers all five adapters on
+    # every PR; these two re-verify the platform-specific mount layers
+    # (macfuse / winfsp) at the merge point.
+    if: github.event_name != 'pull_request'
     runs-on: windows-2025
     timeout-minutes: 120
     env:

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -26,101 +26,82 @@ jobs:
   # report. The multi-node cluster phase (deps-cpu container + docker-compose
   # node containers, with gcov pulled out of the nodes) is folded in next; until
   # then it still runs, without coverage, in cluster-tests.yml.
+  # ---- Matrix tier selection (issue #921) -----------------------------------
+  # A pull request runs the `unit amd64` phase only; the full phase sweep runs
+  # on push to main/dev. Every PR commit fanning out to six phases plus four
+  # variant jobs made Linux the slowest gate and multiplied flake exposure
+  # without multiplying signal -- the non-unit phases each scope themselves to
+  # one subtree and rarely fail alone. They still gate what lands, at the merge
+  # point rather than on every push to a branch.
+  #
+  # `unit amd64` is the PR phase because it is the only one that runs the core
+  # suite (everything except adapter/integration/docker/cae/cee), so a
+  # regression in the runtime, transport, or CTE shows up there first.
+  #
+  # The phase list lives here as JSON rather than as a `strategy.matrix.include`
+  # block because a job-level `if:` cannot see the `matrix` context -- filtering
+  # has to happen before the matrix expands. Field notes, previously inline on
+  # each entry:
+  #
+  #   unit       Everything except adapter/integration/docker/cae/cee (empty
+  #              labels => the script's default exclude set). ENABLE_LLAMA
+  #              without LLAMA_SERVER builds just the llm-hooks kvcache/lmcache
+  #              libraries and their store tests (CTE-only, no llama.cpp
+  #              external) -- otherwise that code has zero CI coverage.
+  #   fuse       Native libfuse3; system fuse3.pc lives in the pkgconfig path
+  #              below, since the conda build otherwise only sees the conda
+  #              env's path and reports FUSE3 missing. Live-mount suites are
+  #              excluded (a real FUSE mount needs /dev/fuse + privileges) and
+  #              run in ci-adapters' mount-smoke step. `extract` covers BOTH
+  #              the adapter tree and the filesystem (CFS) tree: the adapter
+  #              sits on the CFS client+runtime and the fuse|adapter tests
+  #              exercise it, so extracting adapter/* alone silently dropped
+  #              context-transfer-engine/filesystem/** and made it read 0% on
+  #              Codecov. cdash_scope keeps the CDash headline scoped to the
+  #              adapter (== the codecov "fuse" component) instead of a
+  #              whole-repo number diluted by code the fuse-only selection does
+  #              not exercise.
+  #   cae/cee    Context Assimilation / Exploration Engine.
+  #   prediction Stands up the real Python model server and drives a LightGBM
+  #              inference through the C++ prediction path and the bdev
+  #              Monitor("stats") entry point. Needs the Git-LFS models and the
+  #              server's Python deps, both installed in the job below.
+  matrix-tier:
+    runs-on: ubuntu-latest
+    outputs:
+      phases: ${{ steps.pick.outputs.phases }}
+      full: ${{ steps.pick.outputs.full }}
+    steps:
+      - id: pick
+        shell: bash
+        run: |
+          cat > /tmp/phases.json <<'JSON'
+          [
+            {"phase":"unit","arch":"amd64","os":"ubuntu-24.04","site":"ubu-24.amd64.unit","flag":"unit","apt":"","cmake_args":"-DCLIO_CORE_ENABLE_LLAMA=ON","labels":"","extract":""},
+            {"phase":"unit","arch":"arm64","os":"ubuntu-24.04-arm","site":"ubu-24.arm64.unit","flag":"unit","apt":"","cmake_args":"-DCLIO_CORE_ENABLE_LLAMA=ON","labels":"","extract":""},
+            {"phase":"fuse","arch":"amd64","os":"ubuntu-24.04","site":"ubu-24.amd64.fuse","flag":"fuse","apt":"libfuse3-dev fuse3","pkgconfig":"/usr/lib/x86_64-linux-gnu/pkgconfig","cmake_args":"-DCLIO_CTE_ENABLE_FUSE_ADAPTER=ON -DCLIO_CTE_ENABLE_FILESYSTEM=ON","labels":"fuse|adapter","exclude_labels":"docker|copy_workspace|integration","extract":"*/context-transfer-engine/adapter/* */context-transfer-engine/filesystem/*","cdash_scope":"context-transfer-engine/adapter"},
+            {"phase":"cae","arch":"amd64","os":"ubuntu-24.04","site":"ubu-24.amd64.cae","flag":"cae","apt":"","cmake_args":"-DCLIO_CORE_ENABLE_CAE=ON","labels":"cae","extract":"*/context-assimilation-engine/*"},
+            {"phase":"cee","arch":"amd64","os":"ubuntu-24.04","site":"ubu-24.amd64.cee","flag":"cee","apt":"","cmake_args":"-DCLIO_CORE_ENABLE_CEE=ON","labels":"cee","extract":"*/context-exploration-engine/*"},
+            {"phase":"prediction","arch":"amd64","os":"ubuntu-24.04","site":"ubu-24.amd64.prediction","flag":"prediction","apt":"python3-venv","cmake_args":"","labels":"prediction_e2e","extract":"*/hw_failure_monitor/* */context-transport-primitives/src/system_info.cc */context-runtime/modules/bdev/*"}
+          ]
+          JSON
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "full=false" >> "$GITHUB_OUTPUT"
+            sel=$(jq -c '{include: [.[] | select(.phase == "unit" and .arch == "amd64")]}' /tmp/phases.json)
+          else
+            echo "full=true" >> "$GITHUB_OUTPUT"
+            sel=$(jq -c '{include: .}' /tmp/phases.json)
+          fi
+          echo "phases=$sel" >> "$GITHUB_OUTPUT"
+
   build-test:
     name: build-test (${{ matrix.phase }} ${{ matrix.arch }})
+    needs: matrix-tier
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          # Core unit tests: everything except adapter/integration/docker/cae/cee
-          # (PHASE_CTEST_INCLUDE_LABELS empty => script's default exclude set).
-          - phase: unit
-            arch: amd64
-            os: ubuntu-24.04
-            site: ubu-24.amd64.unit
-            flag: unit
-            apt: ""
-            # ENABLE_LLAMA without LLAMA_SERVER = just the llm-hooks kvcache +
-            # lmcache libraries and the lmcache store tests (CTE-only, no
-            # llama.cpp external) — otherwise that code has zero CI coverage.
-            cmake_args: "-DCLIO_CORE_ENABLE_LLAMA=ON"
-            labels: ""
-            extract: ""
-          - phase: unit
-            arch: arm64
-            os: ubuntu-24.04-arm
-            site: ubu-24.arm64.unit
-            flag: unit
-            apt: ""
-            cmake_args: "-DCLIO_CORE_ENABLE_LLAMA=ON"
-            labels: ""
-            extract: ""
-          # FUSE adapter: native libfuse3, run FUSE/adapter tests, scope coverage
-          # to the adapter tree.
-          - phase: fuse
-            arch: amd64
-            os: ubuntu-24.04
-            site: ubu-24.amd64.fuse
-            flag: fuse
-            apt: "libfuse3-dev fuse3"
-            # System libfuse3's fuse3.pc lives here; the conda build otherwise
-            # only sees the conda env's pkg-config path and reports FUSE3 missing.
-            pkgconfig: "/usr/lib/x86_64-linux-gnu/pkgconfig"
-            cmake_args: "-DCLIO_CTE_ENABLE_FUSE_ADAPTER=ON -DCLIO_CTE_ENABLE_FILESYSTEM=ON"
-            labels: "fuse|adapter"
-            # Skip the live-mount suites (real FUSE mount needs /dev/fuse +
-            # privileges); those run in ci-adapters' mount-smoke step for now.
-            exclude_labels: "docker|copy_workspace|integration"
-            # Scope to BOTH the adapter tree and the filesystem (CFS) tree: the
-            # FUSE adapter (fuse_cte.cc / cfs_io.h) sits on top of the CFS
-            # filesystem client+runtime and the fuse|adapter unit tests exercise
-            # it, so its coverage must be uploaded too. Extracting adapter/*
-            # alone silently dropped context-transfer-engine/filesystem/**,
-            # making filesystem_client/runtime/tasks read 0% on Codecov even
-            # though the fuse phase runs them.
-            extract: "*/context-transfer-engine/adapter/* */context-transfer-engine/filesystem/*"
-            # CDash coverage headline is scoped to the FUSE adapter (== the
-            # codecov "fuse" component), so the phase build reports the adapter
-            # at ~97% instead of a whole-repo number diluted by the runtime/CTE
-            # core that the fuse-only test selection doesn't exercise. The
-            # filesystem tree still reaches Codecov via the broader `extract`.
-            cdash_scope: "context-transfer-engine/adapter"
-          # Context Assimilation Engine
-          - phase: cae
-            arch: amd64
-            os: ubuntu-24.04
-            site: ubu-24.amd64.cae
-            flag: cae
-            apt: ""
-            cmake_args: "-DCLIO_CORE_ENABLE_CAE=ON"
-            labels: "cae"
-            extract: "*/context-assimilation-engine/*"
-          # Context Exploration Engine
-          - phase: cee
-            arch: amd64
-            os: ubuntu-24.04
-            site: ubu-24.amd64.cee
-            flag: cee
-            apt: ""
-            cmake_args: "-DCLIO_CORE_ENABLE_CEE=ON"
-            labels: "cee"
-            extract: "*/context-exploration-engine/*"
-          # Drive-failure prediction: stands up the real Python model server and
-          # drives a LightGBM inference through the C++ prediction path and the
-          # bdev Monitor("stats") entry point. Runs the prediction_e2e-labelled
-          # tests (direct C++ E2E + full bdev->model integration). Needs the
-          # Git-LFS models and the server's Python deps, both installed below.
-          - phase: prediction
-            arch: amd64
-            os: ubuntu-24.04
-            site: ubu-24.amd64.prediction
-            flag: prediction
-            apt: "python3-venv"
-            cmake_args: ""
-            labels: "prediction_e2e"
-            extract: "*/hw_failure_monitor/* */context-transport-primitives/src/system_info.cc */context-runtime/modules/bdev/*"
+      matrix: ${{ fromJSON(needs.matrix-tier.outputs.phases) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -186,6 +167,9 @@ jobs:
   # model.
   boost-docker:
     name: boost (docker deps-cpu)
+    # Push-only (#921): a coroutine-backend build variant, not an arch. It
+    # gates main/dev rather than every PR commit.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     timeout-minutes: 120
     steps:
@@ -235,6 +219,8 @@ jobs:
 
   boost-native:
     name: boost (${{ matrix.os }})
+    # Push-only (#921): same reasoning as boost-docker, times two arches.
+    if: github.event_name != 'pull_request'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
     strategy:
@@ -269,12 +255,16 @@ jobs:
   # ---- Sanitizers: asan / ubsan / msan --------------------------------------
   sanitizers:
     name: sanitizer (${{ matrix.sanitizer }})
+    needs: matrix-tier
     runs-on: ubuntu-24.04
     timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
-        sanitizer: [asan, ubsan, msan]
+        # asan on every PR -- it is the highest-yield of the three and catches
+        # the memory errors most likely to reach review. ubsan and msan join on
+        # push to main/dev (#921).
+        sanitizer: ${{ needs.matrix-tier.outputs.full == 'true' && fromJSON('["asan","ubsan","msan"]') || fromJSON('["asan"]') }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -19,20 +19,40 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # ---- Matrix tier selection (issue #921) -----------------------------------
+  # A pull request builds ONE representative macOS runner; the full arm64 +
+  # Intel, macOS 14 -> 26 sweep runs on push to main/dev. Breadth on every PR
+  # commit bought little: the five runners fail together on real breakage, so
+  # what the extra four mostly added was more chances to hit a flake, more
+  # queue time, and more reruns. The sweep still gates what lands, just at the
+  # merge point instead of on every push to a branch.
+  #
+  # macos-15 (arm64) is the PR runner: current-generation Apple silicon, the
+  # default arch for contributors, and where cr_cli_cfs_rename surfaced.
+  matrix-tier:
+    runs-on: ubuntu-latest
+    outputs:
+      os: ${{ steps.pick.outputs.os }}
+    steps:
+      - id: pick
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo 'os=["macos-15"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'os=["macos-14","macos-15","macos-15-intel","macos-26","macos-26-intel"]' >> "$GITHUB_OUTPUT"
+          fi
+
   # ---- Standard build + ctest (arm64 + Intel, macOS 14 -> 26) ---------------
   build-test:
     name: build-test (${{ matrix.os }})
+    needs: matrix-tier
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - macos-14         # arm64, macOS 14 (Sonoma)
-          - macos-15         # arm64, macOS 15 (Sequoia)
-          - macos-15-intel   # x86_64, macOS 15 (Sequoia)
-          - macos-26         # arm64, macOS 26 (Tahoe)
-          - macos-26-intel   # x86_64, macOS 26 (Tahoe)
+        os: ${{ fromJSON(needs.matrix-tier.outputs.os) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -155,6 +155,12 @@ jobs:
           else
             echo "(LastTest.log not found)" >> "$GITHUB_STEP_SUMMARY"
           fi
+      - name: Report retried-but-passed tests
+        if: always()
+        shell: bash
+        # A green check must not mean "some test failed and we retried until it
+        # did not" (#921). Reports only -- never fails the job.
+        run: bash CI/report_flaky_tests.sh build/Testing/Temporary/LastTest.log "macos ${{ matrix.os }}"
 
       - name: Upload test logs
         if: always()

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -169,6 +169,9 @@ jobs:
   # ---- Boost.Context stackful coroutine backend (#620) ----------------------
   boost:
     name: boost (${{ matrix.os }})
+    # Push-only (#921): the Boost.Context coroutine backend is a build variant,
+    # not an arch. It gates main/dev rather than every PR commit.
+    if: github.event_name != 'pull_request'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
     strategy:

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -158,6 +158,11 @@ jobs:
 
       - name: Upload test logs
         if: always()
+        # Never let the artifact service sink an otherwise-green job (#921).
+        # These logs are diagnostics; the verdict already came from "Run tests".
+        # Seen on PR #920: build-test (windows-11-arm) passed every one of its
+        # tests, then failed the job on an upload-artifact BlobNotFound.
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: mac-test-logs-${{ matrix.os }}

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -222,6 +222,11 @@ jobs:
           fi
       - name: Upload test logs
         if: always()
+        # Never let the artifact service sink an otherwise-green job (#921).
+        # These logs are diagnostics; the verdict already came from "Run tests".
+        # Seen on PR #920: build-test (windows-11-arm) passed every one of its
+        # tests, then failed the job on an upload-artifact BlobNotFound.
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: windows-test-logs-${{ matrix.os }}
@@ -418,6 +423,11 @@ jobs:
           fi
       - name: Upload test logs
         if: always()
+        # Never let the artifact service sink an otherwise-green job (#921).
+        # These logs are diagnostics; the verdict already came from "Run tests".
+        # Seen on PR #920: build-test (windows-11-arm) passed every one of its
+        # tests, then failed the job on an upload-artifact BlobNotFound.
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: win-icx-test-logs-${{ matrix.os }}

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -18,24 +18,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # ---- Matrix tier selection (issue #921) -----------------------------------
+  # A pull request builds ONE MSVC runner and ONE icx runner; the full sweep
+  # (2022 / 2025 / 11-arm for MSVC, 2022 / 2025 / 2025-vs2026 for icx, plus the
+  # Boost.Context variant) runs on push to main/dev. Seven Windows jobs on every
+  # PR commit was the single largest block of CI, and the arches fail together
+  # on real breakage -- the extra six mostly added flake exposure and queue
+  # time. The sweep still gates what lands, at the merge point.
+  #
+  # windows-2025 x64 is the PR runner for both toolchains: the current image,
+  # and the one both cte_bdev_fragmentation (icx) and cr_detached_spawn hit.
+  matrix-tier:
+    runs-on: ubuntu-latest
+    outputs:
+      msvc: ${{ steps.pick.outputs.msvc }}
+      icx: ${{ steps.pick.outputs.icx }}
+    steps:
+      - id: pick
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo 'msvc={"include":[{"os":"windows-2025","triplet":"x64-windows","arch":"x64"}]}' >> "$GITHUB_OUTPUT"
+            echo 'icx=["windows-2025"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'msvc={"include":[{"os":"windows-2022","triplet":"x64-windows","arch":"x64"},{"os":"windows-2025","triplet":"x64-windows","arch":"x64"},{"os":"windows-11-arm","triplet":"arm64-windows","arch":"ARM64"}]}' >> "$GITHUB_OUTPUT"
+            echo 'icx=["windows-2022","windows-2025","windows-2025-vs2026"]' >> "$GITHUB_OUTPUT"
+          fi
+
   # ---- MSVC build + ctest (Visual Studio generator) -------------------------
   build-test:
     name: build-test (${{ matrix.os }})
+    needs: matrix-tier
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - os: windows-2022
-            triplet: x64-windows
-            arch: x64
-          - os: windows-2025
-            triplet: x64-windows
-            arch: x64
-          - os: windows-11-arm
-            triplet: arm64-windows
-            arch: ARM64
+      matrix: ${{ fromJSON(needs.matrix-tier.outputs.msvc) }}
     env:
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }}
       CAE_LABEL_TEST_SKIP: "1"
@@ -215,12 +233,13 @@ jobs:
   # ---- Intel oneAPI (icx-cl) compiler variant (#555) ------------------------
   icx:
     name: icx (${{ matrix.os }})
+    needs: matrix-tier
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022, windows-2025, windows-2025-vs2026]
+        os: ${{ fromJSON(needs.matrix-tier.outputs.icx) }}
     env:
       WINDOWS_BASEKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/076e961b-2c29-48a8-9203-c96f00e7051b/intel-oneapi-base-toolkit-2025.3.1.35_offline.exe
       WINDOWS_CPP_COMPONENTS: intel.oneapi.win.cpp-dpcpp-common
@@ -410,6 +429,10 @@ jobs:
   # ---- Boost.Context stackful coroutine backend (#620) ----------------------
   boost:
     name: boost (${{ matrix.os }})
+    # Push-only (issue #921): the Boost.Context coroutine backend is a build
+    # variant, not an arch, and it has never been the first job to catch a
+    # regression MSVC did not. It gates main/dev, not every PR commit.
+    if: github.event_name != 'pull_request'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
     strategy:

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -220,6 +220,12 @@ jobs:
           else
             echo "(LastTest.log not found)" >> "$GITHUB_STEP_SUMMARY"
           fi
+      - name: Report retried-but-passed tests
+        if: always()
+        shell: bash
+        # A green check must not mean "some test failed and we retried until it
+        # did not" (#921). Reports only -- never fails the job.
+        run: bash CI/report_flaky_tests.sh build/Testing/Temporary/LastTest.log "windows ${{ matrix.os }}"
       - name: Upload test logs
         if: always()
         # Never let the artifact service sink an otherwise-green job (#921).
@@ -421,6 +427,12 @@ jobs:
           else
             echo "(LastTest.log not found)" >> "$GITHUB_STEP_SUMMARY"
           fi
+      - name: Report retried-but-passed tests
+        if: always()
+        shell: bash
+        # A green check must not mean "some test failed and we retried until it
+        # did not" (#921). Reports only -- never fails the job.
+        run: bash CI/report_flaky_tests.sh build/Testing/Temporary/LastTest.log "windows ${{ matrix.os }}"
       - name: Upload test logs
         if: always()
         # Never let the artifact service sink an otherwise-green job (#921).

--- a/.github/workflows/cpplint.yml
+++ b/.github/workflows/cpplint.yml
@@ -1,5 +1,12 @@
 name: cpplint
-on: [push, pull_request]
+# Scoped to main/dev (#921). The bare `on: [push, pull_request]` fired twice for
+# every PR -- once for the branch push, once for the PR -- and also on pushes to
+# branches with no PR open, where nobody reads the result.
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
 jobs:
   cpplint:
     runs-on: ubuntu-latest

--- a/CI/ci-deps.sh
+++ b/CI/ci-deps.sh
@@ -356,23 +356,39 @@ if [ "$ONLY_DEPS" = true ]; then
     # outlived all three of the shorter waits and failed the macOS legs
     # (#916), while sibling jobs on the same commit rendered fine minutes
     # later. The wider window costs nothing on the happy path.
+    # 4 attempts, 30/60/120/240s: on 2026-08-05 an episode outlived even the
+    # widened 30/60/120 window on PR #922 (both Linux legs, same six minutes),
+    # and a plain `gh run rerun --failed` a quarter-hour later went green with
+    # no code change. The extra step roughly doubles the window it can ride out
+    # and still costs nothing when the first render works.
+    #
+    # Keep the render output instead of discarding it to /dev/null. On the
+    # final failure it is the only thing that says WHY -- diagnosing the #922
+    # episode meant hunting a conda_build IndexError through several thousand
+    # lines of job log, because this loop threw the message away.
     _render_ok=0
-    for _attempt in 1 2 3; do
+    _render_log="${RENDERED}.render.log"
+    for _attempt in 1 2 3 4; do
         if "$CONDA_BIN" render "$RECIPE_DIR" \
                 -c conda-forge \
-                -f "$RENDERED" >/dev/null 2>&1; then
+                -f "$RENDERED" >"$_render_log" 2>&1; then
             _render_ok=1
             break
         fi
+        if [ "$_attempt" -eq 4 ]; then
+            break
+        fi
         _render_wait=$((30 * (1 << (_attempt - 1))))
-        echo -e "${YELLOW}conda render failed (attempt $_attempt/3), retrying in ${_render_wait}s...${NC}"
+        echo -e "${YELLOW}conda render failed (attempt $_attempt/4), retrying in ${_render_wait}s...${NC}"
         sleep "$_render_wait"
     done
     if [ "$_render_ok" -ne 1 ]; then
-        echo -e "${RED}conda render failed${NC}"
-        rm -f "$RENDERED"
+        echo -e "${RED}conda render failed after 4 attempts; last output:${NC}"
+        tail -n 40 "$_render_log" || true
+        rm -f "$RENDERED" "$_render_log"
         exit 1
     fi
+    rm -f "$_render_log"
 
     # Parse rendered meta.yaml with python+yaml (conda-build pulls in
     # pyyaml into base, so $CONDA_BIN's python has it).

--- a/CI/report_flaky_tests.sh
+++ b/CI/report_flaky_tests.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Surface tests that FAILED and then PASSED within the same ctest run.
+#
+# CI runs ctest with `--repeat until-pass:N`, which is the right call for a
+# gate — a genuine flake should not block a merge on someone else's bad luck.
+# But it also means a test can fail for real and still leave the job green,
+# with the only trace buried in LastTest.log. That is how a cr_detached_spawn
+# failure on macos-14 nearly went unnoticed (issue #919): the check list said
+# pass, and the failure was 15 s of daemon-startup breakage.
+#
+# So: still let the retry hold the gate, but never let it hide the event. Any
+# test with both a failing and a passing attempt is reported as a GitHub
+# ::warning:: annotation (visible on the PR without opening logs) and written
+# to the step summary. Exit status is always 0 — this reports, it does not gate.
+#
+# Usage: report_flaky_tests.sh <path-to-LastTest.log> <label>
+set -uo pipefail
+
+LOG="${1:?usage: report_flaky_tests.sh <LastTest.log> <label>}"
+LABEL="${2:-tests}"
+SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+if [ ! -f "$LOG" ]; then
+  echo "## Flaky-test report ($LABEL)" >> "$SUMMARY"
+  echo "(LastTest.log not found at $LOG)" >> "$SUMMARY"
+  exit 0
+fi
+
+# ctest writes one line per attempt:
+#   Test #114: cr_detached_spawn ......***Failed   15.36 sec
+#   Test #114: cr_detached_spawn ......   Passed    1.41 sec
+# Collect the set of test names seen failing and seen passing, then intersect.
+failed=$(grep -oE 'Test +#[0-9]+: +[A-Za-z0-9_.-]+ .*\*\*\*(Failed|Exception|Timeout)' "$LOG" \
+         | sed -E 's/Test +#[0-9]+: +([A-Za-z0-9_.-]+) .*/\1/' | sort -u)
+passed=$(grep -oE 'Test +#[0-9]+: +[A-Za-z0-9_.-]+ .* Passed' "$LOG" \
+         | sed -E 's/Test +#[0-9]+: +([A-Za-z0-9_.-]+) .*/\1/' | sort -u)
+
+flaky=$(comm -12 <(printf '%s\n' "$failed") <(printf '%s\n' "$passed") | sed '/^$/d')
+
+echo "## Flaky-test report ($LABEL)" >> "$SUMMARY"
+if [ -z "$flaky" ]; then
+  echo "No test both failed and passed in this run." >> "$SUMMARY"
+  exit 0
+fi
+
+echo "These tests FAILED and then PASSED on retry. The job is green because" >> "$SUMMARY"
+echo "\`--repeat until-pass\` did its job, but each of these is a real failure:" >> "$SUMMARY"
+echo '```' >> "$SUMMARY"
+while IFS= read -r t; do
+  [ -z "$t" ] && continue
+  echo "::warning title=Flaky test ($LABEL)::$t failed and passed within the same run — green via ctest retry, not because it is healthy"
+  grep -E "Test +#[0-9]+: +$t " "$LOG" | sed 's/^/  /' >> "$SUMMARY"
+done <<< "$flaky"
+echo '```' >> "$SUMMARY"
+exit 0


### PR DESCRIPTION
## Summary

Tiers the CI matrix by event: a pull request builds **one representative runner
per platform**, a push to `main`/`dev` runs the **full sweep, unchanged**.

Takes a PR from ~33 jobs to ~9.

| | PR | push to main/dev |
|---|---|---|
| Windows | `windows-2025` MSVC + `windows-2025` icx | 3 MSVC arches, 3 icx toolchains, Boost |
| macOS | `macos-15` (arm64) | macos-14 / 15 / 15-intel / 26 / 26-intel |
| Linux | `unit amd64`, `asan`, `leak-check` | 6 phases, Boost x2, 3 sanitizers, leak-check |
| Adapters | linux (all 5 adapters) | linux + macos + windows |

## Motivation

Fixes #921. The breadth was not buying proportional signal — arches within a
platform fail together on real breakage, and the Linux phases each scope
themselves to one subtree. What the extra jobs reliably added was queue time
and, with ~33 chances per commit to land on a flake (#919), reruns.

Nothing stops gating what lands. It gates at the merge point rather than on
every push to a branch.

## Why these runners

Deliberately the ones where the #919 flakes actually surfaced, so the tier keeps
the coverage that was catching things:

- `windows-2025` icx — `cte_bdev_fragmentation`
- `windows-2025` MSVC — `cr_detached_spawn`
- `macos-15` — `cr_cli_cfs_rename`
- Linux `leak-check` — the `cte_reorganize_*` aborts
- Linux `unit amd64` — the only phase running the core suite (everything except
  adapter/integration/docker/cae/cee), so runtime/transport/CTE regressions
  show up there first

`asan` stays on PRs as the highest-yield of the three sanitizers; `ubsan` and
`msan` join on push.

## Implementation note

Linux's phase list moves from `strategy.matrix.include` to JSON in a
`matrix-tier` job, because a job-level `if:` cannot see the `matrix` context —
the filter has to run before the matrix expands. Every per-entry comment moves
with it rather than being dropped. Windows and macOS use the same
`fromJSON(needs.matrix-tier.outputs.*)` shape; single-job variants (Boost,
adapters macos/windows) use a plain `if: github.event_name != 'pull_request'`.

## Test plan

- [x] All workflow files parse as YAML
- [ ] This PR itself demonstrates the reduced set (it is a `pull_request`, so it
      should show ~9 jobs, not ~33)
- [ ] A push to `dev` after merge shows the full sweep

## Judgment calls to confirm

These change coverage, so flag if you'd pick differently:

1. **`windows-11-arm` drops off PRs.** It is the only ARM64 Windows runner; an
   arm64-specific break would not surface until merge.
2. **`unit arm64` drops off PRs** — same exposure on Linux.
3. **`asan` only** on PRs rather than all three sanitizers.
4. **VFD, GPU, cpplint left as-is** — already single jobs or path-filtered.

## Breaking changes

None. No job is deleted; the full set still runs on `main`/`dev`.
