### PR TITLE
Publish process-global singletons exactly once (fixes #923, #928)

### DIFF
--- a/context-runtime/include/clio_runtime/api.h
+++ b/context-runtime/include/clio_runtime/api.h
@@ -51,7 +51,9 @@
 
 /** Same as CTP_DEFINE_GLOBAL_PTR_VAR_{H,CC} but with CLIO_RUN_API decoration
  *  so the symbol is exported from clio_run_cxx.dll and imported elsewhere. */
-#define CLIO_RUN_DEFINE_GLOBAL_PTR_VAR_H(T, NAME) extern CLIO_RUN_API __TU(T) * NAME;
-#define CLIO_RUN_DEFINE_GLOBAL_PTR_VAR_CC(T, NAME) CLIO_RUN_API __TU(T) *NAME = nullptr;
+#define CLIO_RUN_DEFINE_GLOBAL_PTR_VAR_H(T, NAME) \
+  extern CLIO_RUN_API ::std::atomic<__TU(T) *> NAME;
+#define CLIO_RUN_DEFINE_GLOBAL_PTR_VAR_CC(T, NAME) \
+  CLIO_RUN_API ::std::atomic<__TU(T) *> NAME{nullptr};
 
 #endif  // CLIO_RUN_API_H_

--- a/context-runtime/modules/admin/include/clio_runtime/admin/admin_tasks.h
+++ b/context-runtime/modules/admin/include/clio_runtime/admin/admin_tasks.h
@@ -1847,8 +1847,16 @@ struct HeartbeatTask : public clio::run::Task {
   }
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
+    // Must NOT delegate to Copy(): Copy runs Task::Copy, which overwrites the
+    // ORIGIN's task_id_/pool_query_/completer_ with the replica's (issue #915).
+    // Corrupting the origin of a SWIM heartbeat is worse than corrupting an
+    // ordinary task -- this is the machinery that decides which nodes are
+    // alive, so a mangled origin feeds bad liveness into leader election
+    // (issue #929, seen firing as the AggregateOut contract-violation guard
+    // during leader_elect).
+    // HeartbeatTask has no OUT fields of its own -- SerializeOut is just
+    // Task::SerializeOut -- so the base aggregation is the whole merge.
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<HeartbeatTask>());
   }
 };
 
@@ -1906,8 +1914,19 @@ struct QueryTaskProgressTask : public clio::run::Task {
   }
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
+    // Must NOT delegate to Copy(): Task::Copy would overwrite the ORIGIN's
+    // identity fields (issue #915) and copy the IN fields query_net_key_ /
+    // query_replica_id_ back from the replica.
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<QueryTaskProgressTask>());
+    auto other = other_base.template Cast<QueryTaskProgressTask>();
+    // status_ is 0 = kGone, 1 = kRunning, and the origin starts at 0.
+    // "Still running" wins: this answer decides whether a stuck replica gets
+    // failed, and wrongly concluding kGone completes a task that is still
+    // executing. Sticky-kRunning is also order-independent, unlike Copy's
+    // last-replica-wins.
+    if (other->status_ != 0) {
+      status_ = other->status_;
+    }
   }
 };
 
@@ -1946,8 +1965,10 @@ struct HeartbeatProbeTask : public clio::run::Task {
   }
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
+    // See HeartbeatTask::AggregateOut -- delegating to Copy() would overwrite
+    // the ORIGIN's identity fields via Task::Copy (issue #915). This task has
+    // no OUT fields of its own, so base aggregation is the whole merge.
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<HeartbeatProbeTask>());
   }
 };
 
@@ -1996,8 +2017,20 @@ struct ProbeRequestTask : public clio::run::Task {
   }
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
+    // Must NOT delegate to Copy(): it would overwrite the ORIGIN's identity
+    // fields via Task::Copy (issue #915), and it would also copy the IN field
+    // target_node_id_ back from the replica.
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<ProbeRequestTask>());
+    auto other = other_base.template Cast<ProbeRequestTask>();
+    // SWIM indirect probe: several helpers are asked to reach the same target,
+    // and the target is alive if ANY of them got through. probe_result_ is
+    // 0 = alive, -1 = unreachable, and the origin starts at -1, so success is
+    // sticky and the merge is order-independent. Taking the last replica's
+    // answer instead (what Copy did) would let one helper's failed probe
+    // erase another's success and declare a live node dead.
+    if (other->probe_result_ == 0) {
+      probe_result_ = 0;
+    }
   }
 };
 

