### PR TITLE
docker: clone jarvis-cd's dev branch in the CPU images

### DIFF
--- a/docker/deploy-cpu.Dockerfile
+++ b/docker/deploy-cpu.Dockerfile
@@ -45,7 +45,7 @@ ENV PATH="${VIRTUAL_ENV}/bin:/home/iowarp/.local/bin:${PATH}"
 
 RUN sudo chown -R $(whoami):$(whoami) /workspace && \
     git submodule update --init --recursive && \
-    git clone --depth 1 https://github.com/grc-iit/jarvis-cd.git \
+    git clone --depth 1 --branch dev https://github.com/grc-iit/jarvis-cd.git \
         /workspace/external/jarvis-cd && \
     cd /workspace/external/jarvis-cd && \
     pip install -r requirements.txt && \

--- a/docker/deps-cpu.Dockerfile
+++ b/docker/deps-cpu.Dockerfile
@@ -432,8 +432,17 @@ ENV VIRTUAL_ENV="/home/iowarp/venv"
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
 # Install Jarvis-CD (deployment and pipeline management)
+#
+# --branch dev, not the default branch. jarvis_clio_core's packages
+# (clio_runtime, clio_cte, clio_cte_libfuse) import container_kwargs from
+# jarvis_cd.util.container_utils, which exists on jarvis-cd's dev branch and
+# NOT on main. Cloning the default branch produces an image where every one of
+# those packages raises ModuleNotFoundError on import -- which is what kept the
+# distributed stop test red once it could finally run. clio_runtime's own
+# Dockerfile.deploy already pins --branch dev; this aligns the deps image with
+# it.
 RUN cd /home/iowarp \
-    && git clone https://github.com/grc-iit/jarvis-cd.git jarvis-cd \
+    && git clone --branch dev https://github.com/grc-iit/jarvis-cd.git jarvis-cd \
     && cd jarvis-cd \
     && pip install -r requirements.txt \
     && pip install -e .


### PR DESCRIPTION
**Not merging this without your say-so** — it changes the shared deps image, and the branch-vs-commit-pin question is yours. Opening it so the diagnosis and the one-line fix are on the record.

## The bug

`jarvis_clio_core`'s packages import `container_kwargs` from `jarvis_cd.util.container_utils`:

- `jarvis_clio_core/clio_runtime/pkg.py:10`
- `jarvis_clio_core/clio_cte/pkg.py:11`
- `jarvis_clio_core/clio_cte_libfuse/pkg.py:11`

That module exists on jarvis-cd's **`dev`** branch (`container_kwargs` at `container_utils.py:78`) and **not on `main`** — which is the default branch a bare `git clone` gets. So the published `deps-cpu` image ships a jarvis-cd where all three packages fail at import:

```
ImportError: Failed to import module 'jarvis_clio_core.clio_runtime.pkg'
  from path '/workspace/jarvis_clio_core':
  No module named 'jarvis_cd.util.container_utils'
```

That is what the distributed stop test hit the moment #987 let it run far enough to load a package.

The tree was already inconsistent about this — `clio_runtime/Dockerfile.deploy:47` pins `--branch dev` and always has. Only the two `docker/` images were unpinned:

| File | Before | After |
|---|---|---|
| `jarvis_clio_core/clio_runtime/Dockerfile.deploy:47` | `--branch dev` | unchanged |
| `docker/deps-cpu.Dockerfile:436` | *(default → main)* | `--branch dev` |
| `docker/deploy-cpu.Dockerfile:48` | *(default → main)* | `--branch dev` |

## On tracking a moving branch

Worth being explicit: both images already tracked whatever `main` happened to be at build time, so this doesn't introduce a dependency on a moving branch — it points the existing exposure at the branch the code actually requires. A commit pin would be better, but that's a call for whoever owns the jarvis-cd integration, and it needs a policy for advancing the pin.

## Verification limits

This **cannot** be verified by dispatching the stop test: `ci-docker-distributed.yml` pulls `iowarp/deps-cpu:latest` from Docker Hub rather than building it, so the change only takes effect once the deps image is rebuilt and published. The honest status is "root cause confirmed against upstream sources, fix unverified end to end."

## Related

- #987 (merged) — exec bit + `jarvis ppl append`, the two fixes that got the test this far
- The stop test has still never passed; this is the third distinct bug in it

🤖 Generated with [Claude Code](https://claude.com/claude-code)