### PR TITLE
Release 2.2.0: wheel FUSE packaging fixes

### DIFF
--- a/.github/workflows/build-pip.yml
+++ b/.github/workflows/build-pip.yml
@@ -5,6 +5,20 @@ on:
   push:
     branches: main
     tags: ['v*']
+  # Validate packaging changes BEFORE they reach main (#953). Without this the
+  # workflow only ran post-merge, so a packaging break was discovered on main
+  # -- which is exactly how the wheels shipped for days with the FUSE adapter
+  # silently disabled, and how a Linux+FUSE combination that had never once
+  # been compiled in CI got enabled. Paths-filtered so ordinary source PRs do
+  # not pay for a full multi-arch wheel matrix; anything that can change what
+  # lands in a wheel is listed here.
+  pull_request:
+    paths:
+      - 'pyproject.toml'
+      - 'installers/pip/**'
+      - '.github/workflows/build-pip.yml'
+      - 'CMakeLists.txt'
+      - 'context-transfer-engine/adapter/libfuse/**'
 
 permissions:
   contents: write

--- a/.github/workflows/build-pip.yml
+++ b/.github/workflows/build-pip.yml
@@ -409,6 +409,18 @@ jobs:
             elif command -v dnf &>/dev/null; then
               dnf install -y -q fuse3 fuse3-libs >/dev/null 2>&1
             fi
+            # Assert the BINARY is in the wheel before exercising it. The
+            # `clio_cte_fuse` console script is a [project.scripts] entry
+            # point, so it exists even when the binary behind it does not --
+            # it then exits nonzero-but-not-signalled, which the heuristic
+            # below tolerates. That blind spot is why every wheel shipped
+            # without the FUSE adapter and only the Windows job (which does
+            # Test-Path on the .exe) ever noticed.
+            BIN_DIR=$(python -c "import iowarp_core; print(iowarp_core.get_bin_dir())")
+            if [ ! -x "$BIN_DIR/clio_cte_fuse" ]; then
+              echo "FAIL: clio_cte_fuse missing from wheel bin dir ($BIN_DIR)"
+              exit 1
+            fi
             clio_cte_fuse --help || rc=$?
             rc=${rc:-0}
             if [ "$rc" -ge 128 ]; then

--- a/context-transfer-engine/adapter/libfuse/fuse_cte_main.cc
+++ b/context-transfer-engine/adapter/libfuse/fuse_cte_main.cc
@@ -72,7 +72,11 @@
 // /dev/fuse fd, we need to drive the FUSE protocol on that fd directly
 // instead of having libfuse mount its own. Plain read/writev syscalls
 // suffice; splice is optional.
