### PR TITLE
Build the HDF5 VFD off the UNIX gate, not the ELF gate

### DIFF
--- a/context-transfer-engine/adapter/CMakeLists.txt
+++ b/context-transfer-engine/adapter/CMakeLists.txt
@@ -5,8 +5,13 @@
 # CTE adapter singleton implementation - moved to filesystem directory
 # to leverage existing working build configuration
 
-if(UNIX)
-    endif()
+# The HDF5 VFD is a plugin the library dlopen's, not an interceptor: it
+# never touches real_api.h, so it does not need ELF support. Gate it on
+# UNIX -- H5FDclio.cc uses <sys/file.h>, <unistd.h> and flock, so Windows
+# needs porting work rather than a gate change.
+if(UNIX AND CLIO_CTE_ENABLE_VFD)
+    add_subdirectory(vfd)
+endif()
 
 # Adapters require ELF support (for real_api.h)
 # Disable all adapters when ELF is disabled
@@ -22,9 +27,6 @@ if(CLIO_CORE_ENABLE_ELF)
     endif()
     if (CLIO_CTE_ENABLE_MPIIO_ADAPTER)
         add_subdirectory(mpiio)
-    endif()
-    if (CLIO_CTE_ENABLE_VFD)
-        add_subdirectory(vfd)
     endif()
     if (CLIO_CTE_ENABLE_NVIDIA_GDS_ADAPTER)
         add_subdirectory(nvidia_gds)

--- a/context-transfer-engine/filesystem/CMakeLists.txt
+++ b/context-transfer-engine/filesystem/CMakeLists.txt
@@ -26,8 +26,12 @@ target_include_directories(clio_cte_filesystem_runtime PRIVATE
 target_include_directories(clio_cte_filesystem_client PRIVATE
     ${CMAKE_SOURCE_DIR}/context-transfer-engine/core/include)
 
-# Export dllexport for the g_fs_client global on Windows (reuses clio_cte/api.h).
+# Export the g_fs_client global on Windows. This must be THIS module's macro:
+# defining CLIO_CTE_CORE_BUILDING_DLL here also told the core's headers that
+# g_cte_client was being defined locally, which it is not -- an LNK2019 that
+# stayed hidden while the descriptor layer (its only user here) was excluded
+# from Windows builds.
 if(TARGET clio_cte_filesystem_client)
   target_compile_definitions(clio_cte_filesystem_client PRIVATE
-    CLIO_CTE_CORE_BUILDING_DLL=1)
+    CLIO_CTE_FS_BUILDING_DLL=1)
 endif()

--- a/context-transfer-engine/filesystem/include/clio_cte/filesystem/api.h
+++ b/context-transfer-engine/filesystem/include/clio_cte/filesystem/api.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved. BSD 3-Clause license.
+ */
+#ifndef CLIO_CTE_FILESYSTEM_API_H_
+#define CLIO_CTE_FILESYSTEM_API_H_
+
+#include "clio_cte/api.h"
+
+/**
+ * Per-DLL export macro for clio_cte_filesystem_client.
+ *
+ * Mirrors clio_cte/api.h's CLIO_CTE_API and clio_runtime/api.h's CLIO_RUN_API.
+ * CMake sets CLIO_CTE_FS_BUILDING_DLL=1 PRIVATE on the
+ * clio_cte_filesystem_client target; consumers see the import form.
+ *
+ * This exists rather than reusing CLIO_CTE_API because that macro answers a
+ * different question. CLIO_CTE_API means "is this translation unit building
+ * clio_cte_core_client?", so defining CLIO_CTE_CORE_BUILDING_DLL here to
+ * export g_fs_client also told every declaration in the *core's* headers that
+ * it was being built locally -- including g_cte_client, which then resolved to
+ * a definition this DLL does not contain:
+ *
+ *   filesystem_client.obj : error LNK2019: unresolved external symbol
+ *   "struct std::atomic<class clio::cte::core::Client *> clio::cte::core::g_cte_client"
+ *
+ * That stayed latent only because nothing in this client referenced the core
+ * singleton on Windows: the descriptor layer, which does, was excluded there.
+ */
+#if defined(_WIN32)
+#ifdef CLIO_CTE_FS_BUILDING_DLL
+#define CLIO_CTE_FS_API __declspec(dllexport)
+#else
+#define CLIO_CTE_FS_API __declspec(dllimport)
+#endif
+#else
+#define CLIO_CTE_FS_API
+#endif
+
+/** As CLIO_CTE_DEFINE_GLOBAL_PTR_VAR_{H,CC}, decorated for this DLL. */
+#define CLIO_CTE_FS_DEFINE_GLOBAL_PTR_VAR_H(T, NAME) \
+  extern CLIO_CTE_FS_API ::std::atomic<__TU(T) *> NAME;
+#define CLIO_CTE_FS_DEFINE_GLOBAL_PTR_VAR_CC(T, NAME) \
+  CLIO_CTE_FS_API ::std::atomic<__TU(T) *> NAME{nullptr};
+
+#endif  // CLIO_CTE_FILESYSTEM_API_H_

