### PR TITLE
fix(conda): declare c_stdlib for macOS, not Linux only

### DIFF
--- a/installers/conda/conda_build_config.yaml
+++ b/installers/conda/conda_build_config.yaml
@@ -15,10 +15,24 @@ python:
 # instead of whatever glibc the CI runner happens to ship, and records a
 # __glibc>=2.28 constraint so older hosts get a clean solver error rather
 # than a package that installs and then fails to load.
+#
+# The macOS half is not optional. conda-build strips non-matching `# [selector]`
+# lines *before* parsing this file, so a Linux-only c_stdlib leaves the key
+# undefined on macOS, and conda_build/jinja_context.py's `_target()` then falls
+# back to the language name itself (`package_prefix = language`, then
+# `f"{package_prefix}_{target_platform}"`) -- rendering {{ stdlib("c") }} as the
+# package `c_osx-arm64`, which does not exist on conda-forge. On macOS the C
+# stdlib package is macosx_deployment_target, exactly as conda-forge's own
+# pinning declares it. Windows needs no entry today: nothing runs CI/ci-deps.sh
+# there (ci-adapters.yml's windows-2025 leg uses vcpkg), and the conda package
+# itself is built ubuntu-only.
 c_stdlib:
-  - sysroot                 # [linux]
+  - sysroot                    # [linux]
+  - macosx_deployment_target   # [osx]
 c_stdlib_version:
-  - '2.28'                  # [linux]
+  - '2.28'                     # [linux]
+  - '11.0'                     # [osx and arm64]
+  - '10.13'                    # [osx and x86_64]
 
 # Bump the macOS x86_64 deployment target. conda-forge's osx-64 default is
 # 10.9, but nanobind uses C++17 aligned new/delete which is only available on


### PR DESCRIPTION
Fixes #983.

## The problem

Every macOS job has been red since `ae532d92` (#973) — `ci-macos.yml`'s two
`build-test` legs and `ci-adapters.yml`'s `macos-15` leg, on `dev` and on every
PR branch. They all die in `CI/ci-deps.sh --only-deps`, three retries deep:

```
Dependencies to install:
  c_osx-arm64 clangxx_osx-arm64 cmake make pkg-config ...

PackagesNotFoundInChannelsError: The following packages are not available
from current channels:

  - c_osx-arm64
```

`c_osx-arm64` has never existed on conda-forge.

#973 added `{{ stdlib("c") }}` to `meta.yaml` so the Linux package builds
against `sysroot_linux-64` 2.28 and installs on RHEL8 — and declared the
matching variant keys with a `# [linux]` selector only. conda-build strips
non-matching selector lines *before* parsing the YAML, so on macOS `c_stdlib` is
undefined, and `jinja_context._target()` falls back to the language name itself:

```python
if component == "compiler":
    package_prefix = native_compiler(language, config)
else:
    package_prefix = language          # "c", for stdlib
...
package = f"{package_prefix}_{target_platform}"      # -> c_osx-arm64
```

`{{ compiler('cxx') }}` is unaffected because `native_compiler()` supplies
`clangxx` when `cxx_compiler` is unset — which is why the rendered list carries a
valid `clangxx_osx-arm64` right next to the bogus entry.

## The change

The macOS entry, using the mapping conda-forge's own pinning publishes:
`macosx_deployment_target`, whose per-target build
`macosx_deployment_target_osx-arm64` is a real package. Versions are the floors
this file already documents in the comment just below — 11.0 the osx-arm64
default, 10.13 the x86_64 floor nanobind's C++17 aligned new/delete needs.

Windows gets no entry deliberately: nothing runs `ci-deps.sh` there
(`ci-adapters.yml`'s `windows-2025` leg uses vcpkg) and the conda package is
built ubuntu-only. Easy to add if that changes.

## Verification

Rendering the recipe for each subdir with the conda-build CI installs (26.7.0),
`IOWARP_PRESET=release CONDA_SUBDIR=<subdir> conda render installers/conda -c conda-forge`:

| subdir | before | after |
| --- | --- | --- |
| `osx-arm64` | build env **unresolved** — 5 raw specs, incl. `c_osx-arm64` | 46 packages, incl. `macosx_deployment_target_osx-arm64` |
| `linux-64` | 40 packages, `sysroot_linux-64 2.28 h4ee821c_9` | **identical** — same 40, same builds |

So #973's glibc floor is untouched; the diff only fills in the platform it did
not cover.

End to end on a real runner: the same fix applied to a `dev` checkout on
`macos-26` gets `ci-deps.sh --only-deps release` through to completion and then
builds HDF5 and the CLIO VOL connector —
[hyoklee/hpf run 32059271329](https://github.com/hyoklee/hpf/actions/runs/32059271329),
green, with `macosx_deployment_target_osx-arm64` in the installed set and no
`c_osx-arm64` anywhere.

## One thing this does not fix

`--only-deps` strips version pins and installs by name, so `c_stdlib_version` is
honored during render but not at install — that `macos-26` run picked up
`macosx_deployment_target_osx-arm64-26.0`, not 11.0. Harmless for a CI build that
runs on the runner that built it, but the deployment-target floor does not reach
the installed env. Left alone here since it is a separate change to the install
path in `ci-deps.sh`; happy to follow up if you want it pinned.