-#ifndef __APPLE__
+// The FUSE_VERSION arm matches the guard in main(): below libfuse 3.14 the
+// custom-io path is compiled out entirely, and defining these here anyway
+// would leave two unused statics behind (-Wunused-function, fatal under
+// -Werror).
+#if !defined(__APPLE__) && FUSE_VERSION >= FUSE_MAKE_VERSION(3, 14)
 static ssize_t cte_custom_writev(int fd, struct iovec *iov, int count,
                                  void * /*userdata*/) {
   return writev(fd, iov, count);
@@ -81,7 +85,7 @@ static ssize_t cte_custom_read(int fd, void *buf, size_t buf_len,
                                void * /*userdata*/) {
   return read(fd, buf, buf_len);
 }
-#endif  // __APPLE__
+#endif  // !__APPLE__ && FUSE_VERSION >= 3.14
 #endif  // _WIN32
 
 int main(int argc, char *argv[]) {
@@ -119,6 +123,28 @@ int main(int argc, char *argv[]) {
   if (prefd == -1) {
     return fuse_main(argc, argv, &cte_fuse_ops, nullptr);
   }
+
+#if FUSE_VERSION < FUSE_MAKE_VERSION(3, 14)
+  // Built against libfuse older than 3.14, where `struct fuse_custom_io` is
+  // not declared at all. The dlsym dance below handles a RUNTIME libfuse that
+  // lacks fuse_session_custom_io, but it cannot help here: the struct is an
+  // incomplete type, so the initializer below is a hard compile error rather
+  // than a link error. The manylinux images ship libfuse 3.10.2, which is
+  // exactly this case -- enabling the FUSE adapter for Linux wheels without
+  // this guard fails the wheel build outright.
+  //
+  // Only the Apptainer fd-injection path is lost. Normal mounting still works
+  // through the fuse_main() path above, which is what every non-Apptainer
+  // caller (including the wheel's documented `clio_cte_fuse <mnt>` usage)
+  // takes. The message matches the runtime-missing-symbol case below.
+  (void)new_argc;
+  std::fprintf(stderr,
+               "clio_cte_fuse: this binary was built against libfuse %d.%d; "
+               "--fusemount (/dev/fd/N) mode needs 3.14+ headers at build "
+               "time.\n",
+               FUSE_MAJOR_VERSION, FUSE_MINOR_VERSION);
+  return 1;
+#else
 
   // Apptainer 1.2.5 (unprivileged, no starter-suid) doesn't actually
   // call mount(2) when --fusemount kicks in for a user-supplied
@@ -222,5 +248,6 @@ int main(int argc, char *argv[]) {
   fuse_destroy(fuse);
   fuse_opt_free_args(&args);
   return ret;
+#endif  // FUSE_VERSION < 3.14
 #endif  // _WIN32 || __APPLE__
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,14 @@ CLIO_CORE_ENABLE_MPI = "OFF"
 CLIO_CORE_ENABLE_HDF5 = "OFF"
 CLIO_CORE_ENABLE_ELF = "OFF"
 CLIO_CTE_ENABLE_COMPRESS = "OFF"
+# FUSE adapter: OFF here is the macOS value; Linux and Windows wheels turn
+# it ON via the per-OS overrides at the bottom of this file (#899).
 CLIO_CTE_ENABLE_FUSE_ADAPTER = "OFF"
+# Cache + replication chimods ship by default (#886/#899). They already
+# default ON in CMake; pin them here so a future default flip cannot
+# silently drop them from published wheels.
+CLIO_CTE_ENABLE_CACHE = "ON"
+CLIO_CTE_ENABLE_REPLICATION = "ON"
 CLIO_CORE_ENABLE_ENCRYPT = "OFF"
 CLIO_CORE_ENABLE_CUDA = "OFF"
 CLIO_CORE_ENABLE_ROCM = "OFF"
@@ -95,3 +102,39 @@ CTP_LOG_LEVEL = "1"
 provider = "scikit_build_core.metadata.regex"
 input = "CMakeLists.txt"
 regex = 'project\(iowarp-core VERSION (?P<value>[\d.]+)'
+
+# ---------------------------------------------------------------------------
+# Per-OS overrides (#899): ship the OS-specific FUSE adapter by default.
+# `if.platform-system` regex-matches sys.platform ("linux", "win32",
+# "darwin").
+#   - Linux: libfuse3. The binary links libfuse3.so.3, which the wheel does
+#     NOT bundle (see repair_wheel.sh — external system libs stay external);
+#     users need their distro's fuse3/libfuse3 packages at mount time, as
+#     documented in iowarp_core._cli.cte_fuse_main.
+#   - Windows: WinFsp (https://winfsp.dev). The build finds WinFsp's
+#     FUSE3-compatible SDK (adapter/libfuse/CMakeLists.txt); end users need
+#     the WinFsp runtime installed.
+#   - macOS: stays OFF — there is no fuse3 pkg-config on macOS (macFUSE
+#     exposes the FUSE2 API), so the base define above applies.
+#
+# These MUST live here, not only in installers/pip/pyproject.toml: CI runs
+# `cibuildwheel` from the repo root with no working-directory, so cibuildwheel
+# builds THIS file's package. #899 added the overrides to the installers/pip
+# copy only, so every published wheel silently shipped without the FUSE
+# adapter -- and only the Windows wheel test caught it, because the Linux
+# check tolerates a nonzero exit from the `clio_cte_fuse` console script,
+# which exists as an entry point even when the binary behind it does not.
+# ---------------------------------------------------------------------------
+# inherit.cmake.define = "append" is load-bearing: without it an override's
+# cmake.define table REPLACES the whole base table (verified against
+# scikit-build-core 0.12 and re-verified against 1.0.3), silently dropping
+# STATIC_DEPS and every other base define from the wheel build.
+[[tool.scikit-build.overrides]]
+if.platform-system = "linux"
+inherit.cmake.define = "append"
+cmake.define.CLIO_CTE_ENABLE_FUSE_ADAPTER = "ON"
+
+[[tool.scikit-build.overrides]]
+if.platform-system = "win32"
+inherit.cmake.define = "append"
+cmake.define.CLIO_CTE_ENABLE_FUSE_ADAPTER = "ON"


### PR DESCRIPTION
Syncs `dev` into `main` so the v2.2.0 tag can be moved onto a commit that actually produces wheels.

Contains #954 (fixes #953):

- The #899 per-OS FUSE overrides now live in `/pyproject.toml`, the copy `cibuildwheel` actually builds. They had been added only to `installers/pip/pyproject.toml`, which CI never reads — so every published wheel was built with the FUSE adapter disabled, `Test Windows wheels` failed on the missing binary, and `Publish to PyPI` was skipped on every run for days, including the v2.2.0 tag.
- The Apptainer fd-injection path is compiled out below libfuse 3.14. manylinux ships 3.10.2, where `struct fuse_custom_io` is an incomplete type — enabling FUSE for Linux wheels without this fails the build outright. Only `--fusemount` is lost, and it could never have worked on pre-3.14 anyway; normal mounting goes through `fuse_main()` above the guard.
- The Linux wheel test now asserts the binary exists. It previously ran the `clio_cte_fuse` console script and tolerated any exit below 128 — but that script is a `[project.scripts]` entry point that exists even when the binary does not, so Linux wheels had been shipping without the adapter just as silently as Windows.
- The wheel workflow now runs on packaging pull requests, not only after merge. That gap is why none of this was visible in review.

## Validation

Full wheel matrix dispatched on the branch: **all build and test jobs green on Linux (x86_64 + aarch64), macOS and Windows**, including `Test Windows wheels`. The five Linux `test-wheels` jobs passed *with* the new binary-existence assertion, proving Linux wheels now genuinely contain `clio_cte_fuse`.

PR checks: 34 success, 0 failures.

## After merge

`v2.2.0` moves to this commit so 2.2.0 wheels publish. The tag push triggers PyPI publish and attaches the wheels to the existing release via `upload --clobber`, preserving the release notes.