### PR TITLE
Export g_fs_client through the filesystem's own DLL macro

### DIFF
--- a/context-transfer-engine/filesystem/CMakeLists.txt
+++ b/context-transfer-engine/filesystem/CMakeLists.txt
@@ -26,8 +26,12 @@ target_include_directories(clio_cte_filesystem_runtime PRIVATE
 target_include_directories(clio_cte_filesystem_client PRIVATE
     ${CMAKE_SOURCE_DIR}/context-transfer-engine/core/include)
 
-# Export dllexport for the g_fs_client global on Windows (reuses clio_cte/api.h).
+# Export the g_fs_client global on Windows. This must be THIS module's macro:
+# defining CLIO_CTE_CORE_BUILDING_DLL here also told the core's headers that
+# g_cte_client was being defined locally, which it is not -- an LNK2019 that
+# stayed hidden while the descriptor layer (its only user here) was excluded
+# from Windows builds.
 if(TARGET clio_cte_filesystem_client)
   target_compile_definitions(clio_cte_filesystem_client PRIVATE
-    CLIO_CTE_CORE_BUILDING_DLL=1)
+    CLIO_CTE_FS_BUILDING_DLL=1)
 endif()

--- a/context-transfer-engine/filesystem/include/clio_cte/filesystem/api.h
+++ b/context-transfer-engine/filesystem/include/clio_cte/filesystem/api.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved. BSD 3-Clause license.
+ */
+#ifndef CLIO_CTE_FILESYSTEM_API_H_
+#define CLIO_CTE_FILESYSTEM_API_H_
+
+#include "clio_cte/api.h"
+
+/**
+ * Per-DLL export macro for clio_cte_filesystem_client.
+ *
+ * Mirrors clio_cte/api.h's CLIO_CTE_API and clio_runtime/api.h's CLIO_RUN_API.
+ * CMake sets CLIO_CTE_FS_BUILDING_DLL=1 PRIVATE on the
+ * clio_cte_filesystem_client target; consumers see the import form.
+ *
+ * This exists rather than reusing CLIO_CTE_API because that macro answers a
+ * different question. CLIO_CTE_API means "is this translation unit building
+ * clio_cte_core_client?", so defining CLIO_CTE_CORE_BUILDING_DLL here to
+ * export g_fs_client also told every declaration in the *core's* headers that
+ * it was being built locally -- including g_cte_client, which then resolved to
+ * a definition this DLL does not contain:
+ *
+ *   filesystem_client.obj : error LNK2019: unresolved external symbol
+ *   "struct std::atomic<class clio::cte::core::Client *> clio::cte::core::g_cte_client"
+ *
+ * That stayed latent only because nothing in this client referenced the core
+ * singleton on Windows: the descriptor layer, which does, was excluded there.
+ */
+#if defined(_WIN32)
+#ifdef CLIO_CTE_FS_BUILDING_DLL
+#define CLIO_CTE_FS_API __declspec(dllexport)
+#else
+#define CLIO_CTE_FS_API __declspec(dllimport)
+#endif
+#else
+#define CLIO_CTE_FS_API
+#endif
+
+/** As CLIO_CTE_DEFINE_GLOBAL_PTR_VAR_{H,CC}, decorated for this DLL. */
+#define CLIO_CTE_FS_DEFINE_GLOBAL_PTR_VAR_H(T, NAME) \
+  extern CLIO_CTE_FS_API ::std::atomic<__TU(T) *> NAME;
+#define CLIO_CTE_FS_DEFINE_GLOBAL_PTR_VAR_CC(T, NAME) \
+  CLIO_CTE_FS_API ::std::atomic<__TU(T) *> NAME{nullptr};
+
+#endif  // CLIO_CTE_FILESYSTEM_API_H_

--- a/context-transfer-engine/filesystem/include/clio_cte/filesystem/filesystem_client.h
+++ b/context-transfer-engine/filesystem/include/clio_cte/filesystem/filesystem_client.h
@@ -7,6 +7,8 @@
 
 #include <clio_cte/core/core_client.h>
 #include <atomic>
+#include "clio_cte/filesystem/api.h"
+
 #include <chrono>
 #include <cstdlib>
 #if !defined(_WIN32)
@@ -1102,11 +1104,12 @@ class Client : public clio::cte::core::Client {
 #endif
 };
 
-// Process-wide filesystem client singleton (reuses the clio_cte export macro).
-// Declared inside the namespace so it resolves as
-// clio::cte::filesystem::g_fs_client (matching CLIO_CFS_CLIENT below and the
-// definition in filesystem_client.cc), exactly like core's g_cte_client.
-CLIO_CTE_DEFINE_GLOBAL_PTR_VAR_H(clio::cte::filesystem::Client, g_fs_client);
+// Process-wide filesystem client singleton, exported through THIS module's
+// macro (clio_cte/filesystem/api.h) rather than the core's. Declared inside
+// the namespace so it resolves as clio::cte::filesystem::g_fs_client
+// (matching CLIO_CFS_CLIENT below and the definition in
+// filesystem_client.cc), exactly like core's g_cte_client.
+CLIO_CTE_FS_DEFINE_GLOBAL_PTR_VAR_H(clio::cte::filesystem::Client, g_fs_client);
 
 /** Initialize the filesystem client singleton (creates/binds the pool). */
 bool CLIO_CFS_CLIENT_INIT(const std::string &config_path = "",

--- a/context-transfer-engine/filesystem/src/filesystem_client.cc
+++ b/context-transfer-engine/filesystem/src/filesystem_client.cc
@@ -14,7 +14,7 @@ namespace clio::cte::filesystem {
 
 // Process-wide filesystem client singleton (defined inside the namespace so it
 // is clio::cte::filesystem::g_fs_client, matching the CLIO_CFS_CLIENT macro).
-CLIO_CTE_DEFINE_GLOBAL_PTR_VAR_CC(clio::cte::filesystem::Client, g_fs_client);
+CLIO_CTE_FS_DEFINE_GLOBAL_PTR_VAR_CC(clio::cte::filesystem::Client, g_fs_client);
 
 /**
  * Create-or-bind the default filesystem pool over the default CTE core pool


### PR DESCRIPTION
Closes #945. First of three, stacked: **this → #946's PR → #947's PR**, on top
of #938.

`filesystem/CMakeLists.txt` set `CLIO_CTE_CORE_BUILDING_DLL=1` on
`clio_cte_filesystem_client` to export its own `g_fs_client`, reusing the
core's macro. That define means *"is this TU building `clio_cte_core_client`?"*,
so it also switched the **core's** declarations to `dllexport` inside this DLL
— including `g_cte_client`, which then had to resolve to a local definition
that does not exist:

```
filesystem_client.obj : error LNK2019: unresolved external symbol
"struct std::atomic<class clio::cte::core::Client *> clio::cte::core::g_cte_client"
```

Latent today only because nothing here references the core singleton on
Windows — the descriptor layer, which does through `CLIO_CTE_CLIENT`, is
excluded there. It surfaces the moment that exclusion is lifted.

The fix follows the pattern this repo already uses twice (`clio_cte/api.h`,
`clio_runtime/api.h`): a `clio_cte/filesystem/api.h` with `CLIO_CTE_FS_API` /
`CLIO_CTE_FS_BUILDING_DLL`. `g_cte_client` keeps the import form and resolves
against `clio_cte_core_client.lib`.

**Independent of #938** — it is stacked only to keep the chain linear. Happy to
rebase onto `dev` if you would rather take it first.
