### PR TITLE
feat(cte): evict to make room when a droppable put hits a full tier

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,6 +259,99 @@ NEVER DO MOCK CODE OR STUB CODE UNLESS SPECIFICALLY STATED OTHERWISE. ALWAYS IMP
 - Built with MPI, HDF5, and ZeroMQ support
 - SST is disabled due to ARM64 Linux compatibility issues in the DILL library
 
+### Local build hygiene
+
+#### Local tests fail deterministically while CI is green
+
+**Symptom.** The CTE registers no storage targets, so every `PutBlob` returns
+rc=11 (`available_targets` empty) even though the bdev pools compose fine and
+`RegisterTarget` reports success. `GetCapacity` reports 0 indefinitely. Whole
+families go red at once — `cte_evict`, `cte_tiered_storage_all`,
+`cte_reorganize_all`, the HDF5 VOL/VFD suites.
+
+**Cause.** A build directory that has been incrementally rebuilt across many
+commits. A stale tree can fail most of the CTE suite while a tree
+configured fresh at the same commit passes it.
+
+**Fix.** Configure a NEW build directory, alongside the old one. Per the CRITICAL
+BUILD RULE above, do not `rm -rf` the existing one — just make another:
+
+```bash
+cmake -S /workspace -B /workspace/build-fresh \
+      -DBUILD_TESTING=ON -DCLIO_CORE_ENABLE_TESTS=ON
+cmake --build /workspace/build-fresh -j "$(nproc)"
+```
+
+**Do not** restart the container or rebuild the devcontainer image first.
+Neither is the cause, and every built library already agreed on the coroutine
+backend.
+
+#### ...or root-owned leftovers in /tmp
+
+A second, unrelated environmental trap with a different signature. Sessions that
+ran the container as `root` leave test artifacts behind; the container now runs
+as `iowarp`, which cannot open them. Affected tests fail in seconds with a
+permission error rather than a timeout:
+
+```
+ERROR Init Failed to open bdev file: /tmp/clio_vol_io_backend.dat (Permission denied)
+ERROR RegisterTarget Failed to create bdev container /tmp/clio_vol_io_backend.dat : 2
+PermissionError: [Errno 13] Permission denied: '/tmp/hdf5compat/clio_suite.yaml'
+```
+
+This hits the adapter suites hardest — `cte_hdf5_vol_io_*`, the VOL and VFD
+compat suites — because each keeps a fixed backing file or work directory in
+`/tmp`. Fix by taking ownership of the leftovers:
+
+```bash
+sudo chown -R iowarp:iowarp /tmp/hdf5compat /tmp/hdf5vfdcompat
+sudo find /tmp -maxdepth 1 -user root \
+     \( -name 'clio*' -o -name '*.dat' -o -name '*.h5' \) \
+     -exec chown iowarp:iowarp {} +
+```
+
+**Telling the two apart.** They look alike — whole families red while CI is
+green — and can be present at the same time:
+
+| symptom | cause |
+|---|---|
+| `PutBlob` rc=11, `available_targets` empty, `GetCapacity` 0 forever | stale build tree |
+| `RegisterTarget` rc=1, log shows `Permission denied` on a `/tmp` path | root-owned leftovers |
+
+#### Rebuild everything after touching a task struct
+
+Task structs (`PutBlobTask`, `EvictTask`, ...) cross the client/runtime boundary
+through shared memory, so their layout is ABI. Add or reorder a field, build
+only one target, and the other side reads at stale offsets — which surfaces as
+plausible garbage rather than a crash. Adding `EvictTask::droppable_only_` and
+rebuilding only the test binary made `cte_evict` report `bytes_evicted=0
+blobs_evicted=2097152`: the byte budget landing in the wrong field.
+
+After any task-struct change, build with no `--target`:
+
+```bash
+cmake --build /workspace/build-fresh -j "$(nproc)"
+```
+
+#### Adapter tests need their adapter enabled
+
+`CLIO_CORE_ENABLE_HDF5=ON` enables HDF5 **in the CAE only**. The two HDF5
+connectors are separate options, both default OFF:
+
+- `-DCLIO_CTE_ENABLE_HDF5_VOL=ON` — builds `clio_vol.cc` and the
+  `cte_hdf5_vol_*` tests
+- `-DCLIO_CTE_ENABLE_VFD=ON` — builds `H5FDclio.cc` and the VFD suites
+
+Without them, a change to a connector compiles nothing and its tests silently
+do not exist in the tree. Check that the file was actually compiled before
+claiming a build is clean.
+
+#### CI green is weaker evidence than it looks
+
+`ci-linux.yml` runs ctest with `--repeat until-pass:3`, and its boost-backend
+job excludes `cte_tiered_storage_all` and `cte_tiered_dram_default_all`. A test
+can be flaky, or skipped outright, and still show green.
+
 ### Component Build Options
 The unified IOWarp Core build system provides options to enable/disable components:
 - `CLIO_CORE_ENABLE_RUNTIME`: Enable runtime component (default: ON)

