### PR TITLE
Port the filesystem descriptor layer to Windows

### DIFF
--- a/context-transfer-engine/filesystem/include/clio_cte/filesystem/filesystem_client.h
+++ b/context-transfer-engine/filesystem/include/clio_cte/filesystem/filesystem_client.h
@@ -7,18 +7,14 @@
 
 #include <clio_cte/core/core_client.h>
 #include <atomic>
-#include "clio_cte/filesystem/api.h"
-
 #include <chrono>
 #include <cstdlib>
-#if !defined(_WIN32)
-// The descriptor layer below is POSIX-shaped (ssize_t/off_t/O_SYNC/S_IFREG)
-// and has no Windows port -- this is the same constraint that kept the old
-// adapter/cfs out of Windows builds at the CMake level. The rest of this
-// client (tasks, deferred writes, the SHM caches) is portable and still
-// compiles there, so guard the descriptor layer rather than the whole header.
-#include <fcntl.h>
-#include <sys/stat.h>
+// The descriptor layer below is POSIX-SHAPED but not POSIX-only: nothing
+// in it makes a system call. posix_compat.h supplies the vocabulary it is
+// written in (FsSsize/FsOff/FsSsize) on every platform.
+#include "clio_cte/filesystem/api.h"
+#include "clio_cte/filesystem/posix_compat.h"
+#ifndef _WIN32
 #include <unistd.h>
 #endif
 #include <cerrno>
@@ -70,14 +66,12 @@ inline std::string StripClioPrefix(const std::string &path) {
   return path.substr(0, pos) + path.substr(pos + kClioPrefixLen);
 }
 
-#if !defined(_WIN32)
 /** CTE-issued descriptors start here so they never collide with kernel fds. */
 static constexpr int kCfsFdBase = 8192;
 /** Preferred block size reported by stat (matches the chimod page size). */
 static constexpr size_t kCfsBlkSize = 1024 * 1024;
 /** Synthetic device id -- same for every clio:: file. */
 static constexpr dev_t kClioStDev = static_cast<dev_t>(0xC110);
-#endif  // !_WIN32
 
 /**
  * Filesystem client — the single API every interceptor (POSIX, STDIO,
@@ -91,7 +85,7 @@ class Client : public clio::cte::core::Client {
   Client() = default;
   explicit Client(const clio::run::PoolId &fs_pool_id) { Init(fs_pool_id); }
 
-#if CTP_IS_HOST && !defined(_WIN32)
+#if CTP_IS_HOST
   // Copyable by hand, because the descriptor table below carries a std::mutex
   // and the compiler-generated copies would be deleted. The base client is
   // copyable by contract (its deferred-write registry is process-wide for
@@ -443,14 +437,16 @@ class Client : public clio::cte::core::Client {
     return ipc->Send(task);
   }
 
-#if !defined(_WIN32)
   // =========================================================================
   // Byte-oriented filesystem I/O with POSIX semantics (issues #817, #862).
   //
-  // POSIX-only: these return ssize_t and the descriptor layer below adds
-  // off_t/O_SYNC/S_IFREG. Windows builds get the task API (AsyncRead/
-  // AsyncWrite/...) which is portable; the old adapter/cfs was excluded from
-  // Windows at the CMake level for exactly this reason.
+  // POSIX-SHAPED, but not POSIX-only: nothing here makes a system call. The
+  // layer is a descriptor table and a set of seek offsets over the task API,
+  // so what tied it to POSIX was its vocabulary -- ssize_t, off_t, O_SYNC --
+  // rather than its behaviour. That vocabulary comes from posix_compat.h now
+  // (FsSsize/FsOff), and the layer builds on Windows too. Offsets are FsOff
+  // and deliberately not off_t: MSVC's off_t is 32 bits and would cap every
+  // offset here at 2 GiB.
   //
   // THIS is the interface an interceptor calls. An adapter (POSIX, STDIO,
   // MPI-IO, libfuse) should own nothing but its handle table and its seek
@@ -553,7 +549,7 @@ class Client : public clio::cte::core::Client {
    *        durability over latency and honouring that is the point of the flag.
    * @return bytes accepted, or -1 with errno set.
    */