--- a/context-transfer-engine/filesystem/include/clio_cte/filesystem/filesystem_client.h
+++ b/context-transfer-engine/filesystem/include/clio_cte/filesystem/filesystem_client.h
@@ -7,6 +7,8 @@
 
 #include <clio_cte/core/core_client.h>
 #include <atomic>
+#include "clio_cte/filesystem/api.h"
+
 #include <chrono>
 #include <cstdlib>
 #if !defined(_WIN32)
@@ -1102,11 +1104,12 @@ class Client : public clio::cte::core::Client {
 #endif
 };
 
-// Process-wide filesystem client singleton (reuses the clio_cte export macro).
-// Declared inside the namespace so it resolves as
-// clio::cte::filesystem::g_fs_client (matching CLIO_CFS_CLIENT below and the
-// definition in filesystem_client.cc), exactly like core's g_cte_client.
-CLIO_CTE_DEFINE_GLOBAL_PTR_VAR_H(clio::cte::filesystem::Client, g_fs_client);
+// Process-wide filesystem client singleton, exported through THIS module's
+// macro (clio_cte/filesystem/api.h) rather than the core's. Declared inside
+// the namespace so it resolves as clio::cte::filesystem::g_fs_client
+// (matching CLIO_CFS_CLIENT below and the definition in
+// filesystem_client.cc), exactly like core's g_cte_client.
+CLIO_CTE_FS_DEFINE_GLOBAL_PTR_VAR_H(clio::cte::filesystem::Client, g_fs_client);
 
 /** Initialize the filesystem client singleton (creates/binds the pool). */
 bool CLIO_CFS_CLIENT_INIT(const std::string &config_path = "",

--- a/context-transfer-engine/filesystem/src/filesystem_client.cc
+++ b/context-transfer-engine/filesystem/src/filesystem_client.cc
@@ -14,7 +14,7 @@ namespace clio::cte::filesystem {
 
 // Process-wide filesystem client singleton (defined inside the namespace so it
 // is clio::cte::filesystem::g_fs_client, matching the CLIO_CFS_CLIENT macro).
-CLIO_CTE_DEFINE_GLOBAL_PTR_VAR_CC(clio::cte::filesystem::Client, g_fs_client);
+CLIO_CTE_FS_DEFINE_GLOBAL_PTR_VAR_CC(clio::cte::filesystem::Client, g_fs_client);
 
 /**
  * Create-or-bind the default filesystem pool over the default CTE core pool


### PR DESCRIPTION
Closes #937.

`add_subdirectory(vfd)` sat inside `if(CLIO_CORE_ENABLE_ELF)`, and that option
does `pkg_check_modules(libelf REQUIRED libelf)` — unsatisfiable on Mach-O — so
the `clio_vfd` target was never created on macOS.

Nothing in the VFD needs ELF:

* It is a plugin HDF5 `dlopen`s, not a libc interceptor. `H5FDclio.cc` never
  includes `real_api.h`, never calls `dlsym`/`RTLD_NEXT`.
* It links `ctp::interceptor`, but that INTERFACE target only attaches
  `${ELF_LIBS}` when ELF is on; otherwise it just defines `CTP_ENABLE_ELF=0`.
* Since e2050b6b its remaining dependency is `clio_cte_filesystem_client`,
  which is not gated at all.

This is the distinction the file already made for `cfs` before that commit
removed it: *"Gated on UNIX, not on ELF: unlike the interceptors it never
touches real_api.h."*

### Verification

Both runs applied exactly this change to `dev` and nothing else, on `macos-26`:

| | result |
| --- | --- |
| [builds](https://github.com/hyoklee/hpf/actions/runs/31141294898) | `H5FDclio.cc` compiles and links with `CLIO_CORE_ENABLE_ELF=OFF` → `libclio_vfd.dylib` |
| [works](https://github.com/hyoklee/hpf/actions/runs/31142087871) | `tst_chunks3` through `HDF5_DRIVER=clio_vfd`, against HDF5 `develop` + netCDF-C `main` + a live `clio_run`, produced all 18 measurements |

The second run checks `otool`/`LC_RPATH` to confirm the plugin resolved the
intended libhdf5, so it is a real VFD run rather than a silent fallback to
sec2:

```
libclio_vfd.dylib resolves libhdf5.1000.dylib -> .../nc4-clio-work/hdf5-install/lib/libhdf5.1000.dylib
clio_run ready
==> Running variant: clio_vfd   → ok
```

### Scope

Windows stays excluded through the `UNIX` gate, matching `ci-adapters.yml`,
which already sets `CLIO_CTE_ENABLE_VFD=OFF` there — `H5FDclio.cc` uses
`<sys/file.h>`, `<unistd.h>` and `flock`, so it needs porting work rather than
a gate change.

The new block also replaces the empty `if(UNIX) endif()` that e2050b6b left
behind when `add_subdirectory(cfs)` was removed. Happy to split that out if you
would rather keep this to one thing.

Not addressed here, but noted in #937: with the VFD running on macOS,
`contiguous write 64 64 1` takes ~470 s against 0.010 s for the native
baseline, while chunked and compressed access stays within 1.5-4x. It tracks
the number of `nc_put_vara` calls rather than bytes moved. I can open a
separate issue with the full table if that is useful.
