### PR TITLE
fix(hdf5): make the VOL's coherence stamp portable off glibc (macOS + Windows build failure)

### DIFF
--- a/context-transfer-engine/adapter/hdf5_vol/clio_vol.cc
+++ b/context-transfer-engine/adapter/hdf5_vol/clio_vol.cc
@@ -30,7 +30,7 @@
 #endif
 
 #include <sys/stat.h>       /* stat() -- coherence stamp */
-#include <time.h>           /* clock_gettime() -- stamp granularity check */
+#include <time.h>           /* time_t, for struct stat's mtime members */
 
 #include <cstdint>
 #include <cstdlib>
@@ -802,6 +802,47 @@ static void clio_resolve_config(hid_t fapl_id, size_t *chunk_size,
    which HDF5 always renders with a leading '/'. */
 static constexpr const char *kStampBlobName = "__clio_coherence_stamp";
 
+/* The file's modification time, split into whole seconds and nanoseconds.
+ *
+ * `struct stat` does not agree across the platforms this connector builds on:
+ * POSIX-2008 (and glibc) names the timespec member st_mtim, Darwin predates
+ * that name and calls the same member st_mtimespec, and MSVC's struct stat has
+ * no sub-second member at all -- only st_mtime, in whole seconds. Reading
+ * st_mtim unconditionally is what stopped this file compiling anywhere but
+ * glibc; every use goes through here instead.
+ *
+ * Callers keep the two halves separate rather than taking a single nanosecond
+ * count, because the stamp string embeds them as "<sec>.<nsec>" and that text
+ * is compared against stamps already stored in a tier. */
+static void clio_stat_mtime(const struct stat &st, long long *sec,
+                            long long *nsec) {
+#if defined(_WIN32)
+  /* No sub-second field exists; see clio_stamp_granularity_ns, which widens the
+     ambiguity window to match this coarser clock. */
+  *sec = static_cast<long long>(st.st_mtime);
+  *nsec = 0;
+#elif defined(__APPLE__)
+  *sec = static_cast<long long>(st.st_mtimespec.tv_sec);
+  *nsec = static_cast<long long>(st.st_mtimespec.tv_nsec);
+#else
+  *sec = static_cast<long long>(st.st_mtim.tv_sec);
+  *nsec = static_cast<long long>(st.st_mtim.tv_nsec);
+#endif
+}
+
+/* Wall-clock now, in nanoseconds since the epoch.
+ *
+ * std::chrono::system_clock rather than clock_gettime(CLOCK_REALTIME): MSVC has
+ * neither the function nor the macro, and system_clock is the same wall clock
+ * on every implementation this builds against. It is also unfailing, which
+ * removes the "cannot read the clock" arm the caller used to need. */
+static long long clio_realtime_now_ns() {
+  return static_cast<long long>(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(
+          std::chrono::system_clock::now().time_since_epoch())
+          .count());
+}
+
 /* Identity + state of the native file, as a string. dev/ino catch the file
    being replaced (a new inode at the same path -- h5repack, rsync, mv); size
    and mtime catch it being modified in place.
@@ -815,12 +856,14 @@ static constexpr const char *kStampBlobName = "__clio_coherence_stamp";
 static std::string clio_file_stamp(const char *path) {
   struct stat st;
   if (!path || stat(path, &st) != 0) return std::string();
+  long long mtime_sec = 0, mtime_nsec = 0;
+  clio_stat_mtime(st, &mtime_sec, &mtime_nsec);
   return std::string("2:") +
          std::to_string(static_cast<unsigned long long>(st.st_dev)) + ":" +
          std::to_string(static_cast<unsigned long long>(st.st_ino)) + ":" +
          std::to_string(static_cast<unsigned long long>(st.st_size)) + ":" +
-         std::to_string(static_cast<long long>(st.st_mtim.tv_sec)) + "." +
-         std::to_string(static_cast<long long>(st.st_mtim.tv_nsec));
+         std::to_string(mtime_sec) + "." +
+         std::to_string(mtime_nsec);
 }
 
 /* Does the stored stamp still describe this file? Anything but kMatched means
@@ -879,7 +922,16 @@ static uint64_t clio_stamp_granularity_ns() {
         if (end != e && *end == '\0') return static_cast<uint64_t>(v);
       }
     }
+#if defined(_WIN32)
+    /* Windows' stat() reports mtime in whole seconds (and only to two on a
+       FAT-formatted volume), so a 10 ms granule would call a file unambiguous
+       whose very next write lands in the same reported second -- exactly the
+       case this check exists to refuse. One second is the smallest default that
+       still fails closed there. */
+    return 1000ull * 1000ull * 1000ull;  /* 1 s */
+#else
     return 10ull * 1000ull * 1000ull;  /* 10 ms */
+#endif
   }();
   return g;
 }
