### PR TITLE
Bump version to 2.2.1 for the release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(iowarp-core VERSION 2.2.0 LANGUAGES C CXX)
+project(iowarp-core VERSION 2.2.1 LANGUAGES C CXX)
 
 #------------------------------------------------------------------------------
 # MSVC-like front end detection

--- a/installers/conda/meta.yaml
+++ b/installers/conda/meta.yaml
@@ -7,7 +7,7 @@
    build exposes a working environ-bridge again; the CMake-side source
    of truth is in /CMakeLists.txt project(iowarp-core VERSION X.Y.Z),
    keep this number in sync when bumping. #}
-{% set version = "2.2.0" %}
+{% set version = "2.2.1" %}
 {% set preset = environ.get('IOWARP_PRESET', 'release') %}
 
 package:


### PR DESCRIPTION
Version bump only: `CMakeLists.txt` `project(iowarp-core VERSION 2.2.1)` (source of truth checked by the tag-push release workflows) + manual re-sync of `installers/conda/meta.yaml`. Same shape as the 2.2.0 bump (d5e33622).

## IOWarp Core 2.2.1

Patch release on top of 2.2.0: portability and packaging fixes, a CTE WAL-replay deadlock fix, reliable `clio_run stop`, and an HDF5 cache tier.

### Fixes
- **CTE:** resolve `RestoreMetadataFromLog` deadlock during WAL replay (#982, fixes #972)
- **Runtime:** `clio_run stop` is now convergent and robust — real teardown, `--force`, `runtime status` (#962, #710); each pool gets one persistent task-stat model owned by a real static container (#957)
- **HDF5:** VOL coherence stamp portable off glibc (macOS + Windows build fix) (#971); VFD built off the UNIX gate, not the ELF gate (#938); `g_fs_client` exported through the filesystem's own DLL macro (#948); GPUH5 ↔ HDF5 import/export files relocated (#969)
- **Packaging:** pip + conda packages built against glibc 2.28 so RHEL8 works (#974, fixes #973); conda `c_stdlib` declared for macOS (#984); every build-packages job bounded with `timeout-minutes` (#992)
- **Tests/CI:** unit tests hermetic against the developer's config (#979, #978); CEE comprehensive test gets its own composed pool chain (#964); distributed docker stop test actually runs and passes (#998, #985, #987, #989)

### Features
- **HDF5:** CLIO cache tier for the VOL and VFD connectors (#967)
- **GPUH5:** persistent kernel, fixed async double buffering, CTE optimizations (#778)

🤖 Generated with [Claude Code](https://claude.com/claude-code)