### PR TITLE
ci(#710): make the distributed docker stop test actually run and pass

### DIFF
--- a/.github/workflows/ci-docker-distributed.yml
+++ b/.github/workflows/ci-docker-distributed.yml
@@ -55,10 +55,13 @@ jobs:
       - name: Pull dependency image
         run: docker pull "$DEPS_IMAGE"
 
-      # Compile ONLY clio_run (its runtime start/stop/status subcommands are all
-      # this test needs) inside deps-cpu, so it links the same libraries the node
-      # containers provide at runtime.
-      - name: Build clio_run (inside deps-cpu)
+      # Compile ONLY clio_run plus the admin ChiMod inside deps-cpu, so they link
+      # the same libraries the node containers provide at runtime. clio_run's
+      # start/stop/status subcommands are all this test drives, but `runtime
+      # start` refuses to come up without libclio_admin_runtime.so ("Admin
+      # ChiMod not found! This is a required system component."), and the
+      # runtime discovers ChiMods by scanning LD_LIBRARY_PATH (build/bin here).
+      - name: Build clio_run + admin ChiMod (inside deps-cpu)
         run: |
           docker run --rm \
             -v "${{ github.workspace }}":/workspace -w /workspace -u 0 \
@@ -69,7 +72,7 @@ jobs:
               export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig:$PKG_CONFIG_PATH
               git config --global --add safe.directory /workspace
               cmake --preset release -DCLIO_CORE_ENABLE_PYTHON=OFF
-              cmake --build build -j"$(nproc)" --target clio_run
+              cmake --build build -j"$(nproc)" --target clio_run clio_admin_runtime
               # Hand ownership back to the runner so the test cluster (which runs
               # as the runner uid) and post-job cleanup can access build/.
               chown -R "$HOST_UID:$HOST_GID" build

--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,9 @@ CMakeUserPresents.json
 external/boost-*.tar.gz
 external/boost-*/
 external/boost/
+# jarvis-cd checkout provisioned by the distributed docker CI test
+# (context-runtime/test/integration/chimaera_stop/run_tests.sh)
+external/jarvis-cd/
 
 # Model weights (large binaries)
 models/

--- a/context-runtime/test/integration/chimaera_stop/docker-compose.yaml
+++ b/context-runtime/test/integration/chimaera_stop/docker-compose.yaml
@@ -33,10 +33,11 @@ services:
       - NODE_IP=172.30.0.10
       - PATH=/workspace/build/bin:/home/iowarp/venv/bin:/home/iowarp/.cargo/bin:/usr/local/bin:/usr/bin:/bin
       - LD_LIBRARY_PATH=/workspace/build/bin:/usr/local/cuda/lib64:/usr/local/lib
-      # Prefer a workspace jarvis-cd checkout over the older one baked into
-      # iowarp/deps-* images, when one is present. PYTHONPATH is processed
-      # before site-packages; a non-existent path is simply ignored, so this
-      # transparently falls back to the venv's jarvis-cd.
+      # Prefer the workspace jarvis-cd checkout (run_tests.sh clones jarvis-cd
+      # `dev` here when absent -- jarvis_clio_core needs its container_utils)
+      # over the older `main` baked into iowarp/deps-* images. PYTHONPATH is
+      # processed before site-packages; a non-existent path is simply ignored,
+      # so this transparently falls back to the venv's jarvis-cd.
       - PYTHONPATH=/workspace/external/jarvis-cd
       - OMPI_ALLOW_RUN_AS_ROOT=1
       - OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1

--- a/context-runtime/test/integration/chimaera_stop/entrypoint.sh
+++ b/context-runtime/test/integration/chimaera_stop/entrypoint.sh
@@ -71,6 +71,12 @@ jarvis hostfile set "${HOSTFILE}"
 
 echo '[node1] building pipeline (clio_runtime only, tcp:9413)'
 jarvis ppl create chimaera_stop
+# Capture PATH/LD_LIBRARY_PATH (etc.) into the pipeline env. `ppl create`
+# starts with an EMPTY env, and PsshExec only forwards the pipeline env to the
+# remote shells -- without this every pssh'd `clio_run` on both nodes fails
+# with `bash: clio_run: command not found` (the runtime never starts).
+# `jarvis ppl run yaml` does this automatically; the imperative flow does not.
+jarvis ppl env build
 jarvis ppl append jarvis_clio_core.clio_runtime runtime
 jarvis pkg conf runtime \
     port=9413 \
@@ -95,7 +101,9 @@ assert_all() {
     local want="$1" host out rc fail=0
     while read -r host; do
         [ -z "$host" ] && continue
-        out=$(ssh -o BatchMode=yes "$host" "$STATUS_CMD" 2>&1); rc=$?
+        # -n: keep ssh from swallowing the rest of the hostfile on stdin --
+        # without it the loop silently probes only the first host.
+        out=$(ssh -n -o BatchMode=yes "$host" "$STATUS_CMD" 2>&1); rc=$?
         echo "[status:$want] $host -> rc=$rc"
         echo "$out" | sed 's/^/    /'
         if [ "$want" = running ]; then

--- a/context-runtime/test/integration/chimaera_stop/run_tests.sh
+++ b/context-runtime/test/integration/chimaera_stop/run_tests.sh
@@ -57,6 +57,27 @@ fi
 
 export HOST_UID="$(id -u)" HOST_GID="$(id -g)"
 
+# jarvis_clio_core's packages import jarvis_cd.util.container_utils, which only
+# exists on jarvis-cd's `dev` branch; the jarvis-cd baked into iowarp/deps-*
+# images is an older `main` checkout that lacks it ("No module named
+# 'jarvis_cd.util.container_utils'" at `jarvis pkg append`). The compose file
+# already puts /workspace/external/jarvis-cd first on PYTHONPATH, so provision
+# a jarvis-cd checkout there when the workspace doesn't have one. Override the
+# ref with JARVIS_CD_REF, or point JARVIS_CD_REPO at a fork.
+JARVIS_CD_DIR="$REPO_ROOT/external/jarvis-cd"
+if [ ! -d "$JARVIS_CD_DIR/jarvis_cd" ]; then
+    JARVIS_CD_REPO="${JARVIS_CD_REPO:-https://github.com/grc-iit/jarvis-cd.git}"
+    JARVIS_CD_REF="${JARVIS_CD_REF:-dev}"
+    log "cloning jarvis-cd ($JARVIS_CD_REF) into external/jarvis-cd"
+    if ! git clone --quiet --depth 1 --branch "$JARVIS_CD_REF" \
+            "$JARVIS_CD_REPO" "$JARVIS_CD_DIR"; then
+        err "FAIL: could not clone jarvis-cd ($JARVIS_CD_REPO @ $JARVIS_CD_REF)"
+        exit 1
+    fi
+else
+    log "using existing external/jarvis-cd checkout"
+fi
+
 log "starting 2-node cluster (image: $IOWARP_DOCKER_IMAGE)"
 docker compose down -v 2>/dev/null || true
 docker compose up -d


### PR DESCRIPTION
## Summary

The **Docker Distributed Stop Test** workflow (`ci-docker-distributed.yml`) has failed on every push to `dev` since it landed. It was failing at three successive layers, each masked by the one before it, plus the gate itself had a bug that made it non-distributed. All four are fixed here; the test now passes end-to-end locally with the workflow's exact build recipe.

### 1. jarvis-cd in the CI image is too old (the instant failure on dev)
`jarvis_clio_core.{clio_runtime,clio_cte,clio_cte_libfuse}` import `jarvis_cd.util.container_utils`, which only exists on jarvis-cd **`dev`**. `iowarp/deps-cpu:latest` ships a `main` checkout → `jarvis ppl append` dies with `No module named 'jarvis_cd.util.container_utils'`.

da63e60f (#989) already fixes the Dockerfile, but `build-dep-containers.yaml` only rebuilds/publishes the image on pushes to **`main`** (path-filtered) — last publish was 2026-05-21 — so `dev` stays red until then. `run_tests.sh` now clones jarvis-cd `dev` into `external/jarvis-cd` when absent (`JARVIS_CD_REPO` / `JARVIS_CD_REF` overrides); the compose file already puts that path first on `PYTHONPATH`. The test no longer depends on which jarvis-cd the deps image happens to carry. `external/jarvis-cd/` is gitignored.

### 2. Empty pipeline env → `clio_run: command not found` on both nodes
The imperative `jarvis ppl create` starts with an **empty** env, and `PsshExec` only forwards the pipeline env to the remote shells, so every pssh'd `clio_run` failed and the runtime never started. Added `jarvis ppl env build` (captures `PATH`/`LD_LIBRARY_PATH`). `jarvis ppl run yaml` does this implicitly, which is why the sibling `jarvis_deploy` test never hit it.

### 3. Admin ChiMod not built → `Admin ChiMod not found! This is a required system component.`
The workflow compiled only `clio_run`, but `clio_run runtime start` needs `libclio_admin_runtime.so` (discovered by scanning `LD_LIBRARY_PATH` = `build/bin`). Now builds `clio_run clio_admin_runtime`.

### 4. Gate only ever probed node1
`ssh` inside `while read host ... < "$HOSTFILE"` swallowed the rest of the hostfile on stdin, so `assert_all` silently checked node1 only — node2 was never asserted. `ssh -n` fixes it.

## Verification
Ran `run_tests.sh` locally against a build produced with the workflow's exact recipe (deps-cpu image, `cmake --preset release -DCLIO_CORE_ENABLE_PYTHON=OFF`, targets `clio_run clio_admin_runtime`):

```
[status:running] iowarp-jarvis-stop-node1 -> rc=0   clio runtime (port 9413): RUNNING (pid 81)
[status:running] iowarp-jarvis-stop-node2 -> rc=0   clio runtime (port 9413): RUNNING (pid 53)
[status:stopped] iowarp-jarvis-stop-node1 -> rc=1   clio runtime (port 9413): STOPPED (clean)
[status:stopped] iowarp-jarvis-stop-node2 -> rc=1   clio runtime (port 9413): STOPPED (clean)
=== Phase 2: force stop ... ===   (same, both nodes RUNNING → STOPPED (clean))
RESULT: PASS -- clio_run stop killed the whole runtime on every node, no stale artifacts
```

Note: the workflow only triggers on `push` to `main`/`dev` and `workflow_dispatch`, so it won't run on this PR automatically — dispatch it on this branch to see it green before merge, or it'll run on the merge to `dev`.

Refs #710. Follows #985/#987/#989.

🤖 Generated with [Claude Code](https://claude.com/claude-code)