### PR TITLE
Re-check blob liveness under the read pin; document FUSE in the quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,8 @@ no separate `compose` step is required:
 
 ```bash
 clio_run start &
-mkdir -p /mnt/clio
-CLIO_WITH_RUNTIME=0 clio_cte_fuse /mnt/clio -f
+mkdir -p ~/clio-mnt
+CLIO_WITH_RUNTIME=0 clio_cte_fuse ~/clio-mnt -f
 ```
 
 `CLIO_WITH_RUNTIME=0` attaches to the runtime you just started rather than
@@ -178,14 +178,14 @@ is handed to `fuse_main`, so standard libfuse options apply (`-o allow_other`,
 The mount then behaves like any other filesystem:
 
 ```bash
-cp big_input.h5 /mnt/clio/
-python analysis.py /mnt/clio/big_input.h5
+cp big_input.h5 ~/clio-mnt/
+python analysis.py ~/clio-mnt/big_input.h5
 ```
 
 **3. Unmount:**
 
 ```bash
-fusermount3 -u /mnt/clio      # or: fusermount -u /mnt/clio
+fusermount3 -u ~/clio-mnt      # or: fusermount -u ~/clio-mnt
 ```
 
 To size the storage tiers explicitly instead of taking the defaults, compose a

--- a/README.md
+++ b/README.md
@@ -82,20 +82,9 @@ The wheel includes the CLIO runtime, the `clio_run` CLI, the CTE, CAE, and
 CEE engines, and the `clio_cee` Python bindings. A default configuration is
 seeded at `~/.clio/clio.yaml` on first import.
 
-### Conda
+### Extra features
 
-Prebuilt `iowarp-core` packages are published to the
-[`iowarp` channel on Anaconda.org](https://anaconda.org/iowarp/iowarp-core).
-With [Miniconda](https://www.anaconda.com/download/success) installed:
-
-```bash
-conda create -n iowarp -c iowarp -c conda-forge iowarp-core
-conda activate iowarp
-```
-
-Dependencies are pulled from conda-forge instead of being statically linked.
-
-Switch to a source build below if you need any of:
+The pip wheel covers the common case. Build from source if you need any of:
 
 - NVIDIA GPU (CUDA) or AMD GPU (ROCm) acceleration
 - MPI for distributed multi-node deployment
@@ -105,27 +94,19 @@ Switch to a source build below if you need any of:
 - Custom ChiMods built against the C++ headers
 - Sanitizer or debug builds
 
-### Source build (Conda)
-
-Build the conda recipe yourself to enable extra features. `IOWARP_PRESET`
-selects a [CMake preset](CMakePresets.json):
-
 ```bash
 git clone --recurse-submodules https://github.com/iowarp/clio-core.git
 cd clio-core
 
-# conda-build is a base-env plugin — install it there
-conda install -n base -y conda-build -c conda-forge
-
 # Common presets: release, debug, cuda-release, rocm-release
-IOWARP_PRESET=release conda build installers/conda/ \
-    -c conda-forge --output-folder build/conda-output
-conda install -c conda-forge build/conda-output/*/iowarp-core-*.conda
+cmake --preset=release
+cmake --build build -j"$(nproc)"
+sudo cmake --install build
 ```
 
-For a full **bare-metal source build** (without Conda) with the per-feature
-apt / dnf dependency list and the complete `CLIO_*_ENABLE_*` flag checklist,
-see [INSTALL.md](INSTALL.md). Other methods (Docker, Spack) are documented in
+For the per-feature apt / dnf dependency list and the complete
+`CLIO_*_ENABLE_*` flag checklist, see [INSTALL.md](INSTALL.md). Other install
+methods (Conda, Docker, Spack) are documented in
 [docs/getting-started/installation](docs/docs/getting-started/installation.mdx).
 
 ## Components
@@ -156,6 +137,70 @@ To override the configuration, point `CLIO_SERVER_CONF` at your own YAML file:
 export CLIO_SERVER_CONF=/path/to/my_config.yaml
 clio_run start
 ```
+
+### FUSE filesystem
+
+`clio_cte_fuse` exposes the Context Transfer Engine as a POSIX filesystem, so
+unmodified applications read and write IOWarp-managed data through ordinary
+file I/O. The wheel ships this binary on Linux and Windows; macOS wheels do not
+(macOS has no FUSE3 API).
+
+**1. Install the FUSE runtime.** `libfuse3` is a system dependency and is
+deliberately not bundled in the wheel, so install your distribution's package:
+
+```bash
+sudo apt install fuse3 libfuse3-3      # Debian / Ubuntu
+sudo dnf install fuse3 fuse3-libs      # Fedora / RHEL
+```
+
+On Windows, install [WinFsp](https://winfsp.dev) instead. The `clio_cte_fuse`
+console script prepends WinFsp's `bin` directory to `PATH` itself, so
+`winfsp-x64.dll` resolves without a system-wide `PATH` edit.
+
+**2. Mount.** Start the runtime, then point the daemon at a mountpoint. The
+daemon create-or-binds the filesystem pool and the CTE pool underneath it, so
+no separate `compose` step is required:
+
+```bash
+clio_run start &
+mkdir -p /mnt/clio
+CLIO_WITH_RUNTIME=0 clio_cte_fuse /mnt/clio -f
+```
+
+`CLIO_WITH_RUNTIME=0` attaches to the runtime you just started rather than
+spawning an embedded one — without it the daemon brings up its own runtime and
+the data will not be visible to other clients. `-f` keeps the daemon in the
+foreground, which is the configuration CI exercises. Every remaining argument
+is handed to `fuse_main`, so standard libfuse options apply (`-o allow_other`,
+`-d` for protocol tracing). On Windows the mountpoint is a drive letter:
+`clio_cte_fuse Z:`.
+
+The mount then behaves like any other filesystem:
+
+```bash
+cp big_input.h5 /mnt/clio/
+python analysis.py /mnt/clio/big_input.h5
+```
+
+**3. Unmount:**
+
+```bash
+fusermount3 -u /mnt/clio      # or: fusermount -u /mnt/clio
+```
+
+To size the storage tiers explicitly instead of taking the defaults, compose a
+CTE pool before mounting — see
+[`context-transfer-engine/test/integration/fuse-manual/cte_compose.yaml`](context-transfer-engine/test/integration/fuse-manual/cte_compose.yaml)
+for a working single-tier example:
+
+```bash
+clio_run compose start my_cte.yaml
+```
+
+Two semantics worth knowing: writes are write-through, so each `write()`
+reaches the chimod synchronously and the logical file size is always exact;
+and the kernel attribute and entry caches are disabled, so metadata that
+another client changed is never served stale.
 
 ### Python: bundle, query, retrieve
 

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -2464,6 +2464,41 @@ clio::run::TaskResume Runtime::GetBlobImpl(clio::run::shared_ptr<TaskT> &task) {
     }
     BlobReadPinGuard read_pin_guard(blob_info_ptr.get());
 
+    // Liveness re-check, and it MUST be here -- after the pin, not before it
+    // (issue #753). The torn-layout loop above only waits while a writer HOLDS
+    // the token; once DelBlob finishes it releases the token, frees every
+    // extent and erases the name binding -- but a reader that resolved
+    // blob_info_ptr before that still holds the BlobInfo alive. Checking the
+    // size before TryPinRead leaves the whole delete free to complete in the
+    // window between the check and the pin: the reader then pins a dead blob,
+    // snapshots an EMPTY blocks_, and ReadData reports success without reading
+    // a byte (it succeeds for ranges no block covers). The caller gets rc=0
+    // and its own untouched buffer -- indistinguishable from a real read, and
+    // once the freed extents are recycled by another put the same window hands
+    // back whatever now lives there. That is the failure
+    // 'DelBlob under pipelined reads never yields garbage' asserts on.
+    //
+    // Once the pin is held the state is stable: TryPinRead refuses while the
+    // drain bit is set, so no extent-freeing mutator can be mid-flight here.
+    // Either the delete already finished -- caught below -- or it has not
+    // started and must drain this pin first.
+    //
+    // A deleted blob must read as ABSENT, exactly like the replica case above.
+    // This does not change past-EOF behaviour for a live blob: a non-empty blob
+    // whose range extends beyond its size still takes the short-read path.
+    // The replica arm is re-checked here for the same reason: the early-out
+    // above runs before the pin, so it has the identical window. Re-reading it
+    // under the pin is what actually makes it safe.
+    const bool blob_is_gone =
+        replica_sel > 0
+            ? blob_info_ptr->GetReplica(replica_sel, false)->total_size_cache_ ==
+                  0
+            : blob_info_ptr->GetTotalSize() == 0;
+    if (blob_is_gone) {
+      task->return_code_ = 1;
+      CLIO_CO_RETURN;
+    }
+
     // Snapshot the block layout BEFORE the read I/O. ReadData co_awaits a bdev
     // read per block; a concurrent PutBlob/Truncate (holding the per-blob write
     // token) may ExtendBlob/ResizeBlob and push_back into the SAME blocks_


### PR DESCRIPTION
## Summary

- Fix the `cte_reorganize_all` race by re-checking blob liveness **under** the read pin instead of before it. This was the only real test failure left on `dev`.
- Document the FUSE filesystem in the quickstart, and finish the conda → pip move in the install section.

## Motivation

Fixes #943.

`GetBlobImpl` takes its extent pin with `TryPinRead()`, and that pin is what forces `DelBlob`/`ReorganizeBlob`/`Truncate` to drain readers before freeing extents. The liveness check ran *before* the pin was acquired, which leaves the whole delete free to complete in the window between the two:

1. Reader observes a live, non-empty blob.
2. `DelBlob` takes the write token and drains instantly — no pin is held yet — frees every extent, and clears `kReadDrainBit` on the way out.
3. Reader pins the now-dead blob (the drain bit is clear, so `TryPinRead` succeeds) and snapshots an empty `blocks_`.
4. `ReadData` reports success without reading a byte; it succeeds for ranges no block covers.

The caller gets `rc=0` and its own untouched buffer, and once a later put recycles those extents the same window hands back whatever now lives there. `test_reorganize_blob.cc:1060` asserts exactly this.

Moving the check after the pin makes it meaningful: `TryPinRead` refuses while `kReadDrainBit` is set, so under the pin no extent-freeing mutator can be mid-flight. Either the delete already finished — now caught, `rc=1`, the blob-gone outcome the test explicitly accepts — or it has not started and must drain this pin first. The replica arm had the same hole and is re-checked in the same place.

The FUSE docs cover what a pip user cannot discover from the wheel: the binary ships on Linux and Windows but `libfuse3` is deliberately **not** bundled (#899), `CLIO_WITH_RUNTIME=0` is what attaches the daemon to an already-running runtime rather than spawning an embedded one, and no `compose` step is needed because the daemon create-or-binds its own pools. Every documented flag was read off the adapter and `CI/fuse_mount_smoke.sh` rather than assumed.

## Test plan

- [x] `cte_reorganize_all` **30/30**. Baseline was 9/10; adding the same check merely *before* the pin gave 25/30, i.e. no better than baseline — the placement is the fix, not the check.
- [x] CTE regression sweep: 85/91 `cte_*` pass. The 6 failures are all `*_docker` integration tests, which die on a Docker-Desktop host-path mapping error (`mount denied: ... too many colons`) before any test code runs — pre-existing and environmental on this box.
- [x] Clean build, no new warnings.
- [ ] `build-test (windows-2025)` green — this is the job that was red on #940 with the same test and same assertion line.

## Breaking changes

None, verified rather than assumed.

The guard fires only for a blob that holds a valid name binding *and* reports zero total size. The obvious candidate for reaching that state outside the race is a zero-length blob, since zero-length puts are permitted (`test_getblob_priv.cc:431`). I checked it directly by compiling the guard out and re-running: reading a positive range from a zero-length blob returns nonzero **either way**, so the guard changes nothing observable there.

That leaves the post-delete race as the only state that actually reaches it, which is the state this PR is about. Reading a zero-length *range* is unaffected — it is rejected client-side before it reaches the runtime (`test_tag_operations.cc:436`).