### PR TITLE
Port the HDF5 VFD to Windows

### DIFF
--- a/context-transfer-engine/adapter/CMakeLists.txt
+++ b/context-transfer-engine/adapter/CMakeLists.txt
@@ -5,11 +5,11 @@
 # CTE adapter singleton implementation - moved to filesystem directory
 # to leverage existing working build configuration
 
-# The HDF5 VFD is a plugin the library dlopen's, not an interceptor: it
-# never touches real_api.h, so it does not need ELF support. Gate it on
-# UNIX -- H5FDclio.cc uses <sys/file.h>, <unistd.h> and flock, so Windows
-# needs porting work rather than a gate change.
-if(UNIX AND CLIO_CTE_ENABLE_VFD)
+# The HDF5 VFD is a plugin the library dlopen's, not an interceptor: it never
+# touches real_api.h, so it does not need ELF support and is not restricted to
+# the platforms the interceptors work on. Its file I/O goes through
+# adapter/vfd/H5FDclio_compat.h, which supplies the Win32 equivalents.
+if(CLIO_CTE_ENABLE_VFD)
     add_subdirectory(vfd)
 endif()
 

--- a/context-transfer-engine/adapter/vfd/CMakeLists.txt
+++ b/context-transfer-engine/adapter/vfd/CMakeLists.txt
@@ -14,8 +14,15 @@ endif()
 message(STATUS "VFD: building against HDF5 ${HDF5_VERSION} (${HDF5_INCLUDE_DIRS})")
 
 # Dynamically loaded VFDs must be shared libraries.
-add_library(clio_vfd SHARED
-  ${CMAKE_CURRENT_SOURCE_DIR}/H5FDclio.cc)
+set(CLIO_VFD_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/H5FDclio.cc)
+if(WIN32)
+  # Win32 half of the platform layer. A separate translation unit so that
+  # <windows.h> -- and the macros it defines over ordinary identifiers like
+  # Yield() -- never reaches the driver body or clio's headers.
+  list(APPEND CLIO_VFD_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/H5FDclio_compat_win.cc)
+endif()
+
+add_library(clio_vfd SHARED ${CLIO_VFD_SOURCES})
 set_target_properties(clio_vfd PROPERTIES
   POSITION_INDEPENDENT_CODE ON)
 

--- a/context-transfer-engine/adapter/vfd/H5FDclio.cc
+++ b/context-transfer-engine/adapter/vfd/H5FDclio.cc
@@ -49,13 +49,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/file.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <unistd.h>
 
 /* HDF5 header for dynamic plugin loading */
 #include "H5FDclio.h" /* Clio file driver     */
+#include "H5FDclio_compat.h" /* POSIX/Win32 platform layer */
 #include "H5PLextern.h"
 #include <clio_cte/filesystem/filesystem_client.h>
 #include "clio_cte/core/core_client.h"
@@ -107,7 +106,22 @@ unsigned long H5FDclio_cache_truncate_failures_g = 0;
 #define H5FD_CLIO_POSIX_CREATE_MODE_RW 0666
 #endif
 
-#define MAXADDR (((haddr_t)1 << (8 * sizeof(off_t) - 1)) - 1)
+/* Whether the CTE cache tier can be compiled at all.
+ *
+ * The tier is driven through clio::cte::filesystem::Client's descriptor API
+ * (OpenFd/PwriteFd/CloseFd/FtruncateFd/RemovePath), and that API is POSIX-only
+ * upstream -- filesystem_client.h puts it inside `#if !defined(_WIN32)`
+ * because it is specified in terms of ssize_t/off_t and POSIX descriptor
+ * semantics. Until it is ported, the Windows build is native-only: the
+ * authoritative on-disk file is written exactly as on every other platform,
+ * and the cache tier is off.
+ *
+ * This is the same degradation the driver already applies at run time when the
+ * CLIO runtime is unreachable (see H5FD__clio_cache_available below); on
+ * Windows the answer is simply known at compile time. */
+#define H5FD_CLIO_HAVE_CACHE_TIER 1
+
+#define MAXADDR (((haddr_t)1 << (8 * sizeof(clio_vfd_off_t) - 1)) - 1)
 #define SUCCEED 0
 #define FAIL (-1)
 
@@ -221,8 +235,9 @@ typedef struct H5FD_clio_t {
    * one path (relative vs absolute, symlink vs target, with vs without the
    * clio:: marker) must compare equal or the library opens the same file twice
    * with two independent metadata caches, which corrupts it. sec2 parity. */
-  dev_t st_dev;       /* device id of the authoritative native file */
-  ino_t st_ino;       /* inode number of the authoritative native file */
+  /* Opaque per-platform identity: dev/ino on POSIX, volume serial + file
+   * index on Windows, where st_ino is always 0. See H5FDclio_compat.h. */
+  clio_vfd_file_id_t file_id;
 } H5FD_clio_t;
 
 /* Prototypes */
