### PR TITLE
ci: fix the MSVC build of the hdf5_vol IO test (Windows adapters leg)

### DIFF
--- a/context-transfer-engine/test/unit/adapters/hdf5_vol/test_hdf5_vol_io.cc
+++ b/context-transfer-engine/test/unit/adapters/hdf5_vol/test_hdf5_vol_io.cc
@@ -43,6 +43,28 @@ const std::string kH5File = "/tmp/clio_vol_io_test.h5";
 constexpr size_t kNumElems = 4096;  // 16 KiB of ints
 
 /**
+ * Portable setenv/unsetenv. MSVC has neither, so every env tweak in this file
+ * must go through these -- a raw setenv() call compiles everywhere except the
+ * Windows adapter leg, where it fails as "identifier not found".
+ */
+void SetEnvVar(const char *key, const char *value) {
+#ifdef _WIN32
+  _putenv_s(key, value);
+#else
+  setenv(key, value, 1);
+#endif
+}
+
+void UnsetEnvVar(const char *key) {
+#ifdef _WIN32
+  // _putenv_s with an empty value removes the variable outright.
+  _putenv_s(key, "");
+#else
+  unsetenv(key);
+#endif
+}
+
+/**
  * Stand up the in-process runtime + CTE client + a file bdev target exactly
  * once. Mirrors initializeRuntime() in the POSIX adapter test. Returns the VOL
  * connector id (registered once, valid for the process lifetime).
@@ -54,12 +76,8 @@ hid_t setupVolEnvironment() {
   }
 
   // Small chunk size so the multi-chunk AsyncPutBlob loop is exercised even by
-  // a modest dataset (16 KiB / 4 KiB = 4 chunks). setenv is POSIX-only.
-#ifdef _WIN32
-  _putenv_s("CLIO_VOL_CHUNK_SIZE", "4096");
-#else
-  setenv("CLIO_VOL_CHUNK_SIZE", "4096", 1);
-#endif
+  // a modest dataset (16 KiB / 4 KiB = 4 chunks).
+  SetEnvVar("CLIO_VOL_CHUNK_SIZE", "4096");
 
   REQUIRE(clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, true));
   SimpleTest::g_test_finalize = clio::run::CLIO_RUNTIME_FINALIZE;
@@ -387,7 +405,7 @@ TEST_CASE("HDF5 VOL IO - Whole rewrite invalidates when staging is skipped",
   // next whole read served pre-rewrite bytes with a success status.
   hid_t vol_id = setupVolEnvironment();
   hid_t fapl = makeFapl(vol_id);
-  setenv("CLIO_VOL_ADMIT", "read-miss", 1);
+  SetEnvVar("CLIO_VOL_ADMIT", "read-miss");
 
   const std::string path = "/tmp/clio_vol_io_rewrite.h5";
   std::remove(path.c_str());
@@ -423,7 +441,7 @@ TEST_CASE("HDF5 VOL IO - Whole rewrite invalidates when staging is skipped",
   H5Sclose(space);
   REQUIRE(H5Fclose(file) >= 0);
   REQUIRE(H5Pclose(fapl) >= 0);
-  unsetenv("CLIO_VOL_ADMIT");
+  UnsetEnvVar("CLIO_VOL_ADMIT");
 }
 
 TEST_CASE("HDF5 VOL IO - Partial-write-first dataset stays cacheable",


### PR DESCRIPTION
`dev` has been red on every push since #974. Two independent causes; this PR now covers **only the Windows one** — see "Scope" below.

## Windows adapters — MSVC has no `setenv`

The `adapters (windows, hdf5_vol + winfsp)` leg fails to compile:

```
test_hdf5_vol_io.cc(390,3): error C3861: 'setenv': identifier not found
test_hdf5_vol_io.cc(426,3): error C3861: 'unsetenv': identifier not found
```

A test added in #967 grew a raw `setenv`/`unsetenv` pair. The file's older call site already carried the `_putenv_s` ifdef, so this hoists it into `SetEnvVar`/`UnsetEnvVar` helpers and routes all three call sites through them — the next one cannot reintroduce this.

`_putenv_s(key, "")` is the documented way to remove a variable on Windows. That the pre-existing `_putenv_s` call site was *not* in the error list is the evidence that spelling already resolves on this leg.

## Scope: the macOS half is #984's

This PR originally also fixed the macOS `c_osx-arm64` dependency-install failure by gating `{{ stdlib("c") }}` on `# [linux]`. @hyoklee's #984 fixes the same bug and does it better — it declares `c_stdlib` for macOS (`macosx_deployment_target`) as conda-forge's own pinning does, rather than disabling the declaration off Linux, and it names the mechanism precisely (`_target()` in `conda_build/jinja_context.py` falls back to the language name when `c_stdlib` is undefined, yielding `c` + `_osx-arm64`).

I render-checked #984's config locally at `CONDA_SUBDIR=osx-arm64` — clean, no `c_*` package — and its `build-test (macos-15)` leg is green. So that half is reverted here (commit e8b2afe) and **#984 should merge for macOS to go green**.

## Not addressed

- `Test Windows wheels` failed in the same batch on `choco install winfsp` → "package was not found with the source(s) listed" — a chocolatey.org outage, not our code. The same step went green on runs the following day.
- `cte_safe_bdev_recovery_e2e` failed once on `build-test (windows-2025)` in this PR's first run (`ReadData: READ FAILED - task[1] read 0 bytes, expected 65536`, `REQUIRE(t->GetReturnCode() == 0)` at `test_safe_bdev_recovery_e2e.cc:169`). It passes on #984 from the same `dev` base and is unrelated to anything here; rerunning to confirm it is a flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
