### PR TITLE
Build pip and conda packages against glibc 2.28 so RHEL8 works (#973)

### DIFF
--- a/.github/workflows/build-pip.yml
+++ b/.github/workflows/build-pip.yml
@@ -57,6 +57,17 @@ jobs:
 
   #------------------------------------------------------------
   # Build manylinux wheels via cibuildwheel
+  #
+  # Image choice (#973): manylinux_2_28 (AlmaLinux 8, glibc 2.28), NOT
+  # manylinux_2_34 (AlmaLinux 9, glibc 2.34).  A manylinux_2_34 wheel is
+  # uninstallable on the RHEL8 family -- Rocky/Alma/RHEL 8 ship glibc 2.28
+  # and are still the standard HPC login-node OS, so `pip install
+  # iowarp-core` failed there with "no wheels with a matching platform tag"
+  # and there is no sdist fallback.  manylinux_2_28 wheels install on
+  # glibc >= 2.28, i.e. RHEL8 *and* every newer distro the 2_34 wheels
+  # already covered, so this is a strict widening.  Do not bump this image
+  # without a matching bump in installers/pip/repair_wheel.sh (which stamps
+  # the platform tag) and a reason to drop RHEL8.
   #------------------------------------------------------------
   build-wheels:
     runs-on: ${{ matrix.runner }}
@@ -68,7 +79,7 @@ jobs:
           - runner: ubuntu-latest
             arch: x86_64
             cibw_build: "cp310-manylinux_x86_64 cp311-manylinux_x86_64 cp312-manylinux_x86_64 cp313-manylinux_x86_64"
-            cibw_image: manylinux_2_34
+            cibw_image: manylinux_2_28
             cibw_environment: >-
               CMAKE_PREFIX_PATH=/usr/local
               PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
@@ -77,7 +88,7 @@ jobs:
           - runner: ubuntu-24.04-arm
             arch: aarch64
             cibw_build: "cp310-manylinux_aarch64 cp311-manylinux_aarch64 cp312-manylinux_aarch64 cp313-manylinux_aarch64"
-            cibw_image: manylinux_2_34
+            cibw_image: manylinux_2_28
             cibw_environment: >-
               CMAKE_PREFIX_PATH=/usr/local
               PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
@@ -113,9 +124,20 @@ jobs:
         CIBW_ENVIRONMENT: ${{ matrix.cibw_environment }}
         CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
           bash {project}/installers/pip/repair_wheel.sh {dest_dir} {wheel}
+          ${{ matrix.cibw_image }}
         CIBW_TEST_COMMAND: >
           python -c "import iowarp_core; print('Version:', iowarp_core.get_version())"
       run: cibuildwheel --output-dir installers/pip/wheelhouse
+
+    # Guard for #973: repair_wheel.sh stamps the manylinux tag with
+    # `wheel tags`, which rewrites metadata without ever inspecting the
+    # binaries.  So a wheel can claim manylinux_2_28 while actually
+    # importing GLIBC_2.34 symbols -- pip installs it and the import then
+    # dies with a link error.  Verify the claim against what the ELF files
+    # really require.
+    - name: Verify wheel glibc requirements match the platform tag
+      run: |
+        python3 installers/pip/check_wheel_glibc.py installers/pip/wheelhouse/*.whl
 
     - name: Upload wheels
       uses: actions/upload-artifact@v4
@@ -300,6 +322,16 @@ jobs:
       matrix:
         include:
           # x86_64 tests
+          #
+          # rockylinux:8 is the regression test for #973: glibc 2.28, the
+          # oldest distro the manylinux_2_28 wheels claim to support, and the
+          # RHEL8-family login-node OS the 2_34 wheels locked out entirely.
+          # Keep it first -- if the image ever gets bumped past 2_28 this is
+          # the job that must fail.
+          - runner: ubuntu-latest
+            arch: x86_64
+            distro: rockylinux:8
+            pkg_manager: dnf
           - runner: ubuntu-latest
             arch: x86_64
             distro: ubuntu:22.04
@@ -317,6 +349,12 @@ jobs:
             distro: fedora:40
             pkg_manager: dnf
           # aarch64 tests
+          # The aarch64 wheel is a separately built and separately tagged
+          # artifact, so it needs its own glibc-2.28 regression test (#973).
+          - runner: ubuntu-24.04-arm
+            arch: aarch64
+            distro: rockylinux:8
+            pkg_manager: dnf
           - runner: ubuntu-24.04-arm
             arch: aarch64
             distro: ubuntu:22.04
@@ -351,7 +389,16 @@ jobs:
               apt-get update -qq
               apt-get install -y -qq python3 python3-pip python3-venv >/dev/null 2>&1
             elif command -v dnf &>/dev/null; then
-              dnf install -y -q python3 python3-pip >/dev/null 2>&1
+              # RHEL8 family (rockylinux:8, #973): the stock python3 is 3.6,
+              # older than the oldest wheel we build (cp310). Pull the 3.12
+              # AppStream module and put it ahead of the stock interpreter so
+              # the venv below matches a wheel we actually ship. Newer distros
+              # fall through to their default python3.
+              if dnf install -y -q python3.12 python3.12-pip >/dev/null 2>&1; then
+                ln -sf /usr/bin/python3.12 /usr/local/bin/python3
+              else
+                dnf install -y -q python3 python3-pip >/dev/null 2>&1
+              fi
             fi
 
             # Create clean venv

--- a/.github/workflows/install-conda.yml
+++ b/.github/workflows/install-conda.yml
@@ -107,6 +107,25 @@ jobs:
             --no-anaconda-upload \
             --output-folder build/conda-output
 
+      # Guard for #973. Nothing in `conda build` verifies that the binaries
+      # it produced can actually run on the glibc floor the recipe declares
+      # (c_stdlib_version), and the failure mode is silent: 2.2.0 shipped
+      # linking GLIBC_2.38 -- the runner host glibc -- so it installed fine
+      # on Rocky 8 and then died at import. Check the built package before
+      # it can be uploaded.
+      - name: Verify package glibc floor
+        shell: bash -l {0}
+        run: |
+          set -e
+          shopt -s nullglob
+          PKGS=(build/conda-output/linux-64/*.conda build/conda-output/linux-64/*.tar.bz2)
+          if [ ${#PKGS[@]} -eq 0 ]; then
+            echo "::error::conda build produced no linux-64 package to verify"
+            exit 1
+          fi
+          # Must match c_stdlib_version in installers/conda/conda_build_config.yaml
+          python3 installers/pip/check_wheel_glibc.py --max-glibc 2.28 "${PKGS[@]}"
+
       - name: Upload to Anaconda.org
         if: startsWith(github.ref, 'refs/tags/v')
         shell: bash -l {0}

--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ It provides:
 
 The pip wheel ships a **portable, self-contained build** with all
 dependencies statically linked. No system installs are required beyond
-glibc and Python 3.10+.
+glibc 2.28+ (`manylinux_2_28`: RHEL/Rocky/AlmaLinux 8 and newer, Ubuntu
+20.04+, Debian 11+) and Python 3.10+.
 
 ```bash
 pip install iowarp-core

--- a/installers/conda/conda_build_config.yaml
+++ b/installers/conda/conda_build_config.yaml
@@ -6,6 +6,20 @@
 python:
   - 3.12
 
+# glibc floor for the Linux package (#973).
+#
+# 2.28 == RHEL/Rocky/AlmaLinux 8, still the standard HPC login-node OS, and
+# the same floor the pip wheels use (manylinux_2_28, see
+# .github/workflows/build-pip.yml). Together with {{ stdlib("c") }} in
+# meta.yaml this makes conda-build compile against sysroot_linux-64 2.28
+# instead of whatever glibc the CI runner happens to ship, and records a
+# __glibc>=2.28 constraint so older hosts get a clean solver error rather
+# than a package that installs and then fails to load.
+c_stdlib:
+  - sysroot                 # [linux]
+c_stdlib_version:
+  - '2.28'                  # [linux]
+
 # Bump the macOS x86_64 deployment target. conda-forge's osx-64 default is
 # 10.9, but nanobind uses C++17 aligned new/delete which is only available on
 # macOS 10.13+, so the Intel-mac build fails to compile nanobind. osx-arm64

--- a/installers/conda/meta.yaml
+++ b/installers/conda/meta.yaml
@@ -26,6 +26,19 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
+    # {{ stdlib("c") }} pulls in sysroot_linux-64 (version pinned by
+    # c_stdlib_version in conda_build_config.yaml) and adds the matching
+    # __glibc>=x.y run-constraint to the package.
+    #
+    # Without it (#973) the conda-forge compiler activation packages no
+    # longer bring a sysroot of their own, so the build silently compiled
+    # against the CI runner host headers -- /usr on ubuntu-latest, glibc
+    # 2.39. The published 2.2.0 linux-64 package imports GLIBC_2.38
+    # symbols (__isoc23_strtol, ...) and GLIBC_2.34 pthread_create, so it
+    # cannot load on RHEL8-family HPC nodes (glibc 2.28) -- and because no
+    # __glibc constraint was recorded either, conda installed it there
+    # anyway and the failure only surfaced at import time.
+    - {{ stdlib("c") }}
     - cmake >=3.20
     - make
     - pkg-config

--- a/installers/pip/build_deps_manylinux.sh
+++ b/installers/pip/build_deps_manylinux.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # build_deps_manylinux.sh
-# Builds IOWarp's external dependencies from source inside a manylinux_2_34
-# container (AlmaLinux 9). All libraries are built with both shared and static
-# archives, with -fPIC so the static archives can be linked into shared objects.
+# Builds IOWarp's external dependencies from source inside a manylinux_2_28
+# container (AlmaLinux 8, glibc 2.28). All libraries are built with both shared
+# and static archives, with -fPIC so the static archives can be linked into
+# shared objects.
 #
 # Install prefix: /usr/local
 #
@@ -12,9 +13,10 @@ set -euo pipefail
 PREFIX=/usr/local
 NPROC=$(nproc)
 
-# AlmaLinux 9 / manylinux_2_34: the default compiler may generate x86_64_v2
-# instructions (SSE4.2, POPCNT) because RHEL 9 requires x86_64_v2 hardware.
-# Force baseline x86_64 so the wheel runs on any x86_64 CPU.
+# Force baseline x86_64 so the wheel runs on any x86_64 CPU. This mattered on
+# the old manylinux_2_34 image (AlmaLinux 9 defaults to x86_64_v2: SSE4.2,
+# POPCNT); AlmaLinux 8 does not, but keeping the flag costs nothing and keeps
+# the wheel's ISA floor pinned regardless of which image we build in.
 # On aarch64 we leave the flags alone — the compiler defaults are fine.
 ARCH=$(uname -m)
 if [ "$ARCH" = "x86_64" ]; then
@@ -36,7 +38,12 @@ download_tar() {
     while [ $attempt -lt $max_attempts ]; do
         attempt=$((attempt + 1))
         echo "  Downloading $url (attempt $attempt/$max_attempts)..."
-        if curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors "$url" -o "$dest"; then
+        # No --retry-all-errors: it needs curl >= 7.71 and AlmaLinux 8
+        # (manylinux_2_28) ships 7.61, where the unknown option makes curl
+        # exit immediately -- every download fails, on every attempt. The
+        # retry loop around this call already retries on any failure,
+        # including the non-transient errors --retry-all-errors covered.
+        if curl -fsSL --retry 3 --retry-delay 5 "$url" -o "$dest"; then
             if file "$dest" | grep -qE "gzip|XZ|bzip2|tar archive"; then
                 return 0
             fi

--- a/installers/pip/check_wheel_glibc.py
+++ b/installers/pip/check_wheel_glibc.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Verify that a manylinux wheel's real glibc requirement matches its tag.
+
+Background (iowarp/clio-core#973): the wheels are repaired by
+``installers/pip/repair_wheel.sh``, which stamps the platform tag with
+``python -m wheel tags``.  That command rewrites the filename and the WHEEL
+metadata and nothing else -- it never looks at the binaries.  auditwheel,
+which *would* check, is deliberately not used (see repair_wheel.sh).
+
+So nothing in the pipeline connects the tag the wheel advertises to the
+glibc symbol versions its ELF files actually import.  Get that pairing
+wrong in either direction and users lose:
+
+  * tag too new (the #973 bug): every glibc-2.28 host -- Rocky/Alma/RHEL 8,
+    i.e. most HPC login nodes -- is told "no wheels with a matching platform
+    tag" and there is no sdist to fall back to.
+  * tag too old: pip installs the wheel happily and ``import iowarp_core``
+    then dies with "version `GLIBC_2.34' not found".
+
+This script closes that gap: it unpacks the wheel, reads the versioned
+symbol requirements out of every ELF file it contains, and fails if any of
+them needs a newer glibc than the wheel's own ``manylinux_<x>_<y>`` tag
+promises.
+
+The same check applies to the conda package, which had the identical defect
+for the identical reason (nothing tied the built binaries to a declared
+glibc floor), so this also accepts ``.conda`` archives and plain directories
+together with an explicit ``--max-glibc``.
+
+Usage:
+    python3 check_wheel_glibc.py <wheel> [<wheel> ...]
+    python3 check_wheel_glibc.py --max-glibc 2.28 <pkg.conda|directory> ...
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+# manylinux_<major>_<minor>_<arch> -- the glibc version the wheel promises.
+TAG_RE = re.compile(r"manylinux_(\d+)_(\d+)_(?:x86_64|aarch64|i686|ppc64le|s390x)")
+# `objdump -T` prints undefined imports as e.g. "... (GLIBC_2.34) pthread_create".
+SYMVER_RE = re.compile(r"\(GLIBC_(\d+)\.(\d+)\)")
+
+ELF_MAGIC = b"\x7fELF"
+
+# Cap the per-package failure listing (see check_package).
+MAX_REPORTED = 15
+
+
+def wheel_glibc_tag(wheel: Path) -> tuple[int, int] | None:
+    """The (major, minor) glibc version claimed by the wheel filename."""
+    matches = TAG_RE.findall(wheel.name)
+    if not matches:
+        return None
+    # A wheel may carry several platform tags; the oldest glibc is the
+    # weakest promise, and that is the one that has to hold.
+    return min((int(a), int(b)) for a, b in matches)
+
+
+def elf_files(root: Path) -> list[Path]:
+    found = []
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        try:
+            with path.open("rb") as fh:
+                if fh.read(4) == ELF_MAGIC:
+                    found.append(path)
+        except OSError:
+            continue
+    return found
+
+
+def max_glibc_requirement(elf: Path) -> tuple[tuple[int, int], list[str]]:
+    """Highest GLIBC_x.y this ELF imports, plus the symbols that need it."""
+    out = subprocess.run(
+        ["objdump", "-T", str(elf)],
+        capture_output=True,
+        text=True,
+        check=False,
+    ).stdout
+    worst = (0, 0)
+    culprits: list[str] = []
+    for line in out.splitlines():
+        m = SYMVER_RE.search(line)
+        if not m:
+            continue
+        ver = (int(m.group(1)), int(m.group(2)))
+        symbol = line.split()[-1]
+        if ver > worst:
+            worst, culprits = ver, [symbol]
+        elif ver == worst:
+            culprits.append(symbol)
+    return worst, culprits
+
+
+def unpack(archive: Path, dest: Path) -> None:
+    """Extract a wheel, a .conda package, or a legacy .tar.bz2 into dest."""
+    if archive.name.endswith(".tar.bz2"):
+        # conda-build still emits this format when told to.
+        subprocess.run(["tar", "-xf", str(archive), "-C", str(dest)], check=True)
+        return
+
+    with zipfile.ZipFile(archive) as zf:
+        zf.extractall(dest)
+    # A .conda package is a zip of zstd tarballs; the payload one holds the
+    # installed files. Unpack it so the ELF scan below sees real binaries.
+    # tarfile only learned zstd in 3.14, so shell out to GNU tar instead of
+    # requiring a new interpreter on the runner.
+    for inner in list(dest.glob("pkg-*.tar.zst")):
+        subprocess.run(
+            ["tar", "--use-compress-program=unzstd", "-xf", str(inner), "-C", str(dest)],
+            check=True,
+        )
+        inner.unlink()
+
+
+def check_package(pkg: Path, max_glibc: tuple[int, int] | None) -> bool:
+    claimed = max_glibc or wheel_glibc_tag(pkg)
+    if claimed is None:
+        print(f"SKIP {pkg.name}: not a manylinux wheel and no --max-glibc given")
+        return True
+
+    print(f"=== {pkg.name} (must need glibc <= {claimed[0]}.{claimed[1]}) ===")
+    ok = True
+    with TemporaryDirectory() as tmp:
+        if pkg.is_dir():
+            root = pkg
+        else:
+            root = Path(tmp)
+            unpack(pkg, root)
+
+        files = elf_files(root)
+        if not files:
+            print("  ERROR: contains no ELF files -- nothing was built?")
+            return False
+
+        worst_overall = (0, 0)
+        # A package that is built wrong is built wrong for every binary in
+        # it (157 of them, in the case that motivated this script), so cap
+        # the listing -- the pattern is clear long before the end.
+        failures = 0
+        for elf in sorted(files):
+            need, symbols = max_glibc_requirement(elf)
+            worst_overall = max(worst_overall, need)
+            if need > claimed:
+                ok = False
+                failures += 1
+                if failures <= MAX_REPORTED:
+                    rel = elf.relative_to(root)
+                    print(
+                        f"  FAIL {rel}: needs GLIBC_{need[0]}.{need[1]} "
+                        f"(e.g. {', '.join(sorted(set(symbols))[:5])})"
+                    )
+        if failures > MAX_REPORTED:
+            print(f"  ... and {failures - MAX_REPORTED} more failing ELF files")
+        print(
+            f"  highest glibc actually required: "
+            f"{worst_overall[0]}.{worst_overall[1]} across {len(files)} ELF files"
+        )
+    if ok:
+        print("  OK")
+    return ok
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "packages",
+        nargs="+",
+        type=Path,
+        help="wheels, .conda packages, or directories of built files",
+    )
+    ap.add_argument(
+        "--max-glibc",
+        metavar="X.Y",
+        help="glibc floor to enforce. Required for .conda packages and "
+        "directories; wheels default to the version in their manylinux tag.",
+    )
+    args = ap.parse_args()
+
+    max_glibc = None
+    if args.max_glibc:
+        major, _, minor = args.max_glibc.partition(".")
+        max_glibc = (int(major), int(minor or 0))
+
+    if not all(check_package(p, max_glibc) for p in args.packages):
+        print(
+            "\nERROR: at least one package requires a newer glibc than it "
+            "promises. Either build against an older glibc (manylinux image "
+            "for pip, c_stdlib_version for conda) or raise the declared "
+            "floor -- which drops support for older distros, see #973."
+        )
+        return 1
+    print("\nAll packages are consistent with their declared glibc floor.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/installers/pip/repair_wheel.sh
+++ b/installers/pip/repair_wheel.sh
@@ -7,12 +7,25 @@
 # We then use `wheel tags` to apply the correct manylinux platform tag.
 #
 # Usage (called by cibuildwheel):
-#   bash repair_wheel.sh {dest_dir} {wheel}
+#   bash repair_wheel.sh {dest_dir} {wheel} [manylinux_tag]
+#
+# manylinux_tag is the glibc part of the platform tag ("2_28" by default,
+# see MANYLINUX_TAG below).
 
 set -euo pipefail
 
-DEST_DIR="${1:?Usage: repair_wheel.sh <dest_dir> <wheel>}"
-WHEEL="${2:?Usage: repair_wheel.sh <dest_dir> <wheel>}"
+DEST_DIR="${1:?Usage: repair_wheel.sh <dest_dir> <wheel> [manylinux_tag]}"
+WHEEL="${2:?Usage: repair_wheel.sh <dest_dir> <wheel> [manylinux_tag]}"
+
+# glibc version stamped into the platform tag.  MUST match the manylinux
+# image the wheel was actually built in (build-pip.yml's matrix.cibw_image)
+# -- `wheel tags` only rewrites metadata, it does not verify the binary,
+# so an over-optimistic tag here produces a wheel that pip happily installs
+# and that then fails at import with a GLIBC_x.y-not-found link error.
+# 2_28 = AlmaLinux 8 / RHEL8 family, which is what CI builds in (#973).
+MANYLINUX_TAG="${3:-${CLIO_MANYLINUX_TAG:-2_28}}"
+# Accept either "2_28" or a full image name like "manylinux_2_28".
+MANYLINUX_TAG="${MANYLINUX_TAG#manylinux_}"
 
 echo "=== Repairing wheel: $(basename "$WHEEL") ==="
 
@@ -123,14 +136,14 @@ with zipfile.ZipFile(out, 'w', zipfile.ZIP_DEFLATED) as zf:
 " "$WORK_DIR/unpack" "$REPACK_DIR/$WHEEL_NAME"
 
 # Detect the architecture and apply the manylinux platform tag.
-# PyPI rejects raw linux_* platform tags; we need manylinux_2_34_*.
+# PyPI rejects raw linux_* platform tags; we need manylinux_<glibc>_*.
 # `wheel tags` properly updates the filename, WHEEL metadata, and RECORD.
 ARCH=$(echo "$WHEEL_NAME" | grep -oP 'linux_\K(x86_64|aarch64|i686|ppc64le|s390x)')
 if [ -n "$ARCH" ]; then
-    echo "Retagging wheel with manylinux_2_34_${ARCH}..."
+    echo "Retagging wheel with manylinux_${MANYLINUX_TAG}_${ARCH}..."
     pip install -q wheel
     python3 -m wheel tags \
-        --platform-tag "manylinux_2_34_${ARCH}" \
+        --platform-tag "manylinux_${MANYLINUX_TAG}_${ARCH}" \
         --remove \
         "$REPACK_DIR/$WHEEL_NAME"
 fi

--- a/installers/pip/test/Dockerfile.build
+++ b/installers/pip/test/Dockerfile.build
@@ -1,8 +1,9 @@
 # =============================================================================
-# Dockerfile.build - Build pip wheel in manylinux_2_34
+# Dockerfile.build - Build pip wheel in manylinux_2_28
 # =============================================================================
 # Replicates what cibuildwheel does in CI:
-#   1. Start from manylinux_2_34 (AlmaLinux 9)
+#   1. Start from manylinux_2_28 (AlmaLinux 8, glibc 2.28 -- see #973 and the
+#      image-choice comment in .github/workflows/build-pip.yml)
 #   2. Install build dependencies from source (CIBW_BEFORE_ALL)
 #   3. Build the wheel with scikit-build-core
 #   4. Repair wheel with repair_wheel.sh (CIBW_REPAIR_WHEEL_COMMAND_LINUX)
@@ -13,10 +14,11 @@
 #       -f installers/pip/test/Dockerfile.build .
 # =============================================================================
 
-FROM quay.io/pypa/manylinux_2_34_x86_64:latest AS builder
+FROM quay.io/pypa/manylinux_2_28_x86_64:latest AS builder
 
-# Match CI: yum install curl patchelf
-RUN yum install -y curl patchelf
+# Match CI: yum install curl patchelf fuse3-devel (the Linux wheel builds the
+# FUSE adapter, see the platform override in pyproject.toml)
+RUN yum install -y curl patchelf fuse3-devel
 
 # Copy source tree
 COPY . /project
@@ -42,6 +44,10 @@ RUN cd /project && \
 RUN mkdir -p /tmp/wheelhouse && \
     WHEEL=$(ls /tmp/raw_wheelhouse/iowarp_core*.whl | head -1) && \
     bash /project/installers/pip/repair_wheel.sh /tmp/wheelhouse "$WHEEL"
+
+# Verify the wheel's real glibc requirement matches the tag it now claims
+# (same guard as the CI "Verify wheel glibc requirements" step, #973)
+RUN python3 /project/installers/pip/check_wheel_glibc.py /tmp/wheelhouse/*.whl
 
 # Verify static linking: no dynamic deps on yaml-cpp/zmq/sodium/uring
 RUN cd /tmp && mkdir -p verify && \

--- a/installers/pip/test/test_wheel.sh
+++ b/installers/pip/test/test_wheel.sh
@@ -4,7 +4,7 @@
 # =============================================================================
 # Replicates the full .github/workflows/build-pip.yml pipeline:
 #
-#   Phase 1 (build-wheels): Build the wheel in manylinux_2_34, same as
+#   Phase 1 (build-wheels): Build the wheel in manylinux_2_28, same as
 #       cibuildwheel. Installs deps from source, builds with scikit-build-core,
 #       fixes RPATHs, and verifies static linking.
 #
@@ -36,7 +36,7 @@ SKIP_BUILD=false
 BUILD_ONLY=false
 # Default distros matching CI matrix. ubuntu:24.04 and fedora:40 have cp312;
 # ubuntu:22.04 (cp310) and debian:12 (cp311) need their own wheels.
-DISTROS=("ubuntu:22.04" "ubuntu:24.04" "debian:12" "fedora:40")
+DISTROS=("rockylinux:8" "ubuntu:22.04" "ubuntu:24.04" "debian:12" "fedora:40")
 CUSTOM_DISTRO=""
 
 while [[ $# -gt 0 ]]; do
@@ -73,10 +73,10 @@ echo "  Wheelhouse:   $WHEELHOUSE"
 echo ""
 
 # ==================================================================
-# Phase 1: Build the wheel in manylinux_2_34
+# Phase 1: Build the wheel in manylinux_2_28
 # ==================================================================
 if [[ "$SKIP_BUILD" == "false" ]]; then
-    echo ">>> Phase 1: Building wheel in manylinux_2_34..."
+    echo ">>> Phase 1: Building wheel in manylinux_2_28..."
     echo ""
 
     mkdir -p "$WHEELHOUSE"
@@ -146,7 +146,14 @@ for DISTRO in "${DISTROS[@]}"; do
                 apt-get update -qq
                 apt-get install -y -qq python3 python3-pip python3-venv binutils >/dev/null 2>&1
             elif command -v dnf &>/dev/null; then
-                dnf install -y -q python3 python3-pip binutils >/dev/null 2>&1
+                # RHEL8 family: stock python3 is 3.6, older than any wheel we
+                # build. Prefer the 3.12 AppStream module (#973).
+                dnf install -y -q binutils >/dev/null 2>&1
+                if dnf install -y -q python3.12 python3.12-pip >/dev/null 2>&1; then
+                    ln -sf /usr/bin/python3.12 /usr/local/bin/python3
+                else
+                    dnf install -y -q python3 python3-pip >/dev/null 2>&1
+                fi
             elif command -v yum &>/dev/null; then
                 yum install -y -q python3 python3-pip binutils >/dev/null 2>&1
             fi
@@ -155,11 +162,23 @@ for DISTRO in "${DISTROS[@]}"; do
             python3 -m venv /tmp/test-venv
             source /tmp/test-venv/bin/activate
 
-            # Install the wheel matching this Python version
-            if ! pip install --quiet --no-index --find-links /wheels iowarp-core 2>&1; then
+            # Install the wheel matching this Python version.
+            #
+            # Select it by file path and Python tag, the way CI does, and skip
+            # ONLY when no wheel for this interpreter exists. The previous
+            # version installed by name under --no-index, which fails for two
+            # very different reasons -- no matching wheel, or a runtime
+            # dependency (pyyaml, flask, msgpack) that --no-index forbids
+            # fetching -- and reported both as "SKIP: No compatible wheel".
+            # That turns any genuine install failure into a green skip.
+            PYTAG=cp$(python -c "import sys; print(str(sys.version_info[0]) + str(sys.version_info[1]))")
+            WHEEL=$(ls /wheels/iowarp_core-*-${PYTAG}-*.whl 2>/dev/null | head -1)
+            if [ -z "$WHEEL" ]; then
                 echo "SKIP: No compatible wheel for this Python version"
                 exit 99
             fi
+            echo "Installing built wheel: $WHEEL"
+            pip install --quiet --find-links /wheels --no-cache-dir "$WHEEL"
 
             echo "=== Import test ==="
             python -c "import iowarp_core; print(\"Version:\", iowarp_core.get_version())"


### PR DESCRIPTION
Fixes #973 — `iowarp-core` is uninstallable on the RHEL8 family (Rocky/Alma/RHEL 8, glibc 2.28), the standard HPC login-node OS. Both distribution channels were broken, for two different reasons.

## pip (the reported bug)

Wheels were built in `manylinux_2_34` (AlmaLinux 9) and tagged to match, so pip on a glibc-2.28 host reports "no wheels with a matching platform tag" — and there is no sdist to fall back to.

Build in `manylinux_2_28` instead. This is a strict widening: a 2_28 wheel installs on glibc >= 2.28, covering RHEL8 *and* every distro the 2_34 wheels already covered. `installers/pip/README.md` already documented `manylinux_2_28`, so this realigns CI with the documented intent.

## conda (found while checking whether the same issue existed — it does, and it's worse)

I pulled the published 2.2.0 package off anaconda.org and inspected it: `libclio_run_cxx.so` imports `GLIBC_2.38` symbols (`__isoc23_strtol` and friends), and 157 ELF files in the package are affected.

The recipe declared `{{ compiler('cxx') }}` but not `{{ stdlib("c") }}`. Modern conda-forge compiler packages no longer carry a sysroot of their own, so the build compiled against the CI runner's `/usr` headers (ubuntu-latest, glibc 2.39). And because no `__glibc` constraint was recorded either, conda **installs it on Rocky 8 anyway** and the failure only surfaces at import — a silent failure rather than a clean solver error.

Fixed with `{{ stdlib("c") }}` + `c_stdlib_version: 2.28`. `conda-build render` confirms the build env now gets `sysroot_linux-64 2.28` and the package records `__glibc >=2.28,<3.0.a0`.

## Why nothing caught either one

Nothing in either pipeline connected the binaries actually produced to the glibc floor being advertised. `repair_wheel.sh` stamps the platform tag with `python -m wheel tags`, which rewrites metadata and never opens an ELF file (auditwheel, which *would* check, is deliberately not used). `conda build` doesn't check either. That gap is what let both defects ship.

This PR adds `installers/pip/check_wheel_glibc.py`: it unpacks a wheel or `.conda`, reads the versioned symbol requirements out of every ELF file, and fails if any needs a newer glibc than the package promises. It runs in both publish workflows before upload, and in the local `Dockerfile.build`.

It catches drift in both directions — a tag too new (this bug: users locked out) and a tag too old (wheel installs, then dies with `version 'GLIBC_2.34' not found`).

## Two incidental bugs found while verifying

- **`build_deps_manylinux.sh` used `curl --retry-all-errors`**, which requires curl >= 7.71. AlmaLinux 8 ships 7.61, where the unknown option makes curl exit immediately — so **every dependency download failed, on every retry**. Only caught by actually running the build in the new image. The wrapper's own retry loop already covers what the flag did.
- **`test_wheel.sh` reported `SKIP: No compatible wheel` for any install failure**, including real ones. It installed by name under `--no-index`, which fails both when no wheel matches the interpreter *and* when a runtime dep (pyyaml, flask, msgpack) can't be fetched — reporting both as a green skip. Now selects the wheel by path with the index available for runtime deps, as CI does.

## Other changes

- `repair_wheel.sh` takes the manylinux tag as an argument, passed from `matrix.cibw_image`, so the tag can't drift from the build image.
- `test-wheels` matrix gains `rockylinux:8` (x86_64 and aarch64) as the regression test, installing python3.12 from AppStream since the stock python3 is 3.6.
- README documents the actual floor: glibc 2.28+.

## Verification

Not just CI-config edits — this was built and run end to end locally:

- Built the full wheel in `manylinux_2_28`, FUSE adapter included (against el8's fuse3 3.3.0). Max glibc required: **2.27** across 29 ELF files.
- `iowarp_core-2.2.0-cp312-cp312-manylinux_2_28_x86_64.whl` installs on **rockylinux:8 (glibc 2.28)** and passes import / CLI / visualizer / symbol-resolution checks. Also passes on ubuntu:24.04 (no regression for existing users).
- The new checker was confirmed to **reject** the published 2.2.0 conda package, and to reject the same good wheel relabelled `2_17` (`memfd_create` pins the true floor at 2.27, so 2.28 is near-minimal).
- `conda-build render` verified for the recipe change.

## Not addressed here

The RPM/DEB/AppImage artifacts in `build-packages.yml` are built on Fedora 40 / Ubuntu 24.04 and also won't run on RHEL8. The distro packages are inherently distro-targeted; the AppImage claims portability and would need its own older build base. Worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
