### PR TITLE
Fix/970 client finalize wait

### DIFF
--- a/context-runtime/include/clio_runtime/ipc/ipc_cpu2cpu_impl.h
+++ b/context-runtime/include/clio_runtime/ipc/ipc_cpu2cpu_impl.h
@@ -35,6 +35,30 @@ Future<TaskT> IpcCpu2Cpu::SendIn(IpcManager *ipc,
 #else
   if (task_ptr.IsNull()) return Future<TaskT>();
 
+  // Finalized-client guard (issue #970). ClientFinalize resets the transports
+  // this function is about to use, so a submit after it dereferences a dangling
+  // one. Complete the task with an error instead.
+  //
+  // Placed HERE rather than in IpcManager::Send, which is where it started: Send
+  // is not the only way in. ClientConnect (reconnect) and RegisterMemory call
+  // this directly from ipc_manager.cc -- five sites that bypass Send entirely --
+  // and each of them would hit the same dangling transport. Guarding the
+  // transport entry points covers those too, and needs no CTP_IS_HOST block of
+  // its own because this body is already the host half of one.
+  //
+  // The runtime self-send path (IpcCpu2Self::SendIn) is deliberately untouched:
+  // it uses none of these transports, so excluding it is structural here rather
+  // than an is_runtime test.
+  if (ipc->client_finalized_.load(std::memory_order_acquire)) {
+    HLOG(kWarning,
+         "Send(SHM): client is finalized; failing task instead of submitting on a "
+         "torn-down transport (issue #970)");
+    Future<TaskT> future(task_ptr->pool_id_, task_ptr->method_, task_ptr);
+    task_ptr->SetReturnCode(static_cast<u32>(-1));
+    task_ptr->SetComplete();
+    return future;
+  }
+
   // #642: the task's virtual address is the response key the worker echoes back
   // so this client thread can match the result to the right Future.
   size_t net_key = reinterpret_cast<size_t>(task_ptr.get());
@@ -116,6 +140,25 @@ bool IpcCpu2Cpu::RecvOut(IpcManager *ipc,
   TaskT *task_ptr = future.get();
   const size_t want_key = task_ptr->task_id_.net_key_;
 
+  // Finalized-client escape (issue #970). A task submitted AFTER
+  // ClientFinalize can never complete — the response listener is gone and the
+  // recv threads are joined — so waiting for it is an unbounded park with no
+  // possible wakeup. The reported case is an HDF5 VOL application: clio's
+  // atexit handler runs before H5_term_library (atexit is LIFO and the
+  // connector cannot register earlier than HDF5), so clio_file_close submits
+  // a DelBlob on a torn-down client and exit() never returns.
+  //
+  // Checked before the spin/park below rather than only inside the loop, so
+  // this costs nothing on the healthy path and returns immediately on the
+  // dead one.
+  if (ipc->client_finalized_.load(std::memory_order_acquire) &&
+      !task_ptr->IsComplete()) {
+    HLOG(kWarning,
+         "Recv(SHM): client is finalized; failing task instead of waiting "
+         "for a response that cannot arrive (issue #970)");
+    return false;
+  }
+
   // Block on this thread's EventManager until RecvShmClientThread marks this
   // task complete and signals us (SHM analogue of IpcCpu2CpuZmq::RecvOut). The
   // dedicated recv thread — not this thread — drains the single response ring,
@@ -171,6 +214,13 @@ bool IpcCpu2Cpu::RecvOut(IpcManager *ipc,
       HLOG(kWarning,
            "Recv(SHM): server died mid-wait; handing off to reconnect path");
       return IpcCpu2CpuZmq::RecvOut(ipc, future, max_sec);
+    }
+    // The twin of the entry check above, for a wait that was already parked
+    // when another thread began teardown (issue #970).
+    if (ipc->client_finalized_.load(std::memory_order_acquire)) {
+      HLOG(kWarning,
+           "Recv(SHM): client finalized mid-wait; failing task (issue #970)");
+      return false;
     }
   }
 

--- a/context-runtime/include/clio_runtime/ipc/ipc_cpu2cpu_zmq_impl.h
+++ b/context-runtime/include/clio_runtime/ipc/ipc_cpu2cpu_zmq_impl.h
@@ -25,6 +25,30 @@ Future<TaskT> IpcCpu2CpuZmq::SendIn(IpcManager *ipc,
 #else
   if (task_ptr.IsNull()) return Future<TaskT>();
 
+  // Finalized-client guard (issue #970). ClientFinalize resets the transports
+  // this function is about to use, so a submit after it dereferences a dangling
+  // one. Complete the task with an error instead.
+  //
+  // Placed HERE rather than in IpcManager::Send, which is where it started: Send
+  // is not the only way in. ClientConnect (reconnect) and RegisterMemory call
+  // this directly from ipc_manager.cc -- five sites that bypass Send entirely --
+  // and each of them would hit the same dangling transport. Guarding the
+  // transport entry points covers those too, and needs no CTP_IS_HOST block of
+  // its own because this body is already the host half of one.
+  //
+  // The runtime self-send path (IpcCpu2Self::SendIn) is deliberately untouched:
+  // it uses none of these transports, so excluding it is structural here rather
+  // than an is_runtime test.
+  if (ipc->client_finalized_.load(std::memory_order_acquire)) {
+    HLOG(kWarning,
+         "Send(ZMQ): client is finalized; failing task instead of submitting on a "
+         "torn-down transport (issue #970)");
+    Future<TaskT> future(task_ptr->pool_id_, task_ptr->method_, task_ptr);
+    task_ptr->SetReturnCode(static_cast<u32>(-1));
+    task_ptr->SetComplete();
+    return future;
+  }
+
   // Set net_key for response routing
   size_t net_key = reinterpret_cast<size_t>(task_ptr.get());
   task_ptr->task_id_.net_key_ = net_key;
@@ -81,6 +105,19 @@ bool IpcCpu2CpuZmq::RecvOut(IpcManager *ipc,
   TaskT *task_ptr = future.get();
   ClientOrigin origin = future_shm->origin_;
 
+  // Finalized-client escape (issue #970), before the reconnect head below.
+  // Reaching here during teardown means the SHM path handed off after seeing
+  // the server flagged dead; reconnecting would rebuild transports the caller
+  // is concurrently destroying, and the resent task still has no listener to
+  // answer it.
+  if (ipc->client_finalized_.load(std::memory_order_acquire) &&
+      !task_ptr->IsComplete()) {
+    HLOG(kWarning,
+         "Recv: client is finalized; failing task instead of reconnecting "
+         "(issue #970)");
+    return false;
+  }
+
   // If origin was SHM but server is dead, reconnect and resend via ZMQ
   if (origin == ClientOrigin::kClientShm) {
     if (ipc->client_retry_timeout_ == 0 && ipc->client_try_new_servers_ <= 0) {
@@ -107,6 +144,11 @@ bool IpcCpu2CpuZmq::RecvOut(IpcManager *ipc,
         std::chrono::duration<float>(std::chrono::steady_clock::now() - start)
             .count();
     if (max_sec > 0 && elapsed >= max_sec) return false;
+    if (ipc->client_finalized_.load(std::memory_order_acquire)) {
+      HLOG(kWarning,
+           "Recv: client finalized mid-wait; failing task (issue #970)");
+      return false;
+    }
     if (!ipc->server_alive_.load() && !ipc->reconnecting_.load()) {
       if (ipc->client_retry_timeout_ == 0 &&
           ipc->client_try_new_servers_ <= 0) {

--- a/context-runtime/include/clio_runtime/ipc_manager.h
+++ b/context-runtime/include/clio_runtime/ipc_manager.h
@@ -1739,6 +1739,19 @@ class IpcManager {
   std::atomic<bool> heartbeat_running_{false};
   std::atomic<bool> server_alive_{true};
 
+  // Set at the TOP of ClientFinalize, before any transport is torn down
+  // (issue #970). Once teardown has begun, a response can never arrive: the
+  // response listener is destroyed and the recv threads are joined. The waits
+  // in IpcCpu2Cpu::RecvOut and IpcCpu2CpuZmq::RecvOut therefore treat this as
+  // a terminal condition and fail the task instead of parking on it.
+  //
+  // This is deliberately NOT folded into server_alive_. That flag means "the
+  // runtime went away and we may be able to reconnect to it", and it drives a
+  // reconnect/resend path that is exactly wrong here — the runtime is fine, it
+  // is THIS client that is gone, and reconnecting during teardown would build
+  // transports that the caller is in the middle of destroying.
+  std::atomic<bool> client_finalized_{false};
+
   // A client-side in-flight async submission, tracked by net_key. The async
   // recv thread marks the task complete (Task::is_complete_/is_new_data_) and
   // wakes the waiter thread recorded on the FutureShm. Both pointers stay valid

--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -203,6 +203,12 @@ bool IpcManager::ClientInit() {
   if (is_initialized_) {
     return true;
   }
+  // A genuine (re)initialisation builds fresh transports, so clear the
+  // finalized flag (issue #970). Deliberately AFTER the early return above:
+  // when ClientInit is a no-op because the manager is already initialised, the
+  // transports torn down by a previous ClientFinalize are NOT rebuilt, and a
+  // wait on them must keep failing fast rather than parking forever.
+  client_finalized_.store(false, std::memory_order_release);
   // Optional Windows timer-resolution bump (CLIO_WIN_TIMER_MS, issue #768).
   ctp::SystemInfo::RequestTimerResolutionFromEnv();
 
@@ -610,6 +616,12 @@ bool IpcManager::ServerInit() {
 }
 
 void IpcManager::ClientFinalize() {
+  // FIRST, before anything is torn down (issue #970): publish that this client
+  // is going away, so any wait — one already parked on another thread, or one
+  // submitted later from a still-to-run atexit handler — fails fast instead of
+  // blocking on a response that provably cannot arrive.
+  client_finalized_.store(true, std::memory_order_release);
+
   // Mark shutdown so ZeroMqTransport leaks shared-context sockets instead of
   // zmq_close-ing them on Windows (avoids libzmq's signaler WSASTARTUP abort).
   ctp::lbm::sock::SetSocketLibShutdown();

--- a/context-runtime/test/unit/cli/CMakeLists.txt
+++ b/context-runtime/test/unit/cli/CMakeLists.txt
@@ -184,6 +184,45 @@ if(CLIO_CORE_ENABLE_TESTS)
     LABELS "msan_skip;leak;crash"
   )
 
+  # Issue #970: a task submitted AFTER ClientFinalize must fail rather than park
+  # forever, or the process never leaves exit(). Forks a client that registers an
+  # atexit handler BEFORE clio init -- reproducing HDF5's position in the LIFO
+  # ordering, without needing HDF5 -- and asserts the child exits.
+  add_executable(clio_run_client_exit_wait_test test_client_exit_wait.cc)
+  target_include_directories(clio_run_client_exit_wait_test PRIVATE
+    ${CLIO_RUN_ROOT}/include
+    ${CLIO_RUN_ROOT}/test
+  )
+  target_link_libraries(clio_run_client_exit_wait_test
+    clio_cte_core_client
+    clio_admin_client
+    clio_run_cxx
+    ctp::cxx
+    ${CMAKE_THREAD_LIBS_INIT}
+  )
+  target_compile_definitions(clio_run_client_exit_wait_test PRIVATE
+    CLIO_RUN_EXE="$<TARGET_FILE:clio_run>")
+  add_dependencies(clio_run_client_exit_wait_test
+    clio_run clio_cte_core_runtime clio_bdev_runtime)
+  set_target_properties(clio_run_client_exit_wait_test PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED ON
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  )
+  add_test(
+    NAME cr_cli_client_exit_wait
+    COMMAND clio_run_client_exit_wait_test
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  )
+  # TIMEOUT comfortably exceeds the test's own 30s child budget, so a real hang
+  # is reported by the test's FAIL message rather than as an opaque ctest kill.
+  set_tests_properties(cr_cli_client_exit_wait PROPERTIES
+    ENVIRONMENT "${_cli_live_env}"
+    RESOURCE_LOCK "clio_runtime"
+    TIMEOUT 180
+    LABELS "msan_skip"
+  )
+
   # Filesystem chimod test: compose bdev->cte_core->filesystem, drive the cfs
   # client (open/write/getattr/read/truncate), assert EXACT logical size.
   # Only built when the filesystem chimod is enabled.

--- a/context-runtime/test/unit/cli/test_client_exit_wait.cc
+++ b/context-runtime/test/unit/cli/test_client_exit_wait.cc
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ * BSD 3-Clause License. See LICENSE file.
+ */
+
+/**
+ * Regression test for issue #970: a task submitted after ClientFinalize must
+ * fail, not hang the process in exit() forever.
+ *
+ * The reported symptom is an HDF5 VOL application that never exits. The cause
+ * is an atexit ordering that the connector cannot influence:
+ *
+ *   1. HDF5 registers atexit(H5_term_library) during its FIRST API call
+ *      (hdf5/src/H5.c, H5_init_library).
+ *   2. The VOL connector initialises the clio client lazily, inside that same
+ *      first H5Fcreate, so clio's atexit handler is registered SECOND.
+ *   3. atexit runs handlers in reverse order, so clio tears the client down
+ *      FIRST, and H5_term_library then closes the file HDF5 still held open.
+ *   4. clio_file_close -> clio_write_stamp submits a DelBlob on the dead client
+ *      and waits on a response that can never arrive.
+ *
+ * Registering clio's handler earlier cannot fix this: earlier registration
+ * means later execution, and the connector is not loaded until HDF5 is already
+ * initialised.
+ *
+ * This test reproduces the ordering WITHOUT HDF5, because HDF5 contributes
+ * nothing to the mechanism except "a handler registered before clio's". The
+ * child registers its own handler before CLIO_INIT and submits a DelBlob from
+ * it -- the same call clio_write_stamp makes. Keeping HDF5 out means this runs
+ * in every CI configuration, not just the ones that build the VOL.
+ *
+ * Why the existing suites miss it: vol_compat_suite.py drives the connector
+ * through h5py, which closes its objects, so H5_term_library never has a file
+ * to close and the exit path is never exercised.
+ *
+ * The assertion is that the child EXITS. Its exit code additionally
+ * distinguishes a real pass from a vacuous one -- a child that could not reach
+ * a live runtime reports a distinct code and fails the test rather than
+ * "passing" by exiting early.
+ *
+ * POSIX-only (fork()/waitpid); the whole cli/ directory is gated on NOT WIN32.
+ */
+#include <fcntl.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <clio_runtime/clio_runtime.h>
+#include <clio_cte/core/core_client.h>
+
+#include "runtime_server.h"
+#include "simple_test.h"
+
+namespace fs = std::filesystem;
+
+namespace {
+
+// Distinct from the other live-runtime cli tests (which also serialize on the
+// "clio_runtime" RESOURCE_LOCK).
+constexpr unsigned kPort = 10617;
+
+// How long the child gets to exit. The failure mode is an UNBOUNDED wait, so
+// any finite budget separates pass from fail; this one is generous enough to
+// absorb a slow CI runner without making a real hang cost the whole ctest
+// timeout.
+constexpr int kExitBudgetSec = 30;
+
+// Child exit codes. Anything other than kOk fails the test with a specific
+// cause, so a child that never reached the runtime cannot masquerade as a pass.
+constexpr int kOk = 0;
+constexpr int kInitFailed = 2;
+constexpr int kCteInitFailed = 3;
+constexpr int kPutFailed = 4;
+constexpr int kAtexitRegFailed = 5;
+
+/** Run the clio_run binary as a subprocess with a timeout; returns its exit
+ *  code (negative on spawn/timeout failure). Mirrors test_cte_fallback.cc. */
+int RunCliTimed(const std::vector<std::string> &args, int timeout_sec) {
+  std::vector<std::string> full;
+  full.push_back(CLIO_RUN_EXE);
+  full.insert(full.end(), args.begin(), args.end());
+  std::vector<char *> argv;
+  for (auto &a : full) argv.push_back(a.data());
+  argv.push_back(nullptr);
+  pid_t pid = fork();
+  if (pid < 0) return -1;
+  if (pid == 0) {
+    int n = open("/dev/null", O_WRONLY);
+    if (n >= 0) { dup2(n, 1); dup2(n, 2); close(n); }
+    execv(argv[0], argv.data());
+    _exit(127);
+  }
+  auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(timeout_sec);
+  int status = 0;
+  while (true) {
+    pid_t r = waitpid(pid, &status, WNOHANG);
+    if (r == pid) return WIFEXITED(status) ? WEXITSTATUS(status) : -2;
+    if (std::chrono::steady_clock::now() >= deadline) {
+      kill(pid, SIGKILL);
+      waitpid(pid, &status, 0);
+      return -3;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+}
+
+const char *kTagName = "issue970_exit_tag";
+const char *kBlobName = "stamp";
+
+clio::cte::core::Client *g_cte = nullptr;
+clio::cte::core::TagId g_tag_id;
+
+/**
+ * Stands in for H5_term_library. Registered BEFORE CLIO_INIT, so atexit's LIFO
+ * ordering runs it AFTER clio's teardown -- exactly HDF5's position.
+ *
+ * The body is the shape of clio_write_stamp's ambiguous branch
+ * (clio_vol.cc, AsyncDelBlob followed by an unconditional Wait). Before the
+ * fix this parks forever in IpcCpu2Cpu::RecvOut; after it, Wait returns false
+ * and the task carries an error code, which is what the VOL's existing
+ * "stamp could not be dropped" warning path already handles.
+ */
+void LateTeardown() {
+  if (g_cte == nullptr) return;
+  auto del = g_cte->AsyncDelBlob(g_tag_id, std::string(kBlobName));
+  del.Wait();  // must RETURN; the defect is that it never does
+}
+
+/** Runs in the forked child. Never returns: ends via exit() so atexit runs. */
+[[noreturn]] void ExitClientMain() {
+  // Silence the child's client chatter; the parent asserts on its exit code.
+  int devnull = open("/dev/null", O_WRONLY);
+  if (devnull >= 0) { dup2(devnull, 1); dup2(devnull, 2); close(devnull); }
+
+  // THE ORDERING UNDER TEST. Registered before CLIO_INIT, therefore run after
+  // clio's own handler. Moving this line below CLIO_INIT would make the test
+  // pass for the wrong reason.
+  if (std::atexit(LateTeardown) != 0) _exit(kAtexitRegFailed);
+
+  if (!clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, false)) {
+    _exit(kInitFailed);
+  }
+  if (!clio::cte::core::CLIO_CTE_CLIENT_INIT()) _exit(kCteInitFailed);
+  g_cte = CLIO_CTE_CLIENT;
+
+  clio::cte::core::Tag tag{std::string(kTagName)};
+  g_tag_id = tag.GetTagId();
+
+  // Put the blob the late handler will try to delete, and prove in passing that
+  // this child really did reach a healthy runtime.
+  char payload[8] = {'s', 't', 'a', 'm', 'p', '!', '\0', '\0'};
+  auto put = g_cte->AsyncPutBlob(g_tag_id, std::string(kBlobName), 0,
+                                 sizeof(payload), payload);
+  put.Wait();
+  if (put->GetReturnCode() != 0) _exit(kPutFailed);
+
+  // exit(), NOT _exit(): the whole point is to run the atexit handlers.
+  std::exit(kOk);
+}
+
+}  // namespace
+
+TEST_CASE("ClientExit - task submitted after ClientFinalize does not hang exit",
+          "[cr][cli][issue970]") {
+  clio::run::test::SetEnvVar("CLIO_PORT", std::to_string(kPort));
+
+  const fs::path work = fs::temp_directory_path() / "clio_client_exit_test";
+  fs::remove_all(work);
+  fs::create_directories(work);
+
+  // Self-contained CTE core pool (512.0) on a ram device; CTE creates its own
+  // bdev target locally. Mirrors test_client_crash_putblob.cc.
+  const fs::path compose_yaml = work / "compose.yaml";
+  {
+    std::ofstream f(compose_yaml);
+    f << "compose:\n"
+         "  - mod_name: clio_cte_core\n"
+         "    pool_name: cte_client_exit\n"
+         "    pool_query: local\n"
+         "    pool_id: \"512.0\"\n"
+         "    storage:\n"
+         "      - path: " << (work / "ram_dev").string() << "\n"
+         "        bdev_type: ram\n"
+         "        capacity_limit: 256mb\n"
+         "    dpe:\n"
+         "      dpe_type: random\n";
+  }
+
+  clio::run::test::RuntimeServer server;
+  REQUIRE(server.Start(kPort, "127.0.0.1", /*ephemeral=*/true));
+  REQUIRE(server.WaitForReady());
+  REQUIRE(RunCliTimed({"compose", "start", compose_yaml.string()}, 60) == 0);
+
+  // Client mode does not dlopen ChiMods, so fork without exec is safe here
+  // (same rationale as test_client_crash_putblob.cc).
+  pid_t child = fork();
+  REQUIRE(child >= 0);
+  if (child == 0) ExitClientMain();  // never returns
+
+  // Poll rather than block: a blocking waitpid on the defect would hang the
+  // TEST too, turning a clear failure into a ctest timeout with no message.
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(kExitBudgetSec);
+  int status = 0;
+  bool exited = false;
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (waitpid(child, &status, WNOHANG) == child) { exited = true; break; }
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  }
+  if (!exited) {
+    kill(child, SIGKILL);
+    waitpid(child, &status, 0);
+    FAIL("child did not exit within " << kExitBudgetSec << "s: a task "
+         "submitted after ClientFinalize is parked in an unbounded wait "
+         "(issue #970)");
+  }
+
+  REQUIRE(WIFEXITED(status));
+  const int code = WEXITSTATUS(status);
+  INFO("child exit code: " << code);
+  REQUIRE(code != kInitFailed);      // never reached a runtime
+  REQUIRE(code != kCteInitFailed);   // no CTE pool
+  REQUIRE(code != kPutFailed);       // runtime unhealthy
+  REQUIRE(code != kAtexitRegFailed);
+  REQUIRE(code == kOk);
+
+  server.Stop();
+}
+
+int main(int argc, char **argv) {
+  // Allows driving the child role by hand for debugging:
+  //   ./clio_run_client_exit_wait_test exit-client
+  if (argc > 1 && std::string(argv[1]) == "exit-client") {
+    ExitClientMain();  // never returns
+  }
+  int result = SimpleTest::run_all_tests(argc > 1 ? argv[1] : "");
+  SIMPLE_TEST_PROCESS_EXIT(result);
+  if (SimpleTest::g_test_finalize) SimpleTest::g_test_finalize();
+  return result;
+}


### PR DESCRIPTION
When ClientFinalize runs, it tears down the client's transports. It resets the
ZMQ transport, destroys the response listener, and joins the recv threads. Work
submitted after that point was neither rejected nor bounded, and failed two
different ways. On ZMQ/IPC, SendIn dereferenced the reset transport and
segfaulted. On SHM, the submit survived but the wait never returned:
Future::Wait defaults to max_sec = -1, and RecvOut's only escape is
server_alive_, which the heartbeat thread can no longer clear once it has been
joined.

Any HDF5 VOL application that still holds a file open when main returns hits
this and never exits. The atexit ordering that gets it there is described in
#970.

The fix adds a client_finalized_ flag, set at the top of ClientFinalize before
any transport is torn down. IpcManager::Send checks it and completes the task
with an error instead of submitting on a dead transport. Send is the single
chokepoint both client transports pass through, so one check covers both
failure shapes. Both RecvOut waits check it too, which handles a wait that was
already parked when another thread started teardown. Callers already handle a
non-zero return code, so the VOL needs no change: its coherence stamp just
degrades to "the next open fails closed". The flag is kept separate from
server_alive_, which means the runtime went away and we might reconnect. That
is the wrong response here. The runtime is fine; it is this client that is
gone.

Resolves #970