### PR TITLE
Build wheels with the FUSE adapter the root pyproject actually controls

### DIFF
--- a/.github/workflows/build-pip.yml
+++ b/.github/workflows/build-pip.yml
@@ -5,6 +5,20 @@ on:
   push:
     branches: main
     tags: ['v*']
+  # Validate packaging changes BEFORE they reach main (#953). Without this the
+  # workflow only ran post-merge, so a packaging break was discovered on main
+  # -- which is exactly how the wheels shipped for days with the FUSE adapter
+  # silently disabled, and how a Linux+FUSE combination that had never once
+  # been compiled in CI got enabled. Paths-filtered so ordinary source PRs do
+  # not pay for a full multi-arch wheel matrix; anything that can change what
+  # lands in a wheel is listed here.
+  pull_request:
+    paths:
+      - 'pyproject.toml'
+      - 'installers/pip/**'
+      - '.github/workflows/build-pip.yml'
+      - 'CMakeLists.txt'
+      - 'context-transfer-engine/adapter/libfuse/**'
 
 permissions:
   contents: write

--- a/.github/workflows/build-pip.yml
+++ b/.github/workflows/build-pip.yml
@@ -409,6 +409,18 @@ jobs:
             elif command -v dnf &>/dev/null; then
               dnf install -y -q fuse3 fuse3-libs >/dev/null 2>&1
             fi
+            # Assert the BINARY is in the wheel before exercising it. The
+            # `clio_cte_fuse` console script is a [project.scripts] entry
+            # point, so it exists even when the binary behind it does not --
+            # it then exits nonzero-but-not-signalled, which the heuristic
+            # below tolerates. That blind spot is why every wheel shipped
+            # without the FUSE adapter and only the Windows job (which does
+            # Test-Path on the .exe) ever noticed.
+            BIN_DIR=$(python -c "import iowarp_core; print(iowarp_core.get_bin_dir())")
+            if [ ! -x "$BIN_DIR/clio_cte_fuse" ]; then
+              echo "FAIL: clio_cte_fuse missing from wheel bin dir ($BIN_DIR)"
+              exit 1
+            fi
             clio_cte_fuse --help || rc=$?
             rc=${rc:-0}
             if [ "$rc" -ge 128 ]; then

--- a/context-transfer-engine/adapter/libfuse/fuse_cte_main.cc
+++ b/context-transfer-engine/adapter/libfuse/fuse_cte_main.cc
@@ -72,7 +72,11 @@
 // /dev/fuse fd, we need to drive the FUSE protocol on that fd directly
 // instead of having libfuse mount its own. Plain read/writev syscalls
 // suffice; splice is optional.