-  ssize_t Write(clio::run::u64 handle, const std::string &path,
+  FsSsize Write(clio::run::u64 handle, const std::string &path,
                 clio::run::u64 off, const void *buf, size_t count,
                 bool sync = false) {
     if (count == 0) {
@@ -599,9 +595,9 @@ class Client : public clio::cte::core::Client {
     auto t3 = prof ? tick() : std::chrono::steady_clock::time_point{};
     if (blocking) {
       fut.Wait();
-      ssize_t ret;
+      FsSsize ret;
       if (fut->GetReturnCode() == 0) {
-        ret = static_cast<ssize_t>(fut->bytes_written_);
+        ret = static_cast<FsSsize>(fut->bytes_written_);
       } else {
         errno = EIO;
         ret = -1;
@@ -643,7 +639,7 @@ class Client : public clio::cte::core::Client {
       p.window_ns.fetch_add(std::chrono::duration_cast<ns>(t5 - t4).count(),
                             std::memory_order_relaxed);
     }
-    return static_cast<ssize_t>(count);
+    return static_cast<FsSsize>(count);
   }
 
   /**
@@ -655,7 +651,7 @@ class Client : public clio::cte::core::Client {
    *
    * @return bytes read (possibly 0 at EOF), or -1 with errno set.
    */
-  ssize_t Read(clio::run::u64 handle, const std::string &path,
+  FsSsize Read(clio::run::u64 handle, const std::string &path,
                clio::run::u64 off, void *buf, size_t count) {
     if (count == 0) {
       return 0;
@@ -665,7 +661,7 @@ class Client : public clio::cte::core::Client {
     if (served > 0) {
       // Fully covered by in-flight writes: those bytes ARE the current value,
       // and the file is necessarily at least this long.
-      return static_cast<ssize_t>(count);
+      return static_cast<FsSsize>(count);
     }
     if (served == -1) {
       // PARTIAL coverage: the bytes outside the in-flight writes are stale in
@@ -676,7 +672,7 @@ class Client : public clio::cte::core::Client {
       // of the same file.
       DeferAwaitKey(key);
     }
-    ssize_t fast = TryReadShm(path, off, buf, count);
+    FsSsize fast = TryReadShm(path, off, buf, count);
     if (fast >= 0) {
       return fast;
     }
@@ -688,13 +684,13 @@ class Client : public clio::cte::core::Client {
     }
     auto t = AsyncRead(handle, off, count, ctp::ipc::ShmPtr<>(shm.shm_));
     t.Wait();
-    ssize_t ret;
+    FsSsize ret;
     if (t->GetReturnCode() == 0) {
       size_t got = static_cast<size_t>(t->bytes_read_);
       if (got > 0) {
         std::memcpy(buf, shm.ptr_, got);
       }
-      ret = static_cast<ssize_t>(got);
+      ret = static_cast<FsSsize>(got);
     } else {
       errno = EIO;
       ret = -1;
@@ -841,7 +837,13 @@ class Client : public clio::cte::core::Client {
 #ifdef O_DSYNC
     if (flags & O_DSYNC) return true;
 #endif
+#ifdef O_SYNC
     return (flags & O_SYNC) != 0;
+#else
+    /* MSVC defines neither, so no caller there can have requested it. */
+    (void)flags;
+    return false;
+#endif
   }
 
   /** Whether fd was issued by us (and is still open). */
@@ -885,19 +887,19 @@ class Client : public clio::cte::core::Client {
   static bool EnsureInit();
 
   int OpenFd(const std::string &raw_path, int flags, int mode);
-  ssize_t ReadFd(int fd, void *buf, size_t count);
-  ssize_t WriteFd(int fd, const void *buf, size_t count);
-  ssize_t PreadFd(int fd, void *buf, size_t count, off_t offset);
-  ssize_t PwriteFd(int fd, const void *buf, size_t count, off_t offset);
-  off_t SeekFd(int fd, off_t offset, int whence);
-  off_t TellFd(int fd);
-  off_t SizeFd(int fd);
+  FsSsize ReadFd(int fd, void *buf, size_t count);
+  FsSsize WriteFd(int fd, const void *buf, size_t count);
+  FsSsize PreadFd(int fd, void *buf, size_t count, FsOff offset);
+  FsSsize PwriteFd(int fd, const void *buf, size_t count, FsOff offset);
+  FsOff SeekFd(int fd, FsOff offset, int whence);
+  FsOff TellFd(int fd);
+  FsOff SizeFd(int fd);
   int CloseFd(int fd);
   /** fsync(2): drain this file's deferred writes, reporting a latched
    *  failure exactly once. */
   int SyncFd(int fd);
-  int FtruncateFd(int fd, off_t length);
-  int TruncatePath(const std::string &raw_path, off_t length);
+  int FtruncateFd(int fd, FsOff length);
+  int TruncatePath(const std::string &raw_path, FsOff length);
   int RemovePath(const std::string &raw_path);
   int RenamePath(const std::string &raw_src, const std::string &raw_dst);
   int ReaddirPath(const std::string &raw_path, std::vector<std::string> *out);
@@ -918,10 +920,12 @@ class Client : public clio::cte::core::Client {
     buf->st_nlink = 1;
     buf->st_uid = CTP_SYSTEM_INFO->uid_;
     buf->st_gid = CTP_SYSTEM_INFO->gid_;
-    buf->st_size = static_cast<off_t>(size);
-    buf->st_blksize = static_cast<blksize_t>(kCfsBlkSize);
+    // Cast to whatever the caller's own struct declares rather than to fixed
+    // POSIX types: this is a template instantiated with their stat struct.
+    buf->st_size = static_cast<decltype(buf->st_size)>(size);
+    buf->st_blksize = static_cast<decltype(buf->st_blksize)>(kCfsBlkSize);
     // POSIX st_blocks counts 512-byte units; round up so non-empty != 0.
-    buf->st_blocks = static_cast<blkcnt_t>((size + 511) / 512);
+    buf->st_blocks = static_cast<decltype(buf->st_blocks)>((size + 511) / 512);
   }
 
   /** fstat(2): fill *buf from the fd's chimod metadata. */
@@ -957,7 +961,7 @@ class Client : public clio::cte::core::Client {
     return 0;
   }
 
-  ssize_t TryReadShm(const std::string &path, clio::run::u64 off, void *buf,
+  FsSsize TryReadShm(const std::string &path, clio::run::u64 off, void *buf,
                      size_t count) {
     // Attach lazily, and RETRY when not yet attached, rather than latching
     // the result of one attempt at init. A client can legitimately come up
@@ -1034,7 +1038,7 @@ class Client : public clio::cte::core::Client {
            "active)");
     });
     ShmReadHits().fetch_add(1, std::memory_order_relaxed);
-    return static_cast<ssize_t>(done);
+    return static_cast<FsSsize>(done);
   }
 
   // Zero-IPC read accounting. A silently-disabled fast path and a working one
@@ -1082,7 +1086,6 @@ class Client : public clio::cte::core::Client {
     }();
     return v;
   }
-#endif  // !_WIN32
 #endif  // CTP_IS_HOST
 
 #if CTP_IS_HOST
@@ -1092,7 +1095,6 @@ class Client : public clio::cte::core::Client {
   // may drop the cache at any time, which is why every read is validated.
   ShmFsCacheRoot *shm_fs_root_ = nullptr;
 
-#if !defined(_WIN32)
   // ---- POSIX descriptor table ----
   // Guarded by fd_mu_. Held only around map lookups and insertions -- never
   // across a task Wait, so a slow chimod call cannot block an unrelated
@@ -1100,7 +1102,6 @@ class Client : public clio::cte::core::Client {
   mutable std::mutex fd_mu_;
   std::unordered_map<int, OpenFile> fds_;
   int next_fd_ = kCfsFdBase;
-#endif  // !_WIN32
 #endif
 };
 

--- a/context-transfer-engine/filesystem/include/clio_cte/filesystem/posix_compat.h
+++ b/context-transfer-engine/filesystem/include/clio_cte/filesystem/posix_compat.h
@@ -1,0 +1,62 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * POSIX-shaped types for the filesystem client's descriptor layer.
+ *
+ * The descriptor layer (OpenFd/ReadFd/PwriteFd/SeekFd/...) is a descriptor
+ * table and a set of seek offsets over the chimod's task API. It makes no
+ * system calls: what tied it to POSIX was its vocabulary -- ssize_t, off_t,
+ * O_SYNC, blksize_t -- not its behaviour. This header supplies that vocabulary
+ * everywhere, so the layer builds on Windows as well.
+ *
+ * Two of those need care rather than a typedef:
+ *
+ *   off_t    MSVC defines it, as a 32-bit long, and it cannot be redefined.
+ *            Using it would cap every offset in the layer at 2 GiB. The API
+ *            therefore names FsOff, which is 64-bit on every platform; POSIX
+ *            callers pass off_t and it converts.
+ *
+ *   O_SYNC   MSVC has neither O_SYNC nor O_DSYNC, and no caller there can ask
+ *            for them, so IsSyncFd() reports "not requested" rather than
+ *            pretending a flag bit exists.
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef CLIO_CTE_FILESYSTEM_POSIX_COMPAT_H_
+#define CLIO_CTE_FILESYSTEM_POSIX_COMPAT_H_
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include <cstdint>
+
+#if defined(_WIN32)
+#include <BaseTsd.h>
+
+/* MSVC has no ssize_t at all, so defining it is safe (unlike off_t). */
+#if !defined(_SSIZE_T_DEFINED)
+typedef SSIZE_T ssize_t;
+#define _SSIZE_T_DEFINED
+#endif
+
+/* Only ever used for the casts in the synthesized stat; MSVC's struct stat has
+ * no st_blksize/st_blocks, and the code that fills them is a template that is
+ * never instantiated there. */
+#if !defined(_BLKSIZE_T_DEFINED)
+typedef long blksize_t;
+typedef int64_t blkcnt_t;
+#define _BLKSIZE_T_DEFINED
+#endif
+#endif /* _WIN32 */
+
+namespace clio::cte::filesystem {
+
+/** 64-bit file offset for the descriptor API. Deliberately not off_t: MSVC's
+ * is 32 bits, and on POSIX this is the same width as off_t already, so callers
+ * on either platform pass their native type unchanged. */
+using FsOff = int64_t;
+
+/** Byte count / error return for the descriptor API, mirroring ssize_t. */
+using FsSsize = int64_t;
+
+}  // namespace clio::cte::filesystem
+
+#endif  // CLIO_CTE_FILESYSTEM_POSIX_COMPAT_H_

--- a/context-transfer-engine/filesystem/src/filesystem_client.cc
+++ b/context-transfer-engine/filesystem/src/filesystem_client.cc
@@ -69,7 +69,6 @@ bool CLIO_CFS_CLIENT_INIT(const std::string &config_path,
   return true;
 }
 
-#if !defined(_WIN32)
 // Descriptor layer -- POSIX only, see filesystem_client.h.
 
 /**
@@ -127,24 +126,24 @@ int Client::OpenFd(const std::string &raw_path, int flags, int mode) {
   return fd;
 }
 
-ssize_t Client::ReadFd(int fd, void *buf, size_t count) {
+FsSsize Client::ReadFd(int fd, void *buf, size_t count) {
   OpenFile of;
   if (!LookupFd(fd, &of)) {
     return -1;
   }
-  ssize_t n = Read(of.handle, of.path, of.off, buf, count);
+  FsSsize n = Read(of.handle, of.path, of.off, buf, count);
   if (n > 0) {
     AdvanceFd(fd, static_cast<clio::run::u64>(n));
   }
   return n;
 }
 
-ssize_t Client::WriteFd(int fd, const void *buf, size_t count) {
+FsSsize Client::WriteFd(int fd, const void *buf, size_t count) {
   OpenFile of;
   if (!LookupFd(fd, &of)) {
     return -1;
   }
-  ssize_t n = Write(of.handle, of.path, of.off, buf, count,
+  FsSsize n = Write(of.handle, of.path, of.off, buf, count,
                                      IsSyncFd(of.flags));
   if (n > 0) {
     AdvanceFd(fd, static_cast<clio::run::u64>(n));
@@ -152,7 +151,7 @@ ssize_t Client::WriteFd(int fd, const void *buf, size_t count) {
   return n;
 }
 
-ssize_t Client::PreadFd(int fd, void *buf, size_t count, off_t offset) {
+FsSsize Client::PreadFd(int fd, void *buf, size_t count, FsOff offset) {
   OpenFile of;
   if (!LookupFd(fd, &of)) {
     return -1;
@@ -161,7 +160,7 @@ ssize_t Client::PreadFd(int fd, void *buf, size_t count, off_t offset) {
                                static_cast<clio::run::u64>(offset), buf, count);
 }
 
-ssize_t Client::PwriteFd(int fd, const void *buf, size_t count, off_t offset) {
+FsSsize Client::PwriteFd(int fd, const void *buf, size_t count, FsOff offset) {
   OpenFile of;
   if (!LookupFd(fd, &of)) {
     return -1;
@@ -171,7 +170,7 @@ ssize_t Client::PwriteFd(int fd, const void *buf, size_t count, off_t offset) {
                                 IsSyncFd(of.flags));
 }
 
-off_t Client::SeekFd(int fd, off_t offset, int whence) {
+FsOff Client::SeekFd(int fd, FsOff offset, int whence) {
   OpenFile of;
   if (!LookupFd(fd, &of)) {
     return -1;
@@ -199,7 +198,7 @@ off_t Client::SeekFd(int fd, off_t offset, int whence) {
       errno = EINVAL;
       return -1;
   }
-  off_t newoff = static_cast<off_t>(base) + offset;
+  FsOff newoff = static_cast<FsOff>(base) + offset;
   if (newoff < 0) {
     errno = EINVAL;
     return -1;
@@ -214,15 +213,15 @@ off_t Client::SeekFd(int fd, off_t offset, int whence) {
   return newoff;
 }
 
-off_t Client::TellFd(int fd) {
+FsOff Client::TellFd(int fd) {
   OpenFile of;
   if (!LookupFd(fd, &of)) {
     return -1;
   }
-  return static_cast<off_t>(of.off);
+  return static_cast<FsOff>(of.off);
 }
 
-off_t Client::SizeFd(int fd) {
+FsOff Client::SizeFd(int fd) {
   OpenFile of;
   if (!LookupFd(fd, &of)) {
     return -1;
@@ -231,7 +230,7 @@ off_t Client::SizeFd(int fd) {
   if (!GetSize(of.path, &size)) {
     return -1;
   }
-  return static_cast<off_t>(size);
+  return static_cast<FsOff>(size);
 }
 
 int Client::SyncFd(int fd) {
@@ -245,7 +244,7 @@ int Client::SyncFd(int fd) {
   return Flush(of.path);
 }
 
-int Client::FtruncateFd(int fd, off_t length) {
+int Client::FtruncateFd(int fd, FsOff length) {
   OpenFile of;
   if (!LookupFd(fd, &of)) {
     return -1;
@@ -253,7 +252,7 @@ int Client::FtruncateFd(int fd, off_t length) {
   return TruncatePath(std::string(kClioPrefix) + of.path, length);
 }
 
-int Client::TruncatePath(const std::string &raw_path, off_t length) {
+int Client::TruncatePath(const std::string &raw_path, FsOff length) {
   if (!EnsureInit()) {
     errno = EIO;
     return -1;
@@ -358,6 +357,5 @@ int Client::CloseFd(int fd) {
   return (t->GetReturnCode() == 0) ? 0 : -1;
 }
 
-#endif  // !_WIN32
 
 }  // namespace clio::cte::filesystem


### PR DESCRIPTION
Closes #946. Second of three, stacked on #948 (base is its branch, so the diff
here is only this change).

The descriptor layer was excluded from Windows by `#if !defined(_WIN32)`. The
exclusion is about vocabulary, not behaviour — **nothing in the layer makes a
system call.** It is a descriptor table and a set of seek offsets over the
chimod's task API. The whole POSIX surface in the guarded region:

| dependency | uses | resolution |
| --- | --- | --- |
| `ssize_t` | 22 | MSVC has none, so defining it is safe |
| `off_t` | 22 | MSVC's is 32-bit **and unredefinable** → `FsOff` |
| `O_SYNC`/`O_DSYNC` | 9 | absent on MSVC; `IsSyncFd()` reports "not requested" |
| `blksize_t`/`blkcnt_t` | 2 | `decltype` of the caller's own stat fields |
| system calls | **0** | — |

The `off_t` line is the one worth pausing on: shimming it to MSVC's 32-bit type
would compile cleanly and silently cap every offset in the layer at 2 GiB.

The copy constructor also loses its `!_WIN32` guard — it exists *because* the
fd table carries a `std::mutex`, and that table is no longer Windows-excluded,
so without this the class would have deleted copies on a platform where callers
copy it.

### Verified

- **Windows**: `clio_cte_filesystem_client.dll` builds and links on
  `windows-2025`.
- **Linux**: builds, and `clio_cte_posix` / `clio_cte_stdio` — the callers whose
  signatures the rename touches — still build. That job caught a bad edit of
  mine during development, which is why it is in the loop.

`FsOff`/`FsSsize` are `int64_t`, the same width as `off_t`/`ssize_t` on 64-bit
POSIX, so callers there pass their native types unchanged.