--- a/context-runtime/test/unit/cli/test_cte_wal_restart.cc
+++ b/context-runtime/test/unit/cli/test_cte_wal_restart.cc
@@ -149,17 +149,23 @@ TEST_CASE("CteWalRestart - WAL snapshot, replay on daemon restart",
   auto* ipc = CLIO_IPC;
   REQUIRE(ipc != nullptr);
 
-  auto put_blob = [&](const clio::cte::core::TagId& tag_id,
-                      const std::string& name, char fill) {
+  auto put_blob_flagged = [&](const clio::cte::core::TagId& tag_id,
+                              const std::string& name, char fill,
+                              clio::run::u32 flags) {
     constexpr size_t kSize = 4096;
     ctp::ipc::FullPtr<char> buf = ipc->AllocateBuffer(kSize);
     REQUIRE(!buf.IsNull());
     memset(buf.ptr_, fill, kSize);
     ctp::ipc::ShmPtr<> shm_ref(buf.shm_);
-    auto put = cte->AsyncPutBlob(tag_id, name, 0, kSize, shm_ref, 1.0f);
+    auto put = cte->AsyncPutBlob(tag_id, name, 0, kSize, shm_ref, 1.0f,
+                                 clio::cte::core::Context(), flags);
     put.Wait();
     REQUIRE(put->GetReturnCode() == 0);
     ipc->FreeBuffer(buf);
+  };
+  auto put_blob = [&](const clio::cte::core::TagId& tag_id,
+                      const std::string& name, char fill) {
+    put_blob_flagged(tag_id, name, fill, 0);
   };
 
   // Tag with two blobs; delete one (kCreateTag/kCreateNewBlob/kDelBlob WAL).
@@ -168,6 +174,10 @@ TEST_CASE("CteWalRestart - WAL snapshot, replay on daemon restart",
   REQUIRE(tag_a->GetReturnCode() == 0);
   put_blob(tag_a->tag_id_, "blob_keep", 'k');
   put_blob(tag_a->tag_id_, "blob_drop", 'd');
+  // Droppable blob written BEFORE the snapshot: its droppability has to
+  // survive via the snapshot's blob record, not the WAL.
+  put_blob_flagged(tag_a->tag_id_, "blob_droppable_pre", 'x',
+                   clio::cte::core::kCtePutDroppable);
   auto del_blob = cte->AsyncDelBlob(tag_a->tag_id_, "blob_drop");
   del_blob.Wait();
   REQUIRE(del_blob->GetReturnCode() == 0);
@@ -190,6 +200,12 @@ TEST_CASE("CteWalRestart - WAL snapshot, replay on daemon restart",
   tag_c.Wait();
   REQUIRE(tag_c->GetReturnCode() == 0);
   put_blob(tag_c->tag_id_, "blob_post_snapshot", 'p');
+  // ...and one AFTER it, which can only return through the WAL record. Between
+  // them both persistence paths are written and re-read by the restart.
+  //
+  // This pins that the restore PARSES both formats: a malformed record fails
+  // the re-compose below. It does not pin that the bit came back set, which
+  // would need a client that reconnects to the restarted daemon.
 
   // --- Phase 2: clean stop.
   REQUIRE(RunCliTimed({"stop", "--grace-period", "2000"}, 90) == 0);

--- a/context-transfer-engine/adapter/hdf5_vol/clio_vol.cc
+++ b/context-transfer-engine/adapter/hdf5_vol/clio_vol.cc
@@ -186,6 +186,19 @@ static clio_dataset_t *make_dataset_wrapper(void *under, hid_t under_vol_id,
    holding less than it believes it does, so the caller invalidates the
    dataset's cache rather than leave a partially-staged image that a later read
    would treat as a hit. The native file is authoritative and unaffected. */
+/* Flags on every CTE put this connector makes.
+ *
+ * kCtePutDroppable marks the bytes expendable: the connector is
+ * native-preserving, so every write reaches the HDF5 file first and a CTE blob
+ * here is never the only copy. Unconditional rather than configurable --
+ * it describes what the data is, not a preference.
+ *
+ * Includes the coherence stamp. A discarded stamp reads back as absent, which
+ * already fails closed to a cache miss; excluding stamps would instead pin one
+ * unevictable blob per file ever cached. */
+static constexpr clio::run::u32 kCliovolPutFlags =
+    clio::cte::core::kCtePutDroppable;
+
 /* CTE PutBlob return codes this adapter can say something useful about.
    core_runtime.cc sets `return_code_ = 10 + alloc_result`, so 11-13 are one
    band -- "the tier could not place these bytes" -- with ExtendBlob's three
@@ -227,6 +240,11 @@ static const char *clio_put_rc_meaning(int rc) {
  * When a put fails because the tier is out of space, stop offering: skip the
  * staging path until a cooldown elapses, then let one attempt through as a
  * probe. Success reopens the gate; failure re-arms it.
+ *
+ * These puts are droppable, so the tier has already tried to reclaim space and
+ * retry before reporting failure. A placement failure reaching here therefore
+ * means space could not be reclaimed at all, which is exactly when backing off
+ * is right.
  *
  * Scope is process-wide because fullness is a property of the TIER, which
  * every file in this process shares; a per-dataset latch would re-learn the
@@ -377,11 +395,10 @@ static clio::cte::core::Client *get_cte_client() {
      client singleton is unbound and the first AsyncGetOrCreateTag segfaults.
      Config comes from CLIO_SERVER_CONF, same as the runtime.
 
-     Returns nullptr when the runtime is unreachable. Callers MUST check: the
-     attach result was previously discarded, so an absent runtime faulted inside
-     H5Fcreate. There is always a correct fallback -- pass everything through to
-     the native VOL -- because the native file is authoritative and the CTE tier
-     is a performance layer, not a correctness one. */
+     Returns nullptr when the runtime is unreachable. Callers MUST check, and
+     fall back to passing everything through to the native VOL: the native file
+     is authoritative and the CTE tier is a performance layer, not a
+     correctness one. */
   static std::once_flag once;
   static bool attached = false;
   std::call_once(once, []() {
@@ -663,8 +680,8 @@ static void *clio_wrap_object(void *under_obj, H5I_type_t obj_type,
   void *under_wrap_ctx = ctx ? ctx->under_wrap_ctx : nullptr;
 
   /* Let the underlying (native) VOL wrap the raw iteration object first.
-     Skipping this step — as the old code did — left the object unusable by the
-     native VOL and made link/object iteration abort. */
+     Without this the object is unusable by the native VOL and link/object
+     iteration aborts. */
   void *under = H5VLwrap_object(under_obj, obj_type, under_vol_id,
                                 under_wrap_ctx);
   if (!under) return nullptr;
@@ -674,7 +691,7 @@ static void *clio_wrap_object(void *under_obj, H5I_type_t obj_type,
      non-empty path) and their transfers fall back to the native VOL. But the
      parent file IS known via the wrap context, so thread it through: a wrapped
      dataset then inherits file->trace and its reads/writes are recorded by
-     CLIO_VOL_TRACE (previously they were silently dropped). */
+     CLIO_VOL_TRACE. */
   clio_file_t *parent_file = ctx ? ctx->parent_file : nullptr;
   if (obj_type == H5I_DATASET) {
     return make_dataset_wrapper(under, under_vol_id, parent_file, nullptr);
@@ -718,7 +735,7 @@ static void *clio_unwrap_object(void *obj) {
   /* Symmetric with clio_wrap_object()'s H5VLwrap_object(): peel the native
      wrapper back off before discarding our wrapper. */
   void *under = H5VLunwrap_object(o->under_object, o->under_vol_id);
-  /* Free the wrapper either way -- returning NULL previously leaked it. */
+  /* Free the wrapper either way; returning NULL must not leak it. */
   clio_destroy_wrapper(o);
   return under;
 }
@@ -743,8 +760,7 @@ static herr_t clio_free_wrap_ctx(void *_wrap_ctx) {
  * ======================================================================== */
 
 /* Resolve the per-open connector config in ONE place so create and open cannot
-   disagree (open previously never read the info struct at all, so a chunk_size
-   set through H5Pset_vol was honoured on create and ignored on open).
+   disagree about a setting made through H5Pset_vol.
 
    chunk_size: connector info, overridden by CLIO_VOL_CHUNK_SIZE, else default.
    cache: an explicit "off" from EITHER the info struct or the environment wins;
@@ -834,8 +850,8 @@ static void clio_stat_mtime(const struct stat &st, long long *sec,
  *
  * std::chrono::system_clock rather than clock_gettime(CLOCK_REALTIME): MSVC has
  * neither the function nor the macro, and system_clock is the same wall clock
- * on every implementation this builds against. It is also unfailing, which
- * removes the "cannot read the clock" arm the caller used to need. */
+ * on every implementation this builds against. It also cannot fail, so callers
+ * need no "clock unreadable" arm. */
 static long long clio_realtime_now_ns() {
   return static_cast<long long>(
       std::chrono::duration_cast<std::chrono::nanoseconds>(
@@ -847,12 +863,10 @@ static long long clio_realtime_now_ns() {
    being replaced (a new inode at the same path -- h5repack, rsync, mv); size
    and mtime catch it being modified in place.
 
-   The leading "2:" is the cache-layout version. Chunk blobs used to be written
-   at their absolute image offset; they are now written at blob offset 0.
-   A tier populated by the old layout would read back hole-zeros under the new
-   one while the file itself is unchanged -- the one staleness the file
-   identity cannot catch -- so a layout change must bump this and let the
-   mismatch drop the tag. */
+   The leading "2:" is the cache-layout version. A tier populated under a
+   different blob layout reads back hole-zeros while the file itself is
+   unchanged -- the one staleness file identity cannot catch -- so any layout
+   change must bump this and let the mismatch drop the tag. */
 static std::string clio_file_stamp(const char *path) {
   struct stat st;
   if (!path || stat(path, &st) != 0) return std::string();
@@ -947,9 +961,8 @@ static uint64_t clio_stamp_granularity_ns() {
  * cross a tick boundary, which is why it looked flaky rather than broken.
  *
  * True means "cannot tell", and the caller withholds the stamp so the next
- * open fails closed. This is the same rule the rest of the stamp path already
- * follows -- absent, unreadable and unstattable all mean do-not-trust -- with
- * one more case that used to take the confident-yes path by omission. */
+ * open fails closed -- the same rule the rest of the stamp path follows, where
+ * absent, unreadable and unstattable all mean do-not-trust. */
 static bool clio_stamp_ambiguous(const char *path) {
   struct stat st;
   if (!path || stat(path, &st) != 0) return true;
@@ -1006,15 +1019,13 @@ static void clio_write_stamp(clio::cte::core::Client *cte_client,
   }
   std::memcpy(buffer.ptr_, stamp.data(), stamp.size());
   ctp::ipc::ShmPtr<> blob_data = buffer.shm_.template Cast<void>();
-  /* score: -1.0f is "unknown / let the tier place it". The documented domain is
-     -1.0 or [0.0, 1.0]; anything outside it is REJECTED. Passing an increasing
-     counter here (an attempt at recency ordering) made every put after the
-     second fail, which silently disabled caching for every file after the
-     first -- see the regression test. Score is a PLACEMENT hint, not a
-     priority; do not repurpose it. */
+  /* score: -1.0f is "unknown / let the tier place it". The domain is -1.0 or
+     [0.0, 1.0] and anything outside it is REJECTED, which fails the put. Score
+     is a PLACEMENT hint, not a priority; do not repurpose it. */
   auto put = cte_client->AsyncPutBlob(tag_id, kStampBlobName, 0, stamp.size(),
                                       blob_data, -1.0f,
-                                      clio::cte::core::Context(), 0);
+                                      clio::cte::core::Context(),
+                                      kCliovolPutFlags);
   put.Wait();  /* the stamp must land before the tag is reused */
   if (put->GetReturnCode() != 0) {
     /* Checked, and loudly. An unchecked failure here is invisible at the moment
@@ -1679,9 +1690,9 @@ static herr_t clio_dataset_write(size_t count, void *dset[],
     }
     auto *cte_client = get_cte_client();
 
-    /* Compute total data size from memory dataspace. When we had to ask the
-       native dataset for its space we own that hid_t and must close it -- the
-       previous code leaked one per whole-dataset write. */
+    /* Compute total data size from memory dataspace. Asking the native dataset
+       for its space yields an hid_t this code owns and must close, or it leaks
+       one per whole-dataset write. */
     hid_t space = mem_space_id[d];
     hid_t owned_space = H5I_INVALID_HID;
     if (space == H5S_ALL) {
@@ -1752,7 +1763,7 @@ static herr_t clio_dataset_write(size_t count, void *dset[],
          this. */
       auto future = cte_client->AsyncPutBlob(
           dataset->file->tag_id, blob_name, 0, this_size,
-          blob_data, -1.0f, clio::cte::core::Context(), 0);
+          blob_data, -1.0f, clio::cte::core::Context(), kCliovolPutFlags);
 
       dataset->pending_puts.push_back(std::move(future));
       dataset->pending_buffers.push_back(std::move(buffer));
@@ -2056,7 +2067,7 @@ static herr_t clio_dataset_read(size_t count, void *dset[],
                                                  dxpl_id) &&
                           !clio_is_collective(dxpl_id);
     if (!cacheable_flat) {
-      /* Propagate the native status: a failed read previously returned success
+      /* Propagate the native status, so a failed read cannot report success
          with the user's buffer untouched. */
       herr_t rc = H5VLdataset_read(1, &dataset->obj.under_object,
                         dataset->obj.under_vol_id,
@@ -2188,7 +2199,7 @@ static herr_t clio_dataset_read(size_t count, void *dset[],
            lives in the name. See the comment there. */
         auto fut = cte_client->AsyncPutBlob(
             dataset->file->tag_id, blob_name, 0, this_size, blob_data,
-            -1.0f, clio::cte::core::Context(), 0);
+            -1.0f, clio::cte::core::Context(), kCliovolPutFlags);
         fut.Wait();
         const int put_rc = fut->GetReturnCode();
         if (put_rc != 0) {
@@ -2246,9 +2257,8 @@ static herr_t clio_dataset_specific(void *obj,
   auto *dset = static_cast<clio_dataset_t *>(obj);
   /* Safe mode: H5Dflush is a durability barrier at DATASET granularity, and the
      spec names it alongside H5Fflush -- so drain this dataset's pending CTE puts
-     before delegating, exactly as file_specific does for the whole file. This
-     was previously a bare pass-through, so H5Dflush returned with async puts
-     still in flight.
+     before delegating, exactly as file_specific does for the whole file,
+     so H5Dflush cannot return with async puts still in flight.
 
      H5Dset_extent changes the dataset's element count, which is what the linear
      blob image is sized by, so the cached image no longer describes the dataset:
@@ -2636,9 +2646,8 @@ static herr_t clio_introspect_get_conn_cls(void *obj,
 static herr_t clio_introspect_get_cap_flags(const void *info,
                                               uint64_t *cap_flags) {
   (void)info;
-  /* Same constant the class advertises. These previously disagreed -- the class
-     literal omitted LINK_BASIC and OBJECT_BASIC that this callback reported --
-     so what the connector claimed depended on which one HDF5 asked. */
+  /* Same constant the class advertises: if the two disagree, what the
+     connector claims depends on which one HDF5 asks. */
   *cap_flags = CLIO_VOL_CAP_FLAGS;
   return 0;
 }

--- a/context-transfer-engine/core/include/clio_cte/core/core_client.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_client.h
@@ -2411,11 +2411,13 @@ class Client : public clio::run::ContainerClient {
    */
   clio::run::Future<EvictTask> AsyncEvict(
       float min_tier_score, clio::run::u64 bytes,
-      const clio::run::PoolQuery &pool_query = clio::run::PoolQuery::Broadcast()) {
+      const clio::run::PoolQuery &pool_query = clio::run::PoolQuery::Broadcast(),
+      clio::run::u32 droppable_only = 0) {
     auto *ipc_manager = CLIO_CPU_IPC;
     auto task = ipc_manager->NewTask<EvictTask>(clio::run::CreateTaskId(),
                                                 pool_id_, pool_query,
-                                                min_tier_score, bytes);
+                                                min_tier_score, bytes,
+                                                droppable_only);
     return ipc_manager->Send(task);
   }
 

--- a/context-transfer-engine/core/include/clio_cte/core/core_runtime.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_runtime.h
@@ -703,11 +703,46 @@ private:
    * @param blob_score Score for target selection
    * @param error_code Output: 0 for success, non-zero for failure
    * @param min_persistence_level Minimum persistence level for target filtering
+   * @param shortfall Optional output: on a placement failure (error_code 1-3),
+   *                  the bytes that could not be placed; 0 on success.
    */
   clio::run::TaskResume ExtendBlob(BlobInfo &blob_info, clio::run::u64 offset, clio::run::u64 size,
                              float blob_score, clio::run::u32 &error_code,
                              int min_persistence_level = 0,
-                             clio::run::u64 preallocate = 0);
+                             clio::run::u64 preallocate = 0,
+                             clio::run::u64 *shortfall = nullptr);
+
+  /**
+   * One placement attempt for a put: grow-to-cover (ExtendBlob) or
+   * wholesale-replace (ResizeBlob), chosen by kCtePutReplace in put_flags.
+   * Shared by the initial attempt and the retry, which must issue an identical
+   * call.
+   * @param error_code Output: 0 on success, allocator code otherwise
+   * @param shortfall Output: bytes that could not be placed (see ExtendBlob)
+   */
+  clio::run::TaskResume PlaceBlobBytesOnce(BlobInfo &blob_info,
+                                     clio::run::u32 put_flags,
+                                     clio::run::u64 offset, clio::run::u64 size,
+                                     float blob_score,
+                                     int min_persistence_level,
+                                     clio::run::u64 preallocate,
+                                     clio::run::u32 &error_code,
+                                     clio::run::u64 &shortfall);
+
+  /**
+   * Place a put's bytes, making room once if the tier is full.
+   *
+   * On a capacity failure for an expendable put (kCtePutDroppable), reclaims
+   * the shortfall from other expendable blobs and retries once. Any other
+   * failure is returned as-is.
+   * @param error_code Output: 0 on success, allocator code otherwise
+   */
+  clio::run::TaskResume PlaceBlobBytes(BlobInfo &blob_info,
+                                 clio::run::u32 put_flags,
+                                 clio::run::u64 offset, clio::run::u64 size,
+                                 float blob_score, int min_persistence_level,
+                                 clio::run::u64 preallocate,
+                                 clio::run::u32 &error_code);
 
   /**
    * Resize a blob to exactly new_size: grow (allocate appended blocks via
@@ -719,10 +754,12 @@ private:
    * @param blob_score Score for target selection on grow
    * @param error_code Output: 0 for success, non-zero for failure
    * @param min_persistence_level Minimum persistence level for target filtering
+   * @param shortfall Optional output: see ExtendBlob.
    */
   clio::run::TaskResume ResizeBlob(BlobInfo &blob_info, clio::run::u64 new_size,
                              float blob_score, clio::run::u32 &error_code,
-                             int min_persistence_level = 0);
+                             int min_persistence_level = 0,
+                             clio::run::u64 *shortfall = nullptr);
 
   /**
    * Write data to existing blob blocks

--- a/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
@@ -1012,6 +1012,9 @@ struct BlobInfo {
   // under-refusing hands back codec bytes as if they were data. Cleared only
   // when the blob itself is destroyed.
   clio::run::u32 transform_flags_;
+  // Non-zero when this blob is an expendable cache copy the tier may evict.
+  // Write-once: set at creation, never changed. See kCtePutDroppable.
+  clio::run::u32 droppable_;
   int compress_lib_;     // Compression library ID *requested* for this blob
                          // (0 = none). Provenance/telemetry only -- NOT a
                          // reliable answer to "is this blob compressed?";
@@ -1179,6 +1182,7 @@ struct BlobInfo {
         last_read_(0),
         access_count_(0),
         transform_flags_(kBlobTransformNone),
+        droppable_(0),
         compress_lib_(0),
         compress_preset_(2),
         trace_key_(0),
@@ -1200,6 +1204,7 @@ struct BlobInfo {
         last_read_(0),
         access_count_(0),
         transform_flags_(kBlobTransformNone),
+        droppable_(0),
         compress_lib_(0),
         compress_preset_(2),
         trace_key_(0),
@@ -1222,6 +1227,7 @@ struct BlobInfo {
         last_read_(GetCurrentTimeNs()),
         access_count_(0),
         transform_flags_(kBlobTransformNone),
+        droppable_(0),
         compress_lib_(0),
         compress_preset_(2),
         trace_key_(0),
@@ -1244,6 +1250,7 @@ struct BlobInfo {
         last_read_(other.last_read_),
         access_count_(other.access_count_),
         transform_flags_(other.transform_flags_),
+        droppable_(other.droppable_),
         compress_lib_(other.compress_lib_),
         compress_preset_(other.compress_preset_),
         trace_key_(other.trace_key_),
@@ -1678,6 +1685,31 @@ enum class CteOp : clio::run::u32 {
  * explicit TruncateBlob op share Runtime::ResizeBlob.
  */
 GLOBAL_CROSS_CONST clio::run::u32 kCtePutReplace = 0x1u;
+
+/**
+ * kCtePutDroppable: this blob's bytes are EXPENDABLE -- a cache copy of data
+ * that is authoritative elsewhere, which the tier may discard at any time.
+ *
+ * Only the writer can know this, so only the writer may say it. Two effects,
+ * and both are needed for the guarantee to hold: the put may trigger eviction
+ * when placement fails, and the blob becomes eligible to BE evicted by such a
+ * put. Without the flag a put neither evicts nor is evicted.
+ *
+ * Droppability is decided at creation and never changes. Eviction selects
+ * candidates from a scan and deletes them afterwards, so a blob that changed
+ * sides in between would be deleted on an answer that is no longer true. A put
+ * WITHOUT the flag to a blob that has it is therefore refused with
+ * kCteDroppabilityConflictRc: a cache copy and authoritative data claiming one
+ * name is a collision worth surfacing. The reverse is allowed and leaves the
+ * blob authoritative.
+ */
+GLOBAL_CROSS_CONST clio::run::u32 kCtePutDroppable = 0x2u;
+
+/**
+ * PutBlob refused: the blob is an expendable cache copy (kCtePutDroppable) and
+ * this put would take ownership of bytes the tier may discard.
+ */
+GLOBAL_CROSS_CONST clio::run::u32 kCteDroppabilityConflictRc = 14;
 
 /**
  * CTE Telemetry data structure for performance monitoring
@@ -2384,6 +2416,10 @@ struct ReorganizeBlobTask : public clio::run::Task {
 struct EvictTask : public clio::run::Task {
   IN float min_tier_score_;   // Only evict blobs on targets with score >= this
   IN clio::run::u64 bytes_;   // Reclaim at least this many bytes from the tier
+  // Non-zero: reclaim only from blobs marked kCtePutDroppable, so eviction
+  // cannot destroy data somebody still owns. Set by PutBlob's make-room retry;
+  // 0 for callers that ask for eviction directly.
+  IN clio::run::u32 droppable_only_;
   OUT clio::run::u64 bytes_evicted_;  // Physical bytes actually reclaimed
   OUT clio::run::u64 blobs_evicted_;  // Number of blobs evicted
 
@@ -2392,6 +2428,7 @@ struct EvictTask : public clio::run::Task {
       : clio::run::Task(),
         min_tier_score_(0.0f),
         bytes_(0),
+        droppable_only_(0),
         bytes_evicted_(0),
         blobs_evicted_(0) {}
 
@@ -2399,10 +2436,12 @@ struct EvictTask : public clio::run::Task {
   CTP_CROSS_FUN explicit EvictTask(const clio::run::TaskId &task_id,
                                    const clio::run::PoolId &pool_id,
                                    const clio::run::PoolQuery &pool_query,
-                                   float min_tier_score, clio::run::u64 bytes)
+                                   float min_tier_score, clio::run::u64 bytes,
+                                   clio::run::u32 droppable_only = 0)
       : clio::run::Task(task_id, pool_id, pool_query, Method::kEvict),
         min_tier_score_(min_tier_score),
         bytes_(bytes),
+        droppable_only_(droppable_only),
         bytes_evicted_(0),
         blobs_evicted_(0) {
     task_id_ = task_id;
@@ -2415,7 +2454,7 @@ struct EvictTask : public clio::run::Task {
   template <typename Archive>
   CTP_CROSS_FUN void SerializeIn(Archive &ar) {
     Task::SerializeIn(ar);
-    ar(min_tier_score_, bytes_);
+    ar(min_tier_score_, bytes_, droppable_only_);
   }
 
   template <typename Archive>
@@ -2428,6 +2467,9 @@ struct EvictTask : public clio::run::Task {
     Task::Copy(other.template Cast<Task>());
     min_tier_score_ = other->min_tier_score_;
     bytes_ = other->bytes_;
+    // Every IN field must be copied here: this is the per-replica duplication
+    // path, so an omission silently reverts to the default on remote shards.
+    droppable_only_ = other->droppable_only_;
     bytes_evicted_ = other->bytes_evicted_;
     blobs_evicted_ = other->blobs_evicted_;
   }

--- a/context-transfer-engine/core/include/clio_cte/core/transaction_log.h
+++ b/context-transfer-engine/core/include/clio_cte/core/transaction_log.h
@@ -82,6 +82,18 @@ enum class TxnType : uint8_t {
    * layout at log time (full replacement on replay, not a delta).
    */
   kExtendReplica = 7,
+  /**
+   * Blob is an expendable cache copy (kCtePutDroppable).
+   *
+   * Separate from kCreateNewBlob because droppability is classified under the
+   * per-blob write token, which is acquired after the create record is
+   * written. Without this record, replay restores every blob as authoritative,
+   * and since droppability is write-once it can never be marked again.
+   *
+   * Appending a type is safe for an older runtime: replay ignores types it
+   * does not recognise.
+   */
+  kSetBlobDroppable = 8,
 };
 
 /** A single block entry within TxnExtendBlob */
@@ -94,6 +106,13 @@ struct TxnExtendBlobBlock {
 };
 
 /** Payload: create a new blob (metadata only, no blocks yet) */
+struct TxnSetBlobDroppable {
+  clio::run::u32 tag_major_;
+  clio::run::u32 tag_minor_;
+  std::string blob_name_;
+  clio::run::u32 droppable_;
+};
+
 struct TxnCreateNewBlob {
   clio::run::u32 tag_major_;
   clio::run::u32 tag_minor_;
@@ -183,6 +202,15 @@ class TransactionLog {
   }
 
   // ---- Log helpers for each transaction type ----
+
+  void Log(TxnType type, const TxnSetBlobDroppable &txn) {
+    buffer_.clear();
+    WriteU32(buffer_, txn.tag_major_);
+    WriteU32(buffer_, txn.tag_minor_);
+    WriteString(buffer_, txn.blob_name_);
+    WriteU32(buffer_, txn.droppable_);
+    WriteRecord(type, buffer_);
+  }
 
   void Log(TxnType type, const TxnCreateNewBlob &txn) {
     buffer_.clear();
@@ -339,6 +367,17 @@ class TransactionLog {
   }
 
   // ---- Static deserialization helpers ----
+
+  static TxnSetBlobDroppable DeserializeSetBlobDroppable(
+      const std::vector<char> &data) {
+    TxnSetBlobDroppable txn;
+    size_t off = 0;
+    txn.tag_major_ = ReadU32(data, off);
+    txn.tag_minor_ = ReadU32(data, off);
+    txn.blob_name_ = ReadString(data, off);
+    txn.droppable_ = ReadU32(data, off);
+    return txn;
+  }
 
   static TxnCreateNewBlob DeserializeCreateNewBlob(const std::vector<char> &data) {
     TxnCreateNewBlob txn;

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -106,6 +106,29 @@ namespace {
 
 constexpr const char *kTagRefPrefix = "$tagid{";
 
+// ExtendBlob/ResizeBlob placement failure codes. These are the RAW allocator
+// codes; PutBlob surfaces them to clients as 10 + code, which is the 11-13
+// band the HDF5 adapters key on.
+constexpr clio::run::u32 kCteAllocNoTargetSpace = 1;    // -> 11
+constexpr clio::run::u32 kCteAllocNoHealthyTarget = 2;  // -> 12
+constexpr clio::run::u32 kCteAllocExhausted = 3;        // -> 13
+
+// All three mean the tier could not hold the bytes, and all three are
+// retryable. Code 2 reads like a device-health rejection, but ExtendBlob sets
+// it whenever the placement engine returns no target able to hold the request
+// -- which is what an ordinary out-of-space tier looks like -- so excluding it
+// disables the retry for the common case.
+//
+// 4 and up are defects, not placement, and must never cost data.
+constexpr bool CteAllocIsCapacityFailure(clio::run::u32 rc) {
+  return rc >= kCteAllocNoTargetSpace && rc <= kCteAllocExhausted;
+}
+
+// min_tier_score for the make-room eviction: 0.0 offers every tier as a
+// candidate. Scoping it to the tier that actually failed would need the
+// placement engine's target choice, which is not exposed here.
+constexpr float kCteEvictAnyTier = 0.0f;
+
 // #680 per-blob write-token re-check period (microseconds). Default 10us: a
 // loser is parked ONLY during active same-blob write contention, where a fast
 // hand-off beats the CPU saved by sleeping. 10us lands in the worker's fastest
@@ -1671,6 +1694,35 @@ clio::run::TaskResume Runtime::PutBlobImpl(clio::run::shared_ptr<TaskT> &task) {
     }
     BlobWriteLockGuard blob_write_guard(blob_info_ptr.get(), lock_tok);
 
+    // Droppability: decided at creation, never revisited. Both branches run
+    // under the write token, like every other mutation of this blob.
+    // See kCtePutDroppable.
+    if (blob_info_ptr->droppable_ != 0 &&
+        !(task->flags_ & kCtePutDroppable)) {
+      task->return_code_ = kCteDroppabilityConflictRc;
+      CLIO_CO_RETURN;
+    }
+    // Mark at creation only. The emptiness check covers the case where this
+    // task created the blob but another writer took the token first and wrote
+    // to it: a blob that already holds bytes is never marked.
+    if ((task->flags_ & kCtePutDroppable) && !blob_found &&
+        blob_info_ptr->GetTotalSize() == 0) {
+      blob_info_ptr->droppable_ = 1;
+      // Persist it. The create record is written before the token is acquired
+      // and cannot carry this, so droppability needs its own record or it is
+      // lost on replay. Logged once per blob, at the transition.
+      if (!task->context_.emulate_ && !blob_txn_logs_.empty()) {
+        clio::run::u32 wid = CLIO_CUR_WORKER->GetWorkerStats().worker_id_;
+        TxnSetBlobDroppable txn;
+        txn.tag_major_ = tag_id.major_;
+        txn.tag_minor_ = tag_id.minor_;
+        txn.blob_name_ = blob_name;
+        txn.droppable_ = blob_info_ptr->droppable_;
+        blob_txn_logs_[wid % blob_txn_logs_.size()]->Log(
+            TxnType::kSetBlobDroppable, txn);
+      }
+    }
+
     // Replica-targeted put (issue #886): Context::replica_ == N > 0 diverts
     // this ENTIRE write to replica N's block layout — the primary's blocks,
     // size, tag accounting, and SHM mirror are untouched, which is the whole
@@ -1730,7 +1782,8 @@ clio::run::TaskResume Runtime::PutBlobImpl(clio::run::shared_ptr<TaskT> &task) {
             ? blob_info_ptr->blocks_[old_num_blocks - 1].size_
             : 0;
 
-    // Step 1+2: size the blob to fit the write.
+    // Step 1+2: size the blob to fit the write, making room if the tier is
+    // full. See PlaceBlobBytes.
     //  - default (partial modify): grow to cover [offset, offset+size) but
     //    NEVER shrink — writing must not truncate the tail (POSIX write
     //    semantics). This is what makes out-of-order / descending partial
@@ -1740,16 +1793,10 @@ clio::run::TaskResume Runtime::PutBlobImpl(clio::run::shared_ptr<TaskT> &task) {
     //  - kCtePutReplace (wholesale replace): resize to exactly offset+size,
     //    shrinking if needed, via the shared ResizeBlob helper.
     clio::run::u32 alloc_result = 0;
-    if (task->flags_ & kCtePutReplace) {
-      CLIO_CO_AWAIT(ResizeBlob(*blob_info_ptr, offset + size, blob_score,
-                          alloc_result,
-                          task->context_.min_persistence_level_));
-    } else {
-      CLIO_CO_AWAIT(ExtendBlob(*blob_info_ptr, offset, size, blob_score,
-                          alloc_result,
-                          task->context_.min_persistence_level_,
-                          task->context_.preallocate_));
-    }
+    CLIO_CO_AWAIT(PlaceBlobBytes(*blob_info_ptr, task->flags_, offset, size,
+                                 blob_score,
+                                 task->context_.min_persistence_level_,
+                                 task->context_.preallocate_, alloc_result));
     if (alloc_result != 0) {
       task->return_code_ = 10 + alloc_result;
       CLIO_CO_RETURN;
@@ -3595,6 +3642,8 @@ clio::run::TaskResume Runtime::Evict(clio::run::shared_ptr<EvictTask> &task) {
   CLIO_TASK_BODY_BEGIN
   const float min_tier_score = task->min_tier_score_;
   const clio::run::u64 target_bytes = task->bytes_;
+  // Only blobs marked expendable may be taken. See kCtePutDroppable.
+  const bool droppable_only = (task->droppable_only_ != 0);
   task->bytes_evicted_ = 0;
   task->blobs_evicted_ = 0;
 
@@ -3637,7 +3686,22 @@ clio::run::TaskResume Runtime::Evict(clio::run::shared_ptr<EvictTask> &task) {
     tag_blob_name_to_info_.for_each(
         [&](const std::string &composite_key,
             const std::shared_ptr<BlobInfo> &blob_info_sp) {
+          // Never evict a blob under an active write. Reclaiming one takes
+          // its write token, and a caller awaiting this eviction may be the
+          // holder -- which would spin forever, since the token cannot be
+          // released until the eviction returns.
+          if (blob_info_sp->IsWriteLocked()) {
+            return;
+          }
           const BlobInfo &blob_info = *blob_info_sp;
+          // Reclaiming a cache replica is correctness-free -- it is a second
+          // copy the authoritative chain can refill -- but under
+          // droppable_only it is still limited to blobs whose writer
+          // volunteered them, so a write cannot drain another subsystem's
+          // cache to make room for itself.
+          if (droppable_only && blob_info.droppable_ == 0) {
+            return;
+          }
           for (size_t ri = 0; ri < blob_info.replicas_.size(); ++ri) {
             const Replica &rep = blob_info.replicas_[ri];
             if (!(rep.flags_ & REPLICA_CACHE) || rep.blocks_.empty()) {
@@ -3707,7 +3771,16 @@ clio::run::TaskResume Runtime::Evict(clio::run::shared_ptr<EvictTask> &task) {
   tag_blob_name_to_info_.for_each(
       [&](const std::string &composite_key,
           const std::shared_ptr<BlobInfo> &blob_info_sp) {
+        // See the write-lock note in the cache-replica loop above.
+        if (blob_info_sp->IsWriteLocked()) {
+          return;
+        }
         const BlobInfo &blob_info = *blob_info_sp;
+        // A whole-blob eviction destroys the only copy, so under
+        // droppable_only it is limited to blobs marked expendable.
+        if (droppable_only && blob_info.droppable_ == 0) {
+          return;
+        }
         clio::run::u64 evict_bytes = 0;
         for (const auto &block : blob_info.blocks_) {
           if (on_qualifying_target(block.bdev_client_.pool_id_)) {
@@ -4901,17 +4974,22 @@ clio::run::TaskResume Runtime::FlushMetadata(clio::run::shared_ptr<FlushMetadata
     // Write BlobInfo entries (entry_type 2; see below)
     tag_blob_name_to_info_.for_each([&](const std::string &key,
                                         const std::shared_ptr<BlobInfo> &blob_info_sp) { const BlobInfo &blob_info = *blob_info_sp; (void)blob_info;
-      // Entry type 2 == blob record carrying transform_flags_ (issue #818).
-      // A NEW type rather than an extra field on type 1, because this log has
-      // no version header: an old reader given an appended field would parse it
+      // Entry type 2 == blob record carrying transform_flags_ (issue #818);
+      // type 3 additionally carries droppable_. A NEW type each time rather
+      // than an extra field on the previous one, because this log has no
+      // version header: an old reader given an appended field would parse it
       // as block data and silently reconstruct garbage placement, whereas an
       // unknown entry type stops the restore loudly.
-      uint8_t entry_type = 2;
+      //
+      // droppable_ belongs here as well as in the WAL, which is truncated once
+      // folded into this snapshot.
+      uint8_t entry_type = 3;
       uint32_t key_len = static_cast<uint32_t>(key.size());
       uint32_t blob_name_len =
           static_cast<uint32_t>(blob_info.blob_name_.size());
       float score = blob_info.score_;
       uint32_t transform_flags = blob_info.transform_flags_;
+      uint32_t droppable = blob_info.droppable_;
       int32_t compress_lib = blob_info.compress_lib_;
       int32_t compress_preset = blob_info.compress_preset_;
       clio::run::u64 trace_key = blob_info.trace_key_;
@@ -4927,6 +5005,7 @@ clio::run::TaskResume Runtime::FlushMetadata(clio::run::shared_ptr<FlushMetadata
       ofs.write(reinterpret_cast<const char *>(&score), sizeof(score));
       ofs.write(reinterpret_cast<const char *>(&transform_flags),
                 sizeof(transform_flags));
+      ofs.write(reinterpret_cast<const char *>(&droppable), sizeof(droppable));
       ofs.write(reinterpret_cast<const char *>(&compress_lib),
                 sizeof(compress_lib));
       ofs.write(reinterpret_cast<const char *>(&compress_preset),
@@ -5334,11 +5413,13 @@ void Runtime::RestoreMetadataFromLog() {
       }
       tags_restored++;
 
-    } else if (entry_type == 1 || entry_type == 2) {
+    } else if (entry_type == 1 || entry_type == 2 || entry_type == 3) {
       // BlobInfo entry. Type 1 is the pre-#818 layout with no transform_flags_;
-      // type 2 carries it. Both are accepted so an existing metadata log still
-      // restores after an upgrade.
-      const bool has_transform_flags = (entry_type == 2);
+      // type 2 carries it; type 3 additionally carries droppable_. All are
+      // accepted so an existing metadata log still restores after an upgrade;
+      // older layouts restore as non-droppable.
+      const bool has_transform_flags = (entry_type >= 2);
+      const bool has_droppable = (entry_type >= 3);
       uint32_t key_len;
       ifs.read(reinterpret_cast<char *>(&key_len), sizeof(key_len));
       std::string composite_key(key_len, '\0');
@@ -5352,9 +5433,13 @@ void Runtime::RestoreMetadataFromLog() {
       float score;
       ifs.read(reinterpret_cast<char *>(&score), sizeof(score));
       uint32_t transform_flags = 0;
+      uint32_t droppable = 0;
       if (has_transform_flags) {
         ifs.read(reinterpret_cast<char *>(&transform_flags),
                  sizeof(transform_flags));
+      }
+      if (has_droppable) {
+        ifs.read(reinterpret_cast<char *>(&droppable), sizeof(droppable));
       }
       int32_t compress_lib;
       ifs.read(reinterpret_cast<char *>(&compress_lib), sizeof(compress_lib));
@@ -5374,6 +5459,7 @@ void Runtime::RestoreMetadataFromLog() {
       blob_info.compress_lib_ = compress_lib;
       blob_info.compress_preset_ = compress_preset;
       blob_info.trace_key_ = trace_key;
+      blob_info.droppable_ = droppable;
       if (has_transform_flags) {
         blob_info.transform_flags_ = transform_flags;
       } else if (compress_lib != 0) {
@@ -5616,6 +5702,10 @@ void Runtime::ReplayTransactionLogs() {
               tag_blob_name_to_info_.get(composite_key);
           if (existing) {
             blob_info.transform_flags_ = existing->transform_flags_;
+            // Carry DROPPABILITY too -- same outlives-the-flush hazard.
+            // Replaying the create record would reset it, and the field is
+            // write-once so nothing could mark it again.
+            blob_info.droppable_ = existing->droppable_;
             // Carry the REPLICAS too (issue #886) — same outlives-the-flush
             // hazard as the transform mark: the metadata snapshot (or an
             // earlier WAL shard's kExtendReplica) restored this blob's
@@ -5747,6 +5837,20 @@ void Runtime::ReplayTransactionLogs() {
             tag_blob_name_to_info_.get(composite_key);
         if (blob_info_ptr) {
           blob_info_ptr->transform_flags_ |= txn.transform_flags_;
+          MirrorBlobToShm(composite_key, *blob_info_ptr);
+          blobs_replayed++;
+        }
+
+      } else if (type == TxnType::kSetBlobDroppable) {
+        auto txn = TransactionLog::DeserializeSetBlobDroppable(payload);
+        TagId tag_id{txn.tag_major_, txn.tag_minor_};
+        std::string composite_key = std::to_string(tag_id.major_) + "." +
+                                    std::to_string(tag_id.minor_) + "." +
+                                    txn.blob_name_;
+        std::shared_ptr<BlobInfo> blob_info_ptr =
+            tag_blob_name_to_info_.get(composite_key);
+        if (blob_info_ptr) {
+          blob_info_ptr->droppable_ = txn.droppable_;
           MirrorBlobToShm(composite_key, *blob_info_ptr);
           blobs_replayed++;
         }
@@ -6125,15 +6229,95 @@ std::shared_ptr<BlobInfo> Runtime::CreateNewBlob(const std::string &blob_name,
   return blob_info_ptr;
 }
 
-clio::run::TaskResume Runtime::ExtendBlob(BlobInfo &blob_info, clio::run::u64 offset,
-                                    clio::run::u64 size, float blob_score,
-                                    clio::run::u32 &error_code,
-                                    int min_persistence_level,
-                                    clio::run::u64 preallocate) {
+clio::run::TaskResume Runtime::PlaceBlobBytesOnce(
+    BlobInfo &blob_info, clio::run::u32 put_flags, clio::run::u64 offset,
+    clio::run::u64 size, float blob_score, int min_persistence_level,
+    clio::run::u64 preallocate, clio::run::u32 &error_code,
+    clio::run::u64 &shortfall) {
 #ifdef CLIO_ENABLE_BOOST_COROUTINES
   clio::run::shared_ptr<clio::run::Task> cur_task = clio::run::GetCurrentTask();
 #endif
   CLIO_TASK_BODY_BEGIN
+  if (put_flags & kCtePutReplace) {
+    CLIO_CO_AWAIT(ResizeBlob(blob_info, offset + size, blob_score, error_code,
+                             min_persistence_level, &shortfall));
+  } else {
+    CLIO_CO_AWAIT(ExtendBlob(blob_info, offset, size, blob_score, error_code,
+                             min_persistence_level, preallocate, &shortfall));
+  }
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
+clio::run::TaskResume Runtime::PlaceBlobBytes(
+    BlobInfo &blob_info, clio::run::u32 put_flags, clio::run::u64 offset,
+    clio::run::u64 size, float blob_score, int min_persistence_level,
+    clio::run::u64 preallocate, clio::run::u32 &error_code) {
+#ifdef CLIO_ENABLE_BOOST_COROUTINES
+  clio::run::shared_ptr<clio::run::Task> cur_task = clio::run::GetCurrentTask();
+#endif
+  CLIO_TASK_BODY_BEGIN
+  clio::run::u64 shortfall = 0;
+  error_code = 0;
+  CLIO_CO_AWAIT(PlaceBlobBytesOnce(blob_info, put_flags, offset, size,
+                                   blob_score, min_persistence_level,
+                                   preallocate, error_code, shortfall));
+
+  // Placement failed. Make room and try once more, but only for a put whose
+  // bytes are expendable and only by reclaiming other expendable bytes: CTE
+  // core also stores blobs that ARE the data, and evicting those to admit a
+  // write would destroy bytes their owner still expects. A put without the
+  // flag fails here exactly as it would have without this path.
+  //
+  // One retry. Either eviction freed enough or it did not, and looping turns a
+  // full tier into a treadmill.
+  if (!(put_flags & kCtePutDroppable) ||
+      !CteAllocIsCapacityFailure(error_code) || shortfall == 0) {
+    CLIO_CO_RETURN;
+  }
+
+  auto evict = client_.AsyncEvict(kCteEvictAnyTier, shortfall,
+                                  clio::run::PoolQuery::Broadcast(),
+                                  /*droppable_only=*/1);
+  CLIO_CO_AWAIT(evict);
+  const clio::run::u64 reclaimed = evict->bytes_evicted_;
+  if (reclaimed == 0) {
+    CLIO_CO_RETURN;  // nothing expendable; keep the original error_code
+  }
+
+  HLOG(kInfo,
+       "PutBlob: tier could not place {} byte(s) (rc={}); evicted {} byte(s) "
+       "across {} blob(s), retrying",
+       shortfall, error_code, reclaimed, evict->blobs_evicted_);
+
+  // Re-issue the same call. Both paths are resumable: a partial extend keeps
+  // the blocks it placed and resyncs the size cache, so the retry asks only
+  // for the remainder.
+  error_code = 0;
+  shortfall = 0;
+  CLIO_CO_AWAIT(PlaceBlobBytesOnce(blob_info, put_flags, offset, size,
+                                   blob_score, min_persistence_level,
+                                   preallocate, error_code, shortfall));
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
+clio::run::TaskResume Runtime::ExtendBlob(BlobInfo &blob_info, clio::run::u64 offset,
+                                    clio::run::u64 size, float blob_score,
+                                    clio::run::u32 &error_code,
+                                    int min_persistence_level,
+                                    clio::run::u64 preallocate,
+                                    clio::run::u64 *shortfall) {
+#ifdef CLIO_ENABLE_BOOST_COROUTINES
+  clio::run::shared_ptr<clio::run::Task> cur_task = clio::run::GetCurrentTask();
+#endif
+  CLIO_TASK_BODY_BEGIN
+  // Every exit below is either a success (nothing outstanding) or sets this to
+  // the bytes it could not place; default it once here so no path leaks a
+  // stale value from the caller.
+  if (shortfall != nullptr) {
+    *shortfall = 0;
+  }
   // Calculate required additional space
   clio::run::u64 current_blob_size = blob_info.GetTotalSize();
   clio::run::u64 required_size = offset + size;
@@ -6203,6 +6387,9 @@ clio::run::TaskResume Runtime::ExtendBlob(BlobInfo &blob_info, clio::run::u64 of
     }
   }
   if (available_targets.empty()) {
+    if (shortfall != nullptr) {
+      *shortfall = additional_size;
+    }
     error_code = 1;
     CLIO_CO_RETURN;
   }
@@ -6254,6 +6441,9 @@ clio::run::TaskResume Runtime::ExtendBlob(BlobInfo &blob_info, clio::run::u64 of
        ordered_targets.size());
 
   if (ordered_targets.empty()) {
+    if (shortfall != nullptr) {
+      *shortfall = additional_size;
+    }
     error_code = 2;
     CLIO_CO_RETURN;
   }
@@ -6357,8 +6547,14 @@ clio::run::TaskResume Runtime::ExtendBlob(BlobInfo &blob_info, clio::run::u64 of
   // space
   if (remaining_to_allocate > 0) {
     // Partial allocation left blocks_ inconsistent; resync the size cache from
-    // the authoritative sum before bailing (cold error path).
+    // the authoritative sum before bailing (cold error path). The blocks that
+    // DID land are kept, so a retry recomputes additional_size against the
+    // grown blob and asks only for what is still missing -- which is exactly
+    // remaining_to_allocate.
     blob_info.RecomputeTotalSize();
+    if (shortfall != nullptr) {
+      *shortfall = remaining_to_allocate;
+    }
     error_code = 3;
     CLIO_CO_RETURN;
   }
@@ -6374,12 +6570,16 @@ clio::run::TaskResume Runtime::ExtendBlob(BlobInfo &blob_info, clio::run::u64 of
 
 clio::run::TaskResume Runtime::ResizeBlob(BlobInfo &blob_info, clio::run::u64 new_size,
                                     float blob_score, clio::run::u32 &error_code,
-                                    int min_persistence_level) {
+                                    int min_persistence_level,
+                                    clio::run::u64 *shortfall) {
 #ifdef CLIO_ENABLE_BOOST_COROUTINES
   clio::run::shared_ptr<clio::run::Task> cur_task = clio::run::GetCurrentTask();
 #endif
   CLIO_TASK_BODY_BEGIN
   error_code = 0;
+  if (shortfall != nullptr) {
+    *shortfall = 0;
+  }
   clio::run::u64 current_size = blob_info.GetTotalSize();
   if (new_size == current_size) {
     CLIO_CO_RETURN;
@@ -6387,7 +6587,8 @@ clio::run::TaskResume Runtime::ResizeBlob(BlobInfo &blob_info, clio::run::u64 ne
   if (new_size > current_size) {
     // Grow: allocate appended blocks up to new_size (shared with ExtendBlob)...
     CLIO_CO_AWAIT(ExtendBlob(blob_info, 0, new_size, blob_score, error_code,
-                             min_persistence_level));
+                             min_persistence_level, /*preallocate=*/0,
+                             shortfall));
     if (error_code != 0) {
       CLIO_CO_RETURN;
     }

--- a/context-transfer-engine/test/unit/CMakeLists.txt
+++ b/context-transfer-engine/test/unit/CMakeLists.txt
@@ -79,6 +79,12 @@ add_executable(test_evict
     test_evict.cc
 )
 
+# PutBlob's make-room-and-retry trigger: the caller side of kEvict, which had
+# no non-test caller until now.
+add_executable(test_evict_trigger
+    test_evict_trigger.cc
+)
+
 # Internal data organizer (issue #738): factory/frecency-score/config units
 # plus the end-to-end periodic DynamicReorganize promote/demote flow.
 add_executable(test_data_organizer
@@ -348,6 +354,18 @@ target_link_libraries(test_reorganize_blob
 
 # Link test_evict - using simple_test.h framework (NOT Catch2)
 target_link_libraries(test_evict
+    clio_cte_core_runtime         # CTE core runtime library
+    clio_cte_core_client          # CTE core client library
+    clio::run::admin_runtime      # Admin module runtime (required for runtime mode)
+    clio::run::admin_client       # Admin module client
+    clio::run::bdev_runtime       # Bdev module runtime (required for runtime mode)
+    clio::run::bdev_client        # Bdev client for BdevType enum
+    ctp::cxx                    # ClioCtp library
+    ${CMAKE_THREAD_LIBS_INIT}    # Threading support
+)
+
+# Link test_evict_trigger - same dependency set as test_evict
+target_link_libraries(test_evict_trigger
     clio_cte_core_runtime         # CTE core runtime library
     clio_cte_core_client          # CTE core client library
     clio::run::admin_runtime      # Admin module runtime (required for runtime mode)
@@ -1152,6 +1170,21 @@ set_tests_properties(
         ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CLIO_TEST_DATA_DIR=${CMAKE_BINARY_DIR};CLIO_BIND_ADDR=127.0.0.1"
 )
 
+# PutBlob's make-room-and-retry trigger. The TIMEOUT is load-bearing here: if
+# the eviction candidate filter regresses, the grow case livelocks on its own
+# blob's write lock rather than failing an assertion, so the timeout is what
+# turns that into a red test.
+add_test(NAME cte_evict_trigger
+    COMMAND test_evict_trigger)
+
+set_tests_properties(
+    cte_evict_trigger
+    PROPERTIES
+        TIMEOUT 300
+        LABELS "unit;evict;cte"
+        ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CLIO_TEST_DATA_DIR=${CMAKE_BINARY_DIR};CLIO_BIND_ADDR=127.0.0.1"
+)
+
 # Add data organizer tests (issue #738)
 # NOTE: like the reorganize tests, the cases share global fixture state
 # (blobs put in one case are checked/cleaned in later cases), so they run
@@ -1408,7 +1441,7 @@ set_tests_properties(
 # ------------------------------------------------------------------------------
 # Install Targets
 # ------------------------------------------------------------------------------
-set(_CTE_TEST_TARGETS cte_core_unit_tests cte_core_functionality_simple_tests test_core_functionality test_query test_cte_config_dpe test_tag_operations test_core_client_config test_core_runtime_coverage test_tiered_storage_stress test_tiered_storage_dram_default test_blob_block_reuse test_reorganize_blob test_evict test_data_organizer test_io_emulation)
+set(_CTE_TEST_TARGETS cte_core_unit_tests cte_core_functionality_simple_tests test_core_functionality test_query test_cte_config_dpe test_tag_operations test_core_client_config test_core_runtime_coverage test_tiered_storage_stress test_tiered_storage_dram_default test_blob_block_reuse test_reorganize_blob test_evict test_evict_trigger test_data_organizer test_io_emulation)
 # (The legacy test_cte_gpu_coroutine / test_gpu_core / test_gpu_create targets
 # and their ctest registrations were removed along with the GPU runtime. CTE
 # GPU coverage now lives in test_cte_devmem_putget (cte_devmem_putget_cuda).)

--- a/context-transfer-engine/test/unit/test_evict_trigger.cc
+++ b/context-transfer-engine/test/unit/test_evict_trigger.cc
@@ -1,0 +1,551 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * EVICTION TRIGGER TEST
+ *
+ * PutBlob makes room and retries once when placement fails, for puts whose
+ * bytes are marked expendable. These cases cover:
+ *
+ *   1. a tier smaller than the workload keeps accepting writes
+ *   2. data admitted after an eviction reads back byte-correct
+ *   3. a write too large for an empty tier still fails, with a placement code
+ *   4. growing one blob past the tier does not livelock on its own write lock
+ *   5. a put without the flag never evicts, and is never evicted
+ *   6. taking over an expendable blob is refused
+ *   7. every EvictTask input field survives task duplication
+ *
+ * The tier is one small file-backed target. Assertions never assume an exact
+ * usable capacity, only that writes keep succeeding and read back correctly.
+ */
+
+#include <clio_runtime/clio_runtime.h>
+#include <clio_cte/core/core_client.h>
+#include <clio_cte/core/core_tasks.h>
+
+#include <chrono>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "simple_test.h"
+
+namespace fs = std::filesystem;
+
+static std::string chi_test_data_dir() {
+  const char *d = clio::run::env::GetCompat("TEST_DATA_DIR");
+  return (d && *d) ? d : ".";
+}
+
+/* 4 MB blobs against a 64 MB tier: the workload outgrows the tier several
+   times over, so eviction is on the critical path rather than incidental. */
+static constexpr clio::run::u64 kBlobSize = 4 * 1024 * 1024;
+static constexpr clio::run::u64 kTierBytes = 64 * 1024 * 1024;
+
+/* The client-visible "could not place" band (PutBlob reports 10 + the raw
+   allocator code). Kept here so a change to the band is a test failure. */
+static constexpr int kPlaceRcFirst = 11;
+static constexpr int kPlaceRcLast = 13;
+
+class EvictTriggerFixture {
+ public:
+  std::string config_path_;
+  std::string file_storage_path_;
+  bool initialized_ = false;
+
+  EvictTriggerFixture() {
+    config_path_ = chi_test_data_dir() + "/evict_trigger_config.yaml";
+    file_storage_path_ = chi_test_data_dir() + "/evict_trigger_storage.bin";
+    Cleanup();
+    CreateConfigFile();
+    ctp::SystemInfo::Setenv("CLIO_SERVER_CONF", config_path_.c_str(), 1);
+    bool success = clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, true);
+    REQUIRE(success);
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    success = clio::cte::core::CLIO_CTE_CLIENT_INIT();
+    REQUIRE(success);
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    REQUIRE(WaitForTargets());
+    initialized_ = true;
+  }
+
+  /* Block until the CTE has registered at least one storage target. Composing
+     the bdev pools and registering them as CTE targets are separate steps, and
+     a put issued in the gap fails against a tier that is about to exist. */
+  bool WaitForTargets(int timeout_ms = 15000) {
+    auto *cte_client = CLIO_CTE_CLIENT;
+    if (cte_client == nullptr) return false;
+    const int kStepMs = 100;
+    for (int waited = 0; waited < timeout_ms; waited += kStepMs) {
+      auto cap = cte_client->AsyncGetCapacity();
+      cap.Wait();
+      if (cap->GetReturnCode() == 0 && cap->total_capacity_ > 0) {
+        return true;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(kStepMs));
+    }
+    return false;
+  }
+
+  ~EvictTriggerFixture() { Cleanup(); }
+
+  void Cleanup() {
+    if (fs::exists(config_path_)) fs::remove(config_path_);
+    if (fs::exists(file_storage_path_)) fs::remove(file_storage_path_);
+  }
+
+  void CreateConfigFile() {
+    std::ofstream config_file(config_path_);
+    REQUIRE(config_file.is_open());
+    config_file << R"(
+# One file-backed tier, deliberately smaller than the workload so placement
+# failure (and the make-room retry) is reached. File rather than RAM because a
+# file bdev's usable capacity tracks its configured size closely, so the fill
+# point does not depend on the host.
+runtime:
+  num_threads: 2
+  queue_depth: 1024
+  first_busy_wait: 10000
+  max_sleep: 50000
+
+compose:
+  - mod_name: clio_cte_core
+    pool_name: clio_cte
+    pool_query: local
+    pool_id: 512.0
+
+    targets:
+      neighborhood: 1
+      default_target_timeout_ms: 30000
+      poll_period_ms: 5000
+
+    storage:
+      - path: ")" << file_storage_path_ << R"("
+        bdev_type: "file"
+        capacity_limit: "64MB"
+        score: 1.0
+
+    dpe:
+      dpe_type: "max_bw"
+)";
+    config_file.close();
+  }
+
+  /* Write `size` bytes of `pattern` at `offset`. Returns PutBlob's return
+     code rather than asserting, so the give-up cases can inspect it.
+     `droppable` sets kCtePutDroppable. */
+  int PutAt(const clio::cte::core::TagId &tag_id, const std::string &blob_name,
+            clio::run::u64 offset, clio::run::u64 size, float score,
+            char pattern, bool droppable) {
+    auto *cte_client = CLIO_CTE_CLIENT;
+    REQUIRE(cte_client != nullptr);
+    auto shm_buffer = CLIO_IPC->AllocateBuffer(size);
+    REQUIRE(!shm_buffer.IsNull());
+    std::memset(shm_buffer.ptr_, pattern, size);
+    const clio::run::u32 flags =
+        droppable ? clio::cte::core::kCtePutDroppable : 0u;
+    auto put_task = cte_client->AsyncPutBlob(
+        tag_id, blob_name, offset, size, shm_buffer.shm_.template Cast<void>(),
+        score, clio::cte::core::Context(), flags);
+    put_task.Wait();
+    const int rc = put_task->GetReturnCode();
+    CLIO_IPC->FreeBuffer(shm_buffer);
+    return rc;
+  }
+};
+
+static EvictTriggerFixture *g_fixture = nullptr;
+
+/* Read [offset, offset+size) and check every byte equals `pattern`. */
+static bool BlobRegionMatches(clio::cte::core::Client *cte_client,
+                              const clio::cte::core::TagId &tag_id,
+                              const std::string &blob_name,
+                              clio::run::u64 offset, clio::run::u64 size,
+                              char pattern) {
+  auto buf = CLIO_IPC->AllocateBuffer(size);
+  if (buf.IsNull()) return false;
+  std::memset(buf.ptr_, static_cast<char>(~pattern), size);
+  auto get = cte_client->AsyncGetBlob(tag_id, blob_name, offset, size,
+                                      /*flags=*/0,
+                                      buf.shm_.template Cast<void>());
+  get.Wait();
+  bool ok = (get->GetReturnCode() == 0);
+  if (ok) {
+    const char *p = reinterpret_cast<const char *>(buf.ptr_);
+    for (clio::run::u64 i = 0; i < size; ++i) {
+      if (p[i] != pattern) {
+        ok = false;
+        break;
+      }
+    }
+  }
+  CLIO_IPC->FreeBuffer(buf);
+  return ok;
+}
+
+/* Best-effort delete of "<prefix><i>" for i in [0, count). Already-evicted
+   blobs are absent, so return codes are ignored. Cases share one tier, so a
+   case that leaves it full makes the next one measure the wrong thing. */
+static void DropBlobs(clio::cte::core::Client *cte_client,
+                      const clio::cte::core::TagId &tag_id,
+                      const std::string &prefix, int count) {
+  for (int i = 0; i < count; ++i) {
+    cte_client->AsyncDelBlob(tag_id, prefix + std::to_string(i)).Wait();
+  }
+}
+
+/**
+ * A workload several times the tier's size keeps being admitted.
+ */
+TEST_CASE("EvictTrigger - a full tier keeps accepting writes",
+          "[evict_trigger][noleak]") {
+  REQUIRE(g_fixture != nullptr);
+  REQUIRE(g_fixture->initialized_);
+  auto *cte_client = CLIO_CTE_CLIENT;
+  REQUIRE(cte_client != nullptr);
+
+  clio::cte::core::Tag tag("evict_trigger_fill_tag");
+  clio::cte::core::TagId tag_id = tag.GetTagId();
+
+  /* 3x the tier, so eviction has to run repeatedly rather than once. */
+  const int kNumBlobs =
+      static_cast<int>((kTierBytes / kBlobSize) * 3);
+  for (int i = 0; i < kNumBlobs; ++i) {
+    const std::string name = "fill_" + std::to_string(i);
+    const char pattern = static_cast<char>('A' + (i % 26));
+    const int rc = g_fixture->PutAt(tag_id, name, 0, kBlobSize, 0.5f, pattern,
+                                     /*droppable=*/true);
+    INFO("put " << name << " rc=" << rc);
+    REQUIRE(rc == 0);
+  }
+
+  /* Only the most recent write is guaranteed resident; the rest may have been
+     evicted to admit it. */
+  const int last = kNumBlobs - 1;
+  REQUIRE(BlobRegionMatches(cte_client, tag_id, "fill_" + std::to_string(last),
+                            0, kBlobSize,
+                            static_cast<char>('A' + (last % 26))));
+
+  DropBlobs(cte_client, tag_id, "fill_", kNumBlobs);
+}
+
+/**
+ * A single write larger than the whole tier cannot be satisfied by evicting
+ * anything, so it still fails with a placement code.
+ */
+TEST_CASE("EvictTrigger - a write larger than the tier still fails",
+          "[evict_trigger][noleak]") {
+  REQUIRE(g_fixture != nullptr);
+  clio::cte::core::Tag tag("evict_trigger_toobig_tag");
+
+  const clio::run::u64 kTooBig = kTierBytes * 2;
+  const int rc = g_fixture->PutAt(tag.GetTagId(), "too_big", 0, kTooBig, 0.5f, 'X',
+                                   /*droppable=*/true);
+  INFO("oversized put rc=" << rc);
+  REQUIRE(rc >= kPlaceRcFirst);
+  REQUIRE(rc <= kPlaceRcLast);
+}
+
+/**
+ * Growing ONE blob past the tier. Every append after the tier fills triggers
+ * eviction while that blob holds its own write lock, which eviction must skip.
+ * A regression here hangs rather than failing an assertion, so the ctest
+ * TIMEOUT is the real check.
+ *
+ * Also covers retry correctness: a partial extend keeps the blocks it placed,
+ * so the retry must allocate only the remainder. Size and content checks prove
+ * no extent was double-counted or lost.
+ *
+ * Growth stops once the blob owns the tier, since the only remaining candidate
+ * is the blob itself.
+ */
+TEST_CASE("EvictTrigger - growing one blob past the tier does not livelock",
+          "[evict_trigger][noleak]") {
+  REQUIRE(g_fixture != nullptr);
+  auto *cte_client = CLIO_CTE_CLIENT;
+  REQUIRE(cte_client != nullptr);
+
+  clio::cte::core::Tag tag("evict_trigger_grow_tag");
+  clio::cte::core::TagId tag_id = tag.GetTagId();
+
+  /* A neighbour gives eviction something legal to take, so this exercises
+     "skip the locked blob, take the other one". */
+  REQUIRE(g_fixture->PutAt(tag_id, "victim", 0, kBlobSize, 0.1f, 'V',
+                             /*droppable=*/true) == 0);
+
+  /* Phase 1: grow to just under the tier. Reaching this means the neighbour
+     was evicted, since victim + grower exceeds the tier. */
+  const int kFitChunks = static_cast<int>(kTierBytes / kBlobSize) - 2;
+  for (int i = 0; i < kFitChunks; ++i) {
+    const char pattern = static_cast<char>('a' + (i % 26));
+    const int rc = g_fixture->PutAt(tag_id, "grower", i * kBlobSize, kBlobSize,
+                                    0.9f, pattern, /*droppable=*/true);
+    INFO("append chunk " << i << " rc=" << rc);
+    REQUIRE(rc == 0);
+  }
+
+  /* The blob spans exactly what was appended: no extent double-counted by a
+     retried partial allocation, and none lost. */
+  auto size_task = cte_client->AsyncGetBlobSize(tag_id, "grower");
+  size_task.Wait();
+  REQUIRE(size_task->GetReturnCode() == 0);
+  REQUIRE(size_task->size_ ==
+          static_cast<clio::run::u64>(kFitChunks) * kBlobSize);
+
+  /* Every appended chunk reads back as written. */
+  for (int i = 0; i < kFitChunks; ++i) {
+    INFO("verify chunk " << i);
+    REQUIRE(BlobRegionMatches(cte_client, tag_id, "grower",
+                              static_cast<clio::run::u64>(i) * kBlobSize,
+                              kBlobSize, static_cast<char>('a' + (i % 26))));
+  }
+
+  /* Phase 2: past the tier. The blob now owns nearly all of it, so the only
+     candidate left is the blob being written, which is skipped. The put must
+     fail rather than spin -- reaching this assertion is the livelock guard
+     working. */
+  int rc = 0;
+  int extra = 0;
+  for (; extra < 8; ++extra) {
+    rc = g_fixture->PutAt(tag_id, "grower", (kFitChunks + extra) * kBlobSize,
+                          kBlobSize, 0.9f, 'z', /*droppable=*/true);
+    if (rc != 0) break;
+  }
+  INFO("growth stopped after " << extra << " extra chunk(s) with rc=" << rc);
+  REQUIRE(rc >= kPlaceRcFirst);
+  REQUIRE(rc <= kPlaceRcLast);
+
+  /* grower owns nearly the whole tier; leaving it would starve later cases. */
+  cte_client->AsyncDelBlob(tag_id, "grower").Wait();
+  cte_client->AsyncDelBlob(tag_id, "victim").Wait();
+}
+
+/**
+ * A put that does not declare its data expendable evicts nothing, so a full
+ * tier refuses it and everything already written survives.
+ *
+ * Callers that store authoritative blobs rely on this: several fill until the
+ * tier refuses and then operate on what they wrote.
+ */
+TEST_CASE("EvictTrigger - an ordinary put never evicts",
+          "[evict_trigger][noleak]") {
+  REQUIRE(g_fixture != nullptr);
+  auto *cte_client = CLIO_CTE_CLIENT;
+  REQUIRE(cte_client != nullptr);
+
+  clio::cte::core::Tag tag("evict_trigger_plain_tag");
+  clio::cte::core::TagId tag_id = tag.GetTagId();
+
+  /* Fill until the tier refuses. Without the flag this must terminate in a
+     refusal rather than recycling forever. */
+  const int kCap = static_cast<int>((kTierBytes / kBlobSize) * 3);
+  int filled = 0;
+  int rc = 0;
+  for (; filled < kCap; ++filled) {
+    rc = g_fixture->PutAt(tag_id, "plain_" + std::to_string(filled), 0,
+                          kBlobSize, 0.5f, 'P', /*droppable=*/false);
+    if (rc != 0) break;
+  }
+  INFO("plain fill refused after " << filled << " blob(s) with rc=" << rc);
+  REQUIRE(rc >= kPlaceRcFirst);
+  REQUIRE(rc <= kPlaceRcLast);
+  REQUIRE(filled > 0);
+
+  /* Everything that landed is still there. Nothing evicted it. */
+  for (int i = 0; i < filled; ++i) {
+    INFO("plain blob " << i << " must survive");
+    REQUIRE(BlobRegionMatches(cte_client, tag_id,
+                              "plain_" + std::to_string(i), 0, kBlobSize, 'P'));
+  }
+
+  DropBlobs(cte_client, tag_id, "plain_", filled);
+}
+
+/**
+ * Eviction takes expendable blobs only. A droppable put that cannot be
+ * satisfied out of other droppable blobs must fail rather than reclaim space
+ * by destroying authoritative data.
+ */
+TEST_CASE("EvictTrigger - eviction never takes authoritative blobs",
+          "[evict_trigger][noleak]") {
+  REQUIRE(g_fixture != nullptr);
+  auto *cte_client = CLIO_CTE_CLIENT;
+  REQUIRE(cte_client != nullptr);
+
+  clio::cte::core::Tag tag("evict_trigger_mixed_tag");
+  clio::cte::core::TagId tag_id = tag.GetTagId();
+
+  /* Authoritative data at a LOW score, so a score-ranked eviction would reach
+     for it first if it were eligible. */
+  const int kKeepers = static_cast<int>(kTierBytes / kBlobSize) - 3;
+  for (int i = 0; i < kKeepers; ++i) {
+    const int rc = g_fixture->PutAt(tag_id, "keep_" + std::to_string(i), 0,
+                                    kBlobSize, 0.1f, 'K', /*droppable=*/false);
+    INFO("keeper " << i << " rc=" << rc);
+    REQUIRE(rc == 0);
+  }
+
+  /* Push far more droppable data than the remainder holds. These keep
+     succeeding by recycling among themselves, never by taking a keeper. */
+  const int kCached = kKeepers * 2;
+  for (int i = 0; i < kCached; ++i) {
+    const int rc = g_fixture->PutAt(tag_id, "cache_" + std::to_string(i), 0,
+                                    kBlobSize, 0.9f, 'C', /*droppable=*/true);
+    INFO("droppable put " << i << " rc=" << rc);
+    REQUIRE(rc == 0);
+  }
+
+  /* The most recent droppable write is resident and correct, so the recycling
+     stored data rather than merely reporting success. */
+  REQUIRE(BlobRegionMatches(cte_client, tag_id,
+                            "cache_" + std::to_string(kCached - 1), 0,
+                            kBlobSize, 'C'));
+
+  /* Every authoritative blob is intact. */
+  for (int i = 0; i < kKeepers; ++i) {
+    INFO("keeper " << i << " must be untouched");
+    REQUIRE(BlobRegionMatches(cte_client, tag_id, "keep_" + std::to_string(i),
+                              0, kBlobSize, 'K'));
+  }
+
+  DropBlobs(cte_client, tag_id, "keep_", kKeepers);
+  DropBlobs(cte_client, tag_id, "cache_", kCached);
+}
+
+/**
+ * Taking over an expendable blob is refused; the reverse is allowed and leaves
+ * the blob authoritative. See kCtePutDroppable.
+ *
+ * The second half is checked by making eviction try to take the blob.
+ */
+TEST_CASE("EvictTrigger - taking over a droppable blob is refused",
+          "[evict_trigger][noleak]") {
+  REQUIRE(g_fixture != nullptr);
+  auto *cte_client = CLIO_CTE_CLIENT;
+  REQUIRE(cte_client != nullptr);
+
+  clio::cte::core::Tag tag("evict_trigger_conflict_tag");
+  clio::cte::core::TagId tag_id = tag.GetTagId();
+
+  /* A cache copy, then an attempt to take ownership of the same name. */
+  REQUIRE(g_fixture->PutAt(tag_id, "cache_blob", 0, kBlobSize, 0.5f, 'D',
+                           /*droppable=*/true) == 0);
+  const int rc = g_fixture->PutAt(tag_id, "cache_blob", 0, kBlobSize, 0.5f,
+                                  'A', /*droppable=*/false);
+  INFO("takeover rc=" << rc);
+  REQUIRE(rc == static_cast<int>(clio::cte::core::kCteDroppabilityConflictRc));
+
+  /* The cache copy still holds its own bytes and is still writable by its
+     owner. */
+  REQUIRE(BlobRegionMatches(cte_client, tag_id, "cache_blob", 0, kBlobSize,
+                            'D'));
+  REQUIRE(g_fixture->PutAt(tag_id, "cache_blob", 0, kBlobSize, 0.5f, 'E',
+                           /*droppable=*/true) == 0);
+
+  /* Reverse direction: allowed, and must leave the blob authoritative. */
+  REQUIRE(g_fixture->PutAt(tag_id, "auth_blob", 0, kBlobSize, 0.5f, 'K',
+                           /*droppable=*/false) == 0);
+  REQUIRE(g_fixture->PutAt(tag_id, "auth_blob", 0, kBlobSize, 0.5f, 'L',
+                           /*droppable=*/true) == 0);
+
+  /* Push more droppable data than the tier holds. If the droppable put above
+     had flipped the blob, this would consume it. */
+  const int kPressure = static_cast<int>(kTierBytes / kBlobSize) * 2;
+  for (int i = 0; i < kPressure; ++i) {
+    REQUIRE(g_fixture->PutAt(tag_id, "press_" + std::to_string(i), 0, kBlobSize,
+                             0.9f, 'C', /*droppable=*/true) == 0);
+  }
+  REQUIRE(BlobRegionMatches(cte_client, tag_id, "auth_blob", 0, kBlobSize,
+                            'L'));
+
+  DropBlobs(cte_client, tag_id, "press_", kPressure);
+  cte_client->AsyncDelBlob(tag_id, "cache_blob").Wait();
+  cte_client->AsyncDelBlob(tag_id, "auth_blob").Wait();
+}
+
+/**
+ * Every EvictTask input field survives task duplication.
+ *
+ * Broadcast fan-out re-materialises the task per replica through
+ * EvictTask::Copy, where a missing field silently reverts to its default.
+ * Checked directly, since fan-out needs a multi-node pool to reach.
+ */
+TEST_CASE("EvictTrigger - EvictTask::Copy preserves every input field",
+          "[evict_trigger][noleak]") {
+  REQUIRE(g_fixture != nullptr);
+  auto *ipc_manager = CLIO_IPC;
+  auto *pool_manager = CLIO_POOL_MANAGER;
+  auto *cte_client = CLIO_CTE_CLIENT;
+  REQUIRE(ipc_manager != nullptr);
+  REQUIRE(pool_manager != nullptr);
+  REQUIRE(cte_client != nullptr);
+
+  auto container = pool_manager->GetStaticContainer(cte_client->pool_id_).get();
+  REQUIRE(container != nullptr);
+
+  const float kScore = 0.25f;
+  const clio::run::u64 kBytes = 4096;
+  auto orig = ipc_manager->NewTask<clio::cte::core::EvictTask>(
+      clio::run::CreateTaskId(), cte_client->pool_id_,
+      clio::run::PoolQuery::Local(), kScore, kBytes,
+      /*droppable_only=*/static_cast<clio::run::u32>(1));
+  REQUIRE(!orig.IsNull());
+  REQUIRE(orig->droppable_only_ == 1);
+
+  clio::run::shared_ptr<clio::run::Task> task_ptr =
+      orig.template Cast<clio::run::Task>();
+  auto copied = container->NewCopyTask(clio::cte::core::Method::kEvict,
+                                       task_ptr, /*deep=*/true);
+  REQUIRE(!copied.IsNull());
+
+  auto copied_evict = copied.template Cast<clio::cte::core::EvictTask>();
+  REQUIRE(copied_evict->droppable_only_ == 1);
+  REQUIRE(copied_evict->min_tier_score_ == kScore);
+  REQUIRE(copied_evict->bytes_ == kBytes);
+
+  copied.reset();
+  orig.reset();
+}
+
+int main(int argc, char **argv) {
+  g_fixture = new EvictTriggerFixture();
+  std::string filter = (argc > 1) ? argv[1] : "";
+  int result = SimpleTest::run_all_tests(filter);
+  delete g_fixture;
+  g_fixture = nullptr;
+  SIMPLE_TEST_PROCESS_EXIT(result);
+  return result;
+}


### PR DESCRIPTION
Runtime::Evict could reclaim capacity but nothing called it, so a tier that filled up stayed full for the life of the process and the HDF5 cache quietly stopped working after the first N files. PutBlob now reclaims the shortfall and retries once when placement fails.

kCtePutDroppable marks a put's bytes as an expendable copy of data that has an authoritative source elsewhere. Only such a put evicts, and only such blobs are evicted. It is fixed at creation, so a scan-then-delete evictor cannot act on a stale classification, and it survives restart via the WAL and the metadata snapshot. Eviction also skips blobs under an active write, which would otherwise livelock against the caller awaiting it.

The HDF5 VOL marks all three of its CTE writes droppable. It's native-preserving, so a CTE blob there is never the only copy. A full tier now recycles its coldest blobs to keep caching from eventually stopping.

Two gaps: multi-node broadcast fan-out, and the value of droppable_ after a restart, both need harness capabilities that aren't currently implemented. Field-level and parse-level checks stand in for them.

This PR also includes a comment trimming pass over the VOL connector, and an AGENTS.md note on local build/test traps.