### PR TITLE
Fail fast when the WinFsp choco install does not actually install

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -459,8 +459,23 @@ jobs:
       run: |
         C:/vcpkg/vcpkg install --triplet x64-windows zeromq yaml-cpp cereal msgpack-c
 
+    # Retry + assert, mirroring build-pip (#1004): choco can exit 0 on a
+    # community-feed 503, silently building the package without the adapter.
     - name: Install WinFsp (FUSE adapter SDK)
-      run: choco install winfsp -y --no-progress
+      run: |
+        $ok = $false
+        foreach ($attempt in 1..3) {
+          choco install winfsp -y --no-progress
+          if (Test-Path "${env:ProgramFiles(x86)}\WinFsp\inc\fuse3\fuse.h") {
+            $ok = $true
+            break
+          }
+          Write-Host "WinFsp not installed after attempt $attempt; retrying in 30s..."
+          Start-Sleep -Seconds 30
+        }
+        if (-not $ok) {
+          throw "WinFsp SDK missing after 3 install attempts (#1004)"
+        }
 
     # cpack -G NSIS below shells out to makensis. Nothing installed it, so the
     # job failed with "Cannot find NSIS compiler makensis ... Cannot initialize
@@ -519,8 +534,22 @@ jobs:
         name: windows-package-x86_64
         path: pkg/
 
+    # Same hardening for the runtime install used by the smoke test (#1004).
     - name: Install WinFsp (FUSE adapter runtime)
-      run: choco install winfsp -y --no-progress
+      run: |
+        $ok = $false
+        foreach ($attempt in 1..3) {
+          choco install winfsp -y --no-progress
+          if (Test-Path "${env:ProgramFiles(x86)}\WinFsp\bin") {
+            $ok = $true
+            break
+          }
+          Write-Host "WinFsp not installed after attempt $attempt; retrying in 30s..."
+          Start-Sleep -Seconds 30
+        }
+        if (-not $ok) {
+          throw "WinFsp runtime missing after 3 install attempts (#1004)"
+        }
 
     - name: Extract ZIP + smoke test
       shell: pwsh

--- a/.github/workflows/build-pip.yml
+++ b/.github/workflows/build-pip.yml
@@ -179,8 +179,26 @@ jobs:
     # builds against (#899; see adapter/libfuse/CMakeLists.txt). The choco
     # package installs to %ProgramFiles(x86)%\WinFsp, which is the CMake
     # default search path.
+    # Retry transient registry failures, then ASSERT the SDK is really there:
+    # choco has been observed to exit 0 on a community-feed 503 ("Unable to
+    # find package 'winfsp'"), after which the wheel silently built WITHOUT
+    # clio_cte_fuse.exe and the miss only surfaced ~40 minutes later in the
+    # test job, far from the cause (#1004).
     - name: Install WinFsp (FUSE adapter SDK)
-      run: choco install winfsp -y --no-progress
+      run: |
+        $ok = $false
+        foreach ($attempt in 1..3) {
+          choco install winfsp -y --no-progress
+          if (Test-Path "${env:ProgramFiles(x86)}\WinFsp\inc\fuse3\fuse.h") {
+            $ok = $true
+            break
+          }
+          Write-Host "WinFsp not installed after attempt $attempt; retrying in 30s..."
+          Start-Sleep -Seconds 30
+        }
+        if (-not $ok) {
+          throw "WinFsp SDK missing after 3 install attempts -- failing HERE instead of shipping a wheel without the FUSE adapter (#1004)"
+        }
 
     - name: Install cibuildwheel
       run: pip install cibuildwheel


### PR DESCRIPTION
## Summary
- All three `choco install winfsp` steps (build-pip's SDK install, build-packages' SDK and runtime installs) now retry up to 3× with a 30s backoff, then **assert the installation actually landed** (`fuse3/fuse.h` for the SDK, `bin/` for the runtime) and fail the job otherwise.

## Motivation
Fixes #1004. On PR #993's merge CI, community.chocolatey.org answered 503, choco printed `Unable to find package 'winfsp'` — and exited 0. The Windows wheel then silently built **without** `clio_cte_fuse.exe` (the adapter's CMake gate found no SDK), and the failure surfaced ~40 minutes later in `Test Windows wheels` with a misleading symptom. A `--failed` rerun can't repair it, since the test job re-consumes the broken artifact. Same silently-degraded-wheel family as #899/#953.

## Test plan
- [x] Both workflow files parse as valid YAML
- [ ] Validate via `workflow_dispatch` of build-pip (the workflows only exercise these steps on their own triggers)

## Breaking changes
None — a genuinely failed WinFsp install previously produced a broken artifact; now it fails the install step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)