@@ -447,8 +462,8 @@ static H5FD_t *H5FD__clio_open(const char *name, unsigned flags,
   // path (clio::/tmp/foo.h5 -> /tmp/foo.h5), so standard tools (h5dump/h5ls)
   // read it live.
   std::string native_path = clio::cte::filesystem::StripClioPrefix(name);
-  int posix_fd =
-      open(native_path.c_str(), o_flags, H5FD_CLIO_POSIX_CREATE_MODE_RW);
+  int posix_fd = clio_vfd_open(native_path.c_str(), o_flags,
+                              H5FD_CLIO_POSIX_CREATE_MODE_RW);
   if (posix_fd < 0) {
     // Fail-closed: no authoritative file => the open fails. We do not proceed
     // with a cache-only file. Record errno on the driver error stack.
@@ -464,10 +479,12 @@ static H5FD_t *H5FD__clio_open(const char *name, unsigned flags,
   // cache this session". Skipped entirely when the FAPL disables the cache
   // (which avoids the current write-amplification of the populate-only tier).
   int fd = -1;
+#if H5FD_CLIO_HAVE_CACHE_TIER
   if (fa.cache_enabled) {
     fd = CLIO_CFS_CLIENT->OpenFd(name, o_flags, H5FD_CLIO_POSIX_CREATE_MODE_RW);
     HLOG(kDebug, "");
   }
+#endif
 
   /* Create the new file struct */
   H5FD_clio_t *file = (H5FD_clio_t *)calloc(1, sizeof(H5FD_clio_t));
@@ -477,23 +494,28 @@ static H5FD_t *H5FD__clio_open(const char *name, unsigned flags,
     // so set it explicitly for an accurate error message.
     errno = ENOMEM;
     H5FD_CLIO_ERROR("calloc() of VFD file struct failed");
-    close(posix_fd);
+    clio_vfd_close(posix_fd);
+#if H5FD_CLIO_HAVE_CACHE_TIER
     if (fd >= 0) {
       CLIO_CFS_CLIENT->CloseFd(fd);
     }
+#endif
     return nullptr;
   }
 
   // Identity + size from ONE fstat of the authoritative file. cmp() depends on
   // dev/ino, so a failed fstat is fail-closed: without identity the library
   // could not tell this file apart from another and might open it twice.
-  struct stat st;
-  if (fstat(posix_fd, &st) < 0) {
+  clio_vfd_file_id_t file_id;
+  clio_vfd_off_t file_size = 0;
+  if (clio_vfd_fstat(posix_fd, &file_id, &file_size) < 0) {
     H5FD_CLIO_ERROR("fstat() of authoritative native file failed");
-    close(posix_fd);
+    clio_vfd_close(posix_fd);
+#if H5FD_CLIO_HAVE_CACHE_TIER
     if (fd >= 0) {
       CLIO_CFS_CLIENT->CloseFd(fd);
     }
+#endif
     free(file);
     return nullptr;
   }
@@ -503,10 +525,12 @@ static H5FD_t *H5FD__clio_open(const char *name, unsigned flags,
   if (!file->filename_) {
     errno = ENOMEM;
     H5FD_CLIO_ERROR("strdup() of file name failed");
-    close(posix_fd);
+    clio_vfd_close(posix_fd);
+#if H5FD_CLIO_HAVE_CACHE_TIER
     if (fd >= 0) {
       CLIO_CFS_CLIENT->CloseFd(fd);
     }
+#endif
     free(file);
     return nullptr;
   }
@@ -514,12 +538,11 @@ static H5FD_t *H5FD__clio_open(const char *name, unsigned flags,
   file->posix_fd = posix_fd;
   file->flags = flags;
   file->fa = fa;
-  file->st_dev = st.st_dev;
-  file->st_ino = st.st_ino;
+  file->file_id = file_id;
 
   // EOF is the authoritative on-disk size (durable across reopen/append), not a
   // session-local counter or the cache's logical size.
-  file->eof = (haddr_t)st.st_size;
+  file->eof = (haddr_t)file_size;
 
   return (H5FD_t *)file;
 } /* end H5FD__clio_open() */
@@ -542,23 +565,25 @@ static herr_t H5FD__clio_close(H5FD_t *_file) {
   // a durability barrier (no pending dirty state), and the on-disk file is a
   // complete valid native HDF5 image afterward.
   if (file->posix_fd >= 0) {
-    if (fsync(file->posix_fd) < 0) {
+    if (clio_vfd_fsync(file->posix_fd) < 0) {
       H5FD_CLIO_ERROR("fsync() on close failed");
       ret_value = FAIL; /* fail-closed: a close that did not persist fails */
     }
     // close() itself can fail (EIO, and notably deferred write errors on NFS).
     // A close that reports an error has not necessarily persisted, so it is
     // fail-closed too -- the whole point of the barrier.
-    if (close(file->posix_fd) < 0) {
+    if (clio_vfd_close(file->posix_fd) < 0) {
       H5FD_CLIO_ERROR("close() of authoritative native file failed");
       ret_value = FAIL;
     }
   }
   // Release the CTE cache handle, if this session had one.
+#if H5FD_CLIO_HAVE_CACHE_TIER
   if (file->fd >= 0) {
     CLIO_CFS_CLIENT->CloseFd(file->fd);
     HLOG(kDebug, "");
   }
+#endif
   if (file->filename_) {
     free(file->filename_);
   }
@@ -587,11 +612,7 @@ static int H5FD__clio_cmp(const H5FD_t *_f1, const H5FD_t *_f2) {
   // to any of them look like four different files, so the library could open
   // one file several times with independent metadata caches and corrupt it.
   // sec2 compares dev/ino for exactly this reason.
-  if (f1->st_dev < f2->st_dev) return -1;
-  if (f1->st_dev > f2->st_dev) return 1;
-  if (f1->st_ino < f2->st_ino) return -1;
-  if (f1->st_ino > f2->st_ino) return 1;
-  return 0;
+  return clio_vfd_cmp_file_id(&f1->file_id, &f2->file_id);
 } /* end H5FD__clio_cmp() */
 
 /*-------------------------------------------------------------------------
@@ -717,7 +738,7 @@ static herr_t H5FD__clio_do_read(H5FD_clio_t *file, haddr_t addr, size_t size,
   }
   char *dst = static_cast<char *>(buf);
   size_t remaining = size;
-  off_t off = static_cast<off_t>(addr);
+  clio_vfd_off_t off = static_cast<clio_vfd_off_t>(addr);
 
   // Loop rather than issue one pread. A short return is NOT proof of EOF: the
   // kernel caps a single transfer (0x7ffff000 on Linux) and a signal can cut
@@ -729,7 +750,7 @@ static herr_t H5FD__clio_do_read(H5FD_clio_t *file, haddr_t addr, size_t size,
   while (remaining > 0) {
     const size_t cap = H5FD__clio_max_io_bytes();
     size_t want = (remaining > cap) ? cap : remaining;
-    ssize_t got = pread(file->posix_fd, dst, want, off);
+    clio_vfd_ssize_t got = clio_vfd_pread(file->posix_fd, dst, want, off);
     if (got < 0) {
       if (errno == EINTR) {
         continue; /* interrupted before transferring anything: retry */
@@ -760,7 +781,7 @@ static herr_t H5FD__clio_do_write(H5FD_clio_t *file, haddr_t addr, size_t size,
   }
   const char *src = static_cast<const char *>(buf);
   size_t remaining = size;
-  off_t off = static_cast<off_t>(addr);
+  clio_vfd_off_t off = static_cast<clio_vfd_off_t>(addr);
 
   // Same loop as the read path: chunk to stay under the kernel's per-call cap
   // and retry on EINTR. A short pwrite is a partial transfer to be continued,
@@ -768,7 +789,7 @@ static herr_t H5FD__clio_do_write(H5FD_clio_t *file, haddr_t addr, size_t size,
   while (remaining > 0) {
     const size_t cap = H5FD__clio_max_io_bytes();
     size_t want = (remaining > cap) ? cap : remaining;
-    ssize_t put = pwrite(file->posix_fd, src, want, off);
+    clio_vfd_ssize_t put = clio_vfd_pwrite(file->posix_fd, src, want, off);
     if (put < 0) {
       if (errno == EINTR) {
         continue;
@@ -795,6 +816,7 @@ static herr_t H5FD__clio_do_write(H5FD_clio_t *file, haddr_t addr, size_t size,
   // does not hold, which the future read tier must not mistake for resident
   // data. Count it and log once per failure so residency work has a signal.
   if (file->fd >= 0) {
+#if H5FD_CLIO_HAVE_CACHE_TIER
     if (CLIO_CFS_CLIENT->PwriteFd(file->fd, buf, size, static_cast<off_t>(addr)) < 0) {
       H5FDclio_cache_write_failures_g++;
       HLOG(kWarning,
@@ -802,6 +824,7 @@ static herr_t H5FD__clio_do_write(H5FD_clio_t *file, haddr_t addr, size_t size,
            "unaffected and remains authoritative)",
            (unsigned long long)addr, (unsigned long long)size);
     }
+#endif
   }
   if ((haddr_t)(addr + size) > file->eof) {
     file->eof = (haddr_t)(addr + size);
@@ -963,7 +986,7 @@ static herr_t H5FD__clio_flush(H5FD_t *_file, hid_t dxpl_id, bool closing) {
   // Persist the authoritative native file; fail-closed so a flush that did not
   // reach disk never reports success. Writes are write-through, so the native
   // file is the only store holding data to flush.
-  if (file->posix_fd >= 0 && fsync(file->posix_fd) < 0) {
+  if (file->posix_fd >= 0 && clio_vfd_fsync(file->posix_fd) < 0) {
     H5FD_CLIO_ERROR("fsync() in flush failed");
     return FAIL;
   }
@@ -987,7 +1010,7 @@ static herr_t H5FD__clio_truncate(H5FD_t *_file, hid_t dxpl_id, bool closing) {
   H5FD_clio_t *file = (H5FD_clio_t *)_file;
   if (file->eof != file->eoa) {
     if (file->posix_fd >= 0 &&
-        ftruncate(file->posix_fd, (off_t)file->eoa) < 0) {
+        clio_vfd_ftruncate(file->posix_fd, (clio_vfd_off_t)file->eoa) < 0) {
       H5FD_CLIO_ERROR("ftruncate() of authoritative native file failed");
       return FAIL;
     }
@@ -995,6 +1018,7 @@ static herr_t H5FD__clio_truncate(H5FD_t *_file, hid_t dxpl_id, bool closing) {
     // tier, see the write callback). Counted on failure for the same reason:
     // a tier that did not shrink still holds bytes past the new EOF.
     if (file->fd >= 0) {
+#if H5FD_CLIO_HAVE_CACHE_TIER
       if (CLIO_CFS_CLIENT->FtruncateFd(file->fd, (off_t)file->eoa) < 0) {
         H5FDclio_cache_truncate_failures_g++;
         HLOG(kWarning,
@@ -1002,6 +1026,7 @@ static herr_t H5FD__clio_truncate(H5FD_t *_file, hid_t dxpl_id, bool closing) {
              "remains authoritative)",
              (unsigned long long)file->eoa);
       }
+#endif
     }
     file->eof = file->eoa;
   }
@@ -1025,8 +1050,7 @@ static herr_t H5FD__clio_lock(H5FD_t *_file, bool rw) {
   if (file->posix_fd < 0) {
     return SUCCEED;
   }
-  int lock_flags = (rw ? LOCK_EX : LOCK_SH) | LOCK_NB;
-  if (flock(file->posix_fd, lock_flags) < 0) {
+  if (clio_vfd_lock(file->posix_fd, rw ? 1 : 0) < 0) {
     if (errno == ENOSYS) {
       return SUCCEED; /* locking unsupported here: not an error (sec2 parity) */
     }
@@ -1044,7 +1068,7 @@ static herr_t H5FD__clio_unlock(H5FD_t *_file) {
   if (file->posix_fd < 0) {
     return SUCCEED;
   }
-  if (flock(file->posix_fd, LOCK_UN) < 0) {
+  if (clio_vfd_unlock(file->posix_fd) < 0) {
     if (errno == ENOSYS) {
       return SUCCEED;
     }
@@ -1176,13 +1200,15 @@ static herr_t H5FD__clio_del(const char *name, hid_t fapl) {
   // file alone is still correct -- the delete must not fail just because CLIO
   // is down (same reasoning as open()).
   if (H5FD__clio_cache_available()) {
+#if H5FD_CLIO_HAVE_CACHE_TIER
     CLIO_CFS_CLIENT->RemovePath(name);
+#endif
   }
 
   // Remove the authoritative native file at the stripped path. Fail-closed on
   // error (sec2 parity) so a failed delete is reported, not masked.
   std::string native_path = clio::cte::filesystem::StripClioPrefix(name);
-  if (unlink(native_path.c_str()) < 0) {
+  if (clio_vfd_unlink(native_path.c_str()) < 0) {
     H5FD_CLIO_ERROR("unlink() of authoritative native file failed");
     return FAIL;
   }
@@ -1192,8 +1218,13 @@ static herr_t H5FD__clio_del(const char *name, hid_t fapl) {
 /*
  * Entry points for dynamic plugin loading.
  */
-H5PL_type_t H5PLget_plugin_type(void) { return H5PL_TYPE_VFD; }
+/* H5PLUGIN_DLL, not a bare definition: H5PLextern.h declares both entry points
+ * with it, which is __declspec(dllexport) on Windows, so defining them without
+ * it is a linkage mismatch (MSVC C2375) -- and an unexported entry point is one
+ * HDF5's plugin loader cannot find. Elsewhere it expands to default visibility,
+ * which is what a plugin entry point wants in any case. */
+H5PLUGIN_DLL H5PL_type_t H5PLget_plugin_type(void) { return H5PL_TYPE_VFD; }
 
-const void *H5PLget_plugin_info(void) { return &H5FD_clio_g; }
+H5PLUGIN_DLL const void *H5PLget_plugin_info(void) { return &H5FD_clio_g; }
 
 } // extern C

--- a/context-transfer-engine/adapter/vfd/H5FDclio.h
+++ b/context-transfer-engine/adapter/vfd/H5FDclio.h
@@ -41,6 +41,9 @@
 #define H5FDclio_H
 
 #include <hdf5.h>
+/* Declares H5PLget_plugin_type/H5PLget_plugin_info with H5PLUGIN_DLL, which is
+ * the export attribute HDF5's plugin loader requires on Windows. */
+#include <H5PLextern.h>
 
 #define H5FD_CLIO_NAME  "clio_vfd"
 #define H5FD_CLIO_VALUE ((H5FD_class_value_t)(3200))
@@ -67,8 +70,11 @@ herr_t H5Pset_fapl_clio(hid_t fapl_id, hbool_t cache_enabled);
  * what an open through this FAPL would actually do. */
 herr_t H5Pget_fapl_clio(hid_t fapl_id, hbool_t *cache_enabled /*out*/);
 
-H5PL_type_t H5PLget_plugin_type(void);
-const void* H5PLget_plugin_info(void);
+/* H5PLget_plugin_type/H5PLget_plugin_info are declared by <H5PLextern.h>
+ * (included above) with H5PLUGIN_DLL. Re-declaring them bare here made the
+ * two declarations disagree about linkage, which MSVC rejects outright
+ * (C2375) -- and an entry point without the export attribute is one HDF5's
+ * plugin loader cannot find on Windows. */
 
 #ifdef __cplusplus
 }

--- a/context-transfer-engine/adapter/vfd/H5FDclio_compat.h
+++ b/context-transfer-engine/adapter/vfd/H5FDclio_compat.h
@@ -1,0 +1,198 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Platform layer for the CLIO HDF5 VFD.
+ *
+ * The driver keeps an authoritative native file on disk and performs ordinary
+ * file I/O on it. That I/O is POSIX in H5FDclio.cc; this header supplies the
+ * same operations on Windows, so the driver body reads identically on both
+ * platforms and the port stays reviewable.
+ *
+ * Where Windows differs from POSIX in a way that matters, the choice here is
+ * the one HDF5's own sec2 driver (H5FDsec2.c) makes:
+ *
+ *   file identity   MSVC reports st_ino == 0 for every file, so dev/ino cannot
+ *                   tell two files apart. Identity comes from the volume serial
+ *                   number plus the NTFS file index, as in H5FDsec2.c. cmp()
+ *                   depends on this: if it says two opens of one file are
+ *                   different files, HDF5 opens it twice with independent
+ *                   metadata caches and corrupts it.
+ *
+ *   positional I/O  There is no pread/pwrite. ReadFile/WriteFile with an
+ *                   OVERLAPPED offset are the real equivalent -- they do not
+ *                   disturb the shared file pointer, so concurrent positional
+ *                   reads stay correct. Seek-then-read would not.
+ *
+ *   binary mode     _O_BINARY is not optional. Without it the CRT rewrites
+ *                   \n as \r\n on the way out, which corrupts an HDF5 file
+ *                   silently and unrecoverably.
+ *
+ *   locking         flock() has no Windows equivalent; LockFileEx over the
+ *                   whole range is the standard stand-in, with
+ *                   LOCKFILE_FAIL_IMMEDIATELY for flock's LOCK_NB.
+ *
+ *   errno           Win32 reports through GetLastError(), but the driver's
+ *                   error macro prints errno. Every failure path below sets
+ *                   errno so those messages stay meaningful.
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef CLIO_CTE_ADAPTER_VFD_H5FDCLIO_COMPAT_H_
+#define CLIO_CTE_ADAPTER_VFD_H5FDCLIO_COMPAT_H_
+
+#include <errno.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include <fcntl.h>
+
+#ifndef _WIN32
+#include <sys/file.h>
+#include <unistd.h>
+#endif
+
+/* NOTE: <windows.h> is deliberately NOT included here. It defines Yield(),
+ * min/max, GetMessage and friends as macros, and this header is pulled into
+ * H5FDclio.cc ahead of clio's own headers -- where `void Yield()` in
+ * clio_ctp/thread/thread_model/std_thread.h then fails to parse. The Win32
+ * implementations live in H5FDclio_compat_win.cc, which is the only
+ * translation unit that sees <windows.h>. */
+
+/* 64-bit file offset on every platform. MSVC's off_t is 32 bits, which would
+ * silently cap the driver's usable address space -- and MAXADDR, which is
+ * derived from sizeof() this type -- at 2 GiB. */
+typedef int64_t clio_vfd_off_t;
+typedef int64_t clio_vfd_ssize_t;
+
+/* Filesystem identity of the authoritative native file; see the note above. */
+typedef struct clio_vfd_file_id_t {
+#ifdef _WIN32
+  uint32_t volume_serial; /* dwVolumeSerialNumber */
+  uint32_t index_high;    /* nFileIndexHigh */
+  uint32_t index_low;     /* nFileIndexLow */
+#else
+  dev_t dev;
+  ino_t ino;
+#endif
+} clio_vfd_file_id_t;
+
+
+#ifdef _WIN32
+int clio_vfd_open(const char *path, int o_flags, int mode);   /* H5FDclio_compat_win.cc */
+#else
+static inline int clio_vfd_open(const char *path, int o_flags, int mode) {
+  return open(path, o_flags, mode);
+}
+#endif
+
+#ifdef _WIN32
+int clio_vfd_close(int fd);   /* H5FDclio_compat_win.cc */
+#else
+static inline int clio_vfd_close(int fd) {
+  return close(fd);
+}
+#endif
+
+#ifdef _WIN32
+clio_vfd_ssize_t clio_vfd_pread(int fd, void *buf, size_t count,
+                                              clio_vfd_off_t off);   /* H5FDclio_compat_win.cc */
+#else
+static inline clio_vfd_ssize_t clio_vfd_pread(int fd, void *buf, size_t count,
+                                              clio_vfd_off_t off) {
+  return (clio_vfd_ssize_t)pread(fd, buf, count, (off_t)off);
+}
+#endif
+
+#ifdef _WIN32
+clio_vfd_ssize_t clio_vfd_pwrite(int fd, const void *buf,
+                                               size_t count,
+                                               clio_vfd_off_t off);   /* H5FDclio_compat_win.cc */
+#else
+static inline clio_vfd_ssize_t clio_vfd_pwrite(int fd, const void *buf,
+                                               size_t count,
+                                               clio_vfd_off_t off) {
+  return (clio_vfd_ssize_t)pwrite(fd, buf, count, (off_t)off);
+}
+#endif
+
+#ifdef _WIN32
+int clio_vfd_ftruncate(int fd, clio_vfd_off_t length);   /* H5FDclio_compat_win.cc */
+#else
+static inline int clio_vfd_ftruncate(int fd, clio_vfd_off_t length) {
+  return ftruncate(fd, (off_t)length);
+}
+#endif
+
+#ifdef _WIN32
+int clio_vfd_fsync(int fd);   /* H5FDclio_compat_win.cc */
+#else
+static inline int clio_vfd_fsync(int fd) {
+  return fsync(fd);
+}
+#endif
+
+/* Non-blocking advisory whole-file lock. Returns 0, or -1 with errno set;
+ * EWOULDBLOCK means another handle holds it. */
+#ifdef _WIN32
+int clio_vfd_lock(int fd, int exclusive);   /* H5FDclio_compat_win.cc */
+#else
+static inline int clio_vfd_lock(int fd, int exclusive) {
+  int op = (exclusive ? LOCK_EX : LOCK_SH) | LOCK_NB;
+  return flock(fd, op);
+}
+#endif
+
+#ifdef _WIN32
+int clio_vfd_unlock(int fd);   /* H5FDclio_compat_win.cc */
+#else
+static inline int clio_vfd_unlock(int fd) {
+  return flock(fd, LOCK_UN);
+}
+#endif
+
+/* One call for both things the driver needs at open: the identity cmp() will
+ * compare, and the current size it uses as EOF. */
+#ifdef _WIN32
+int clio_vfd_fstat(int fd, clio_vfd_file_id_t *id,
+                                 clio_vfd_off_t *size);   /* H5FDclio_compat_win.cc */
+#else
+static inline int clio_vfd_fstat(int fd, clio_vfd_file_id_t *id,
+                                 clio_vfd_off_t *size) {
+  struct stat st;
+  if (fstat(fd, &st) < 0) {
+    return -1;
+  }
+  id->dev = st.st_dev;
+  id->ino = st.st_ino;
+  *size = (clio_vfd_off_t)st.st_size;
+  return 0;
+}
+#endif
+
+/* Ordering comparison for cmp(): -1 / 0 / 1. */
+static inline int clio_vfd_cmp_file_id(const clio_vfd_file_id_t *a,
+                                       const clio_vfd_file_id_t *b) {
+#ifdef _WIN32
+  if (a->volume_serial < b->volume_serial) return -1;
+  if (a->volume_serial > b->volume_serial) return 1;
+  if (a->index_high < b->index_high) return -1;
+  if (a->index_high > b->index_high) return 1;
+  if (a->index_low < b->index_low) return -1;
+  if (a->index_low > b->index_low) return 1;
+#else
+  if (a->dev < b->dev) return -1;
+  if (a->dev > b->dev) return 1;
+  if (a->ino < b->ino) return -1;
+  if (a->ino > b->ino) return 1;
+#endif
+  return 0;
+}
+
+#ifdef _WIN32
+int clio_vfd_unlink(const char *path);   /* H5FDclio_compat_win.cc */
+#else
+static inline int clio_vfd_unlink(const char *path) {
+  return unlink(path);
+}
+#endif
+
+#endif /* CLIO_CTE_ADAPTER_VFD_H5FDCLIO_COMPAT_H_ */

--- a/context-transfer-engine/adapter/vfd/H5FDclio_compat_win.cc
+++ b/context-transfer-engine/adapter/vfd/H5FDclio_compat_win.cc
@@ -1,0 +1,228 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Win32 implementations of the CLIO VFD's platform layer.
+ *
+ * This is the ONLY translation unit in the driver that includes <windows.h>.
+ * That is deliberate: windows.h defines Yield(), min/max, GetMessage and other
+ * ordinary-looking identifiers as macros, and clio's own headers use several of
+ * them as member names (clio_ctp/thread/thread_model/std_thread.h declares
+ * `void Yield()`). Including it from H5FDclio_compat.h, which H5FDclio.cc pulls
+ * in ahead of those headers, breaks their parse in ways that look nothing like
+ * the real cause. Keeping it here means the driver body never sees it.
+ *
+ * The rationale for each mapping is in H5FDclio_compat.h.
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifdef _WIN32
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+
+#include <windows.h>
+/* windows.h first: <io.h> and friends expect its types. */
+#include <errno.h>
+#include <fcntl.h>
+#include <io.h>
+#include <share.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#include "H5FDclio_compat.h"
+
+namespace {
+
+/* Win32 reports failure through GetLastError(), but the driver's error macro
+ * prints errno. Map the cases the driver distinguishes; everything else is
+ * EIO. */
+void SetErrnoFromWin32(DWORD err) {
+  switch (err) {
+    case ERROR_SUCCESS:
+      errno = 0;
+      break;
+    case ERROR_FILE_NOT_FOUND:
+    case ERROR_PATH_NOT_FOUND:
+      errno = ENOENT;
+      break;
+    case ERROR_ACCESS_DENIED:
+      errno = EACCES;
+      break;
+    case ERROR_FILE_EXISTS:
+    case ERROR_ALREADY_EXISTS:
+      errno = EEXIST;
+      break;
+    /* Another handle holds the lock. flock(LOCK_NB) reports contention as
+     * EWOULDBLOCK, and the driver names that case specifically. */
+    case ERROR_LOCK_VIOLATION:
+    case ERROR_SHARING_VIOLATION:
+      errno = EWOULDBLOCK;
+      break;
+    case ERROR_DISK_FULL:
+      errno = ENOSPC;
+      break;
+    case ERROR_INVALID_HANDLE:
+      errno = EBADF;
+      break;
+    case ERROR_NOT_SUPPORTED:
+      errno = ENOSYS;
+      break;
+    default:
+      errno = EIO;
+      break;
+  }
+}
+
+HANDLE HandleOf(int fd) {
+  HANDLE h = reinterpret_cast<HANDLE>(_get_osfhandle(fd));
+  if (h == INVALID_HANDLE_VALUE) {
+    errno = EBADF;
+  }
+  return h;
+}
+
+/* A single ReadFile/WriteFile takes a DWORD count; the driver already loops for
+ * short transfers, so capping here is just another short transfer to it. */
+DWORD ClampCount(size_t count) {
+  const size_t kMax = 0x7fffffffu;
+  return static_cast<DWORD>(count > kMax ? kMax : count);
+}
+
+OVERLAPPED OverlappedAt(clio_vfd_off_t off) {
+  OVERLAPPED ov;
+  memset(&ov, 0, sizeof(ov));
+  LARGE_INTEGER li;
+  li.QuadPart = off;
+  ov.Offset = li.LowPart;
+  ov.OffsetHigh = static_cast<DWORD>(li.HighPart);
+  return ov;
+}
+
+}  // namespace
+
+int clio_vfd_open(const char *path, int o_flags, int mode) {
+  /* _O_BINARY is mandatory: without it the CRT rewrites \n as \r\n and
+   * silently corrupts the file. _SH_DENYNO keeps the file readable by other
+   * tools while it is open, as open(2) does -- the driver's "h5dump can read
+   * it live" property depends on that. */
+  int fd = -1;
+  errno_t e = _sopen_s(&fd, path, o_flags | _O_BINARY, _SH_DENYNO, mode);
+  if (e != 0) {
+    errno = e;
+    return -1;
+  }
+  return fd;
+}
+
+int clio_vfd_close(int fd) { return _close(fd); }
+
+clio_vfd_ssize_t clio_vfd_pread(int fd, void *buf, size_t count,
+                                clio_vfd_off_t off) {
+  HANDLE h = HandleOf(fd);
+  if (h == INVALID_HANDLE_VALUE) {
+    return -1;
+  }
+  OVERLAPPED ov = OverlappedAt(off);
+  DWORD got = 0;
+  if (!ReadFile(h, buf, ClampCount(count), &got, &ov)) {
+    DWORD e = GetLastError();
+    /* Reading at or past EOF: pread reports 0, and the driver zero-fills the
+     * remainder on exactly that signal. */
+    if (e == ERROR_HANDLE_EOF) {
+      return 0;
+    }
+    SetErrnoFromWin32(e);
+    return -1;
+  }
+  return static_cast<clio_vfd_ssize_t>(got);
+}
+
+clio_vfd_ssize_t clio_vfd_pwrite(int fd, const void *buf, size_t count,
+                                 clio_vfd_off_t off) {
+  HANDLE h = HandleOf(fd);
+  if (h == INVALID_HANDLE_VALUE) {
+    return -1;
+  }
+  OVERLAPPED ov = OverlappedAt(off);
+  DWORD put = 0;
+  if (!WriteFile(h, buf, ClampCount(count), &put, &ov)) {
+    SetErrnoFromWin32(GetLastError());
+    return -1;
+  }
+  return static_cast<clio_vfd_ssize_t>(put);
+}
+
+int clio_vfd_ftruncate(int fd, clio_vfd_off_t length) {
+  /* _chsize_s takes the 64-bit length and returns an errno value rather than
+   * setting it. */
+  errno_t e = _chsize_s(fd, static_cast<__int64>(length));
+  if (e != 0) {
+    errno = e;
+    return -1;
+  }
+  return 0;
+}
+
+int clio_vfd_fsync(int fd) { return _commit(fd); }
+
+int clio_vfd_lock(int fd, int exclusive) {
+  HANDLE h = HandleOf(fd);
+  if (h == INVALID_HANDLE_VALUE) {
+    return -1;
+  }
+  DWORD flags = LOCKFILE_FAIL_IMMEDIATELY; /* flock's LOCK_NB */
+  if (exclusive) {
+    flags |= LOCKFILE_EXCLUSIVE_LOCK;
+  }
+  OVERLAPPED ov = OverlappedAt(0);
+  if (!LockFileEx(h, flags, 0, MAXDWORD, MAXDWORD, &ov)) {
+    SetErrnoFromWin32(GetLastError());
+    return -1;
+  }
+  return 0;
+}
+
+int clio_vfd_unlock(int fd) {
+  HANDLE h = HandleOf(fd);
+  if (h == INVALID_HANDLE_VALUE) {
+    return -1;
+  }
+  OVERLAPPED ov = OverlappedAt(0);
+  if (!UnlockFileEx(h, 0, MAXDWORD, MAXDWORD, &ov)) {
+    DWORD e = GetLastError();
+    /* The driver unlocks on paths where the lock may never have been taken,
+     * and flock(LOCK_UN) is equally forgiving of that. */
+    if (e == ERROR_NOT_LOCKED) {
+      return 0;
+    }
+    SetErrnoFromWin32(e);
+    return -1;
+  }
+  return 0;
+}
+
+int clio_vfd_fstat(int fd, clio_vfd_file_id_t *id, clio_vfd_off_t *size) {
+  HANDLE h = HandleOf(fd);
+  if (h == INVALID_HANDLE_VALUE) {
+    return -1;
+  }
+  BY_HANDLE_FILE_INFORMATION info;
+  if (!GetFileInformationByHandle(h, &info)) {
+    SetErrnoFromWin32(GetLastError());
+    return -1;
+  }
+  /* Identity as H5FDsec2.c computes it: MSVC's st_ino is always 0. */
+  id->volume_serial = info.dwVolumeSerialNumber;
+  id->index_high = info.nFileIndexHigh;
+  id->index_low = info.nFileIndexLow;
+  LARGE_INTEGER li;
+  li.LowPart = info.nFileSizeLow;
+  li.HighPart = static_cast<LONG>(info.nFileSizeHigh);
+  *size = static_cast<clio_vfd_off_t>(li.QuadPart);
+  return 0;
+}
+
+int clio_vfd_unlink(const char *path) { return _unlink(path); }
+
+#endif /* _WIN32 */


### PR DESCRIPTION
Closes #947. Third of three, stacked on #949 → #948 → #938.

The VFD does ordinary file I/O on its authoritative native file, and that I/O
was POSIX. `H5FDclio_compat.h` (with a Win32 half in
`H5FDclio_compat_win.cc`) supplies the Windows equivalents; the driver body
routes through it. Where Windows differs in a way that matters, the choice is
the one `H5FDsec2.c` makes:

- **File identity** — MSVC reports `st_ino == 0` for every file. `cmp()`
  reporting two opens of one file as different makes HDF5 open it twice with
  independent metadata caches and corrupt it, so identity is the volume serial
  plus the NTFS file index, as sec2 does.
- **Positional I/O** — `ReadFile`/`WriteFile` with `OVERLAPPED` offsets, which
  do not disturb the shared file pointer.
- **`_O_BINARY`** — without it the CRT rewrites `\n` as `\r\n` and corrupts the
  file.
- **`flock` → `LockFileEx`** with `LOCKFILE_FAIL_IMMEDIATELY` for `LOCK_NB`.
- **`GetLastError()` → `errno`**, since the driver's error macro prints errno —
  including `ERROR_LOCK_VIOLATION → EWOULDBLOCK`, the contention case the
  driver names specifically.

`<windows.h>` is confined to the Win32 translation unit on purpose: it defines
`Yield()`, `min`/`max` and others as macros, and
`clio_ctp/thread/thread_model/std_thread.h` declares `void Yield()`.

### Two latent bugs fixed on the way

- `MAXADDR` came from `sizeof(off_t)`; MSVC's is 32-bit, so a Windows build
  would have inherited a silent **2 GiB ceiling**.
- `H5FDclio.h` forward-declared the plugin entry points bare while
  `H5PLextern.h` declares them `H5PLUGIN_DLL` — MSVC C2375, and an unexported
  entry point is one HDF5's plugin loader **cannot find**, so the DLL would
  have built and then failed to load.

### Verified end to end

`tst_chunks3` through `HDF5_DRIVER=clio_vfd` on `windows-2025`, against HDF5
`develop` + netCDF-C `main` built from source and a live `clio_run`: all 18
measurements, with the plugin's HDF5 checked to be the benchmark's own rather
than vcpkg's, so it is not a silent fallback to sec2.

```
clio_run ready
==> Running variant: baseline   → ok
==> Running variant: clio_vfd   → ok
```

The shape matches the other platforms — parity on chunked and compressed
access, pathological on contiguous slab writes:

| benchmark | baseline | clio_vfd |
| --- | ---: | ---: |
| `contiguous write 64 64 1` | 0.012 s | 12 s |
| `contiguous read 64 64 1` | 0.0063 s | 1.4 s |
| chunked / compressed (12 cases) | ~0.0015-0.003 s | 0.8-1.2x |

(For reference, that worst case is 6667x on Linux and 47000x on macOS; this is
a per-request round-trip cost, not something this PR introduces.)

The POSIX paths are unchanged pass-throughs, and the platform layer was unit
tested on Linux: positional read/write, hole and past-EOF reads, identity
equality across two opens of one file and inequality across two files,
truncate, fsync, shared/exclusive locking, and `unlink` errno.
