### PR TITLE
Bump version to 2.2.0 for the release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(iowarp-core VERSION 2.1.0 LANGUAGES C CXX)
+project(iowarp-core VERSION 2.2.0 LANGUAGES C CXX)
 
 #------------------------------------------------------------------------------
 # MSVC-like front end detection

--- a/installers/conda/meta.yaml
+++ b/installers/conda/meta.yaml
@@ -7,7 +7,7 @@
    build exposes a working environ-bridge again; the CMake-side source
    of truth is in /CMakeLists.txt project(iowarp-core VERSION X.Y.Z),
    keep this number in sync when bumping. #}
-{% set version = "1.5.8" %}
+{% set version = "2.2.0" %}
 {% set preset = environ.get('IOWARP_PRESET', 'release') %}
 
 package:


### PR DESCRIPTION
## Summary

- Bump `project(iowarp-core VERSION ...)` **2.1.0 → 2.2.0** for the monthly release.
- Re-sync `installers/conda/meta.yaml`, which had drifted **two minors behind**
  (pinned at 1.5.8 while the project was already 2.1.0).

## Motivation

Cutting the 2.2 release. `CMakeLists.txt` is the source of truth:
`build-packages.yml`'s `check-version` job compares the pushed tag against it and
**fails the release if they disagree**, so the tag must be exactly **`v2.2.0`**.

The conda drift is a real bug, not housekeeping. `meta.yaml` hardcodes the
version because conda-build 26.x sandboxed the jinja `environ`, breaking the
`PKG_VERSION` bridge — the file's own comment says to keep the literal in sync
when bumping, and that had not happened for two releases. Every conda package
built since has published under **1.5.8** regardless of the actual source
version. Nothing derives it automatically, so this remains a manual step until
conda-build exposes a working environ bridge again.

## What does NOT need changing

- **pip** — `pyproject.toml` declares `dynamic = ["version"]` via
  `[tool.scikit-build.metadata.version]`, so it follows CMake automatically.
- **spack** — `installers/spack/packages/iowarp/package.py` tracks the `main`
  and `dev` branches rather than pinned versions.

## ⚠️ Do not push the tag yet — GitHub Actions is in a major outage

[githubstatus.com](https://www.githubstatus.com/) reports an **Actions major
outage** that began 2026-08-06 15:22 UTC:

> "Webhook triggers remain throttled to support recovery. **Many push and pull
> request events are not yet triggering new workflow runs**"

This is already visible on this repo: the merge of #908 into `main` at 22:58 UTC
produced **zero** workflow runs, and nothing has run repo-wide for ~3 hours. All
15 workflow files are present on `main`, every workflow is `active`, and Actions
is `enabled` — so this is the outage, not configuration.

`build-packages.yml` and `build-pip.yml` trigger on `tags: ['v*']`. Pushing
`v2.2.0` during the throttle would very likely publish nothing while leaving a
release tag in the history that looks done. **Merge this, then wait for Actions
to recover before tagging**, and confirm the tag actually started
`Build and Publish Binary Packages` + `Build, Test, and Publish Pip Wheels`.

## Release checklist

- [ ] Merge this into `dev`
- [ ] Sync `dev` → `main` (release tags are cut from `main`)
- [ ] Confirm GitHub Actions has recovered
- [ ] Tag **`v2.2.0`** on `main` and push it
- [ ] Verify `check-version` passed (tag == CMake version) rather than assuming
- [ ] Verify the conda package publishes as **2.2.0**, not 1.5.8 — that is the
      regression this PR fixes and the one most likely to go unnoticed

## Test plan

- [x] `CMakeLists.txt` version reads 2.2.0
- [x] `installers/conda/meta.yaml` renders and its `package:` block parses
- [x] Confirmed no other version literal exists in `installers/` needing a bump
- [ ] Full CI (blocked on the Actions outage above)

## Breaking changes

None — version metadata only.
