### PR TITLE
fix(#710): make clio_run stop reliable and robust — convergent shutdown, --force, status

### DIFF
--- a/.github/workflows/ci-docker-distributed.yml
+++ b/.github/workflows/ci-docker-distributed.yml
@@ -1,0 +1,88 @@
+name: Docker Distributed Stop Test
+
+# Distributed docker CI for issue #710 ("Distributed Jarvis Unit Test"):
+# proves that `clio_run stop` consistently kills the WHOLE runtime across a
+# multi-node cluster, leaving zero stale runtime artifacts on any node.
+#
+# clio_run is compiled ONCE inside the iowarp/deps-cpu image so the binary is
+# ABI-compatible with the node containers (which load it from the mounted build
+# dir). run_tests.sh then stands up a 2-node docker-compose cluster wired with
+# SSH and drives Jarvis on node1 to:
+#   * start the runtime on BOTH nodes (Jarvis pssh fan-out),
+#   * stop it via `jarvis ppl stop`  -> `clio_run runtime stop`         (graceful),
+#   * stop it via `jarvis ppl kill`  -> `clio_run runtime stop --force` (force),
+# asserting after each that every node's `clio_run runtime status` reports a
+# clean shutdown (exit 1, no `stale:` paths, no UNRESPONSIVE).
+#
+# This is the GitHub-Actions-native counterpart to the Ares
+# jarvis_clio_core/pipelines/ares/distributed.yaml sweep, which cannot run here
+# because it needs SLURM + apptainer on a real cluster.
+
+on:
+  push:
+    branches: [main, dev]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-docker-distributed-${{ github.ref }}
+  # Cancel superseded PR-branch runs only; a merge to a shared branch must
+  # always finish (see cluster-tests.yml for the rationale).
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  stop-distributed:
+    name: clio_run stop kills the whole runtime (2-node docker + jarvis pssh)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      DEPS_IMAGE: iowarp/deps-cpu:latest
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      # Authenticated pulls avoid Docker Hub's anonymous rate limit. Skipped
+      # automatically on forked-PR runs where the secret is unavailable.
+      - name: Login to Docker Hub
+        if: ${{ env.DOCKER_HUB_USERNAME != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Pull dependency image
+        run: docker pull "$DEPS_IMAGE"
+
+      # Compile ONLY clio_run (its runtime start/stop/status subcommands are all
+      # this test needs) inside deps-cpu, so it links the same libraries the node
+      # containers provide at runtime.
+      - name: Build clio_run (inside deps-cpu)
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}":/workspace -w /workspace -u 0 \
+            -e HOST_UID="$(id -u)" -e HOST_GID="$(id -g)" \
+            "$DEPS_IMAGE" bash -c '
+              set -e
+              export LD_LIBRARY_PATH=/usr/local/lib:/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
+              export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig:$PKG_CONFIG_PATH
+              git config --global --add safe.directory /workspace
+              cmake --preset release -DCLIO_CORE_ENABLE_PYTHON=OFF
+              cmake --build build -j"$(nproc)" --target clio_run
+              # Hand ownership back to the runner so the test cluster (which runs
+              # as the runner uid) and post-job cleanup can access build/.
+              chown -R "$HOST_UID:$HOST_GID" build
+            '
+
+      - name: Distributed stop test (2-node cluster, jarvis pssh)
+        run: ./context-runtime/test/integration/chimaera_stop/run_tests.sh
+
+      # run_tests.sh tears its own cluster down on success and failure; this only
+      # fires if the step was killed before its own cleanup ran.
+      - name: Cleanup cluster
+        if: always()
+        run: |
+          docker compose \
+            -f context-runtime/test/integration/chimaera_stop/docker-compose.yaml \
+            down -v 2>/dev/null || true

--- a/context-runtime/include/clio_runtime/ipc_manager.h
+++ b/context-runtime/include/clio_runtime/ipc_manager.h
@@ -1401,6 +1401,33 @@ class IpcManager {
    */
   size_t ClearUserIpcs();
 
+  /**
+   * Unlink this runtime's own filesystem artifacts without unmapping memory.
+   *
+   * Removes the directory entries this runtime created in the per-user memfd
+   * directory: the main/queue segment symlinks, any on-demand data-segment
+   * symlinks owned by this pid, and the local control socket files. The
+   * backing memfds stay alive through this process's file descriptors and
+   * mappings, so already-mapped memory remains valid (unlink-only, no
+   * shm_destroy). Lock-free and async-signal-tolerant enough to be called
+   * from the shutdown watchdog / force-stop threads.
+   *
+   * @return Number of filesystem entries removed
+   */
+  size_t UnlinkOwnArtifacts();
+
+  /**
+   * Unlink only the memfd-directory entries owned by THIS process: on-demand
+   * data segments (clio_<pid>_<idx>) and per-thread MPSC receive segments
+   * (clio-<pid>-<tid>). Safe in CLIENT mode — never touches the runtime's
+   * named segments or sockets. Called from ClientFinalize so short-lived
+   * clients (CLI tools, benchmarks) don't accumulate dead symlinks that
+   * only the next runtime start would reap.
+   *
+   * @return Number of filesystem entries removed
+   */
+  size_t UnlinkOwnPidEntries();
+
  private:
   // Pool query resolution helpers
   std::vector<PoolQuery> ResolveLocalQuery(const PoolQuery &query,

--- a/context-runtime/include/clio_runtime/manager.h
+++ b/context-runtime/include/clio_runtime/manager.h
@@ -36,6 +36,7 @@
 
 #include "clio_runtime/api.h"
 #include "clio_runtime/types.h"
+#include <atomic>
 #include <memory>
 #include <string>
 
@@ -124,6 +125,38 @@ class RuntimeManager {
    */
   bool IsInitializing() const;
 
+  /** How a requested runtime stop should be carried out */
+  enum class StopMode {
+    kGraceful, /**< full teardown (ServerFinalize) guarded by a watchdog */
+    kForce     /**< immediate death: unlink artifacts, then _exit(0) */
+  };
+
+  /**
+   * Request an asynchronous shutdown of this runtime process.
+   *
+   * Safe to call from any thread, including a worker executing a task
+   * (the admin StopRuntime handler): it never tears down state inline.
+   * kGraceful sets a flag the runtime main loop polls (see IsStopRequested)
+   * so the proven normal-exit path (atexit -> ServerFinalize) runs on the
+   * main thread, and spawns a detached watchdog that force-exits the process
+   * (exit code 2, artifacts unlinked) if teardown wedges past
+   * grace_period_ms plus a fixed margin. kForce spawns a detached thread
+   * that briefly waits for the task ack to flush, unlinks this runtime's
+   * filesystem artifacts, and _exit(0)s without running atexit handlers.
+   * Re-entrant calls are ignored; no-op unless in runtime mode.
+   *
+   * @param mode graceful (default stop) or force (stop --force)
+   * @param grace_period_ms budget for draining in-flight tasks
+   */
+  void RequestStop(StopMode mode, u32 grace_period_ms);
+
+  /**
+   * Check whether a graceful stop has been requested via RequestStop.
+   * Polled by the runtime main loop (clio_run start/restart).
+   * @return true if a stop was requested
+   */
+  bool IsStopRequested() const;
+
  public:
   bool is_restart_ = false;  /**< If true, force restart on compose pools and replay WAL */
 
@@ -136,7 +169,9 @@ class RuntimeManager {
   bool client_is_initializing_ = false;
   bool runtime_is_initializing_ = false;
 
-
+  std::atomic<bool> stop_requested_{false};    /**< set once by RequestStop */
+  std::atomic<bool> finalize_complete_{false}; /**< ServerFinalize finished */
+  std::atomic<u32> stop_grace_period_ms_{5000}; /**< drain budget for stop */
 };
 
 }  // namespace clio::run

--- a/context-runtime/include/clio_runtime/runtime_pid_record.h
+++ b/context-runtime/include/clio_runtime/runtime_pid_record.h
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CLIO_RUNTIME_RUNTIME_PID_RECORD_H_
+#define CLIO_RUNTIME_RUNTIME_PID_RECORD_H_
+
+/**
+ * The runtime's pid record: a one-line file in the per-user memfd dir naming
+ * the process that owns a given runtime port.
+ *
+ * Only Linux backs shared-memory segments with /proc/<pid>/fd symlinks, which
+ * is how `clio_run stop`/`status` normally learn the local runtime's pid.
+ * macOS and BSD have no memfd and no /proc, so their segments are plain files
+ * that name no owner (see SystemInfo::CreateNewSharedMemory) — without this
+ * record, stop cannot escalate SIGTERM/SIGKILL against a wedged runtime and
+ * status cannot report one as UNRESPONSIVE.
+ *
+ * The record is written by the runtime as its segments come up and removed as
+ * they go down, so its lifetime brackets the segments' exactly like the Linux
+ * symlink does. Its name follows the chi_<what>_<user>_<port> convention the
+ * port-scoped sweeps already recognise, so a runtime that dies without its
+ * teardown leaves the record behind as one more stale artifact that
+ * `clio_run stop` removes.
+ */
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <system_error>
+
+#include "clio_ctp/introspect/system_info.h"
+#include "clio_ctp/util/config_parse.h"
+#include "clio_runtime/types.h"
+
+namespace clio::run {
+
+/**
+ * Path of the pid record for a runtime port.
+ * @param port the runtime port the record is keyed on
+ * @return absolute path of the pid record
+ */
+inline std::string RuntimePidRecordPath(u32 port) {
+  const std::string name =
+      ctp::ConfigParse::ExpandPath("chi_runtime_pid_${USER}") + "_" +
+      std::to_string(port);
+  return ctp::SystemInfo::GetMemfdPath(name);
+}
+
+/**
+ * Read the pid recorded for this port. Rejects a partially written record
+ * (one with no terminating newline) and any non-numeric content: a truncated
+ * pid names an unrelated process, and this value drives kill escalation.
+ * @param port the runtime port the record is keyed on
+ * @return the recorded pid (which may be dead), or -1 if absent/unreadable
+ */
+inline int ReadRuntimePidRecord(u32 port) {
+  std::ifstream in(RuntimePidRecordPath(port));
+  std::string line;
+  if (!in.is_open() || !std::getline(in, line) || in.eof() || line.empty()) {
+    return -1;
+  }
+  for (char c : line) {
+    if (c < '0' || c > '9') {
+      return -1;
+    }
+  }
+  const int pid = std::atoi(line.c_str());
+  return pid > 0 ? pid : -1;
+}
+
+/**
+ * Record a pid as the owner of this runtime port. Written as a single line
+ * so a concurrent reader either sees the whole pid or rejects the record.
+ * @param port the runtime port to key the record on
+ * @param pid the owning runtime's pid
+ */
+inline void WriteRuntimePidRecord(u32 port, int pid) {
+  ctp::SystemInfo::EnsureMemfdDir();
+  std::ofstream out(RuntimePidRecordPath(port), std::ios::trunc);
+  if (out.is_open()) {
+    out << pid << "\n";
+  }
+}
+
+/**
+ * Delete this port's pid record. Idempotent: the artifact sweeps remove it
+ * too, for runtimes that died without running their teardown.
+ * @param port the runtime port the record is keyed on
+ */
+inline void RemoveRuntimePidRecord(u32 port) {
+  std::error_code ec;
+  std::filesystem::remove(RuntimePidRecordPath(port), ec);
+}
+
+/** Filename prefix shared by every pid record (used by the memfd-dir sweeps
+ *  to tell a pid record apart from a segment entry). */
+inline constexpr const char *kRuntimePidRecordPrefix = "chi_runtime_pid_";
+
+}  // namespace clio::run
+
+#endif  // CLIO_RUNTIME_RUNTIME_PID_RECORD_H_

--- a/context-runtime/modules/admin/include/clio_runtime/admin/admin_runtime.h
+++ b/context-runtime/modules/admin/include/clio_runtime/admin/admin_runtime.h
@@ -393,11 +393,6 @@ public:
                  const clio::run::shared_ptr<clio::run::Task>& replica_task) override;
 
 private:
-  /**
-   * Initiate runtime shutdown sequence
-   */
-  void InitiateShutdown(clio::run::u32 grace_period_ms);
-
   // SWIM failure detection state
   struct PendingProbe {
     clio::run::Future<HeartbeatTask> future;

--- a/context-runtime/modules/admin/include/clio_runtime/admin/admin_tasks.h
+++ b/context-runtime/modules/admin/include/clio_runtime/admin/admin_tasks.h
@@ -532,6 +532,10 @@ struct DestroyPoolTask : public clio::run::Task {
  * StopRuntimeTask - Stop the entire CLIO Runtime runtime
  */
 struct StopRuntimeTask : public clio::run::Task {
+  /** shutdown_flags_ bit: skip the graceful teardown — unlink this runtime's
+   *  filesystem artifacts and _exit(0) immediately (clio_run stop --force) */
+  static constexpr clio::run::u32 kForceShutdown = 0x1;
+
   // Runtime shutdown parameters
   IN clio::run::u32 shutdown_flags_;   ///< Flags controlling shutdown behavior
   IN clio::run::u32 grace_period_ms_;  ///< Grace period for clean shutdown

--- a/context-runtime/modules/admin/src/admin_runtime.cc
+++ b/context-runtime/modules/admin/src/admin_runtime.cc
@@ -61,12 +61,6 @@
 #include <unordered_set>
 #include <vector>
 
-#ifdef CLIO_COVERAGE
-// abort() in InitiateShutdown skips the gcov at-exit flush; declared here so
-// the shutdown path can dump counters explicitly (see InitiateShutdown).
-extern "C" void __gcov_dump(void);
-#endif
-
 namespace clio::run::admin {
 
 // Method implementations for Runtime class
@@ -298,38 +292,23 @@ clio::run::TaskResume Runtime::StopRuntime(clio::run::shared_ptr<StopRuntimeTask
   task->return_code_ = 0;
   task->error_message_ = "";
 
-  // Die immediately. SWIM will detect the death and trigger recovery.
   is_shutdown_requested_ = true;
-  HLOG(kInfo, "Admin: Runtime shutdown initiated successfully");
-  InitiateShutdown(task->grace_period_ms_);
+  const bool force =
+      (task->shutdown_flags_ & StopRuntimeTask::kForceShutdown) != 0;
+  HLOG(kInfo, "Admin: Runtime shutdown initiated ({})",
+       force ? "forced" : "graceful");
+
+  // This handler runs on a worker thread, so it must not tear down the
+  // runtime inline (ServerFinalize joins this very worker). RequestStop only
+  // sets flags / spawns detached threads; shutdown proceeds asynchronously
+  // after this task's ack is delivered to the client.
+  auto *runtime_manager = CLIO_RUNTIME_MANAGER;
+  runtime_manager->RequestStop(force
+                                   ? clio::run::RuntimeManager::StopMode::kForce
+                                   : clio::run::RuntimeManager::StopMode::kGraceful,
+                               task->grace_period_ms_);
   CLIO_CO_RETURN;
   CLIO_TASK_BODY_END
-}
-
-void Runtime::InitiateShutdown(clio::run::u32 grace_period_ms) {
-  HLOG(kDebug, "Admin: Initiating runtime shutdown with {}ms grace period",
-       grace_period_ms);
-
-  // In a real implementation, this would:
-  // 1. Signal all worker threads to stop
-  // 2. Wait for current tasks to complete (up to grace period)
-  // 3. Clean up all resources
-  // 4. Exit the runtime process
-
-  // For now, we'll just set a flag that other components can check
-  is_shutdown_requested_ = true;
-
-  // Get CLIO Runtime manager to initiate shutdown
-  auto *runtime_manager = CLIO_RUNTIME_MANAGER;
-  if (runtime_manager) {
-    // runtime_manager->InitiateShutdown(grace_period_ms);
-  }
-#ifdef CLIO_COVERAGE
-  // abort() skips the gcov at-exit flush; dump counters explicitly so
-  // daemon-side coverage from runtime tests is not silently discarded.
-  __gcov_dump();
-#endif
-  std::abort();
 }
 
 clio::run::TaskResume Runtime::Flush(clio::run::shared_ptr<FlushTask> &task) {

--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -65,6 +65,7 @@
 #include "clio_runtime/container.h"
 #include "clio_runtime/local_task_archives.h"
 #include "clio_runtime/pool_manager.h"
+#include "clio_runtime/runtime_pid_record.h"
 #include "clio_runtime/scheduler/scheduler_factory.h"
 #include "clio_runtime/task_archives.h"
 
@@ -467,6 +468,17 @@ bool IpcManager::ServerInit() {
   // Initialize memory segments for server
   if (!ServerInitShm()) {
     return false;
+  }
+
+  // Publish this runtime's pid as soon as its segments exist, and withdraw it
+  // in UnlinkOwnArtifacts when they go: the record's lifetime brackets the
+  // segments' exactly like the /proc/<pid>/fd symlink Linux memfds carry. It
+  // is what `clio_run stop`/`status` fall back to on platforms whose segments
+  // are plain files naming no owner (macOS/BSD) — including against a runtime
+  // that wedges partway through this ServerInit.
+  if (ConfigManager *config = CLIO_CONFIG_MANAGER) {
+    WriteRuntimePidRecord(config->GetPort(),
+                          static_cast<int>(ctp::SystemInfo::GetPid()));
   }
 
   // Initialize priority queues
@@ -2896,6 +2908,25 @@ size_t IpcManager::ClearUserIpcs() {
       }
     }
 
+    // The runtime pid record (chi_runtime_pid_<user>_<port>) is a plain file,
+    // so the symlink test above cannot see its owner — it names the owner in
+    // its contents instead. Keep it while that runtime is alive: it is the
+    // only handle `clio_run stop` has on a co-resident runtime whose segments
+    // are not /proc symlinks (macOS/BSD).
+    if (name.rfind(kRuntimePidRecordPrefix, 0) == 0) {
+      std::ifstream pid_file(full_path);
+      std::string pid_line;
+      if (pid_file.is_open() && std::getline(pid_file, pid_line)) {
+        int owner_pid = std::atoi(pid_line.c_str());
+        if (owner_pid > 0 && owner_pid != current_pid &&
+            ctp::SystemInfo::IsProcessAlive(owner_pid)) {
+          HLOG(kDebug, "ClearUserIpcs: keeping {} (runtime pid {} alive)", name,
+               owner_pid);
+          continue;
+        }
+      }
+    }
+
     if (ctp::SystemInfo::RemoveFile(full_path)) {
       HLOG(kDebug, "ClearUserIpcs: Removed memfd symlink: {}", name);
       removed_count++;
@@ -2985,6 +3016,9 @@ size_t IpcManager::UnlinkOwnArtifacts() {
         removed_count++;
       }
     }
+    // The pid record published in ServerInit: this runtime no longer owns the
+    // port, so nothing must be able to escalate a kill against it.
+    RemoveRuntimePidRecord(port);
   }
 
   if (removed_count > 0) {

--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -648,7 +648,11 @@ void IpcManager::ClientFinalize() {
   ClearClientPool();
   zmq_transport_.reset();
 
-  // Clients should not destroy shared resources
+  // Clients must not destroy SHARED resources (the runtime's segments), but
+  // they should remove their OWN memfd-dir entries (per-thread MPSC receive
+  // segments, on-demand data segments) so short-lived clients don't pile up
+  // dead symlinks that only the next runtime start would reap.
+  UnlinkOwnPidEntries();
 }
 
 void IpcManager::RegisterTransportShutdownHook(std::function<void()> hook) {
@@ -733,6 +737,11 @@ void IpcManager::ServerFinalize() {
   // the CLIO_IPC global is intentionally leaked, so ~IpcManager rarely runs.
   // No-op unless built with CTP_ALLOC_TRACK_SIZE (CLIO_CORE_ENABLE_LEAK_CHECK).
   ReportRuntimeLeaks("ServerFinalize");
+
+  // Remove this runtime's directory entries (main/queue segment symlinks,
+  // control sockets) so a clean stop leaves the per-user memfd dir empty.
+  // Unlink-only: the segments stay mapped for the leaked singletons above.
+  UnlinkOwnArtifacts();
 
   is_initialized_ = false;
 }
@@ -2900,6 +2909,88 @@ size_t IpcManager::ClearUserIpcs() {
          removed_count);
   }
 
+  return removed_count;
+}
+
+size_t IpcManager::UnlinkOwnPidEntries() {
+  size_t removed_count = 0;
+  const std::string memfd_dir = ctp::SystemInfo::GetMemfdDir();
+  const int current_pid = ctp::SystemInfo::GetPid();
+
+  // Entries owned by THIS process — on-demand data segments
+  // (clio_<pid>_<idx>) and per-thread MPSC receive segments
+  // (clio-<pid>-<tid>) — identified by their symlink target /proc/<pid>/fd/N.
+  // On platforms where the entries are regular files (macOS), fall back to
+  // the name prefixes. Unlink-only: mapped memory stays valid.
+  const std::string own_proc_prefix =
+      "/proc/" + std::to_string(current_pid) + "/";
+  const std::string own_name_prefixes[] = {
+      "clio_" + std::to_string(current_pid) + "_",
+      "clio-" + std::to_string(current_pid) + "-",
+  };
+  for (const auto &name : ctp::SystemInfo::ListDirectory(memfd_dir)) {
+    const std::string full_path = memfd_dir + "/" + name;
+    bool owned = false;
+    std::error_code ec;
+    auto target = std::filesystem::read_symlink(full_path, ec);
+    if (!ec) {
+      owned = target.string().rfind(own_proc_prefix, 0) == 0;
+    } else {
+      for (const auto &prefix : own_name_prefixes) {
+        if (name.rfind(prefix, 0) == 0) {
+          owned = true;
+          break;
+        }
+      }
+    }
+    if (owned && ctp::SystemInfo::RemoveFile(full_path)) {
+      removed_count++;
+    }
+  }
+  return removed_count;
+}
+
+size_t IpcManager::UnlinkOwnArtifacts() {
+  size_t removed_count = 0;
+  ConfigManager *config = CLIO_CONFIG_MANAGER;
+
+  // Named segments (main + queue) — unlink by name. The backing memfd stays
+  // alive through this process's fds/mappings; only the directory entry goes.
+  if (config) {
+    for (MemorySegment seg : {kMainSegment, kQueueSegment}) {
+      const std::string name = config->GetSharedMemorySegmentName(seg);
+      if (ctp::SystemInfo::RemoveFile(
+              ctp::SystemInfo::GetMemfdPath(name))) {
+        removed_count++;
+      }
+    }
+  }
+
+  // Everything else this pid owns (on-demand + per-thread MPSC segments).
+  removed_count += UnlinkOwnPidEntries();
+
+  // Local control socket files for this runtime's port. Normally unlinked by
+  // ~SocketTransport during graceful teardown; on the force/watchdog paths the
+  // transports are never destroyed, so remove them here (no-op if gone).
+  if (config) {
+    const u32 port = config->GetPort();
+    const std::string socket_paths[] = {
+        ctp::SystemInfo::GetMemfdPath("clio_" + std::to_string(port) +
+                                      ".ipc"),
+        ctp::SystemInfo::GetMemfdPath("clio_zmq_" + std::to_string(port + 3) +
+                                      ".ipc"),
+    };
+    for (const auto &path : socket_paths) {
+      if (ctp::SystemInfo::RemoveFile(path)) {
+        removed_count++;
+      }
+    }
+  }
+
+  if (removed_count > 0) {
+    HLOG(kInfo, "UnlinkOwnArtifacts: Removed {} filesystem entries",
+         removed_count);
+  }
   return removed_count;
 }
 

--- a/context-runtime/src/manager.cc
+++ b/context-runtime/src/manager.cc
@@ -36,14 +36,22 @@
  */
 
 #include <chrono>
+#include <cstdio>
 #include <cstdlib>
 #include <filesystem>
 #include <iomanip>
 #include <iostream>
+#include <thread>
 
 #include "clio_runtime/admin/admin_client.h"
 #include "clio_runtime/restart_log.h"
 #include "clio_runtime/singletons.h"
+
+#ifdef CLIO_COVERAGE
+// The force/watchdog stop paths end in std::_Exit, which skips the gcov
+// at-exit flush; declared here so those paths can dump counters explicitly.
+extern "C" void __gcov_dump(void);
+#endif
 
 // Global pointer variable definition for CLIO Runtime manager singleton
 CLIO_RUN_DEFINE_GLOBAL_PTR_VAR_CC(clio::run::RuntimeManager, g_runtime_manager);
@@ -499,8 +507,9 @@ void RuntimeManager::ServerFinalize() {
   // Flush in-flight (non-periodic) tasks and the net queues while the workers
   // are still running, so client/runtime work completes on its normal path and
   // its task + Future allocations are reclaimed instead of being abandoned by
-  // the abrupt StopWorkers() below.
-  DrainPendingTasks();
+  // the abrupt StopWorkers() below. The budget is the stop grace period
+  // (default 5000 ms; overridden by clio_run stop --grace-period).
+  DrainPendingTasks(stop_grace_period_ms_.load());
 
   // Stop workers and finalize server components
   auto *work_orchestrator = CLIO_WORK_ORCHESTRATOR;
@@ -546,7 +555,91 @@ void RuntimeManager::ServerFinalize() {
   if (!is_client_mode_) {
     is_initialized_ = false;
   }
+
+  // Signal the RequestStop watchdog (if any) that teardown completed so it
+  // stands down instead of force-exiting. Must be the last statement here.
+  finalize_complete_.store(true);
 }
+
+namespace {
+/** Extra time beyond the drain grace period that the stop watchdog allows the
+ *  full teardown (worker joins, container destruction) before force-exiting. */
+constexpr u64 kShutdownTeardownMarginMs = 15000;
+/** Delay before a forced stop kills the process, letting the worker that ran
+ *  the StopRuntime handler flush the task ack to the client. */
+constexpr u64 kForceAckFlushMs = 500;
+
+/**
+ * Unlink this runtime's filesystem artifacts, flush coverage counters, and
+ * terminate the process WITHOUT running atexit handlers or static destructors.
+ * Used by the force-stop and watchdog paths, where running the normal
+ * teardown is either unwanted (force) or already wedged (watchdog) — atexit
+ * would re-enter ServerFinalize from a non-main thread and deadlock.
+ * @param exit_code process exit code (0 = forced stop, 2 = watchdog escalation)
+ */
+[[noreturn]] void ForceProcessExit(int exit_code) {
+  auto *ipc_manager = CLIO_IPC;
+  if (ipc_manager) {
+    ipc_manager->UnlinkOwnArtifacts();
+  }
+#ifdef CLIO_COVERAGE
+  __gcov_dump();
+#endif
+  std::_Exit(exit_code);
+}
+}  // namespace
+
+void RuntimeManager::RequestStop(StopMode mode, u32 grace_period_ms) {
+  if (!is_runtime_mode_) {
+    HLOG(kWarning, "RequestStop: ignored - not in runtime mode");
+    return;
+  }
+  if (mode == StopMode::kGraceful && grace_period_ms == 0) {
+    grace_period_ms = stop_grace_period_ms_.load();
+  }
+  if (stop_requested_.exchange(true)) {
+    HLOG(kDebug, "RequestStop: stop already in progress");
+    return;
+  }
+  stop_grace_period_ms_.store(grace_period_ms);
+
+  if (mode == StopMode::kForce) {
+    HLOG(kInfo, "RequestStop: forced stop - process exits in {} ms",
+         kForceAckFlushMs);
+    std::thread([]() {
+      std::this_thread::sleep_for(std::chrono::milliseconds(kForceAckFlushMs));
+      ForceProcessExit(0);
+    }).detach();
+    return;
+  }
+
+  HLOG(kInfo,
+       "RequestStop: graceful stop requested (grace period: {} ms); main loop "
+       "will run the full teardown",
+       grace_period_ms);
+  // Watchdog: guarantee the process dies even if the graceful teardown wedges
+  // (stuck worker join, hung container destroy). Uses stderr instead of HLOG
+  // at escalation time — the logging system may be part of what wedged.
+  const u64 deadline_ms =
+      static_cast<u64>(grace_period_ms) + kShutdownTeardownMarginMs;
+  std::thread([this, deadline_ms]() {
+    const auto deadline = std::chrono::steady_clock::now() +
+                          std::chrono::milliseconds(deadline_ms);
+    while (std::chrono::steady_clock::now() < deadline) {
+      if (finalize_complete_.load()) {
+        return;  // teardown finished; normal process exit proceeds
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    std::fprintf(stderr,
+                 "RequestStop watchdog: graceful teardown exceeded %llu ms - "
+                 "forcing exit (code 2)\n",
+                 static_cast<unsigned long long>(deadline_ms));
+    ForceProcessExit(2);
+  }).detach();
+}
+
+bool RuntimeManager::IsStopRequested() const { return stop_requested_.load(); }
 
 bool RuntimeManager::IsInitialized() const { return is_initialized_; }
 

--- a/context-runtime/test/integration/chimaera_stop/docker-compose.yaml
+++ b/context-runtime/test/integration/chimaera_stop/docker-compose.yaml
@@ -1,0 +1,79 @@
+# Distributed clio_run-stop CI test (issue #710, "Distributed Jarvis Unit Test").
+#
+# Stands up a 2-node cluster wired with SSH, then drives Jarvis on node1 to
+# start the IOWarp runtime on BOTH nodes and stop it via Jarvis's PsshExec
+# fan-out of `clio_run runtime stop` / `stop --force`. The test asserts that
+# after the stop, EVERY node reports a clean shutdown with zero stale runtime
+# artifacts (`clio_run runtime status`).
+#
+# One entrypoint.sh serves both nodes, branching on NODE_ID:
+#   node1 (primary)   : SSH + Jarvis bring-up, runs the stop gate, exit code IS
+#                       the test result.
+#   node2 (secondary) : SSH server only; its runtime is started/stopped remotely
+#                       by Jarvis (pssh from node1).
+#
+# Usage:
+#   ./run_tests.sh
+#   HOST_WORKSPACE=/host/path/to/workspace ./run_tests.sh   # devcontainers
+
+services:
+  chimaera-stop-node1:
+    image: ${IOWARP_DOCKER_IMAGE:-iowarp/deps-cpu:latest}
+    security_opt:
+      - seccomp:unconfined
+    container_name: chimaera-stop-node1
+    hostname: iowarp-jarvis-stop-node1
+    networks:
+      chimaera-stop-cluster:
+        ipv4_address: 172.30.0.10
+    volumes:
+      - ${HOST_WORKSPACE:-${IOWARP_CORE_ROOT:-/workspace}}:/workspace:rw
+    environment:
+      - NODE_ID=1
+      - NODE_IP=172.30.0.10
+      - PATH=/workspace/build/bin:/home/iowarp/venv/bin:/home/iowarp/.cargo/bin:/usr/local/bin:/usr/bin:/bin
+      - LD_LIBRARY_PATH=/workspace/build/bin:/usr/local/cuda/lib64:/usr/local/lib
+      # Prefer a workspace jarvis-cd checkout over the older one baked into
+      # iowarp/deps-* images, when one is present. PYTHONPATH is processed
+      # before site-packages; a non-existent path is simply ignored, so this
+      # transparently falls back to the venv's jarvis-cd.
+      - PYTHONPATH=/workspace/external/jarvis-cd
+      - OMPI_ALLOW_RUN_AS_ROOT=1
+      - OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+    mem_limit: 16g
+    working_dir: /workspace
+    entrypoint:
+      - /bin/bash
+      - /workspace/context-runtime/test/integration/chimaera_stop/entrypoint.sh
+
+  chimaera-stop-node2:
+    image: ${IOWARP_DOCKER_IMAGE:-iowarp/deps-cpu:latest}
+    security_opt:
+      - seccomp:unconfined
+    container_name: chimaera-stop-node2
+    hostname: iowarp-jarvis-stop-node2
+    networks:
+      chimaera-stop-cluster:
+        ipv4_address: 172.30.0.11
+    volumes:
+      - ${HOST_WORKSPACE:-${IOWARP_CORE_ROOT:-/workspace}}:/workspace:rw
+    environment:
+      - NODE_ID=2
+      - NODE_IP=172.30.0.11
+      - PATH=/workspace/build/bin:/home/iowarp/venv/bin:/usr/local/bin:/usr/bin:/bin
+      - LD_LIBRARY_PATH=/workspace/build/bin:/usr/local/cuda/lib64:/usr/local/lib
+      - PYTHONPATH=/workspace/external/jarvis-cd
+      - OMPI_ALLOW_RUN_AS_ROOT=1
+      - OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+    mem_limit: 16g
+    working_dir: /workspace
+    entrypoint:
+      - /bin/bash
+      - /workspace/context-runtime/test/integration/chimaera_stop/entrypoint.sh
+
+networks:
+  chimaera-stop-cluster:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.30.0.0/24

--- a/context-runtime/test/integration/chimaera_stop/entrypoint.sh
+++ b/context-runtime/test/integration/chimaera_stop/entrypoint.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+# Single entrypoint for the distributed clio_run-stop CI test (issue #710).
+#
+#   NODE_ID=2 -> SSH server only; Jarvis drives this node remotely via pssh.
+#   NODE_ID=1 -> primary: brings up SSH + Jarvis, then runs the stop gate and
+#                exits with the gate's result.
+#
+# The gate: start the runtime on every node via Jarvis, then stop it via
+# Jarvis's PsshExec fan-out (`clio_run runtime stop`, and `stop --force`), and
+# assert every node reports a clean shutdown with zero stale artifacts via
+# `clio_run runtime status`.
+
+TEST_DIR=/workspace/context-runtime/test/integration/chimaera_stop
+SSH_SHARE="${TEST_DIR}/.chimaera_ssh"
+HOSTFILE="${TEST_DIR}/hostfile"
+CLIO_BIN=/workspace/build/bin/clio_run
+export LD_LIBRARY_PATH=/workspace/build/bin:/usr/local/lib:${LD_LIBRARY_PATH:-}
+
+# ---------------------------------------------------------------------------
+# Node 2: SSH server only. The runtime here is started/stopped by Jarvis.
+# ---------------------------------------------------------------------------
+if [ "${NODE_ID}" = "2" ]; then
+    set -e
+    echo '[node2] waiting for node1 public key'
+    mkdir -p /home/iowarp/.ssh && chmod 700 /home/iowarp/.ssh
+    while [ ! -f "${SSH_SHARE}/node1.pub" ]; do sleep 0.5; done
+    cat "${SSH_SHARE}/node1.pub" >> /home/iowarp/.ssh/authorized_keys
+    chmod 600 /home/iowarp/.ssh/authorized_keys
+    echo '[node2] starting sshd (foreground); ready for Jarvis'
+    sudo /usr/sbin/sshd -D
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Node 1: primary. Setup is fail-fast (set -e); the gate section manages its
+# own control flow so a failing probe is reported, not swallowed.
+# ---------------------------------------------------------------------------
+set -e
+# shellcheck source=/dev/null
+source /home/iowarp/venv/bin/activate
+
+echo '[node1] SSH setup'
+mkdir -p /home/iowarp/.ssh && chmod 700 /home/iowarp/.ssh
+ssh-keygen -t rsa -b 2048 -N '' -f /home/iowarp/.ssh/id_rsa -q 2>/dev/null || true
+sudo mkdir -p "${SSH_SHARE}" && sudo chmod 777 "${SSH_SHARE}"
+cp /home/iowarp/.ssh/id_rsa.pub "${SSH_SHARE}/node1.pub"
+cat /home/iowarp/.ssh/id_rsa.pub >> /home/iowarp/.ssh/authorized_keys
+chmod 600 /home/iowarp/.ssh/authorized_keys
+printf 'StrictHostKeyChecking no\nUserKnownHostsFile /dev/null\n' >> /home/iowarp/.ssh/config
+sudo /usr/sbin/sshd
+
+echo '[node1] waiting for node2 sshd'
+NODE2_READY=0
+for _ in $(seq 1 60); do
+    if ssh -o ConnectTimeout=3 -o BatchMode=yes iowarp-jarvis-stop-node2 'echo ready' 2>/dev/null; then
+        NODE2_READY=1; break
+    fi
+    sleep 1
+done
+[ "$NODE2_READY" = 1 ] || { echo 'ERROR: node2 SSH not ready after 60s'; exit 1; }
+
+echo '[node1] initializing Jarvis'
+sudo mkdir -p "${TEST_DIR}/.jarvis-shared" && sudo chmod 777 "${TEST_DIR}/.jarvis-shared"
+jarvis init \
+    /home/iowarp/.ppi-jarvis/config \
+    /home/iowarp/.ppi-jarvis/private \
+    "${TEST_DIR}/.jarvis-shared" \
+    +force
+jarvis repo add /workspace/jarvis_clio_core +force
+jarvis hostfile set "${HOSTFILE}"
+
+echo '[node1] building pipeline (clio_runtime only, tcp:9413)'
+jarvis ppl create chimaera_stop
+jarvis pkg append jarvis_clio_core.clio_runtime runtime
+jarvis pkg conf runtime \
+    port=9413 \
+    ipc_mode=tcp \
+    num_threads=4 \
+    client_data_segment_size=2G \
+    log_level=info \
+    sleep=8
+
+# ---------------------------------------------------------------------------
+# Gate. clio_run runtime status: 0=RUNNING, 1=STOPPED(clean), 2=STOPPED(stale).
+# Status prints to stderr. A live-but-wedged pid prints UNRESPONSIVE yet still
+# returns 1, so the UNRESPONSIVE substring is checked independently of the exit
+# code -- exit-code alone would silently pass a wedged (not stale, not clean)
+# runtime, which is exactly the failure #710 is about.
+# ---------------------------------------------------------------------------
+set +e
+STATUS_CMD="LD_LIBRARY_PATH=/workspace/build/bin:/usr/local/lib ${CLIO_BIN} runtime status"
+
+assert_all() {
+    # $1 = 'running' | 'stopped'
+    local want="$1" host out rc fail=0
+    while read -r host; do
+        [ -z "$host" ] && continue
+        out=$(ssh -o BatchMode=yes "$host" "$STATUS_CMD" 2>&1); rc=$?
+        echo "[status:$want] $host -> rc=$rc"
+        echo "$out" | sed 's/^/    /'
+        if [ "$want" = running ]; then
+            [ "$rc" = 0 ] || { echo "  FAIL: $host expected RUNNING (rc=0), got rc=$rc"; fail=1; }
+        else
+            if echo "$out" | grep -q 'UNRESPONSIVE'; then
+                echo "  FAIL: $host runtime is UNRESPONSIVE (live but wedged)"; fail=1
+            elif [ "$rc" = 2 ]; then
+                echo "  FAIL: $host has STALE runtime artifacts after stop"; fail=1
+            elif [ "$rc" != 1 ]; then
+                echo "  FAIL: $host expected STOPPED clean (rc=1), got rc=$rc"; fail=1
+            fi
+        fi
+    done < "$HOSTFILE"
+    return $fail
+}
+
+overall=0
+
+echo '=== Phase 1: graceful stop (jarvis ppl stop -> clio_run runtime stop) ==='
+jarvis ppl start || { echo 'ERROR: jarvis ppl start failed'; overall=1; }
+assert_all running || { echo 'PRECONDITION FAIL: runtime not RUNNING on all nodes after start'; overall=1; }
+jarvis ppl stop || echo 'note: jarvis ppl stop returned nonzero (status probe below is authoritative)'
+assert_all stopped || { echo 'GATE FAIL: stale runtime after graceful stop'; overall=1; }
+
+echo '=== Phase 2: force stop (jarvis ppl kill -> clio_run runtime stop --force) ==='
+jarvis ppl start || { echo 'ERROR: jarvis ppl start (phase 2) failed'; overall=1; }
+assert_all running || { echo 'PRECONDITION FAIL: runtime not RUNNING on all nodes after restart'; overall=1; }
+jarvis ppl kill || echo 'note: jarvis ppl kill returned nonzero (status probe below is authoritative)'
+assert_all stopped || { echo 'GATE FAIL: stale runtime after force stop'; overall=1; }
+
+echo '[node1] jarvis ppl clean'
+jarvis ppl clean || true
+
+if [ "$overall" = 0 ]; then
+    echo 'RESULT: PASS -- clio_run stop killed the whole runtime on every node, no stale artifacts'
+else
+    echo 'RESULT: FAIL -- see the FAIL lines above'
+fi
+exit $overall

--- a/context-runtime/test/integration/chimaera_stop/hostfile
+++ b/context-runtime/test/integration/chimaera_stop/hostfile
@@ -1,0 +1,2 @@
+iowarp-jarvis-stop-node1
+iowarp-jarvis-stop-node2

--- a/context-runtime/test/integration/chimaera_stop/run_tests.sh
+++ b/context-runtime/test/integration/chimaera_stop/run_tests.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Host driver for the distributed clio_run-stop CI test (issue #710).
+#
+# Brings up a 2-node docker-compose cluster, waits for node1 (which runs the
+# Jarvis stop gate) to finish, and propagates its exit code. Node1's exit code
+# is the test result: 0 iff `clio_run stop` killed the whole runtime on every
+# node with zero stale artifacts.
+#
+# Usage:
+#   ./run_tests.sh                                   # run the test
+#   HOST_WORKSPACE=/host/path/to/workspace ./run_tests.sh   # devcontainers
+#   ./run_tests.sh --keep                            # keep containers on exit
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../../" && pwd)"
+
+# Export workspace path for docker-compose (HOST_WORKSPACE > IOWARP_CORE_ROOT > repo root)
+if [ -n "${HOST_WORKSPACE:-}" ]; then
+    export IOWARP_CORE_ROOT="${HOST_WORKSPACE}"
+elif [ -z "${IOWARP_CORE_ROOT:-}" ]; then
+    export IOWARP_CORE_ROOT="${REPO_ROOT}"
+fi
+
+cd "$SCRIPT_DIR"
+
+KEEP=0
+[ "${1:-}" = "--keep" ] && KEEP=1
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; BLUE='\033[0;34m'; NC='\033[0m'
+log() { echo -e "${BLUE}[stop-ci]${NC} $*"; }
+ok()  { echo -e "${GREEN}[stop-ci]${NC} $*"; }
+err() { echo -e "${RED}[stop-ci]${NC} $*"; }
+
+cleanup() {
+    if [ "$KEEP" = 1 ]; then
+        log "keeping containers (--keep); 'docker compose down -v' to clean up"
+        return
+    fi
+    log "tearing down cluster"
+    docker compose down -v 2>/dev/null || true
+    # Jarvis/SSH artifacts left in the mounted workspace, possibly root-owned.
+    sudo rm -rf "$SCRIPT_DIR/.chimaera_ssh" "$SCRIPT_DIR/.jarvis-shared" 2>/dev/null \
+        || rm -rf "$SCRIPT_DIR/.chimaera_ssh" "$SCRIPT_DIR/.jarvis-shared" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Auto-detect docker image: nvidia if the built clio_run links CUDA, else cpu.
+if [ -z "${IOWARP_DOCKER_IMAGE:-}" ]; then
+    CLIO_BIN="${IOWARP_CORE_ROOT:-/workspace}/build/bin/clio_run"
+    if [ -f "$CLIO_BIN" ] && ldd "$CLIO_BIN" 2>/dev/null | grep -q "libcudart"; then
+        export IOWARP_DOCKER_IMAGE="iowarp/deps-nvidia:latest"
+    else
+        export IOWARP_DOCKER_IMAGE="iowarp/deps-cpu:latest"
+    fi
+fi
+
+export HOST_UID="$(id -u)" HOST_GID="$(id -g)"
+
+log "starting 2-node cluster (image: $IOWARP_DOCKER_IMAGE)"
+docker compose down -v 2>/dev/null || true
+docker compose up -d
+
+log "waiting for node1 to run the stop gate (timeout 300s)"
+EXIT_CODE="$(timeout 300 docker wait chimaera-stop-node1 2>/dev/null || echo 1)"
+
+echo "==================== node1 (gate) log ===================="
+docker logs chimaera-stop-node1 2>&1 | tail -120
+echo "==================== node2 (sshd) log ===================="
+docker logs chimaera-stop-node2 2>&1 | tail -20
+echo "=========================================================="
+
+if [ "$EXIT_CODE" = "0" ]; then
+    ok "PASS: clio_run stop consistently killed the whole runtime (no stale artifacts)"
+else
+    err "FAIL: distributed stop test exited $EXIT_CODE"
+fi
+exit "$EXIT_CODE"

--- a/context-runtime/test/runtime_server.h
+++ b/context-runtime/test/runtime_server.h
@@ -247,6 +247,64 @@ class RuntimeServer {
     return ctp::SystemInfo::IsChildRunning(proc_);
   }
 
+#ifndef _WIN32
+  /** The spawned daemon's pid (-1 if not started or already reaped). */
+  pid_t Pid() const { return proc_.valid ? proc_.pid : -1; }
+
+  /**
+   * Wait for the daemon to exit on its own (e.g. after an external
+   * `clio_run stop`) and capture its exit code. Reaps the process, so the
+   * destructor will not try to kill it again.
+   * @param timeout_ms how long to poll before giving up
+   * @param exit_code out: WEXITSTATUS if the daemon exited normally, or
+   *                  128+signal if it was terminated by a signal
+   * @return true if the daemon exited within the timeout
+   */
+  bool WaitExit(int timeout_ms, int *exit_code) {
+    if (!proc_.valid || proc_.pid <= 0) return false;
+    const int attempts = timeout_ms / 100;
+    for (int i = 0; i <= attempts; ++i) {
+      int status = 0;
+      pid_t ret = waitpid(proc_.pid, &status, WNOHANG);
+      if (ret == proc_.pid) {
+        if (exit_code != nullptr) {
+          if (WIFEXITED(status)) {
+            *exit_code = WEXITSTATUS(status);
+          } else if (WIFSIGNALED(status)) {
+            *exit_code = 128 + WTERMSIG(status);
+          } else {
+            *exit_code = -1;
+          }
+        }
+        proc_.pid = -1;
+        proc_.valid = false;
+        started_ = false;
+        return true;
+      }
+      if (ret < 0) {  // already reaped elsewhere
+        proc_.pid = -1;
+        proc_.valid = false;
+        started_ = false;
+        return false;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    return false;
+  }
+
+  /**
+   * Abandon ownership of the daemon: the destructor will neither kill nor
+   * reap it. Use after the test dispatched the process by other means (e.g.
+   * an external tool killed and reaped it is impossible — reaping is ours —
+   * so pair with a final waitpid by the caller).
+   */
+  void Disown() {
+    started_ = false;
+    proc_.pid = -1;
+    proc_.valid = false;
+  }
+#endif
+
  private:
   /** Absolute path to the clio_run binary. CMake passes CLIO_RUN_EXE via
    *  $<TARGET_FILE:clio_run>; fall back to CLIO_REPO_PATH/clio_run otherwise. */

--- a/context-runtime/test/unit/CMakeLists.txt
+++ b/context-runtime/test/unit/CMakeLists.txt
@@ -462,6 +462,42 @@ set_target_properties(${IPC_TRANSPORT_MODES_TEST_TARGET} PROPERTIES
 )
 endif()
 
+# Create Shutdown Battletest executable (issue #710).
+# POSIX-only: drives the daemon with signals (SIGSTOP/SIGKILL), posix_spawn
+# and waitpid. Emulates the #526 start->load->stop churn and asserts zero
+# stale artifacts after every cycle.
+set(SHUTDOWN_BATTLETEST_TARGET clio_run_shutdown_battletest)
+if(NOT WIN32)
+add_executable(${SHUTDOWN_BATTLETEST_TARGET} test_shutdown_battletest.cc)
+
+target_include_directories(${SHUTDOWN_BATTLETEST_TARGET} PRIVATE
+  ${CLIO_RUN_ROOT}/include
+  ${CLIO_RUN_ROOT}/test  # For simple_test.h / runtime_server.h
+  ${CLIO_RUN_ROOT}/modules/bdev/include
+  ${CLIO_RUN_ROOT}/modules/admin/include
+)
+
+target_link_libraries(${SHUTDOWN_BATTLETEST_TARGET}
+  clio_run_cxx               # Main CLIO Runtime library
+  clio_bdev_client        # Bdev module client (load-client mode)
+  clio_admin_client       # Admin module client
+  ctp::cxx                  # ClioCtp library
+  ${CMAKE_THREAD_LIBS_INIT}  # Threading support
+)
+
+# RuntimeServer launches clio_run; the harness also shells out to it for
+# stop/status.
+add_dependencies(${SHUTDOWN_BATTLETEST_TARGET} clio_run)
+target_compile_definitions(${SHUTDOWN_BATTLETEST_TARGET} PRIVATE
+  CLIO_RUN_EXE="$<TARGET_FILE:clio_run>")
+
+set_target_properties(${SHUTDOWN_BATTLETEST_TARGET} PROPERTIES
+  CXX_STANDARD 20
+  CXX_STANDARD_REQUIRED ON
+  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+endif()
+
 # Create Client Retry test executable.
 # POSIX-only: uses <sys/wait.h> / fork() for parent-child retry orchestration.
 if(NOT WIN32)
@@ -984,6 +1020,38 @@ if(CLIO_CORE_ENABLE_TESTS)
   )
   endif()  # NOT WIN32 (ipc_transport_modes tests)
 
+  # Shutdown Battletest (issue #710) — POSIX-only. Each scenario runs in its
+  # own process on a dedicated port (10600) and RUN_SERIAL so no other
+  # runtime-spawning test races it. Cycle count: CLIO_SHUTDOWN_BT_ITERS
+  # (default 24, mirroring the #526 pipeline's 24 runs).
+  if(NOT WIN32)
+  set(_bt_env "CLIO_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CLIO_BIND_ADDR=127.0.0.1;CLIO_PORT=10600")
+  foreach(_bt_case
+      "churn|Graceful Churn|1800"
+      "load|Churn Under Load|1800"
+      "force|Force Under Load|1800"
+      "watchdog|Watchdog Bound|600"
+      "wedged|Wedged Runtime|600"
+      "crash|Crash Recovery|600"
+      "transports|Transport Churn|1800")
+    string(REPLACE "|" ";" _bt_parts "${_bt_case}")
+    list(GET _bt_parts 0 _bt_tag)
+    list(GET _bt_parts 1 _bt_name)
+    list(GET _bt_parts 2 _bt_timeout)
+    add_test(
+      NAME cr_shutdown_bt_${_bt_tag}
+      COMMAND ${SHUTDOWN_BATTLETEST_TARGET} "ShutdownBattletest - ${_bt_name}"
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+    )
+    set_tests_properties(cr_shutdown_bt_${_bt_tag} PROPERTIES
+      ENVIRONMENT "${_bt_env}"
+      TIMEOUT ${_bt_timeout}
+      RUN_SERIAL TRUE
+      LABELS "shutdown_battletest"
+    )
+  endforeach()
+  endif()  # NOT WIN32 (shutdown battletest)
+
   # Queue-depth flurry test (issue #822): tiny queue_depth + task flurry must
   # not hang (the TIMEOUT is the hang detector).
   if(NOT WIN32)
@@ -1218,6 +1286,7 @@ if(NOT WIN32)
     ${EXTERNAL_CLIENT_TEST_TARGET}
     ${CLIENT_RETRY_TEST_TARGET}
     ${IPC_TRANSPORT_MODES_TEST_TARGET}
+    ${SHUTDOWN_BATTLETEST_TARGET}
   )
 endif()
 if(CLIO_CORE_ENABLE_CAE)

--- a/context-runtime/test/unit/cli/test_clio_run_cli.cc
+++ b/context-runtime/test/unit/cli/test_clio_run_cli.cc
@@ -474,11 +474,17 @@ TEST_CASE("CliDispatch - command help and argument errors", "[cli][dispatch]") {
 
 TEST_CASE("CliClientError - commands fail fast without a runtime",
           "[cli][client_error]") {
-  SECTION("stop fails when no runtime is up");
-  REQUIRE(RunCli("stop") == 1);
+  // stop is convergent/idempotent (issue #710): "ensure the runtime is down
+  // and its artifacts are gone". With no runtime and nothing to sweep it
+  // succeeds instead of erroring, so `clio_run stop` can be retried blindly.
+  SECTION("stop succeeds (idempotently) when no runtime is up");
+  REQUIRE(RunCli("stop") == 0);
 
-  SECTION("legacy runtime stop fails the same way");
-  REQUIRE(RunCli("runtime stop") == 1);
+  SECTION("legacy runtime stop behaves the same way");
+  REQUIRE(RunCli("runtime stop") == 0);
+
+  SECTION("status reports not-running when no runtime is up");
+  REQUIRE(RunCli("status") != 0);
 
   SECTION("monitor --once fails after successful arg parse");
   REQUIRE(RunCli("monitor --once --json --verbose --interval 2") == 1);

--- a/context-runtime/test/unit/test_shutdown_battletest.cc
+++ b/context-runtime/test/unit/test_shutdown_battletest.cc
@@ -1,0 +1,566 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Runtime shutdown battletest (Issue #710).
+ *
+ * Emulates the Issue #526 failure mode — repeated start -> heavy-IO -> stop
+ * cycles where stale state accumulated until the pipeline broke — and asserts
+ * after EVERY cycle that `clio_run stop` left ZERO artifacts: no surviving
+ * process, no memfd-dir entries (segments/sockets), no /dev/shm/chi_*, and a
+ * reusable port. Scenarios cover graceful stop, stop under data-plane load,
+ * forced stop, the teardown watchdog, a wedged (SIGSTOPped) runtime, and
+ * recovery from an outright SIGKILL crash.
+ *
+ * The harness process NEVER calls CLIO_INIT: the runtime is driven via
+ * RuntimeServer (spawns `clio_run start`), stop/status via the clio_run CLI,
+ * and data-plane load via self-exec'd `--load-client` child processes. Each
+ * cycle therefore uses only fresh processes, which is exactly how Jarvis and
+ * the #526 pipeline drive the runtime.
+ *
+ * Cycle count: CLIO_SHUTDOWN_BT_ITERS (default 24, mirroring #526).
+ */
+
+#include "../simple_test.h"
+#include "../runtime_server.h"
+
+#ifndef _WIN32
+
+#include <algorithm>
+#include <arpa/inet.h>
+#include <csignal>
+#include <cstdlib>
+#include <cstring>
+#include <fcntl.h>
+#include <filesystem>
+#include <spawn.h>
+#include <string>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <vector>
+
+#include "clio_ctp/introspect/system_info.h"
+#include "clio_runtime/clio_runtime.h"
+#include "clio_runtime/bdev/bdev_client.h"
+#include "clio_runtime/bdev/bdev_tasks.h"
+
+namespace {
+
+constexpr unsigned kBtPort = 10600;
+/** Exit code the runtime-side watchdog uses when graceful teardown wedges */
+constexpr int kWatchdogExitCode = 2;
+
+/** argv[0] of this binary, for self-exec'ing load clients */
+const char *g_self_exe = "clio_run_shutdown_battletest";
+
+/** @return battletest cycle count (CLIO_SHUTDOWN_BT_ITERS, default 24) */
+int BtIters() {
+  if (const char *env = std::getenv("CLIO_SHUTDOWN_BT_ITERS")) {
+    int n = std::atoi(env);
+    if (n > 0) return n;
+  }
+  return 24;
+}
+
+/**
+ * Run a clio_run subcommand as a child process with the current environment
+ * (CLIO_PORT etc. are exported by RuntimeServer::Start).
+ * @param args subcommand + flags, e.g. "stop --force"
+ * @return the command's exit code (-1 if it could not be run)
+ */
+int RunClioCmd(const std::string &args) {
+  const std::string cmd = std::string(CLIO_RUN_EXE) + " " + args;
+  int ret = std::system(cmd.c_str());
+  if (ret == -1) return -1;
+  if (WIFEXITED(ret)) return WEXITSTATUS(ret);
+  return -1;
+}
+
+/** Snapshot of stale-artifact classes left behind by a runtime on kBtPort */
+struct ArtifactScan {
+  std::vector<std::string> port_scoped; /**< chi_*_<port>, port .ipc files */
+  std::vector<std::string> pid_owned;   /**< entries owned by a given pid */
+  std::vector<std::string> dead_owner;  /**< /proc symlinks to dead pids */
+  std::vector<std::string> dev_shm_chi; /**< legacy /dev/shm/chi_* */
+};
+
+/**
+ * Scan the per-user memfd dir and /dev/shm for runtime leftovers.
+ * @param port runtime port whose keyed artifacts to collect
+ * @param pid runtime pid whose owned entries to collect (<=0 to skip)
+ * @return categorized artifact listing
+ */
+ArtifactScan ScanArtifacts(unsigned port, int pid) {
+  ArtifactScan scan;
+  const std::string memfd_dir = ctp::SystemInfo::GetMemfdDir();
+  const std::string port_suffix = "_" + std::to_string(port);
+  const std::string ipc_name = "clio_" + std::to_string(port) + ".ipc";
+  const std::string zmq_ipc_name =
+      "clio_zmq_" + std::to_string(port + 3) + ".ipc";
+  const std::string pid_proc =
+      pid > 0 ? "/proc/" + std::to_string(pid) + "/" : "";
+  const std::string pid_name =
+      pid > 0 ? "clio_" + std::to_string(pid) + "_" : "";
+
+  for (const auto &name : ctp::SystemInfo::ListDirectory(memfd_dir)) {
+    const std::string full_path = memfd_dir + "/" + name;
+    if (name == ipc_name || name == zmq_ipc_name ||
+        (name.rfind("chi_", 0) == 0 && name.size() >= port_suffix.size() &&
+         name.compare(name.size() - port_suffix.size(), port_suffix.size(),
+                      port_suffix) == 0)) {
+      scan.port_scoped.push_back(full_path);
+    }
+    std::error_code ec;
+    auto target = std::filesystem::read_symlink(full_path, ec);
+    if (!ec) {
+      const std::string t = target.string();
+      if (!pid_proc.empty() && t.rfind(pid_proc, 0) == 0) {
+        scan.pid_owned.push_back(full_path);
+      }
+      if (t.rfind("/proc/", 0) == 0) {
+        int owner = std::atoi(t.c_str() + 6);
+        if (owner > 0 && !ctp::SystemInfo::IsProcessAlive(owner)) {
+          scan.dead_owner.push_back(full_path);
+        }
+      }
+    } else if (!pid_name.empty() && name.rfind(pid_name, 0) == 0) {
+      scan.pid_owned.push_back(full_path);
+    }
+  }
+
+  std::error_code ec;
+  for (auto it = std::filesystem::directory_iterator("/dev/shm", ec);
+       !ec && it != std::filesystem::directory_iterator(); ++it) {
+    if (it->path().filename().string().rfind("chi_", 0) == 0) {
+      scan.dev_shm_chi.push_back(it->path().string());
+    }
+  }
+  return scan;
+}
+
+/** Format a path list for failure messages. */
+std::string JoinPaths(const std::vector<std::string> &paths) {
+  std::string out;
+  for (const auto &p : paths) {
+    out += "\n    " + p;
+  }
+  return out;
+}
+
+/**
+ * The leak oracle: after a stop, the dead runtime must have left NOTHING —
+ * no port-keyed segment/socket entries, no entries owned by its pid, no
+ * legacy /dev/shm/chi_*, no surviving process, and the TCP port must be
+ * bindable again. Dead-owner entries from killed LOAD CLIENTS are permitted
+ * here (they are reaped by the next ServerInit and asserted separately).
+ * @param cycle current cycle (for the failure message)
+ * @param port the stopped runtime's port
+ * @param pid the stopped runtime's pid
+ */
+void AssertRuntimeGoneAndClean(int cycle, unsigned port, int pid) {
+  ArtifactScan scan = ScanArtifacts(port, pid);
+  if (!scan.port_scoped.empty()) {
+    FAIL("cycle " + std::to_string(cycle) + ": leaked port-scoped artifacts:" +
+         JoinPaths(scan.port_scoped));
+  }
+  if (!scan.pid_owned.empty()) {
+    FAIL("cycle " + std::to_string(cycle) + ": leaked pid-owned artifacts:" +
+         JoinPaths(scan.pid_owned));
+  }
+  if (!scan.dev_shm_chi.empty()) {
+    FAIL("cycle " + std::to_string(cycle) + ": leaked /dev/shm entries:" +
+         JoinPaths(scan.dev_shm_chi));
+  }
+  if (pid > 0 && !(kill(pid, 0) == -1 && errno == ESRCH)) {
+    FAIL("cycle " + std::to_string(cycle) + ": runtime pid " +
+         std::to_string(pid) + " still exists after stop");
+  }
+  // Port-free probe (SO_REUSEADDR to sidestep client-side TIME_WAIT noise;
+  // the authoritative recheck is the next cycle's successful Start()).
+  int fd = socket(AF_INET, SOCK_STREAM, 0);
+  REQUIRE(fd >= 0);
+  int opt = 1;
+  setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(static_cast<uint16_t>(port));
+  addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+  int bind_rc = bind(fd, reinterpret_cast<sockaddr *>(&addr), sizeof(addr));
+  close(fd);
+  if (bind_rc != 0) {
+    FAIL("cycle " + std::to_string(cycle) + ": port " + std::to_string(port) +
+         " is not bindable after stop (errno " + std::to_string(errno) + ")");
+  }
+}
+
+/**
+ * Assert the freshly-started runtime's ServerInit (ClearUserIpcs) reaped all
+ * dead-owner leftovers, e.g. segments of load clients SIGKILLed last cycle.
+ * @param cycle current cycle (for the failure message)
+ */
+void AssertDeadOwnerEntriesReaped(int cycle) {
+  ArtifactScan scan = ScanArtifacts(kBtPort, -1);
+  if (!scan.dead_owner.empty()) {
+    FAIL("cycle " + std::to_string(cycle) +
+         ": dead-owner entries survived the next ServerInit:" +
+         JoinPaths(scan.dead_owner));
+  }
+}
+
+/**
+ * Spawn N copies of this binary in `--load-client` mode. Each connects as a
+ * CLIO client and hammers bdev writes until killed. Output goes to /dev/null.
+ * @param n number of load clients
+ * @param port runtime port to attack
+ * @return pids of the spawned clients
+ */
+std::vector<pid_t> SpawnLoadClients(int n, unsigned port) {
+  std::vector<pid_t> pids;
+  const std::string port_str = std::to_string(port);
+  for (int i = 0; i < n; ++i) {
+    posix_spawn_file_actions_t actions;
+    posix_spawn_file_actions_init(&actions);
+    posix_spawn_file_actions_addopen(&actions, 1, "/dev/null", O_WRONLY, 0);
+    posix_spawn_file_actions_adddup2(&actions, 1, 2);
+    const char *argv_child[] = {g_self_exe, "--load-client", port_str.c_str(),
+                                nullptr};
+    pid_t pid = -1;
+    int rc = posix_spawn(&pid, g_self_exe, &actions, nullptr,
+                         const_cast<char *const *>(argv_child), environ);
+    posix_spawn_file_actions_destroy(&actions);
+    if (rc == 0 && pid > 0) {
+      pids.push_back(pid);
+    }
+  }
+  REQUIRE(static_cast<int>(pids.size()) == n);
+  return pids;
+}
+
+/**
+ * SIGKILL and reap the load clients (they are expected to die ugly — that is
+ * the point: #526's clients never shut down cleanly either).
+ * @param pids load-client pids from SpawnLoadClients
+ */
+void KillLoadClients(std::vector<pid_t> &pids) {
+  for (pid_t pid : pids) {
+    kill(pid, SIGKILL);
+  }
+  for (pid_t pid : pids) {
+    int status = 0;
+    waitpid(pid, &status, 0);
+  }
+  pids.clear();
+}
+
+/**
+ * One start -> [load] -> stop -> assert-clean cycle.
+ * @param cycle cycle index (failure messages)
+ * @param stop_args clio_run stop arguments ("stop", "stop --force", ...)
+ * @param n_load_clients data-plane load processes to run during the stop
+ * @param load_ms how long to let the load build before stopping
+ * @param allow_watchdog whether daemon exit code 2 (watchdog) is acceptable
+ */
+void RunStopCycle(int cycle, const std::string &stop_args, int n_load_clients,
+                  int load_ms, bool allow_watchdog) {
+  clio::run::test::RuntimeServer server;
+  REQUIRE(server.Start(kBtPort));
+  REQUIRE(server.WaitForReady());
+  AssertDeadOwnerEntriesReaped(cycle);
+  const int pid = static_cast<int>(server.Pid());
+
+  std::vector<pid_t> load;
+  if (n_load_clients > 0) {
+    load = SpawnLoadClients(n_load_clients, kBtPort);
+    std::this_thread::sleep_for(std::chrono::milliseconds(load_ms));
+  }
+
+  const int stop_rc = RunClioCmd(stop_args);
+  if (stop_rc != 0) {
+    KillLoadClients(load);
+    FAIL("cycle " + std::to_string(cycle) + ": `clio_run " + stop_args +
+         "` returned " + std::to_string(stop_rc));
+  }
+
+  int exit_code = -1;
+  const bool exited = server.WaitExit(45000, &exit_code);
+  KillLoadClients(load);
+  if (!exited) {
+    FAIL("cycle " + std::to_string(cycle) +
+         ": daemon did not exit within 45000 ms after stop");
+  }
+  const bool code_ok =
+      exit_code == 0 || (allow_watchdog && exit_code == kWatchdogExitCode);
+  if (!code_ok) {
+    FAIL("cycle " + std::to_string(cycle) + ": unexpected daemon exit code " +
+         std::to_string(exit_code));
+  }
+  if (exit_code == kWatchdogExitCode) {
+    INFO("cycle " + std::to_string(cycle) + ": watchdog-forced exit (2)");
+  }
+
+  AssertRuntimeGoneAndClean(cycle, kBtPort, pid);
+}
+
+}  // namespace
+
+// ===========================================================================
+// Scenarios
+// ===========================================================================
+
+TEST_CASE("ShutdownBattletest - Graceful Churn", "[bt_churn]") {
+  const int iters = BtIters();
+  for (int cycle = 1; cycle <= iters; ++cycle) {
+    INFO("graceful churn cycle " + std::to_string(cycle) + "/" +
+         std::to_string(iters));
+    RunStopCycle(cycle, "stop", /*n_load_clients=*/0, /*load_ms=*/0,
+                 /*allow_watchdog=*/false);
+  }
+}
+
+TEST_CASE("ShutdownBattletest - Churn Under Load", "[bt_load]") {
+  const int iters = BtIters();
+  for (int cycle = 1; cycle <= iters; ++cycle) {
+    INFO("load churn cycle " + std::to_string(cycle) + "/" +
+         std::to_string(iters));
+    RunStopCycle(cycle, "stop", /*n_load_clients=*/4, /*load_ms=*/2000,
+                 /*allow_watchdog=*/true);
+  }
+}
+
+TEST_CASE("ShutdownBattletest - Force Under Load", "[bt_force]") {
+  const int iters = BtIters();
+  for (int cycle = 1; cycle <= iters; ++cycle) {
+    INFO("force churn cycle " + std::to_string(cycle) + "/" +
+         std::to_string(iters));
+    const auto start = std::chrono::steady_clock::now();
+    RunStopCycle(cycle, "stop --force", /*n_load_clients=*/4,
+                 /*load_ms=*/2000, /*allow_watchdog=*/false);
+    const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                        std::chrono::steady_clock::now() - start).count();
+    INFO("force cycle " + std::to_string(cycle) + " took " +
+         std::to_string(ms) + " ms");
+  }
+}
+
+TEST_CASE("ShutdownBattletest - Watchdog Bound", "[bt_watchdog]") {
+  // Grace period deliberately far too small to drain 4 clients' load: the
+  // invariant is BOUNDED convergence + zero artifacts, whether the teardown
+  // makes it (exit 0) or the watchdog fires (exit 2).
+  const int iters = std::min(BtIters(), 5);
+  for (int cycle = 1; cycle <= iters; ++cycle) {
+    INFO("watchdog cycle " + std::to_string(cycle) + "/" +
+         std::to_string(iters));
+    const auto start = std::chrono::steady_clock::now();
+    RunStopCycle(cycle, "stop --grace-period 100", /*n_load_clients=*/4,
+                 /*load_ms=*/2000, /*allow_watchdog=*/true);
+    const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                        std::chrono::steady_clock::now() - start).count();
+    // grace(0.1s) + watchdog margin(15s) + stop-side wait slack
+    REQUIRE(ms < 60000);
+  }
+}
+
+TEST_CASE("ShutdownBattletest - Wedged Runtime", "[bt_wedged]") {
+  // SIGSTOP freezes every runtime thread: no worker can service the stop
+  // task, so the CLI's kill escalation (SIGTERM has no effect on a stopped
+  // process -> SIGKILL) must converge and sweep the artifacts client-side.
+  const int iters = std::min(BtIters(), 5);
+  for (int cycle = 1; cycle <= iters; ++cycle) {
+    INFO("wedged cycle " + std::to_string(cycle) + "/" + std::to_string(iters));
+    clio::run::test::RuntimeServer server;
+    REQUIRE(server.Start(kBtPort));
+    REQUIRE(server.WaitForReady());
+    const int pid = static_cast<int>(server.Pid());
+
+    REQUIRE(kill(pid, SIGSTOP) == 0);
+
+    const int stop_rc = RunClioCmd("stop");
+    if (stop_rc != 0) {
+      kill(pid, SIGKILL);  // do not leak a stopped daemon on failure
+      FAIL("cycle " + std::to_string(cycle) +
+           ": stop on wedged runtime returned " + std::to_string(stop_rc));
+    }
+
+    int exit_code = -1;
+    REQUIRE(server.WaitExit(10000, &exit_code));
+    REQUIRE(exit_code == 128 + SIGKILL);  // escalation had to SIGKILL it
+
+    AssertRuntimeGoneAndClean(cycle, kBtPort, pid);
+  }
+}
+
+TEST_CASE("ShutdownBattletest - Crash Recovery", "[bt_crash]") {
+  // Emulate today's `pkill -9` reality: SIGKILL the daemon mid-load, then
+  // prove `status` reports the stale wreckage (exit 2), `stop` doubles as
+  // the recovery tool (sweep -> rc 0), `status` then reports clean (exit 1),
+  // and a fresh start succeeds.
+  const int iters = std::min(BtIters(), 5);
+  for (int cycle = 1; cycle <= iters; ++cycle) {
+    INFO("crash cycle " + std::to_string(cycle) + "/" + std::to_string(iters));
+    clio::run::test::RuntimeServer server;
+    REQUIRE(server.Start(kBtPort));
+    REQUIRE(server.WaitForReady());
+    const int pid = static_cast<int>(server.Pid());
+
+    // status on a live runtime: RUNNING (exit 0)
+    REQUIRE(RunClioCmd("status") == 0);
+
+    std::vector<pid_t> load = SpawnLoadClients(2, kBtPort);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+
+    kill(pid, SIGKILL);
+    int exit_code = -1;
+    REQUIRE(server.WaitExit(10000, &exit_code));
+    KillLoadClients(load);
+
+    // The corpse left artifacts: status must expose them.
+    REQUIRE(RunClioCmd("status") == 2);
+    // stop must recover: discover the dead pid, sweep, and return success.
+    REQUIRE(RunClioCmd("stop") == 0);
+    // Now the node is clean.
+    REQUIRE(RunClioCmd("status") == 1);
+    AssertRuntimeGoneAndClean(cycle, kBtPort, pid);
+  }
+}
+
+TEST_CASE("ShutdownBattletest - Transport Churn", "[bt_transports]") {
+  // The stop CLI has distinct paths per IPC mode (SHM maps the task queue;
+  // TCP/IPC go via ZMQ). Churn each mode.
+  const int iters = std::max(2, std::min(BtIters(), 8));
+  for (const char *mode : {"SHM", "TCP", "IPC"}) {
+    clio::run::test::SetEnvVar("CLIO_IPC_MODE", mode);
+    for (int cycle = 1; cycle <= iters; ++cycle) {
+      INFO(std::string("transport ") + mode + " cycle " +
+           std::to_string(cycle) + "/" + std::to_string(iters));
+      RunStopCycle(cycle, "stop", /*n_load_clients=*/2, /*load_ms=*/1000,
+                   /*allow_watchdog=*/true);
+    }
+  }
+  clio::run::test::UnsetEnvVar("CLIO_IPC_MODE");
+}
+
+// ===========================================================================
+// Load-client mode (self-exec'd data-plane stress)
+// ===========================================================================
+
+namespace {
+
+inline clio::run::priv::vector<clio::run::bdev::Block> WrapBlock(
+    const clio::run::bdev::Block &block) {
+  clio::run::priv::vector<clio::run::bdev::Block> blocks(CTP_MALLOC);
+  blocks.push_back(block);
+  return blocks;
+}
+
+/**
+ * Data-plane load client: connect to the runtime and hammer 1 MiB bdev
+ * writes until killed. Large buffers force on-demand shared-memory segment
+ * creation (IncreaseClientShm/IncreaseServerShm) — the artifact class that
+ * accumulated in Issue #526. All failures exit quietly: the runtime dying
+ * underneath us is an EXPECTED part of every scenario.
+ * @param port runtime port to attack
+ * @return process exit code (always 0; the harness SIGKILLs us anyway)
+ */
+int RunLoadClient(unsigned port) {
+  constexpr clio::run::u64 kRamSize = 64ull * 1024 * 1024;
+  constexpr clio::run::u64 kIoSize = 1024 * 1024;
+  clio::run::test::SetEnvVar("CLIO_PORT", std::to_string(port));
+  clio::run::test::SetEnvVar("CLIO_WITH_RUNTIME", "0");
+  clio::run::test::SetEnvVar("CLIO_WAIT_SERVER", "10");
+  if (!clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, false)) {
+    return 0;
+  }
+  try {
+    clio::run::PoolId pool_id(9600, 0);
+    clio::run::bdev::Client client(pool_id);
+    const std::string pool_name = "bt_load_" + std::to_string(getpid());
+    auto create_task = client.AsyncCreate(
+        clio::run::PoolQuery::Dynamic(), pool_name, pool_id,
+        clio::run::bdev::BdevType::kRam, kRamSize);
+    create_task.Wait();
+    if (create_task->return_code_ != 0) return 0;
+    client.pool_id_ = create_task->new_pool_id_;
+
+    auto alloc_task =
+        client.AsyncAllocateBlocks(clio::run::PoolQuery::Local(), kIoSize);
+    alloc_task.Wait();
+    if (alloc_task->return_code_ != 0 || alloc_task->blocks_.size() == 0) {
+      return 0;
+    }
+    clio::run::bdev::Block block = alloc_task->blocks_[0];
+
+    while (true) {
+      auto buffer = CLIO_IPC->AllocateBuffer(kIoSize);
+      if (buffer.IsNull()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        continue;
+      }
+      std::memset(buffer.ptr_, 0xA5, kIoSize);
+      auto write_task = client.AsyncWrite(
+          clio::run::PoolQuery::Local(), WrapBlock(block),
+          buffer.shm_.template Cast<void>().template Cast<void>(), kIoSize);
+      write_task.Wait(1.0f);
+      CLIO_IPC->FreeBuffer(buffer);
+    }
+  } catch (...) {
+    // Runtime went away mid-flight — expected.
+  }
+  return 0;
+}
+
+}  // namespace
+
+/**
+ * Custom main: `--load-client <port>` runs the data-plane stressor; anything
+ * else runs the simple_test suite with argv[1] as the test-name filter (the
+ * same contract as SIMPLE_TEST_MAIN, which we cannot use because of the
+ * load-client dispatch).
+ */
+int main(int argc, char *argv[]) {
+  if (argc > 0 && argv[0] != nullptr && argv[0][0] != '\0') {
+    g_self_exe = argv[0];
+  }
+  if (argc >= 3 && std::strcmp(argv[1], "--load-client") == 0) {
+    return RunLoadClient(static_cast<unsigned>(std::atoi(argv[2])));
+  }
+  std::string filter = argc > 1 ? argv[1] : "";
+  return SimpleTest::run_all_tests(filter);
+}
+
+#else  // _WIN32
+
+/** The battletest drives POSIX signals/spawn; Windows builds compile a stub. */
+int main() { return 0; }
+
+#endif  // _WIN32

--- a/context-runtime/test/unit/test_shutdown_battletest.cc
+++ b/context-runtime/test/unit/test_shutdown_battletest.cc
@@ -75,6 +75,14 @@
 #include "clio_runtime/bdev/bdev_client.h"
 #include "clio_runtime/bdev/bdev_tasks.h"
 
+// glibc declares `environ` in <unistd.h>; macOS declares it in no header and
+// forbids referencing it directly outside main(), so route through the
+// sanctioned _NSGetEnviron() accessor there (used by posix_spawn below).
+#ifdef __APPLE__
+#include <crt_externs.h>
+#define environ (*_NSGetEnviron())
+#endif
+
 namespace {
 
 constexpr unsigned kBtPort = 10600;

--- a/context-runtime/util/CMakeLists.txt
+++ b/context-runtime/util/CMakeLists.txt
@@ -9,6 +9,7 @@ cmake_minimum_required(VERSION 3.10)
 add_library(clio_run_commands STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/clio_run_cmd_runtime_start.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/clio_run_cmd_runtime_stop.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/clio_run_cmd_runtime_status.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/clio_run_cmd_monitor.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/clio_run_cmd_compose.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/clio_run_cmd_config.cc

--- a/context-runtime/util/clio_run.cc
+++ b/context-runtime/util/clio_run.cc
@@ -17,6 +17,9 @@ void PrintUsage() {
             << "  start           Start the Clio runtime server\n"
             << "  restart         Restart the Clio runtime (WAL replay)\n"
             << "  stop            Stop the Clio runtime server\n"
+            << "                  (--force: immediate ungraceful stop;\n"
+            << "                   --grace-period <ms>: drain budget)\n"
+            << "  status          Report runtime state (running/stopped/stale)\n"
             << "  migrate         Migrate a container to a different node\n"
             << "  monitor         Monitor worker statistics\n"
             << "  compose         Manage pools from a compose config:\n"
@@ -67,6 +70,8 @@ int main(int argc, char* argv[]) {
       return RuntimeRestart(new_argc, new_argv);
     } else if (cmd == "stop") {
       return RuntimeStop(new_argc, new_argv);
+    } else if (cmd == "status") {
+      return RuntimeStatus(new_argc, new_argv);
     } else if (cmd == "refresh") {
       return RefreshRepo(new_argc, new_argv);
     } else if (cmd == "migrate") {
@@ -103,6 +108,8 @@ int main(int argc, char* argv[]) {
       return RuntimeRestart(new_argc, new_argv);
     } else if (subcmd == "stop") {
       return RuntimeStop(new_argc, new_argv);
+    } else if (subcmd == "status") {
+      return RuntimeStatus(new_argc, new_argv);
     } else {
       std::cerr << "Unknown runtime subcommand: " << subcmd << "\n";
       std::cerr << "Usage: " << g_progname

--- a/context-runtime/util/clio_run_cmd_runtime_start.cc
+++ b/context-runtime/util/clio_run_cmd_runtime_start.cc
@@ -118,6 +118,28 @@ bool InductNode() {
   return true;
 }
 
+/**
+ * Block until the runtime should exit: either a SIGTERM/SIGINT flipped
+ * g_keep_running, or a StopRuntimeTask requested a graceful stop via
+ * RuntimeManager::RequestStop. Returning lets main() exit normally so the
+ * atexit teardown (ServerFinalize) runs on this main thread.
+ */
+void RunUntilStopped() {
+  auto* runtime_manager = CLIO_RUNTIME_MANAGER;
+  while (g_keep_running &&
+         !(runtime_manager && runtime_manager->IsStopRequested())) {
+    CTP_THREAD_MODEL->SleepForUs(100000);
+  }
+  // Signal-triggered exit (SIGTERM/SIGINT): arm the same teardown watchdog
+  // the task-driven stop uses, so a wedged ServerFinalize can never leave a
+  // half-dead daemon behind (`docker stop` / Jarvis Kill rely on SIGTERM).
+  // No-op if the stop was already requested through RequestStop.
+  if (runtime_manager && !runtime_manager->IsStopRequested()) {
+    runtime_manager->RequestStop(
+        clio::run::RuntimeManager::StopMode::kGraceful, 0);
+  }
+}
+
 void PrintRuntimeStartUsage() {
   HIPRINT("Usage: clio runtime start [--induct] [--ephemeral]");
   HIPRINT("  Starts the Clio runtime server");
@@ -185,9 +207,7 @@ int RuntimeStart(int argc, char* argv[]) {
     }
   }
 
-  while (g_keep_running) {
-    CTP_THREAD_MODEL->SleepForUs(100000);
-  }
+  RunUntilStopped();
 
   HLOG(kDebug, "Shutting down Clio runtime...");
   ShutdownAdminChiMod();
@@ -238,9 +258,7 @@ int RuntimeRestart(int argc, char* argv[]) {
     }
   }
 
-  while (g_keep_running) {
-    CTP_THREAD_MODEL->SleepForUs(100000);
-  }
+  RunUntilStopped();
 
   HLOG(kDebug, "Shutting down Clio runtime...");
   ShutdownAdminChiMod();

--- a/context-runtime/util/clio_run_cmd_runtime_status.cc
+++ b/context-runtime/util/clio_run_cmd_runtime_status.cc
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "clio_runtime/admin/admin_client.h"
+#include "clio_runtime/clio_runtime.h"
+#include "clio_runtime/pool_query.h"
+#include "clio_runtime/types.h"
+#include "clio_run_commands.h"
+#include "clio_run_local_runtime.h"
+
+namespace {
+
+void PrintRuntimeStatusUsage() {
+  HIPRINT("Usage: clio_run status");
+  HIPRINT("  Report the local Clio runtime's state.");
+  HIPRINT("  Exit codes:");
+  HIPRINT("    0  RUNNING - runtime answered a heartbeat probe");
+  HIPRINT("    1  STOPPED (clean) - no runtime, no stale artifacts");
+  HIPRINT("    2  STOPPED (stale artifacts) - no responsive runtime, but");
+  HIPRINT("       leftover segments/sockets exist (listed on stdout)");
+}
+
+/**
+ * Probe the local runtime with a heartbeat task. Assumes CLIO_INIT(kClient)
+ * succeeded.
+ * @return true if the runtime acked the heartbeat within 2 seconds
+ */
+bool ProbeHeartbeat() {
+  try {
+    clio::run::admin::Client admin_client(clio::run::kAdminPoolId);
+    auto task = admin_client.AsyncHeartbeat(clio::run::PoolQuery::Local());
+    if (task.IsNull()) {
+      return false;
+    }
+    return task.Wait(2.0f);
+  } catch (const std::exception&) {
+    return false;
+  }
+}
+
+/**
+ * Report the not-running outcome: scan for stale artifacts and pick the
+ * exit code (1 = clean, 2 = stale artifacts present).
+ * @param port the runtime port that was probed
+ * @return process exit code
+ */
+int ReportStopped(clio::run::u32 port) {
+  const auto stale = clio::run::cli::ListStaleArtifacts(port);
+  const int pid = clio::run::cli::DiscoverRuntimePid(port);
+  if (pid > 0 && ctp::SystemInfo::IsProcessAlive(pid) &&
+      clio::run::cli::PidIsClioRun(pid)) {
+    HIPRINT("clio runtime (port {}): UNRESPONSIVE - process {} is alive but "
+            "did not answer the heartbeat probe", port, pid);
+  }
+  if (stale.empty()) {
+    HIPRINT("clio runtime (port {}): STOPPED (clean)", port);
+    return 1;
+  }
+  HIPRINT("clio runtime (port {}): STOPPED (stale artifacts)", port);
+  for (const auto& path : stale) {
+    HIPRINT("  stale: {}", path);
+  }
+  return 2;
+}
+
+}  // namespace
+
+int RuntimeStatus(int argc, char* argv[]) {
+  for (int i = 0; i < argc; ++i) {
+    if (std::strcmp(argv[i], "--help") == 0 ||
+        std::strcmp(argv[i], "-h") == 0) {
+      PrintRuntimeStatusUsage();
+      return 0;
+    }
+  }
+
+  // Self-cleanup on EVERY exit path: even a failed ClientInit creates this
+  // process's per-thread MPSC segment (clio-<pid>-<tid>) in the memfd dir,
+  // and a status probe must not leave litter of its own. Idempotent with
+  // the ClientFinalize below.
+  struct OwnEntriesGuard {
+    ~OwnEntriesGuard() {
+      auto* ipc = CLIO_IPC;
+      if (ipc) {
+        ipc->UnlinkOwnPidEntries();
+      }
+    }
+  } own_entries_guard;
+
+  // Bound the client-connect wait: status must return promptly whether the
+  // runtime is up, down, or wedged. An explicit CLIO_WAIT_SERVER wins.
+  if (!clio::run::env::GetCompat("WAIT_SERVER")) {
+#ifdef _WIN32
+    _putenv_s("CLIO_WAIT_SERVER", "2");
+#else
+    setenv("CLIO_WAIT_SERVER", "2", 1);
+#endif
+  }
+
+  if (!clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, false)) {
+    return ReportStopped(clio::run::cli::ResolveRuntimePort());
+  }
+
+  // RAII guard: call ClientFinalize() on every return path so the background
+  // ZMQ receive thread is joined and the DEALER socket is closed before the
+  // ZMQ shared-context static destructor runs.
+  struct ClientFinalizeGuard {
+    ~ClientFinalizeGuard() {
+      auto* mgr = CLIO_RUNTIME_MANAGER;
+      if (mgr) {
+        mgr->ClientFinalize();
+      }
+    }
+  } finalize_guard;
+
+  const clio::run::u32 port = clio::run::cli::ResolveRuntimePort();
+  if (ProbeHeartbeat()) {
+    const int pid = clio::run::cli::DiscoverRuntimePid(port);
+    if (pid > 0) {
+      HIPRINT("clio runtime (port {}): RUNNING (pid {})", port, pid);
+    } else {
+      HIPRINT("clio runtime (port {}): RUNNING", port);
+    }
+    return 0;
+  }
+  return ReportStopped(port);
+}

--- a/context-runtime/util/clio_run_cmd_runtime_stop.cc
+++ b/context-runtime/util/clio_run_cmd_runtime_stop.cc
@@ -1,22 +1,358 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <algorithm>
 #include <chrono>
+#include <cstdlib>
 #include <cstring>
+#include <filesystem>
 #include <iostream>
+#include <string>
 #include <thread>
 
+#ifndef _WIN32
+#include <csignal>
+#include <unistd.h>
+#endif
+
+#include "clio_ctp/util/config_parse.h"
 #include "clio_runtime/admin/admin_client.h"
 #include "clio_runtime/clio_runtime.h"
+#include "clio_runtime/config_manager.h"
 #include "clio_runtime/pool_query.h"
 #include "clio_runtime/types.h"
 #include "clio_run_commands.h"
+#include "clio_run_local_runtime.h"
+
+namespace {
+
+using clio::run::cli::DiscoverRuntimePid;
+using clio::run::cli::PidIsClioRun;
+using clio::run::cli::PidIsRunning;
+using clio::run::cli::ResolveRuntimePort;
+
+/** Parsed clio_run stop options */
+struct StopOptions {
+  bool force = false;               /**< --force: immediate ungraceful death */
+  clio::run::u32 grace_period_ms = 5000; /**< --grace-period: drain budget */
+};
+
+/**
+ * Parse the stop subcommand flags (--force, --grace-period <ms>).
+ * @param argc argument count for the subcommand
+ * @param argv argument vector for the subcommand
+ * @return parsed options (defaults: graceful, 5000 ms grace)
+ */
+StopOptions ParseStopArgs(int argc, char* argv[]) {
+  StopOptions opts;
+  for (int i = 0; i < argc; ++i) {
+    if (std::strcmp(argv[i], "--force") == 0) {
+      opts.force = true;
+    } else if (std::strcmp(argv[i], "--grace-period") == 0 && i + 1 < argc) {
+      opts.grace_period_ms =
+          static_cast<clio::run::u32>(std::atoi(argv[++i]));
+      if (opts.grace_period_ms == 0) opts.grace_period_ms = 5000;
+    }
+  }
+  return opts;
+}
+
+#ifndef _WIN32
+
+/**
+ * Remove leftover filesystem artifacts after the local runtime is down.
+ * Removes: memfd-dir entries whose symlink target points at the (dead)
+ * runtime pid, the port-keyed chi_* segment entries, the port's
+ * control-socket files, and any entry owned by a DEAD process (the same
+ * dead-only rule ClearUserIpcs applies at the next runtime start — e.g.
+ * segments of crashed clients). Entries owned by live processes
+ * (co-resident runtimes, active clients) are never touched.
+ * @param pid the dead runtime's pid (<= 0 to skip pid-target matching)
+ * @param port the dead runtime's port
+ * @return number of filesystem entries removed
+ */
+size_t SweepDeadRuntimeArtifacts(int pid, clio::run::u32 port) {
+  size_t removed = 0;
+  const std::string memfd_dir = ctp::SystemInfo::GetMemfdDir();
+  const std::string proc_prefix =
+      pid > 0 ? "/proc/" + std::to_string(pid) + "/" : "";
+  const std::string port_suffix = "_" + std::to_string(port);
+  const std::string ipc_name = "clio_" + std::to_string(port) + ".ipc";
+  const std::string zmq_ipc_name =
+      "clio_zmq_" + std::to_string(port + 3) + ".ipc";
+  const int own_pid = ctp::SystemInfo::GetPid();
+
+  for (const auto& name : ctp::SystemInfo::ListDirectory(memfd_dir)) {
+    const std::string full_path = memfd_dir + "/" + name;
+    bool matches = (name == ipc_name) || (name == zmq_ipc_name);
+    // Port-keyed segment names: chi_<segment>_<user>_<port>
+    if (!matches && name.rfind("chi_", 0) == 0 &&
+        name.size() >= port_suffix.size() &&
+        name.compare(name.size() - port_suffix.size(), port_suffix.size(),
+                     port_suffix) == 0) {
+      matches = true;
+    }
+    if (!matches) {
+      std::error_code ec;
+      auto target = std::filesystem::read_symlink(full_path, ec);
+      if (!ec) {
+        const std::string t = target.string();
+        if (!proc_prefix.empty() && t.rfind(proc_prefix, 0) == 0) {
+          matches = true;  // owned by the dead runtime
+        } else if (t.rfind("/proc/", 0) == 0) {
+          // Owned by some other DEAD process (crashed client etc.)
+          int owner = std::atoi(t.c_str() + 6);
+          matches = owner > 0 && owner != own_pid &&
+                    !ctp::SystemInfo::IsProcessAlive(owner);
+        }
+      }
+    }
+    if (matches && ctp::SystemInfo::RemoveFile(full_path)) {
+      HLOG(kInfo, "stop: swept stale artifact {}", name);
+      removed++;
+    }
+  }
+  return removed;
+}
+
+/**
+ * Last-resort local stop: the runtime did not respond to (or did not die
+ * from) the StopRuntimeTask. Discover its pid from the main segment symlink
+ * and escalate SIGTERM -> SIGKILL, then sweep its leftover artifacts. Also
+ * handles the "runtime already dead but artifacts remain" case (crash /
+ * pkill -9) by sweeping without killing.
+ * @param port the runtime port to target
+ * @return 0 if the runtime is gone and artifacts are swept; 1 on failure
+ */
+int EscalateLocalKill(clio::run::u32 port) {
+  int pid = DiscoverRuntimePid(port);
+  if (pid <= 0) {
+    HLOG(kWarning,
+         "stop: no runtime segment found for port {} - sweeping any "
+         "port-scoped leftovers",
+         port);
+    SweepDeadRuntimeArtifacts(-1, port);
+    return 0;
+  }
+
+  if (PidIsRunning(pid) && PidIsClioRun(pid)) {
+    HLOG(kWarning,
+         "stop: runtime (pid {}) unresponsive - escalating to SIGTERM", pid);
+    kill(pid, SIGTERM);
+    for (int i = 0; i < 100 && PidIsRunning(pid); ++i) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    if (PidIsRunning(pid)) {
+      HLOG(kWarning, "stop: SIGTERM ineffective - escalating to SIGKILL");
+      kill(pid, SIGKILL);
+      for (int i = 0; i < 50 && PidIsRunning(pid); ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      }
+    }
+    if (PidIsRunning(pid)) {
+      HLOG(kError, "stop: runtime pid {} survived SIGKILL", pid);
+      return 1;
+    }
+  } else if (PidIsRunning(pid)) {
+    HLOG(kWarning,
+         "stop: pid {} from stale segment is not clio_run (pid recycled) - "
+         "treating runtime as dead",
+         pid);
+  } else {
+    HLOG(kWarning, "stop: runtime (pid {}) is already dead", pid);
+  }
+
+  size_t swept = SweepDeadRuntimeArtifacts(pid, port);
+  HLOG(kWarning,
+       "stop: escalation complete - runtime is down, {} stale artifacts "
+       "swept",
+       swept);
+  return 0;
+}
+
+#else  // _WIN32
+
+/** Windows stub: pid discovery via /proc symlinks is POSIX-only. */
+int EscalateLocalKill(clio::run::u32 /*port*/) {
+  HLOG(kError,
+       "stop: runtime unresponsive and kill escalation is not supported on "
+       "Windows");
+  return 1;
+}
+
+#endif  // _WIN32
+
+/**
+ * Wait for the runtime process to exit (or become a zombie awaiting its
+ * parent's reap, which counts as stopped). Pid-based liveness is used
+ * instead of ClientConnect probes: probe responses proved unreliable during
+ * teardown (futures can complete without a live server), while process
+ * death is unambiguous.
+ * @param pid the runtime's pid
+ * @param timeout_ms how long to poll before declaring failure
+ * @return true if the process stopped within the timeout
+ */
+bool WaitForRuntimeExit(int pid, clio::run::u64 timeout_ms) {
+#ifdef _WIN32
+  (void)pid;
+  (void)timeout_ms;
+  return false;
+#else
+  const auto deadline = std::chrono::steady_clock::now() +
+                        std::chrono::milliseconds(timeout_ms);
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (!PidIsRunning(pid)) {
+      return true;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  return !PidIsRunning(pid);
+#endif
+}
+
+/**
+ * Deliver the StopRuntimeTask to the local runtime and wait for the process
+ * to die (pid-based). Assumes the client is initialized.
+ * @param opts parsed stop options (force + grace period)
+ * @param pid the runtime's pid (from DiscoverRuntimePid; <= 0 if unknown)
+ * @return 0 if the runtime stopped; 1 if it must be escalated
+ */
+int SendStopTask(const StopOptions& opts, int pid) {
+  clio::run::admin::Client admin_client(clio::run::kAdminPoolId);
+
+  auto* ipc_manager = CLIO_IPC;
+  if (!ipc_manager || !ipc_manager->IsInitialized()) {
+    HLOG(kError, "IPC manager not available - is Clio runtime running?");
+    return 1;
+  }
+
+  clio::run::u32 shutdown_flags = 0;
+  if (opts.force) {
+    shutdown_flags |= clio::run::admin::StopRuntimeTask::kForceShutdown;
+  }
+
+  HLOG(kDebug, "Sending stop runtime task (grace period: {}ms, force: {})...",
+       opts.grace_period_ms, opts.force);
+  const auto start_time = std::chrono::steady_clock::now();
+
+  clio::run::Future<clio::run::admin::StopRuntimeTask> stop_task;
+  try {
+    stop_task = admin_client.AsyncStopRuntime(
+        clio::run::PoolQuery::Local(), shutdown_flags, opts.grace_period_ms);
+    if (stop_task.IsNull()) {
+      HLOG(kError, "Failed to create stop runtime task");
+      return 1;
+    }
+  } catch (const std::exception& e) {
+    HLOG(kError, "Error creating stop runtime task: {}", e.what());
+    return 1;
+  }
+
+  // Harvest the ack for logging only. A missing response is NOT an error: a
+  // forced runtime _exit()s ~500 ms after handling the task and may vanish
+  // before the reply flushes. The authoritative check is the liveness poll
+  // below.
+  if (stop_task.Wait(2.0f)) {
+    HLOG(kDebug, "Stop task acknowledged (return code: {})",
+         stop_task->GetReturnCode());
+  } else {
+    HLOG(kDebug, "No stop-task ack (runtime may have exited first)");
+  }
+
+  // Wait for the runtime process to actually die. The graceful budget must
+  // exceed the runtime-side watchdog deadline (grace + 15 s margin), so even
+  // a wedged teardown resolves within this window via the watchdog's
+  // _exit(2). Force mode only needs the ~500 ms ack-flush delay plus slack.
+  const clio::run::u64 wait_ms =
+      opts.force ? 10000
+                 : static_cast<clio::run::u64>(opts.grace_period_ms) + 25000;
+  if (pid > 0) {
+    if (!WaitForRuntimeExit(pid, wait_ms)) {
+      HLOG(kError, "Runtime (pid {}) did not stop within {} ms", pid, wait_ms);
+      return 1;
+    }
+  } else {
+    // Pid discovery failed (no main-segment symlink): fall back to the
+    // legacy probe-based wait, then let the caller escalate if needed.
+    if (!ipc_manager->WaitForLocalRuntimeStop(
+            static_cast<clio::run::u32>(wait_ms / 1000))) {
+      HLOG(kError, "Runtime did not stop within {} ms", wait_ms);
+      return 1;
+    }
+  }
+
+  const auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::steady_clock::now() - start_time).count();
+  HLOG(kDebug, "Runtime stopped in {}ms", duration);
+  return 0;
+}
+
+}  // namespace
 
 int RuntimeStop(int argc, char* argv[]) {
   HLOG(kDebug, "Stopping Clio runtime...");
+  const StopOptions opts = ParseStopArgs(argc, argv);
+
+  // Self-cleanup on EVERY exit path: even a failed ClientInit creates this
+  // process's per-thread MPSC segment (clio-<pid>-<tid>) in the memfd dir,
+  // and a stop tool must not leave litter of its own. Idempotent with the
+  // ClientFinalize below.
+  struct OwnEntriesGuard {
+    ~OwnEntriesGuard() {
+      auto* ipc = CLIO_IPC;
+      if (ipc) {
+        ipc->UnlinkOwnPidEntries();
+      }
+    }
+  } own_entries_guard;
+
+  // Bound the client-connect wait so stop escalates quickly against a dead
+  // or wedged runtime instead of burning the default 30 s. An explicit user
+  // CLIO_WAIT_SERVER wins.
+  if (!clio::run::env::GetCompat("WAIT_SERVER")) {
+#ifdef _WIN32
+    _putenv_s("CLIO_WAIT_SERVER", "5");
+#else
+    setenv("CLIO_WAIT_SERVER", "5", 1);
+#endif
+  }
 
   try {
     HLOG(kDebug, "Initializing Clio client...");
     if (!clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, false)) {
-      HLOG(kError, "Failed to initialize Clio client components");
-      return 1;
+      HLOG(kWarning,
+           "No responsive runtime to deliver the stop task to - escalating");
+      return EscalateLocalKill(ResolveRuntimePort());
     }
 
     // RAII guard: call ClientFinalize() on every return path so the background
@@ -31,81 +367,24 @@ int RuntimeStop(int argc, char* argv[]) {
       }
     } finalize_guard;
 
-    HLOG(kDebug, "Creating admin client connection...");
-    clio::run::admin::Client admin_client(clio::run::kAdminPoolId);
-
-    auto* ipc_manager = CLIO_IPC;
-    if (!ipc_manager || !ipc_manager->IsInitialized()) {
-      HLOG(kError, "IPC manager not available - is Clio runtime running?");
-      return 1;
+    const clio::run::u32 port = ResolveRuntimePort();
+    const int pid = DiscoverRuntimePid(port);
+    if (SendStopTask(opts, pid) == 0) {
+#ifndef _WIN32
+      // Idempotent residue sweep: a graceful exit unlinks everything itself,
+      // but a watchdog-forced exit can race its own unlink pass. Cheap no-op
+      // in the common case.
+      SweepDeadRuntimeArtifacts(pid, port);
+#endif
+      return 0;
     }
 
-    // Note: TaskQueue is only accessible in SHM mode. In TCP mode (used for
-    // distributed/Docker deployments), the task queue is not mapped into the
-    // client process. Skip the task queue validation in that case and rely on
-    // the ZMQ transport to deliver the stop task to the runtime.
-    auto* task_queue = ipc_manager->GetTaskQueue();
-    if (task_queue) {
-      try {
-        clio::run::u32 num_lanes = task_queue->GetNumLanes();
-        if (num_lanes == 0) {
-          HLOG(kError, "TaskQueue has no lanes configured - runtime initialization incomplete");
-          return 1;
-        }
-        HLOG(kDebug, "TaskQueue validated with {} lanes", num_lanes);
-      } catch (const std::exception& e) {
-        HLOG(kError, "TaskQueue validation failed: {}", e.what());
-        return 1;
-      }
-    } else {
-      HLOG(kDebug, "TaskQueue not in shared memory (TCP mode) - sending stop via ZMQ transport");
-    }
-
-    clio::run::PoolQuery pool_query;
-    clio::run::u32 shutdown_flags = 0;
-    clio::run::u32 grace_period_ms = 5000;
-
-    // Parse --grace-period flag
-    for (int i = 0; i < argc; ++i) {
-      if (std::strcmp(argv[i], "--grace-period") == 0 && i + 1 < argc) {
-        grace_period_ms = static_cast<clio::run::u32>(std::atoi(argv[++i]));
-        if (grace_period_ms == 0) grace_period_ms = 5000;
-      }
-    }
-
-    HLOG(kDebug, "Sending stop runtime task to admin pool (grace period: {}ms)...", grace_period_ms);
-
-    auto start_time = std::chrono::steady_clock::now();
-
-    clio::run::Future<clio::run::admin::StopRuntimeTask> stop_task;
-    try {
-      stop_task = admin_client.AsyncStopRuntime(pool_query, shutdown_flags, grace_period_ms);
-      if (stop_task.IsNull()) {
-        HLOG(kError, "Failed to create stop runtime task - runtime may not be running");
-        return 1;
-      }
-    } catch (const std::exception& e) {
-      HLOG(kError, "Error creating stop runtime task: {}", e.what());
-      return 1;
-    }
-
-    HLOG(kDebug, "Stop runtime task submitted, waiting for runtime to exit...");
-
-    // Wait for the runtime to actually stop by polling with ClientConnect
-    if (!ipc_manager->WaitForLocalRuntimeStop(30)) {
-      HLOG(kError, "Runtime did not stop within 30 seconds");
-      return 1;
-    }
-
-    auto end_time = std::chrono::steady_clock::now();
-    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
-                        end_time - start_time).count();
-
-    HLOG(kDebug, "Runtime stopped in {}ms", duration);
-    return 0;
+    // The task path failed (undeliverable task or the runtime outlived the
+    // wait): guarantee convergence with a direct kill + artifact sweep.
+    return EscalateLocalKill(ResolveRuntimePort());
 
   } catch (const std::exception& e) {
-    HLOG(kError, "Error stopping runtime: {}", e.what());
-    return 1;
+    HLOG(kError, "Error stopping runtime: {} - escalating", e.what());
+    return EscalateLocalKill(ResolveRuntimePort());
   }
 }

--- a/context-runtime/util/clio_run_cmd_runtime_stop.cc
+++ b/context-runtime/util/clio_run_cmd_runtime_stop.cc
@@ -135,6 +135,18 @@ size_t SweepDeadRuntimeArtifacts(int pid, clio::run::u32 port) {
           matches = owner > 0 && owner != own_pid &&
                     !ctp::SystemInfo::IsProcessAlive(owner);
         }
+      } else if (pid > 0) {
+        // No symlink to read: on platforms without memfd (macOS/BSD) the
+        // entries are plain files, so fall back to the pid-keyed names the
+        // runtime gives its on-demand and per-thread segments — the same
+        // fallback IpcManager::UnlinkOwnPidEntries uses on its own entries.
+        for (const auto& prefix : {"clio_" + std::to_string(pid) + "_",
+                                   "clio-" + std::to_string(pid) + "-"}) {
+          if (name.rfind(prefix, 0) == 0) {
+            matches = true;
+            break;
+          }
+        }
       }
     }
     if (matches && ctp::SystemInfo::RemoveFile(full_path)) {

--- a/context-runtime/util/clio_run_commands.h
+++ b/context-runtime/util/clio_run_commands.h
@@ -9,6 +9,7 @@
 int RuntimeStart(int argc, char** argv);
 int RuntimeRestart(int argc, char** argv);
 int RuntimeStop(int argc, char** argv);
+int RuntimeStatus(int argc, char** argv);
 int Monitor(int argc, char** argv);
 int Compose(int argc, char** argv);
 int Config(int argc, char** argv);

--- a/context-runtime/util/clio_run_local_runtime.h
+++ b/context-runtime/util/clio_run_local_runtime.h
@@ -47,9 +47,18 @@
 #include <string>
 #include <vector>
 
+#ifdef __APPLE__
+// macOS has no /proc: process introspection goes through libproc
+// (proc_pidpath) and the KERN_PROC sysctl (process state / zombie check).
+#include <libproc.h>
+#include <sys/proc.h>
+#include <sys/sysctl.h>
+#endif
+
 #include "clio_ctp/introspect/system_info.h"
 #include "clio_ctp/util/config_parse.h"
 #include "clio_runtime/config_manager.h"
+#include "clio_runtime/runtime_pid_record.h"
 #include "clio_runtime/types.h"
 
 namespace clio::run::cli {
@@ -87,11 +96,13 @@ inline std::string MainSegmentPath(u32 port) {
 }
 
 /**
- * Discover the local runtime's pid from its main segment symlink, whose
- * target is /proc/<pid>/fd/<n> (the memfd the runtime created). POSIX-only;
+ * Discover the local runtime's pid: on Linux from its main segment symlink,
+ * whose target is /proc/<pid>/fd/<n> (the memfd the runtime created), and
+ * otherwise from the pid record the runtime writes alongside its segments
+ * (see clio_runtime/runtime_pid_record.h). POSIX-only;
  * returns -1 on Windows.
  * @param port the runtime port (segment names are port-keyed)
- * @return the owning pid (may be dead), or -1 if no segment entry exists
+ * @return the owning pid (may be dead), or -1 if the runtime left no trace
  */
 inline int DiscoverRuntimePid(u32 port) {
 #ifdef _WIN32
@@ -100,16 +111,17 @@ inline int DiscoverRuntimePid(u32 port) {
 #else
   std::error_code ec;
   auto target = std::filesystem::read_symlink(MainSegmentPath(port), ec);
-  if (ec) {
-    return -1;
+  if (!ec) {
+    const std::string t = target.string();
+    constexpr const char *kProc = "/proc/";
+    if (t.rfind(kProc, 0) == 0) {
+      int pid = std::atoi(t.c_str() + std::string(kProc).size());
+      if (pid > 0) {
+        return pid;
+      }
+    }
   }
-  const std::string t = target.string();
-  constexpr const char *kProc = "/proc/";
-  if (t.rfind(kProc, 0) != 0) {
-    return -1;
-  }
-  int pid = std::atoi(t.c_str() + std::string(kProc).size());
-  return pid > 0 ? pid : -1;
+  return ReadRuntimePidRecord(port);
 #endif
 }
 
@@ -118,12 +130,25 @@ inline int DiscoverRuntimePid(u32 port) {
  * kill(pid, 0) treats zombies as alive, but a zombie cannot run, service
  * tasks, or hold sockets — for stop purposes it is dead. The stop CLI is a
  * sibling of the runtime (the parent is Jarvis / a test harness / a shell),
- * so it can never reap the zombie itself. Linux-only; false elsewhere.
+ * so it can never reap the zombie itself.
+ *
+ * This matters most on the kill-escalation path: after SIGKILL the runtime
+ * lingers as a zombie until its parent (the harness / Jarvis) reaps it, and
+ * a stop that cannot see through that reports "survived SIGKILL".
  * @param pid candidate pid
- * @return true if /proc/<pid>/stat reports state 'Z'
+ * @return true if the process is a zombie
  */
 inline bool PidIsZombie(int pid) {
-#ifdef __linux__
+#if defined(__APPLE__)
+  // No /proc: ask the kernel for the process's state directly.
+  struct kinfo_proc info;
+  size_t len = sizeof(info);
+  int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PID, pid};
+  if (sysctl(mib, 4, &info, &len, nullptr, 0) != 0 || len == 0) {
+    return false;
+  }
+  return info.kp_proc.p_stat == SZOMB;
+#elif defined(__linux__)
   std::ifstream stat_file("/proc/" + std::to_string(pid) + "/stat");
   if (!stat_file.is_open()) {
     return false;
@@ -157,12 +182,21 @@ inline bool PidIsRunning(int pid) {
  * Check that a pid currently belongs to a clio_run process (guards kill
  * escalation against pid recycling). POSIX-only; false on Windows.
  * @param pid candidate runtime pid
- * @return true if /proc/<pid>/exe resolves to a clio_run binary
+ * @return true if the process's executable is a clio_run binary
  */
 inline bool PidIsClioRun(int pid) {
-#ifdef _WIN32
+#if defined(_WIN32)
   (void)pid;
   return false;
+#elif defined(__APPLE__)
+  // No /proc/<pid>/exe: libproc reports the executable path, and does so for
+  // same-user processes without any special entitlement.
+  char exe_path[PROC_PIDPATHINFO_MAXSIZE];
+  if (proc_pidpath(pid, exe_path, sizeof(exe_path)) <= 0) {
+    return false;
+  }
+  return std::filesystem::path(exe_path).filename().string().rfind(
+             "clio_run", 0) == 0;
 #else
   std::error_code ec;
   auto exe = std::filesystem::read_symlink(

--- a/context-runtime/util/clio_run_local_runtime.h
+++ b/context-runtime/util/clio_run_local_runtime.h
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CLIO_RUN_UTIL_CLIO_RUN_LOCAL_RUNTIME_H_
+#define CLIO_RUN_UTIL_CLIO_RUN_LOCAL_RUNTIME_H_
+
+/**
+ * Shared client-side helpers for the clio_run stop/status subcommands:
+ * discover the LOCAL runtime's port, pid and leftover filesystem artifacts
+ * without needing a responsive runtime. All lookups are pid/port-scoped so
+ * co-resident runtimes (fallback topology) are never misattributed.
+ */
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "clio_ctp/introspect/system_info.h"
+#include "clio_ctp/util/config_parse.h"
+#include "clio_runtime/config_manager.h"
+#include "clio_runtime/types.h"
+
+namespace clio::run::cli {
+
+/**
+ * Resolve the local runtime's port without requiring a live runtime:
+ * ConfigManager if available, else the CLIO_PORT environment variable,
+ * else the built-in default (9413).
+ * @return the runtime port to target
+ */
+inline u32 ResolveRuntimePort() {
+  auto *config = CLIO_CONFIG_MANAGER;
+  if (config) {
+    return config->GetPort();
+  }
+  if (const char *env = clio::run::env::GetCompat("PORT")) {
+    int port = std::atoi(env);
+    if (port > 0) return static_cast<u32>(port);
+  }
+  return 9413;
+}
+
+/**
+ * Path of the runtime's main shared-memory segment entry in the per-user
+ * memfd directory. Mirrors ConfigManager::GetSharedMemorySegmentName's
+ * default port-keyed recipe so it also works when no config is loaded.
+ * @param port the runtime port the segment name is keyed on
+ * @return absolute path of the main segment entry
+ */
+inline std::string MainSegmentPath(u32 port) {
+  const std::string name =
+      ctp::ConfigParse::ExpandPath("chi_main_segment_${USER}") + "_" +
+      std::to_string(port);
+  return ctp::SystemInfo::GetMemfdPath(name);
+}
+
+/**
+ * Discover the local runtime's pid from its main segment symlink, whose
+ * target is /proc/<pid>/fd/<n> (the memfd the runtime created). POSIX-only;
+ * returns -1 on Windows.
+ * @param port the runtime port (segment names are port-keyed)
+ * @return the owning pid (may be dead), or -1 if no segment entry exists
+ */
+inline int DiscoverRuntimePid(u32 port) {
+#ifdef _WIN32
+  (void)port;
+  return -1;
+#else
+  std::error_code ec;
+  auto target = std::filesystem::read_symlink(MainSegmentPath(port), ec);
+  if (ec) {
+    return -1;
+  }
+  const std::string t = target.string();
+  constexpr const char *kProc = "/proc/";
+  if (t.rfind(kProc, 0) != 0) {
+    return -1;
+  }
+  int pid = std::atoi(t.c_str() + std::string(kProc).size());
+  return pid > 0 ? pid : -1;
+#endif
+}
+
+/**
+ * Check whether a pid is a zombie (exited but not yet reaped by its parent).
+ * kill(pid, 0) treats zombies as alive, but a zombie cannot run, service
+ * tasks, or hold sockets — for stop purposes it is dead. The stop CLI is a
+ * sibling of the runtime (the parent is Jarvis / a test harness / a shell),
+ * so it can never reap the zombie itself. Linux-only; false elsewhere.
+ * @param pid candidate pid
+ * @return true if /proc/<pid>/stat reports state 'Z'
+ */
+inline bool PidIsZombie(int pid) {
+#ifdef __linux__
+  std::ifstream stat_file("/proc/" + std::to_string(pid) + "/stat");
+  if (!stat_file.is_open()) {
+    return false;
+  }
+  std::string stat_line;
+  std::getline(stat_file, stat_line);
+  // Field 3 (state) follows the parenthesized comm, which may contain spaces.
+  size_t close_paren = stat_line.rfind(')');
+  if (close_paren == std::string::npos ||
+      close_paren + 2 >= stat_line.size()) {
+    return false;
+  }
+  return stat_line[close_paren + 2] == 'Z';
+#else
+  (void)pid;
+  return false;
+#endif
+}
+
+/**
+ * Check whether a pid is alive AND runnable (not a zombie). This is the
+ * liveness test the stop flow uses: a zombie counts as stopped.
+ * @param pid candidate pid
+ * @return true if the process exists and is not a zombie
+ */
+inline bool PidIsRunning(int pid) {
+  return ctp::SystemInfo::IsProcessAlive(pid) && !PidIsZombie(pid);
+}
+
+/**
+ * Check that a pid currently belongs to a clio_run process (guards kill
+ * escalation against pid recycling). POSIX-only; false on Windows.
+ * @param pid candidate runtime pid
+ * @return true if /proc/<pid>/exe resolves to a clio_run binary
+ */
+inline bool PidIsClioRun(int pid) {
+#ifdef _WIN32
+  (void)pid;
+  return false;
+#else
+  std::error_code ec;
+  auto exe = std::filesystem::read_symlink(
+      "/proc/" + std::to_string(pid) + "/exe", ec);
+  if (ec) {
+    return false;
+  }
+  return exe.filename().string().rfind("clio_run", 0) == 0;
+#endif
+}
+
+/**
+ * List this port's leftover runtime artifacts: port-keyed chi_* segment
+ * entries and control-socket files in the per-user memfd dir, memfd-dir
+ * entries whose /proc symlink owner is dead, and legacy /dev/shm/chi_*
+ * files (older builds used shm_open naming; still seen on HPC deployments).
+ * @param port the runtime port to scope the scan to
+ * @return absolute paths of stale artifacts found
+ */
+inline std::vector<std::string> ListStaleArtifacts(u32 port) {
+  std::vector<std::string> stale;
+  const std::string memfd_dir = ctp::SystemInfo::GetMemfdDir();
+  const std::string port_suffix = "_" + std::to_string(port);
+  const std::string ipc_name = "clio_" + std::to_string(port) + ".ipc";
+  const std::string zmq_ipc_name =
+      "clio_zmq_" + std::to_string(port + 3) + ".ipc";
+
+  for (const auto &name : ctp::SystemInfo::ListDirectory(memfd_dir)) {
+    const std::string full_path = memfd_dir + "/" + name;
+    bool matches = (name == ipc_name) || (name == zmq_ipc_name);
+    // Port-keyed segment names: chi_<segment>_<user>_<port>
+    if (!matches && name.rfind("chi_", 0) == 0 &&
+        name.size() >= port_suffix.size() &&
+        name.compare(name.size() - port_suffix.size(), port_suffix.size(),
+                     port_suffix) == 0) {
+      matches = true;
+    }
+    if (!matches) {
+      // Entries owned by a dead process (on-demand segments etc.)
+      std::error_code ec;
+      auto target = std::filesystem::read_symlink(full_path, ec);
+      if (!ec) {
+        const std::string t = target.string();
+        constexpr const char *kProc = "/proc/";
+        if (t.rfind(kProc, 0) == 0) {
+          int owner = std::atoi(t.c_str() + std::string(kProc).size());
+          matches = owner > 0 && !ctp::SystemInfo::IsProcessAlive(owner);
+        }
+      }
+    }
+    if (matches) {
+      stale.push_back(full_path);
+    }
+  }
+
+#ifndef _WIN32
+  // Legacy shm_open naming from older builds.
+  std::error_code ec;
+  for (auto it = std::filesystem::directory_iterator("/dev/shm", ec);
+       !ec && it != std::filesystem::directory_iterator(); ++it) {
+    const std::string name = it->path().filename().string();
+    if (name.rfind("chi_", 0) == 0) {
+      stale.push_back(it->path().string());
+    }
+  }
+#endif
+  return stale;
+}
+
+}  // namespace clio::run::cli
+
+#endif  // CLIO_RUN_UTIL_CLIO_RUN_LOCAL_RUNTIME_H_

--- a/jarvis_clio_core/jarvis_clio_core/clio_runtime/pkg.py
+++ b/jarvis_clio_core/jarvis_clio_core/clio_runtime/pkg.py
@@ -6,7 +6,7 @@ and container deployment modes via deploy_mode configuration.
 """
 from jarvis_cd.core.pkg import Service
 from jarvis_cd.shell import Exec, PsshExecInfo
-from jarvis_cd.shell.process import Kill, GdbServer
+from jarvis_cd.shell.process import GdbServer
 from jarvis_cd.util.container_utils import container_kwargs
 from jarvis_cd.util import SizeType
 from jarvis_cd.util.logger import Color
@@ -324,7 +324,7 @@ class ClioRuntime(Service):
         # host-side (unwrapped) on purpose — apptainer shares the host /dev/shm
         # and PID space, and the stale process we're hunting has, by definition,
         # ESCAPED the prior combo's instance:// PID namespace, so the wrapped
-        # `Kill('chimaera')` in the previous stop() could not reach it.
+        # `clio_run runtime stop` in the previous stop() could not reach it.
         #
         # Why this matters (observed on single_node job 21563, combo 18): the
         # sweep is sequential in ONE allocation, so combo N+1's runtime start
@@ -400,59 +400,48 @@ class ClioRuntime(Service):
 
         self.log("Stopping IOWarp runtime")
 
-        # BOUND the graceful stop, and run it INSIDE the instance
-        # (container_kwargs) — symmetric with start(). The earlier
-        # intermittent "shm_attach shm_open failed" during stop was the
-        # host-side stop client trying to attach shm owned by the
-        # in-instance runtime; wrapping puts the stop client in the same
-        # namespace. `timeout` still caps a wedged stop; Kill below is what
-        # actually frees the runtime. `-k 10` SIGKILLs if clio_run ignores
-        # the SIGTERM. Harmless on bare-metal (engine 'none' -> no wrap).
-        Exec('timeout -k 10 45 clio_run runtime stop',
+        # `clio_run runtime stop` is now a convergent graceful shutdown: it
+        # runs the full ServerFinalize teardown, blocks until the daemon is
+        # gone (escalating SIGTERM->SIGKILL itself if the runtime is
+        # unresponsive), and unlinks this runtime's shm/socket artifacts.
+        # Wrap it in container_kwargs so the stop client runs INSIDE the same
+        # apptainer instance as the runtime (symmetric with start()) — the
+        # earlier intermittent "shm_attach shm_open failed" was a host-side
+        # client trying to attach shm owned by an in-instance runtime, which
+        # this now avoids by construction. The old external Kill() + timeout +
+        # /dev/tcp port-poll scaffolding is no longer needed — the CLI
+        # converges (and escalates) entirely on its own.
+        Exec('clio_run runtime stop',
              PsshExecInfo(env=self.env, hostfile=self.hostfile,
                           **container_kwargs(self))).run()
-        # Backstop force-kill under BOTH daemon names: 'chimaera' (pre-rebrand
-        # CLIO, e.g. an older prebuilt image) and 'clio_run' (post Chimaera->Clio
-        # rebrand). Kill of a name with no matches is benign, so the union is
-        # safe whichever CLIO vintage is deployed.
-        Kill('chimaera',
-             PsshExecInfo(env=self.env, hostfile=self.hostfile,
-                          **container_kwargs(self))).run()
-        Kill('clio_run',
-             PsshExecInfo(env=self.env, hostfile=self.hostfile,
-                          **container_kwargs(self))).run()
-
-        port = self.config['port']
-        host = self.hostfile.hosts[0] if self.hostfile.hosts else '127.0.0.1'
-        for i in range(10):
-            try:
-                ret = subprocess.run(
-                    ['bash', '-c', f'echo > /dev/tcp/{host}/{port}'],
-                    capture_output=True, timeout=2)
-                if ret.returncode != 0:
-                    break
-            except subprocess.TimeoutExpired:
-                break
-            time.sleep(1)
-        time.sleep(1)
 
         self.log("IOWarp runtime stopped")
 
     def kill(self):
         self.log("Forcibly killing IOWarp runtime")
-        # Both daemon names — pre-rebrand ('chimaera') and post ('clio_run');
-        # see stop() for rationale.
-        Kill('chimaera', PsshExecInfo(
-            hostfile=self.hostfile,
-            **container_kwargs(self)
-        )).run()
-        Kill('clio_run', PsshExecInfo(
-            hostfile=self.hostfile,
-            **container_kwargs(self)
-        )).run()
+        # `--force` is an immediate ungraceful shutdown: the runtime unlinks
+        # its own shm/socket artifacts and _exit()s, with the client
+        # escalating SIGTERM->SIGKILL if it doesn't die promptly. It is
+        # pid/port-scoped, so unlike a blanket Kill('chimaera')/Kill('clio_run')
+        # it won't disturb a co-resident runtime on the same host. Wrapped in
+        # container_kwargs for the same in-instance reason as stop().
+        Exec('clio_run runtime stop --force',
+             PsshExecInfo(env=self.env, hostfile=self.hostfile,
+                          **container_kwargs(self))).run()
 
     def clean(self):
         self.log("Cleaning IOWarp runtime data")
+
+        # Force-stop any runtime still bound to this port and let it sweep its
+        # own shm/socket artifacts. Idempotent (a no-op if the runtime already
+        # died) and pid/port-scoped, so it reclaims the memfd-backed artifacts
+        # the blanket rm below cannot see, without touching a co-resident
+        # runtime's segments. Wrapped so it can still reach a live in-instance
+        # runtime.
+        if self.config.get('do_start', True):
+            Exec('clio_run runtime stop --force',
+                 PsshExecInfo(env=self.env, hostfile=self.hostfile,
+                              **container_kwargs(self))).run()
 
         if self.config_file and os.path.exists(self.config_file):
             os.remove(self.config_file)
@@ -461,6 +450,9 @@ class ClioRuntime(Service):
         if os.path.exists(log_file):
             os.remove(log_file)
 
+        # BACKSTOP to the scoped force-stop above, which cannot help in one
+        # real case: the pipeline may tear the apptainer instance down before
+        # clean() runs, leaving the wrapped Exec above with nothing to reach.
         # HOST-SIDE (deliberately NOT wrapped): clean() runs *after* stop() has
         # already torn the apptainer instance down, so a wrapped `apptainer exec
         # instance://…` here would target a dead instance and silently no-op —


### PR DESCRIPTION
Closes #710. Two commits: the convergent shutdown + `--force` + `status` runtime work, and a
distributed docker CI that proves `clio_run stop` kills the *whole* runtime across a multi-node
cluster — see [Distributed docker CI](#distributed-docker-ci).

## Problem

`clio_run stop` tore down the runtime by calling `std::abort()`. Shutdown was a crash, not a
state transition, so the runtime had no teardown path to run and no caller could tell whether
it had actually stopped or was still holding its IPC/shared-memory artifacts.

Under sustained churn — the #526 Ares perf-eval sweep starts and stops the runtime dozens of
times per node — this surfaced as a runtime wedging mid-teardown and surviving into the next
benchmark combination. The fresh runtime then came up alongside the survivor with an
inconsistent pool registry, routed a client task to the null pool
(`Container not found for pool_id=PoolId(0,0)`), and hung: job 21563, combo 18, ~8h to the
wall clock.

Jarvis had grown a `pkill -9` / `rm -f /dev/shm/chi_*` self-heal to compensate. It made the
symptom disappear without fixing the shutdown path, and by wiping state before every run it
destroyed the evidence needed to tell a real leak from a flake.

## Add a `--force` flag to `clio_run stop` and use that in jarvis

**Runtime side.** `StopRuntime` in `admin_runtime.cc` decodes a `kForceShutdown` flag and
dispatches to `RuntimeManager::RequestStop(mode, grace_period_ms)`:

- **graceful** — sets a flag the runtime main loop polls, so the proven normal-exit path
  (`atexit` → `ServerFinalize`) runs the real teardown on the main thread. A detached watchdog
  force-exits with code 2 if teardown wedges past the grace period plus a margin.
- **`--force`** — a detached thread waits briefly for the task ack to flush, unlinks this
  runtime's artifacts, and `_exit(0)`s without running `atexit` handlers.

`RequestStop` never tears down inline: the handler runs on a worker thread that `ServerFinalize`
would itself join. Shutdown proceeds asynchronously after the ack reaches the client.

The task is issued with `PoolQuery::Local()`, per the issue — each node stops its own runtime,
which is what makes jarvis's `PsshExec` fan-out the right parallelization primitive.

**Client side.** `clio_run stop` waits for the process to actually disappear and escalates
SIGTERM → SIGKILL itself if it does not.

**Jarvis side.** `jarvis_clio_core/clio_runtime/pkg.py` now relies on that contract:

- `stop()` drops the `timeout -k 10 45` bound, the `Kill('chimaera')`/`Kill('clio_run')`
  backstop, and the `/dev/tcp` port-poll loop — the CLI converges and escalates on its own.
- `kill()` and `clean()` use `clio_run runtime stop --force` in place of the blanket `Kill()`.
  This is the substantive win: the old kill matched *by process name*, so on a shared node it
  could take down a co-resident runtime; `--force` is pid/port-scoped and reclaims the
  memfd-backed artifacts a `rm /dev/shm/chi_*` never sees.

## New: `clio_run status`

The issue's acceptance condition — *"we should NEVER have a stale runtime artifact after this
command"* — was not checkable, because nothing could enumerate the artifacts. `clio_run status`
does:

- exit **0** = `RUNNING`, **1** = `STOPPED (clean)`, **2** = `STOPPED (stale)`, with one
  `stale: <path>` line per artifact.
- Scans both pid-scoped (dead-pid memfd symlinks) and port-scoped classes
  (`chi_*_<port>`, `clio_<port>.ipc`, `clio_zmq_<port+3>.ipc`).
- One caveat worth knowing when consuming it: a *live but wedged* pid prints `UNRESPONSIVE`
  and still returns 1, because a live owner's segments are not stale by definition. Callers
  asserting "nothing left behind" must scan for that substring, not just the exit code.

This is the primitive the [distributed docker CI](#distributed-docker-ci) gate asserts on.

## Key files

| File | Purpose |
|---|---|
| `src/manager.cc`, `include/clio_runtime/manager.h` | `RequestStop` + `StopMode`, main-loop stop flag, teardown watchdog |
| `src/ipc_manager.cc`, `include/clio_runtime/ipc_manager.h` | teardown plumbing, `WaitForLocalRuntimeStop` |
| `modules/admin/src/admin_runtime.cc`, `admin_tasks.h` | `StopRuntime` decodes `kForceShutdown`, dispatches via local pool query |
| `util/clio_run_cmd_runtime_stop.cc` | `--force`/`--grace-period` parsing, ack wait, SIGTERM→SIGKILL escalation |
| `util/clio_run_cmd_runtime_status.cc` *(new)* | `clio_run status` and its 0/1/2 contract |
| `util/clio_run_local_runtime.h` *(new)* | `ListStaleArtifacts(port)` — the shared pid/port-scoped scan |
| `test/unit/test_shutdown_battletest.cc` *(new)* | 7 shutdown scenarios under churn |
| `jarvis_clio_core/clio_runtime/pkg.py` | adopts `stop` / `stop --force`; drops kill+poll scaffolding |
| `.github/workflows/ci-docker-distributed.yml` *(new)* | GHA job: build `clio_run`, run the 2-node stop gate |
| `context-runtime/test/integration/chimaera_stop/` *(new)* | the fixture — compose, entrypoint, hostfile, driver |

## Usage

```bash
clio_run runtime stop                      # convergent graceful teardown
clio_run runtime stop --force              # immediate ungraceful _exit(0)
clio_run runtime stop --grace-period 5000  # drain budget, ms
clio_run runtime status                    # 0 = RUNNING, 1 = STOPPED (clean), 2 = STOPPED (stale)
```

## Testing and results

**Local.** `clio_run_shutdown_battletest` — 7 scenarios (clean stop, `--force`, stop while
under load, repeated stop, stop of an already-dead runtime, unresponsive-runtime escalation,
artifact reclamation) over 24 churn cycles, run twice via `ctest`. Clean both times.

**Ares, #526 perf-eval sweep.** To check the "never a stale artifact" condition end to end,
the jarvis package was temporarily instrumented — the self-heal replaced by a strict
`clio_run status` assertion at every `start()`/`stop()`, so any residue failed the sweep
instead of being wiped. The `single_node.yaml` sweep (24 combinations: I/O size × thread count
over NFS+ior, CTE+libfuse+ior, redis-benchmark, JuiceFS+ior) was then run **3× back-to-back on
the same node with no manual cleanup between runs**:

| Run | Job | Combinations | Stale state on arrival |
|---|---|---|---|
| 1 | 23497 | 24/24 | — (baseline) |
| 2 | 23498 | 24/24 | none |
| 3 | 23499 | 24/24 | none |

The load-bearing column is the last one: runs 2 and 3 *arrived* on the node with zero
`chimaera`/`clio_run` processes, zero `/dev/shm/chi_*`, and zero memfd artifacts — the
condition that previously required the self-heal to hide. 72/72 combinations green.

That instrumentation was validation-only and is **not** part of this PR; the sweep is
single-node, so the distributed case is covered separately by the CI below.

## Distributed docker CI

The issue's second half — proving `clio_run stop` kills the *whole* runtime across a cluster,
in CI rather than by hand on Ares — ships here as `.github/workflows/ci-docker-distributed.yml`
plus a self-contained fixture under `context-runtime/test/integration/chimaera_stop/`. It runs
on push to `main`/`dev` and on `workflow_dispatch`.

It follows the repo's docker-integration convention (a committed fixture directory the workflow
calls; the YAML stays thin) and mirrors the sole jarvis-in-docker precedent, `jarvis_deploy`:

- **Build once, in `iowarp/deps-cpu`.** The workflow compiles only the `clio_run` target inside
  the deps image, so the binary is ABI-compatible with the node containers that load it from the
  mounted build dir.
- **2-node cluster, wired with SSH.** `docker-compose.yaml` stands up `chimaera-stop-node1/2`
  (subnet 172.30.0.0/24, distinct from the other fixtures). One `entrypoint.sh` serves both,
  branching on `NODE_ID`: node2 is an sshd-only secondary; node1 brings up SSH + Jarvis and runs
  the gate. Jarvis drives node2 remotely over its `PsshExec` fan-out — the same parallelization
  primitive the runtime's `PoolQuery::Local()` stop is built around.
- **The gate.** node1 builds a `clio_runtime`-only pipeline, then in two phases starts the
  runtime on *both* nodes and stops it — **Phase 1** via `jarvis ppl stop` → `clio_run runtime
  stop` (graceful), **Phase 2** via `jarvis ppl kill` → `clio_run runtime stop --force`. After
  each stop it asserts over SSH that *every* node's `clio_run runtime status` reports a clean
  shutdown: exit 1, no `stale:` paths, and — checked independently of the exit code — no
  `UNRESPONSIVE`. Assertions run **before** `jarvis ppl clean`, so the clean step's artifact
  sweep cannot erase the evidence the gate needs. node1's exit code *is* the test result.

A green run means what the issue asked for: after `stop`, no node holds a stale runtime artifact.
This is the GHA-native counterpart to the Ares `distributed.yaml` sweep, which cannot run in CI
(it needs SLURM + apptainer on a real cluster).

**First-run note for reviewers.** This is the first CI exercise of jarvis-in-docker
(`cte_jarvis_deploy_integration_docker` is deliberately excluded from `cluster-tests.yml`, and
`external/jarvis-cd` is not vendored in-repo), so Jarvis resolves to the venv baked into
`deps-cpu`. If that copy is too old to accept `PsshExecInfo(env=…)`/`container_kwargs`, the first
run will surface it in node1's log as an import/kwarg error — an infra signal, distinct from a
real `GATE FAIL: stale runtime …`. Fallbacks if so: vendor/pin jarvis-cd, or degrade the gate to
a plain parallel-ssh fan-out.