### PR TITLE
Fix the macFUSE build: Darwin-correct aliases, Linux-only ll target

### DIFF
--- a/context-transfer-engine/adapter/libfuse/CMakeLists.txt
+++ b/context-transfer-engine/adapter/libfuse/CMakeLists.txt
@@ -78,8 +78,13 @@ target_link_libraries(clio_cte_fuse
 
 # EXPERIMENTAL low-level adapter (issue #1007 follow-up): same delegated
 # operations, low-level session — attrs ride in create/lookup replies and
-# readdirplus, eliminating the per-create GETATTR round trips. Linux-only.
-if(NOT WIN32)
+# readdirplus, eliminating the per-create GETATTR round trips.
+#
+# Linux-only, and the guard has to SAY Linux: macFUSE's low-level API diverges
+# from libfuse's (different fuse_reply_entry/attr/create/statfs shapes, no
+# fuse_add_direntry_plus, struct fuse_darwin_attr in place of struct stat), so
+# a `NOT WIN32` guard silently opted macOS in and broke that build.
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   add_executable(clio_cte_fuse_ll
       fuse_cte.cc
       fuse_cte_ll.cc)

--- a/context-transfer-engine/adapter/libfuse/fuse_cte.h
+++ b/context-transfer-engine/adapter/libfuse/fuse_cte.h
@@ -477,13 +477,25 @@ extern const struct fuse_operations cte_fuse_ops;
 
 #if !defined(_WIN32)
 #include <sys/statvfs.h>
-// Linux spellings of the shared-callback types (identical alias
-// redeclarations are legal; fuse_cte.cc declares the same set).
+#ifdef __APPLE__
+#include <sys/param.h>
+#include <sys/mount.h>  // struct statfs (macFUSE's statfs callback type)
+#endif
+// POSIX spellings of the shared-callback types. These MUST stay byte-identical
+// to the block in fuse_cte.cc: an alias may be redeclared only when it names
+// the SAME type, and macFUSE reports through Darwin's struct statfs where
+// libfuse reports statvfs. Declaring the Linux spelling unconditionally here
+// is what broke the macOS adapters build — 'struct statfs' vs 'struct statvfs'
+// redefinition, plus a statfs callback whose signature no longer matched.
 using cte_stat_t = struct stat;
 using cte_off_t = off_t;
 using cte_mode_t = mode_t;
 using cte_timespec_t = struct timespec;
+#ifdef __APPLE__
+using cte_statvfs_t = struct statfs;
+#else
 using cte_statvfs_t = struct statvfs;
+#endif
 #endif
 
 #ifndef _WIN32


### PR DESCRIPTION
## Summary
- `fuse_cte.h` now carries the same `__APPLE__` branch as `fuse_cte.cc`, so `cte_statvfs_t` is `struct statfs` on Darwin and `struct statvfs` elsewhere
- `clio_cte_fuse_ll` is gated on `CMAKE_SYSTEM_NAME STREQUAL "Linux"` instead of `NOT WIN32`, matching what its comment already claimed

## Motivation
Fixes #1011. Unblocks #1006 — `adapters (macos, hdf5_vol + macfuse)` has been failing to compile on dev since `fcbc503f`.

## Test plan
- [x] Linux build clean; `clio_cte_fuse_ll` still builds on Linux
- [ ] `adapters (macos, hdf5_vol + macfuse)` compiles and passes (this PR is the first place it runs — see #1011 for why it was skipped on the PR that broke it)

## Breaking changes
None