-#ifndef __APPLE__
+// The FUSE_VERSION arm matches the guard in main(): below libfuse 3.14 the
+// custom-io path is compiled out entirely, and defining these here anyway
+// would leave two unused statics behind (-Wunused-function, fatal under
+// -Werror).
+#if !defined(__APPLE__) && FUSE_VERSION >= FUSE_MAKE_VERSION(3, 14)
 static ssize_t cte_custom_writev(int fd, struct iovec *iov, int count,
                                  void * /*userdata*/) {
   return writev(fd, iov, count);
@@ -81,7 +85,7 @@ static ssize_t cte_custom_read(int fd, void *buf, size_t buf_len,
                                void * /*userdata*/) {
   return read(fd, buf, buf_len);
 }
-#endif  // __APPLE__
+#endif  // !__APPLE__ && FUSE_VERSION >= 3.14
 #endif  // _WIN32
 
 int main(int argc, char *argv[]) {
@@ -119,6 +123,28 @@ int main(int argc, char *argv[]) {
   if (prefd == -1) {
     return fuse_main(argc, argv, &cte_fuse_ops, nullptr);
   }
+
+#if FUSE_VERSION < FUSE_MAKE_VERSION(3, 14)
+  // Built against libfuse older than 3.14, where `struct fuse_custom_io` is
+  // not declared at all. The dlsym dance below handles a RUNTIME libfuse that
+  // lacks fuse_session_custom_io, but it cannot help here: the struct is an
+  // incomplete type, so the initializer below is a hard compile error rather
+  // than a link error. The manylinux images ship libfuse 3.10.2, which is
+  // exactly this case -- enabling the FUSE adapter for Linux wheels without
+  // this guard fails the wheel build outright.
+  //
+  // Only the Apptainer fd-injection path is lost. Normal mounting still works
+  // through the fuse_main() path above, which is what every non-Apptainer
+  // caller (including the wheel's documented `clio_cte_fuse <mnt>` usage)
+  // takes. The message matches the runtime-missing-symbol case below.
+  (void)new_argc;
+  std::fprintf(stderr,
+               "clio_cte_fuse: this binary was built against libfuse %d.%d; "
+               "--fusemount (/dev/fd/N) mode needs 3.14+ headers at build "
+               "time.\n",
+               FUSE_MAJOR_VERSION, FUSE_MINOR_VERSION);
+  return 1;
+#else
 
   // Apptainer 1.2.5 (unprivileged, no starter-suid) doesn't actually
   // call mount(2) when --fusemount kicks in for a user-supplied
@@ -222,5 +248,6 @@ int main(int argc, char *argv[]) {
   fuse_destroy(fuse);
   fuse_opt_free_args(&args);
   return ret;
+#endif  // FUSE_VERSION < 3.14
 #endif  // _WIN32 || __APPLE__
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,14 @@ CLIO_CORE_ENABLE_MPI = "OFF"
 CLIO_CORE_ENABLE_HDF5 = "OFF"
 CLIO_CORE_ENABLE_ELF = "OFF"
 CLIO_CTE_ENABLE_COMPRESS = "OFF"
+# FUSE adapter: OFF here is the macOS value; Linux and Windows wheels turn
+# it ON via the per-OS overrides at the bottom of this file (#899).
 CLIO_CTE_ENABLE_FUSE_ADAPTER = "OFF"
+# Cache + replication chimods ship by default (#886/#899). They already
+# default ON in CMake; pin them here so a future default flip cannot
+# silently drop them from published wheels.
+CLIO_CTE_ENABLE_CACHE = "ON"
+CLIO_CTE_ENABLE_REPLICATION = "ON"
 CLIO_CORE_ENABLE_ENCRYPT = "OFF"
 CLIO_CORE_ENABLE_CUDA = "OFF"
 CLIO_CORE_ENABLE_ROCM = "OFF"
@@ -95,3 +102,39 @@ CTP_LOG_LEVEL = "1"
 provider = "scikit_build_core.metadata.regex"
 input = "CMakeLists.txt"
 regex = 'project\(iowarp-core VERSION (?P<value>[\d.]+)'
+
+# ---------------------------------------------------------------------------
+# Per-OS overrides (#899): ship the OS-specific FUSE adapter by default.
+# `if.platform-system` regex-matches sys.platform ("linux", "win32",
+# "darwin").
+#   - Linux: libfuse3. The binary links libfuse3.so.3, which the wheel does
+#     NOT bundle (see repair_wheel.sh — external system libs stay external);
+#     users need their distro's fuse3/libfuse3 packages at mount time, as
+#     documented in iowarp_core._cli.cte_fuse_main.
+#   - Windows: WinFsp (https://winfsp.dev). The build finds WinFsp's
+#     FUSE3-compatible SDK (adapter/libfuse/CMakeLists.txt); end users need
+#     the WinFsp runtime installed.
+#   - macOS: stays OFF — there is no fuse3 pkg-config on macOS (macFUSE
+#     exposes the FUSE2 API), so the base define above applies.
+#
+# These MUST live here, not only in installers/pip/pyproject.toml: CI runs
+# `cibuildwheel` from the repo root with no working-directory, so cibuildwheel
+# builds THIS file's package. #899 added the overrides to the installers/pip
+# copy only, so every published wheel silently shipped without the FUSE
+# adapter -- and only the Windows wheel test caught it, because the Linux
+# check tolerates a nonzero exit from the `clio_cte_fuse` console script,
+# which exists as an entry point even when the binary behind it does not.
+# ---------------------------------------------------------------------------
+# inherit.cmake.define = "append" is load-bearing: without it an override's
+# cmake.define table REPLACES the whole base table (verified against
+# scikit-build-core 0.12 and re-verified against 1.0.3), silently dropping
+# STATIC_DEPS and every other base define from the wheel build.
+[[tool.scikit-build.overrides]]
+if.platform-system = "linux"
+inherit.cmake.define = "append"
+cmake.define.CLIO_CTE_ENABLE_FUSE_ADAPTER = "ON"
+
+[[tool.scikit-build.overrides]]
+if.platform-system = "win32"
+inherit.cmake.define = "append"
+cmake.define.CLIO_CTE_ENABLE_FUSE_ADAPTER = "ON"


### PR DESCRIPTION
## Summary

- Add the #899 per-OS FUSE overrides (and the cache/replication pins) to `/pyproject.toml`, the copy CI actually builds.
- Make the Linux wheel test assert `clio_cte_fuse` exists instead of tolerating a missing binary.

## Motivation

Fixes #953. This unblocks `Publish to PyPI`, which has been skipped on every `main` run for days — including the **v2.2.0 release tag**, so 2.2.0 is on GitHub but not on PyPI.

There are two `pyproject.toml` files for the same package, and the root one carries the comment *"Must stay in sync with the installers/pip/pyproject.toml copy"*. CI runs `cibuildwheel` from the repo root with **no `working-directory`**, so it builds the **root** file — but #899 added the FUSE overrides to the `installers/pip` copy only. Every published wheel has therefore been built with `CLIO_CTE_ENABLE_FUSE_ADAPTER=OFF`.

Only the Windows job caught it, because the two tests are asymmetric: Windows does `Test-Path` on the `.exe`, while Linux runs `clio_cte_fuse --help` and fails only on `rc >= 128`. Since `clio_cte_fuse` is a `[project.scripts]` entry point it exists even when the binary does not, exiting nonzero-but-not-signalled — so **Linux wheels have been shipping without the adapter just as silently**. That blind spot is closed here.

## Test plan

- [x] Resolved the overrides against **scikit-build-core 1.0.3** (the version CI installs, not the 0.12 the comments were written against): `linux FUSE=ON`, `win32 FUSE=ON`, `darwin FUSE=OFF`, 25 defines each — `IO_URING=ON` survives, confirming `inherit.cmake.define = "append"` still does not clobber the base table.
- [x] `cmake -DCLIO_CTE_ENABLE_FUSE_ADAPTER=ON` locally → `-- Found FUSE3: 3.14.0`, configure clean.
- [x] Confirmed `install(TARGETS clio_cte_fuse COMPONENT pip_package ...)` exists, so the built binary reaches the wheel.
- [x] YAML and TOML both parse.
- [ ] `Test Windows wheels` green
- [ ] `Publish to PyPI` runs rather than being skipped
- [ ] Linux wheel test fails when the binary is absent

Ruled out by testing rather than inspection: `platform-system` semantics (scikit-build-core matches it against `sys.platform`, so `"win32"` was always correct), a 0.12 → 1.0.3 override regression, and CMake drift between `main` and a local tree.

## Breaking changes

None. Wheels gain a binary they were always meant to ship.

## Note on the release

v2.2.0 is tagged and published on GitHub but never reached PyPI. Once this lands, the wheels need a re-publish and the release updated — see the discussion on how to re-point the tag.
