### PR TITLE
Make two startup failures say what actually happened

### DIFF
--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -3899,9 +3899,10 @@ RouteResult IpcManager::RouteTask(Future<Task> &future, bool force_enqueue) {
         const auto inline_retry_budget = (task_ptr->pool_id_ == kAdminPoolId)
                                              ? std::chrono::seconds(30)
                                              : kInlineRetryBudget;
-        const auto deadline =
-            std::chrono::steady_clock::now() + inline_retry_budget;
-        while (!task_ptr->IsPeriodic() &&
+        const auto retry_start = std::chrono::steady_clock::now();
+        const auto deadline = retry_start + inline_retry_budget;
+        const bool is_periodic = task_ptr->IsPeriodic();
+        while (!is_periodic &&
                (result == RouteResult::Retry || result == RouteResult::Dne) &&
                std::chrono::steady_clock::now() < deadline) {
           std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -3918,12 +3919,30 @@ RouteResult IpcManager::RouteTask(Future<Task> &future, bool force_enqueue) {
           // entry once the popping iteration's owning reference died: the icx
           // windows-2025 cte_tag_large SEGFAULT. Terminal failure is the
           // correct end state.)
-          HLOG(kError,
-               "RouteTask: inline retry exhausted ({} ms) on non-worker "
-               "thread; failing task pool={} method={}",
-               std::chrono::duration_cast<std::chrono::milliseconds>(
-                   inline_retry_budget).count(),
-               task_ptr->pool_id_, task_ptr->method_);
+          // Report what actually happened, not the budget. A PERIODIC task
+          // skips the loop entirely (see above) and is failed instantly and
+          // by design -- printing the budget for it made five harmless drops
+          // read as five 30-second stalls, and that misreading has cost real
+          // diagnosis time twice (issue #923). Log elapsed time and say which
+          // of the two cases this is.
+          const auto elapsed_ms =
+              std::chrono::duration_cast<std::chrono::milliseconds>(
+                  std::chrono::steady_clock::now() - retry_start).count();
+          if (is_periodic) {
+            HLOG(kError,
+                 "RouteTask: periodic task not routable at spawn time; failing "
+                 "it immediately by design (no retry attempted) -- pool={} "
+                 "method={}",
+                 task_ptr->pool_id_, task_ptr->method_);
+          } else {
+            HLOG(kError,
+                 "RouteTask: inline retry exhausted after {} ms (budget {} ms) "
+                 "on non-worker thread; failing task pool={} method={}",
+                 elapsed_ms,
+                 std::chrono::duration_cast<std::chrono::milliseconds>(
+                     inline_retry_budget).count(),
+                 task_ptr->pool_id_, task_ptr->method_);
+          }
           task_ptr->SetReturnCode(static_cast<u32>(-1));
           task_ptr->SetComplete();
         }

--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -4092,11 +4092,19 @@ RouteResult IpcManager::RouteLocal(Future<Task> &future, bool force_enqueue) {
     // no metadata entry, or the entry exists but has no usable container --
     // and those want opposite fixes (issue #923). Printing initialized/pool
     // count here says which, without needing to reproduce.
+    // The instance ADDRESS is the discriminator. CLIO_POOL_MANAGER resolves
+    // through GetGlobalPtrVar, which lazily `new`s a blank PoolManager when the
+    // global pointer is null -- so "initialized=0, pools=0" can mean either a
+    // second, duplicated instance (one per module) or a genuine
+    // access-before-init window on the one instance. Those want different
+    // fixes. Compare this against the address ServerInit logs: two addresses
+    // is duplication, one address is ordering. (issue #923)
     auto *pm_diag = pool_manager;
     HLOG(kDebug,
          "RouteLocal: Container not found for pool={} container_id={} "
-         "method={} (pool_manager initialized={}, pools known={})",
+         "method={} (pool_manager={} initialized={}, pools known={})",
          task_ptr->pool_id_, container_id, task_ptr->method_,
+         static_cast<const void *>(pm_diag),
          pm_diag != nullptr && pm_diag->IsInitialized(),
          pm_diag != nullptr ? pm_diag->GetPoolCount() : 0);
     return RouteResult::Dne;

--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -4087,8 +4087,18 @@ RouteResult IpcManager::RouteLocal(Future<Task> &future, bool force_enqueue) {
     // lines, and a green coverage run logs ~19k of these (issue #849). The
     // callers in RouteTask log the kError summary on first failure and on
     // retry exhaustion.
-    HLOG(kDebug, "RouteLocal: Container not found for pool={} container_id={} method={}",
-         task_ptr->pool_id_, container_id, task_ptr->method_);
+    // Include the pool manager's own state. GetContainer can only return an
+    // invalid handle three ways: the manager is not initialized, the pool has
+    // no metadata entry, or the entry exists but has no usable container --
+    // and those want opposite fixes (issue #923). Printing initialized/pool
+    // count here says which, without needing to reproduce.
+    auto *pm_diag = pool_manager;
+    HLOG(kDebug,
+         "RouteLocal: Container not found for pool={} container_id={} "
+         "method={} (pool_manager initialized={}, pools known={})",
+         task_ptr->pool_id_, container_id, task_ptr->method_,
+         pm_diag != nullptr && pm_diag->IsInitialized(),
+         pm_diag != nullptr ? pm_diag->GetPoolCount() : 0);
     return RouteResult::Dne;
   }
   if (exec_dc.IsPlugged()) {

--- a/context-runtime/src/pool_manager.cc
+++ b/context-runtime/src/pool_manager.cc
@@ -74,6 +74,11 @@ bool PoolManager::ServerInit() {
   }
 
   is_initialized_ = true;
+  // Log the instance address so a later "container not found" miss can be told
+  // apart: same address as the miss => access-before-init ordering; different
+  // address => this manager is duplicated per module (issue #923).
+  HLOG(kInfo, "PoolManager::ServerInit: instance={}",
+       static_cast<const void *>(this));
 
   // Create the admin chimod pool (kAdminPoolId = 1)
   // This is required for flush operations and other admin tasks

--- a/context-runtime/util/clio_run_cmd_runtime_start.cc
+++ b/context-runtime/util/clio_run_cmd_runtime_start.cc
@@ -47,7 +47,22 @@ bool InitializeAdminChiMod() {
     HLOG(kDebug, "Admin pool creation handled by PoolManager::ServerInit()");
 
     if (!pool_manager->HasPool(clio::run::kAdminPoolId)) {
-      HLOG(kError, "Admin pool creation reported success but pool is not found");
+      // HasPool answers false for two very different states -- "the pool
+      // manager is not initialized" and "the pool genuinely is not there" --
+      // and the old message could not tell them apart. This check has fired
+      // intermittently right after ServerInit reported the pool created,
+      // killing the daemon at startup (issue #924, seen as a cr_detached_spawn
+      // failure on macos-14). Say which state it is, so the next occurrence
+      // answers the question instead of posing it.
+      HLOG(kError,
+           "Admin pool creation reported success but pool is not found "
+           "(pool_manager initialized={}, pools known={}). {}",
+           pool_manager->IsInitialized(), pool_manager->GetPoolCount(),
+           pool_manager->IsInitialized()
+               ? "The manager is up, so the admin pool's metadata is genuinely "
+                 "absent -- it was inserted and lost, or never durably inserted."
+               : "The manager reports NOT initialized, so this is an ordering "
+                 "problem in startup, not a missing pool.");
       return false;
     }
 


### PR DESCRIPTION
## Summary

Two log messages that were actively misleading during the #919 flake
investigation. **Neither change alters behaviour** — no control flow, no retry
timing, no new failure modes. They only fix what gets printed.

## Motivation

Contributes to #923 and #924. Both bugs are still open; this makes their next
occurrence self-diagnosing instead of ambiguous.

### 1. `RouteTask` reported the retry *budget*, not the elapsed time

A periodic task skips the retry loop entirely — `while (!task_ptr->IsPeriodic() && ...)`
— and is failed instantly and by design. It still logged:

```
RouteTask: inline retry exhausted (30000 ms) on non-worker thread; ...
```

So five harmless drops during admin container creation read as five 30-second
stalls: 150 s of hang that never happened. **That misreading sent me down the
wrong path twice** while diagnosing #919 — once attributing a macOS failure to
a deadlock it had nothing to do with, which I then had to retract. Now:

```
RouteTask: periodic task not routable at spawn time; failing it immediately
by design (no retry attempted) -- pool=... method=...

RouteTask: inline retry exhausted after 30001 ms (budget 30000 ms) ...
```

### 2. `HasPool` conflates "not initialized" with "not there"

```cpp
if (!is_initialized_) return false;   // indistinguishable from "pool absent"
```

The admin startup check has fired intermittently right after `ServerInit`
reported the pool created, killing the daemon (#924, seen as a
`cr_detached_spawn` failure on macos-14). Which of the two states it is happens
to be *the open question* in that issue, so the call site now reports it:

```
Admin pool creation reported success but pool is not found
(pool_manager initialized=true, pools known=3). The manager is up, so the
admin pool's metadata is genuinely absent -- it was inserted and lost, or
never durably inserted.
```

## Test plan

- [x] Builds clean (`release` preset, `iowarp/deps-cpu`)
- [x] All three new format strings verified present in the shipped binaries
- [x] Full local `ctest` clean — no failures, 2 skipped (prediction tests, LFS
      models absent locally)
- [x] Live daemon start comes up healthy; neither new path fires on a good start
- [ ] Verified in action — by construction these only print when the
      corresponding bug occurs, so CI proves them on the next occurrence

## Breaking changes

None.