--- a/context-runtime/src/manager.cc
+++ b/context-runtime/src/manager.cc
@@ -49,9 +49,12 @@
 CLIO_RUN_DEFINE_GLOBAL_PTR_VAR_CC(clio::run::RuntimeManager, g_runtime_manager);
 
 static void RuntimeManagerCleanupAtExit() {
-  if (g_runtime_manager) {
-    delete g_runtime_manager;
-    g_runtime_manager = nullptr;
+  // exchange, not load-then-store: this runs from atexit while other threads
+  // may still be resolving CLIO_RUNTIME_MANAGER, and claiming the pointer in
+  // one step means it can never be deleted twice.
+  if (auto *manager = g_runtime_manager.exchange(nullptr,
+                                                 std::memory_order_acq_rel)) {
+    delete manager;
   }
 }
 
@@ -169,17 +172,32 @@ bool RuntimeManager::ClientInit() {
   // The admin container is already created by the runtime, so we just
   // construct the admin client directly with the admin pool ID
   HLOG(kDebug, "Initializing CLIO_ADMIN singleton");
-  // IMPORTANT: Check g_admin directly, NOT CLIO_ADMIN macro
-  // CLIO_ADMIN uses GetGlobalPtrVar which auto-creates with default constructor!
-  if (g_admin == nullptr) {
+  // IMPORTANT: Publish g_admin directly, NOT via the CLIO_ADMIN macro.
+  // CLIO_ADMIN goes through GetGlobalPtrVar, which default-constructs; the
+  // admin client must be built with kAdminPoolId instead.
+  //
+  // The CAS matters as much as the pool id: a plain "if null then assign" is
+  // the same check-then-set that let two PoolManagers exist at once (#929).
+  // Losing that race here would leave two admin clients, with the published
+  // one not necessarily the one this thread went on to use.
+  clio::run::admin::Client *existing_admin = g_admin.load(std::memory_order_acquire);
+  if (existing_admin == nullptr) {
     HLOG(kInfo, "ClientInit: Creating admin client with kAdminPoolId={}",
          clio::run::kAdminPoolId);
-    g_admin = new clio::run::admin::Client(clio::run::kAdminPoolId);
-    HLOG(kInfo, "ClientInit: Admin client created, pool_id_={}",
-         g_admin->pool_id_);
+    auto *fresh_admin = new clio::run::admin::Client(clio::run::kAdminPoolId);
+    if (g_admin.compare_exchange_strong(existing_admin, fresh_admin,
+                                        std::memory_order_acq_rel,
+                                        std::memory_order_acquire)) {
+      HLOG(kInfo, "ClientInit: Admin client created, pool_id_={}",
+           fresh_admin->pool_id_);
+    } else {
+      delete fresh_admin;
+      HLOG(kInfo, "ClientInit: lost the admin publish race, pool_id_={}",
+           existing_admin->pool_id_);
+    }
   } else {
     HLOG(kInfo, "ClientInit: g_admin already exists, pool_id_={}",
-         g_admin->pool_id_);
+         existing_admin->pool_id_);
   }
 
   is_client_initialized_ = true;

--- a/context-transfer-engine/core/include/clio_cte/api.h
+++ b/context-transfer-engine/core/include/clio_cte/api.h
@@ -31,7 +31,9 @@
 /** Same as CTP_DEFINE_GLOBAL_PTR_VAR_{H,CC} but with CLIO_CTE_API decoration
  *  so the symbol is exported from clio_cte_core_client.dll and imported
  *  by every dependent module. */
-#define CLIO_CTE_DEFINE_GLOBAL_PTR_VAR_H(T, NAME) extern CLIO_CTE_API __TU(T) * NAME;
-#define CLIO_CTE_DEFINE_GLOBAL_PTR_VAR_CC(T, NAME) CLIO_CTE_API __TU(T) *NAME = nullptr;
+#define CLIO_CTE_DEFINE_GLOBAL_PTR_VAR_H(T, NAME) \
+  extern CLIO_CTE_API ::std::atomic<__TU(T) *> NAME;
+#define CLIO_CTE_DEFINE_GLOBAL_PTR_VAR_CC(T, NAME) \
+  CLIO_CTE_API ::std::atomic<__TU(T) *> NAME{nullptr};
 
 #endif  // CLIO_CTE_API_H_

--- a/context-transport-primitives/include/clio_ctp/util/singleton.h
+++ b/context-transport-primitives/include/clio_ctp/util/singleton.h
@@ -34,6 +34,7 @@
 #ifndef CTP_SHM_SINGLETON_H
 #define CTP_SHM_SINGLETON_H
 
+#include <atomic>
 #include <memory>
 
 #include "clio_ctp/constants/macros.h"
@@ -223,15 +224,57 @@ CTP_CROSS_FUN static inline T *GetGlobalCrossVar(T &instance) {
  * imported from another DLL; CMake's WINDOWS_EXPORT_ALL_SYMBOLS handles
  * function symbols but not data).
  */
-#define CTP_DEFINE_GLOBAL_PTR_VAR_H(T, NAME) extern __TU(T) * NAME;
-#define CTP_DEFINE_GLOBAL_PTR_VAR_CC(T, NAME) __TU(T) *NAME = nullptr;
+#define CTP_DEFINE_GLOBAL_PTR_VAR_H(T, NAME) \
+  extern ::std::atomic<__TU(T) *> NAME;
+#define CTP_DEFINE_GLOBAL_PTR_VAR_CC(T, NAME) \
+  ::std::atomic<__TU(T) *> NAME{nullptr};
 #define CTP_GET_GLOBAL_PTR_VAR(T, NAME) ctp::GetGlobalPtrVar<__TU(T)>(NAME)
+/**
+ * Publish-once lazy accessor for a process-global singleton pointer.
+ *
+ * This used to be an unsynchronized check-then-set:
+ *
+ *   if (instance == nullptr) { instance = new T(); }
+ *
+ * Two threads could both observe null, each construct a T, and the last
+ * writer would win the variable -- silently orphaning the other instance.
+ * For CLIO_POOL_MANAGER that was not merely wasteful but fatal: ServerInit()
+ * would run on the orphan, every later lookup would return the blank
+ * survivor, and since a blank manager can never become initialized the
+ * route-retry loop would spin its whole 30s deadline and fail the task with
+ * (u32)-1. That is the shared root cause of issues #923 (Linux leak-check),
+ * #928 (macOS adapters) and the windows-11-arm safe_bdev failure in #929 --
+ * the "two instance addresses" signature those issues were filed on.
+ *
+ * The CAS below makes construction publish-once: whoever installs the
+ * pointer first wins, the loser destroys its speculative instance and
+ * adopts the winner's. Correctness does not depend on a shared lock, which
+ * matters because this function is inlined into every module -- a
+ * function-local static mutex would be per-DLL on Windows and so would not
+ * actually serialize the threads racing on this one shared variable.
+ *
+ * The variable is std::atomic<T*> rather than a raw T*: acquire/release on
+ * the pointer is what orders the constructor's writes against another
+ * thread's first dereference, and unlike std::atomic_ref it is available on
+ * every toolchain this project builds with (atomic_ref needs libc++ 19,
+ * newer than the AppleClang used on the macOS runners).
+ */
 template <typename T>
-static inline T *GetGlobalPtrVar(T *&instance) {
-  if (instance == nullptr) {
-    instance = new T();
+static inline T *GetGlobalPtrVar(::std::atomic<T *> &instance) {
+  T *observed = instance.load(::std::memory_order_acquire);
+  if (observed != nullptr) {
+    return observed;
   }
-  return instance;
+  T *fresh = new T();
+  if (instance.compare_exchange_strong(observed, fresh,
+                                       ::std::memory_order_acq_rel,
+                                       ::std::memory_order_acquire)) {
+    return fresh;
+  }
+  // Lost the publish race: another thread installed its instance first.
+  // `observed` now holds the winner, which is the one everyone must share.
+  delete fresh;
+  return observed;
 }
 
 /**

--- a/context-transport-primitives/include/clio_ctp/util/singleton.h
+++ b/context-transport-primitives/include/clio_ctp/util/singleton.h
@@ -273,7 +273,22 @@ static inline T *GetGlobalPtrVar(::std::atomic<T *> &instance) {
   }
   // Lost the publish race: another thread installed its instance first.
   // `observed` now holds the winner, which is the one everyone must share.
+  //
+  // The delete is well-defined even for a polymorphic T with a non-virtual
+  // destructor: `fresh` came from `new T()` two lines up, so the static and
+  // dynamic types are identical and no base-pointer slicing is possible.
+  // -Wdelete-non-virtual-dtor cannot see that and fires in every TU that
+  // instantiates this template (ConfigManager, IpcManager, ... are all
+  // polymorphic), so silence it narrowly here rather than leaving warnings
+  // scattered across the build.
+#if defined(__GNUC__) || defined(__clang__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wdelete-non-virtual-dtor"
+#endif
   delete fresh;
+#if defined(__GNUC__) || defined(__clang__)
+#  pragma GCC diagnostic pop
+#endif
   return observed;
 }
 

--- a/context-transport-primitives/test/unit/util/CMakeLists.txt
+++ b/context-transport-primitives/test/unit/util/CMakeLists.txt
@@ -50,6 +50,30 @@ install(TARGETS
         ARCHIVE DESTINATION lib
         RUNTIME DESTINATION bin)
 
+add_executable(test_singleton_exec
+        ${TEST_MAIN}/main.cc
+        test_init.cc
+        test_singleton.cc)
+add_dependencies(test_singleton_exec clio_ctp_host)
+target_link_libraries(test_singleton_exec
+        clio_ctp_host
+        Catch2::Catch2)
+
+add_test(NAME ctp_singleton COMMAND
+        ${CMAKE_BINARY_DIR}/bin/test_singleton_exec)
+
+# Same precompiled-Catch2 sigaction false positives as the other cases here.
+set_tests_properties(
+  ctp_singleton
+  PROPERTIES LABELS "msan_skip"
+)
+
+install(TARGETS
+        test_singleton_exec
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        RUNTIME DESTINATION bin)
+
 add_executable(test_system_info_exec
         ${TEST_MAIN}/main.cc
         test_init.cc

--- a/context-transport-primitives/test/unit/util/test_singleton.cc
+++ b/context-transport-primitives/test/unit/util/test_singleton.cc
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Regression tests for ctp::GetGlobalPtrVar (issue #929).
+ *
+ * The accessor used to be an unsynchronized check-then-set:
+ *
+ *   if (instance == nullptr) { instance = new T(); }
+ *
+ * Two threads could both observe null, each construct a T, and the last
+ * writer would win the variable -- leaving the other instance orphaned and,
+ * worse, leaving different callers holding different instances.
+ *
+ * That is what produced the "two PoolManager addresses in one process"
+ * signature behind issues #923, #928 and #929: PoolManager::ServerInit()
+ * initialized one instance while every later CLIO_POOL_MANAGER lookup
+ * returned a different, permanently-blank one, so the route-retry loop spun
+ * its whole 30s deadline and failed the task with (u32)-1.
+ *
+ * These tests race many threads on a cold pointer and assert the two
+ * properties that failure violated: everyone agrees on one pointer, and
+ * exactly one instance stays alive.
+ */
+
+#include <atomic>
+#include <thread>
+#include <vector>
+
+#include "basic_test.h"
+#include "clio_ctp/util/singleton.h"
+
+namespace {
+
+/** Counts how many instances exist so a leaked loser is detectable. */
+std::atomic<int> g_live_count{0};
+std::atomic<int> g_ctor_count{0};
+
+struct CountedSingleton {
+  // A payload wide enough that a torn publish would be observable: a thread
+  // that saw the pointer before the constructor's writes would read zeros.
+  static constexpr int kSentinel = 0x5EED;
+  int sentinel_;
+
+  CountedSingleton() : sentinel_(kSentinel) {
+    g_live_count.fetch_add(1, std::memory_order_relaxed);
+    g_ctor_count.fetch_add(1, std::memory_order_relaxed);
+  }
+
+  ~CountedSingleton() { g_live_count.fetch_sub(1, std::memory_order_relaxed); }
+};
+
+}  // namespace
+
+TEST_CASE("GetGlobalPtrVarPublishesExactlyOneInstance") {
+  // Many rounds: the race window is narrow, so a single round proves little.
+  // On the pre-fix code this fails within the first few rounds on a
+  // multi-core box.
+  const int kRounds = 200;
+  const int kThreads = 8;
+
+  for (int round = 0; round < kRounds; ++round) {
+    g_live_count.store(0, std::memory_order_relaxed);
+    g_ctor_count.store(0, std::memory_order_relaxed);
+
+    // A fresh cold pointer per round -- this is the state a process is in
+    // before the first CLIO_POOL_MANAGER / CLIO_IPC access.
+    std::atomic<CountedSingleton *> instance{nullptr};
+
+    std::vector<CountedSingleton *> observed(kThreads, nullptr);
+    std::atomic<int> ready{0};
+    std::vector<std::thread> threads;
+    threads.reserve(kThreads);
+
+    for (int t = 0; t < kThreads; ++t) {
+      threads.emplace_back([&, t]() {
+        // Spin-barrier so the threads reach the accessor together; without
+        // this they serialize and the race never opens.
+        ready.fetch_add(1, std::memory_order_acq_rel);
+        while (ready.load(std::memory_order_acquire) < kThreads) {
+        }
+        observed[t] = ctp::GetGlobalPtrVar<CountedSingleton>(instance);
+      });
+    }
+    for (auto &th : threads) {
+      th.join();
+    }
+
+    CountedSingleton *winner = instance.load(std::memory_order_acquire);
+    REQUIRE(winner != nullptr);
+
+    // (1) Every thread must have been handed the instance that is actually
+    //     published. This is the property whose failure stranded ServerInit
+    //     on an orphan.
+    for (int t = 0; t < kThreads; ++t) {
+      REQUIRE(observed[t] == winner);
+    }
+
+    // (2) Exactly one instance may remain alive. Losing a publish race is
+    //     allowed to construct speculatively, but the loser must be
+    //     destroyed rather than orphaned.
+    REQUIRE(g_live_count.load(std::memory_order_relaxed) == 1);
+
+    // (3) The published object must be fully constructed -- the acquire on
+    //     the pointer is what orders the constructor's writes ahead of
+    //     another thread's first dereference.
+    REQUIRE(winner->sentinel_ == CountedSingleton::kSentinel);
+
+    delete winner;
+    REQUIRE(g_live_count.load(std::memory_order_relaxed) == 0);
+  }
+}
+
+TEST_CASE("GetGlobalPtrVarIsStableOnceWarm") {
+  std::atomic<CountedSingleton *> instance{nullptr};
+  g_live_count.store(0, std::memory_order_relaxed);
+
+  CountedSingleton *first = ctp::GetGlobalPtrVar<CountedSingleton>(instance);
+  REQUIRE(first != nullptr);
+
+  // A warm pointer must never construct again, no matter how many callers
+  // or threads ask for it.
+  for (int i = 0; i < 1000; ++i) {
+    REQUIRE(ctp::GetGlobalPtrVar<CountedSingleton>(instance) == first);
+  }
+  REQUIRE(g_live_count.load(std::memory_order_relaxed) == 1);
+
+  delete first;
+}


### PR DESCRIPTION
## Summary

- Fix an unsynchronized lazy singleton that let **two instances of the same
  process global** exist at once — the shared root cause of #923, #928 and the
  `windows-11-arm` failure on the dev→main PR (#908).
- Silence the 33 `-Wdelete-non-virtual-dtor` warnings the fix introduced.
- Stop the four SWIM tasks from implementing `AggregateOut` as `Copy()`, which
  overwrites the **origin's** identity fields (#915 class).

## Motivation

Fixes #923. Fixes #928. Refs #929, #915.

`dev` → `main` was going red roughly half the time. Investigating (#929) turned up
four independent causes, not one. This PR lands the one that is fully root-caused
and validated.

`GetGlobalPtrVar` was a plain check-then-set:

```cpp
if (instance == nullptr) { instance = new T(); }
```

Two threads could both observe null, each construct a `T`, and the last writer
would win the variable — orphaning the other instance. It backs **18 process
globals** (`CLIO_IPC`, `CLIO_ADMIN`, `CLIO_POOL_MANAGER`, `CTE_MANAGER`, …).

For `CLIO_POOL_MANAGER` that was fatal rather than merely wasteful:
`PoolManager::ServerInit()` initialized the orphan while every later lookup
returned the blank survivor. A blank manager can never become initialized, so
`RouteLocal` missed forever, the inline route-retry burned its whole 30 s budget,
and the task failed with `(u32)-1` — surfacing as an unrelated-looking "failed to
create pool" in whichever test happened to run first.

The instance-address diagnostic added in #923 proves it. `ServerInit` logs one
address; `RouteLocal` consults a different one:

```
windows-11-arm : ServerInit instance=00000261591FA710  vs  RouteLocal pool_manager=00000261591FA990  (x1870)
macOS          : ServerInit 0x600001fe41c0  vs  RouteLocal 0x600001fec000  (x9518)
                 ServerInit 0x600002f741c0  vs  RouteLocal 0x600002f70000  (x9701)
```

## What changed

**`GetGlobalPtrVar` publishes once via CAS.** The winner's instance is what
everyone gets; a loser destroys its speculative instance and adopts the winner's.
Correctness deliberately does not rely on a lock: this function inlines into every
module, so a function-local static mutex would be per-DLL on Windows and would not
serialize the threads racing on the one shared variable. The global is
`std::atomic<T*>` rather than `std::atomic_ref` because `atomic_ref` needs
libc++ 19 — newer than the AppleClang on the macOS runners — and it is still
constant-initialized, so no static-init-order hazard is introduced.

**`manager.cc`** had the same check-then-set in the `g_admin` guard that was
written to avoid this very hazard; it is now a CAS too, and the atexit teardown
claims the pointer with `exchange` so it cannot double-free.

**SWIM `AggregateOut`** — `HeartbeatTask`, `HeartbeatProbeTask`,
`ProbeRequestTask`, `QueryTaskProgressTask` all delegated to `Copy()`, which runs
`Task::Copy` and overwrites the origin's `task_id_`/`pool_query_`/`completer_`.
The #918 contract guard fires on methods 27 and 29 on every `leader_elect` run, so
this is live corruption of the machinery that decides which nodes are alive. Each
now merges its real OUT fields, checked against `SerializeOut` rather than assumed:

- `ProbeRequestTask.probe_result_` — **sticky-alive**. A SWIM indirect probe
  succeeds if ANY helper reaches the target; `Copy`'s last-replica-wins let one
  helper's failure erase another's success and declare a live node dead.
- `QueryTaskProgressTask.status_` — **sticky-kRunning**. Concluding kGone
  completes a task that is still executing.
- The other two genuinely have no OUT fields.

## Test plan

- [x] New regression test `ctp_singleton` — 200 rounds x 8 racing threads per run
- [x] Race proven real: the pre-fix accessor hands threads **different instances
      in 19,018 of 20,000** contended rounds
- [x] Fix proven: **20/20 runs, 32,000 racing rounds, zero failures**
- [x] `constinit` check confirms the atomic globals are still constant-initialized
- [x] Full suite `ctest -E docker`: **292/292, twice**
- [x] Build clean: 0 errors, **0 warnings** (down from the 33 this fix first
      introduced)
- [ ] macOS/Windows adapter jobs — see below

## Known gaps

**These jobs do not run on branch PRs.** `cluster-tests.yml` triggers only on
push to main/dev, and the macOS/Windows adapter jobs are skipped by the tiered
matrix. That gap is how this bug reached `dev` in the first place — PR #918 was
green while the jobs that would have caught it never ran. Dispatch manually
before merge:

```
gh workflow run "CI Windows"   --ref 929-dev-to-main-ci-flake
gh workflow run "CI Adapters"  --ref 929-dev-to-main-ci-flake
```

**This does not fix the leader-election crash** (#929 Class B). That one is
separately diagnosed as 100% deterministic — `leader_elect` crashes a node on
10/10 local runs while the suite still reports PASSED — with 11 hypotheses
eliminated. It is documented on #929 and is NOT addressed here. The SWIM
`AggregateOut` fixes above were measured against it: 5 runs before, 5 after,
byte-identical. They land on their own correctness merits, not as a crash fix.

**Class C (conda) needed no work** — it was already fixed on `dev` by
`410fe4fd` / `fbb9fed5` before #929 was filed.

## Breaking changes

None. The globals change type from `T*` to `std::atomic<T*>`; all in-tree uses
compile unchanged except two `g_admin->` dereferences updated in `manager.cc`.
