### PR TITLE
ci: bound every build-packages job with timeout-minutes

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -21,6 +21,7 @@ jobs:
   check-version:
     name: Check tag matches version
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
     - name: Checkout repository
@@ -52,6 +53,7 @@ jobs:
   build-deb:
     name: Build Debian package (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
     needs: [check-version]
     if: always() && (needs.check-version.result == 'success' || needs.check-version.result == 'skipped')
     strategy:
@@ -119,6 +121,7 @@ jobs:
   build-rpm:
     name: Build RPM package (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
     container: fedora:40
     needs: [check-version]
     if: always() && (needs.check-version.result == 'success' || needs.check-version.result == 'skipped')
@@ -188,6 +191,7 @@ jobs:
   build-appimage:
     name: Build AppImage (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
     needs: [check-version]
     if: always() && (needs.check-version.result == 'success' || needs.check-version.result == 'skipped')
     strategy:
@@ -259,6 +263,7 @@ jobs:
     name: Test DEB install (${{ matrix.arch }})
     needs: [build-deb]
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
     container: ubuntu:24.04
     if: always() && needs.build-deb.result == 'success'
     strategy:
@@ -326,6 +331,7 @@ jobs:
     name: Test RPM install (${{ matrix.arch }})
     needs: [build-rpm]
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
     container: fedora:40
     if: always() && needs.build-rpm.result == 'success'
     strategy:
@@ -389,6 +395,7 @@ jobs:
     name: Test AppImage (${{ matrix.arch }})
     needs: [build-appimage]
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
     if: always() && needs.build-appimage.result == 'success'
     strategy:
       fail-fast: false
@@ -455,6 +462,7 @@ jobs:
   build-windows:
     name: Build Windows package (x86_64)
     runs-on: windows-latest
+    timeout-minutes: 45
     needs: [check-version]
     if: always() && (needs.check-version.result == 'success' || needs.check-version.result == 'skipped')
     steps:
@@ -525,6 +533,7 @@ jobs:
     name: Test Windows package (x86_64)
     needs: [build-windows]
     runs-on: windows-latest
+    timeout-minutes: 45
     if: always() && needs.build-windows.result == 'success'
     steps:
     - name: Download Windows package
@@ -600,6 +609,7 @@ jobs:
     name: Publish to GitHub Release
     needs: [build-deb, build-rpm, build-appimage, build-windows, test-deb, test-rpm, test-appimage, test-windows]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write


### PR DESCRIPTION
## What happened

`Build AppImage (x86_64)` on `main` ([run 32093516557](https://github.com/iowarp/clio-core/actions/runs/32093516557)) ran for **six hours** and was killed by the platform, not by us:

```
03:17:40  Get:5 https://archive.ubuntu.com/ubuntu noble-security InRelease
09:16:31  ##[error]The operation was canceled.
```

Nothing in between. `apt-get update` wedged against an Ubuntu mirror during "Install build dependencies" and sat there until GitHub's hard 6-hour job limit expired. Started 03:16:18, completed 09:16:33 — 360 minutes to the second.

## Why this is worth fixing

The mirror hang is external. **The six hours are ours**: `build-packages.yml` declares no `timeout-minutes` on any of its ten jobs, so the platform maximum was the only bound. Every other CI workflow in the repo already sets one — `ci-macos` 120, `ci-adapters` 120, `ci-docker-distributed` 60.

Two further costs beyond the wasted runner:

- The run reports **`cancelled`**, not `failure`. That reads as someone hitting the button or a superseded run, so it is easy to scroll past — I nearly did.
- The other nine jobs in that run all passed. A single hung job took the whole workflow's result with it.

## The bounds

Generous against runtimes observed on that same run:

| Job | Observed | Bound |
|---|---|---|
| Build Debian package (x86_64) | 4m18s | 30 |
| Build RPM package (x86_64) | 3m48s | 30 |
| Build AppImage (arm64) | 2m55s | 30 |
| Build Windows package (x86_64) | 12m50s | 45 |

`check-version` 10, `publish-release` 15, all Linux build/test jobs 30, both Windows jobs 45. A normal run is nowhere near these; a wedged `apt` now fails in half an hour instead of consuming a runner for a working day.

## Verification

The workflow has no `pull_request` trigger (`push: [main, tags]` + `workflow_dispatch`), so this PR's checks do not exercise it. I confirmed the file still parses and that all ten jobs are bounded:

```
check-version 10   build-deb 30   build-rpm 30   build-appimage 30
test-deb 30   test-rpm 30   test-appimage 30
build-windows 45   test-windows 45   publish-release 15
MISSING: none
```

This is a guard rail, not a behaviour change — it cannot make a passing run fail unless that run was already taking 2-4x its normal time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)