@@ -901,12 +953,11 @@ static uint64_t clio_stamp_granularity_ns() {
 static bool clio_stamp_ambiguous(const char *path) {
   struct stat st;
   if (!path || stat(path, &st) != 0) return true;
-  struct timespec now;
-  if (clock_gettime(CLOCK_REALTIME, &now) != 0) return true;
-  const int64_t now_ns = static_cast<int64_t>(now.tv_sec) * 1000000000LL +
-                         static_cast<int64_t>(now.tv_nsec);
-  const int64_t mtime_ns = static_cast<int64_t>(st.st_mtim.tv_sec) * 1000000000LL +
-                           static_cast<int64_t>(st.st_mtim.tv_nsec);
+  long long mtime_sec = 0, mtime_nsec = 0;
+  clio_stat_mtime(st, &mtime_sec, &mtime_nsec);
+  const int64_t now_ns = static_cast<int64_t>(clio_realtime_now_ns());
+  const int64_t mtime_ns = static_cast<int64_t>(mtime_sec) * 1000000000LL +
+                           static_cast<int64_t>(mtime_nsec);
   /* A negative age means the mtime is in the future (clock skew, or a network
      filesystem stamping from a different host). Nothing can be concluded from
      it, so it is ambiguous too. */


### PR DESCRIPTION
## What is broken

`clio_hdf5_vol` has not compiled on macOS or Windows since `6873b60a` added the
coherence stamp. The stamp reads `st.st_mtim` and calls
`clock_gettime(CLOCK_REALTIME, ...)`, and neither exists on both other
platforms:

```
macOS (clang, macos-26):
  clio_vol.cc:822:51: error: no member named 'st_mtim' in 'stat'
  clio_vol.cc:823:51: error: no member named 'st_mtim' in 'stat'
  clio_vol.cc:908:52: error: no member named 'st_mtim' in 'stat'
  clio_vol.cc:909:52: error: no member named 'st_mtim' in 'stat'

Windows (MSVC 19.4x, windows-2025):
  clio_vol.cc(822,51): error C2039: 'st_mtim': is not a member of 'stat'
  clio_vol.cc(823,51): error C2039: 'st_mtim': is not a member of 'stat'
  clio_vol.cc(905,21): error C2065: 'CLOCK_REALTIME': undeclared identifier
  clio_vol.cc(905,7):  error C3861: 'clock_gettime': identifier not found
  clio_vol.cc(908,52): error C2039: 'st_mtim': is not a member of 'stat'
  clio_vol.cc(909,52): error C2039: 'st_mtim': is not a member of 'stat'
```

`struct stat` does not agree across the three platforms: POSIX-2008 and glibc
name the `struct timespec` member `st_mtim`, Darwin predates that name and calls
the same member `st_mtimespec`, and MSVC's `struct stat` has no sub-second
member at all — only `st_mtime`, in whole seconds.

## What this changes

- **`clio_stat_mtime(st, &sec, &nsec)`** — one place that knows the three
  spellings; every stamp read goes through it. It hands back the two halves
  separately rather than a single nanosecond count, so the stamp text stays
  exactly `<sec>.<nsec>` and stamps already stored in a tier still compare equal
  on Linux. No cache-layout version bump is needed.
- **`clio_realtime_now_ns()`** using `std::chrono::system_clock` instead of
  `clock_gettime(CLOCK_REALTIME, ...)`. `<chrono>` was already included; the
  clock is the same wall clock on every implementation this builds against, and
  it cannot fail, which retires the "cannot read the clock" arm of
  `clio_stamp_ambiguous`.
- **One behavioural change, Windows only**: the default stamp granularity
  becomes 1 s there. `stat()` on Windows reports mtime in whole seconds (two on
  a FAT-formatted volume), so keeping the 10 ms default would call a file
  unambiguous whose very next write lands in the same reported second — exactly
  the case `clio_stamp_ambiguous` exists to refuse. 1 s is the smallest default
  that still fails closed on that clock. `CLIO_VOL_STAMP_GRANULARITY_NS`
  overrides it as before.

Nothing else in `clio_vol.cc` is platform-specific: `stat()` itself is fine on
MSVC, and those two were the only POSIX-only uses in the file.

## Verification

- **Linux** (glibc 2.39, gcc 13, HDF5 `develop` 2.3.0): `libclio_hdf5_vol.so`
  builds, and `tst_chunks3` from netCDF-C `nc_perf` driven through
  `HDF5_VOL_CONNECTOR=clio` against a live `clio_run` produces all 18 timings,
  identical to before the change. The stamp text is byte-identical on this
  platform — the same `long long` values through the same `std::to_string`.
- **macOS / Windows**: I have no local access to either, so this repo's own
  adapter CI legs are the check for those two branches of the `#if`. The failures
  quoted above are from real runs on `macos-26` and `windows-2025` (hyoklee/hpf
  CI, 2026-08-13), so if this PR's macOS and Windows legs compile
  `clio_hdf5_vol`, the specific breakage is gone.

## How it was found

Measuring the CLIO adapters against netCDF-4 in
[hyoklee/hpf](https://github.com/hyoklee/hpf): the macOS and Windows dashboards
have had **no `clio_vol` series at all since 2026-08-10**, while Linux publishes
one nightly. The macOS VFD series works and is publishing, which is what made the
VOL's absence stand out.

Unrelated and still open, from the same measurements: #970 (the VOL cannot exit
when HDF5 still holds a file at exit) is a separate bug and is untouched here —
the Linux run above still ends in that hang, exactly as it did before.
