### PR TITLE
fix(runtime): clamp RAM bdev preallocation to the memory budget (#1018)

### DIFF
--- a/context-runtime/modules/bdev/src/transports/mem_bdev_transport.cc
+++ b/context-runtime/modules/bdev/src/transports/mem_bdev_transport.cc
@@ -114,6 +114,41 @@ bool MemBdevTransport::Init(const CreateParams& params,
       break;
   }
 
+  // Eager preallocation commits REAL memory: PreallocateRamPages() allocates
+  // and zeroes every kRamPageSize page, so a DRAM-derived capacity asks the
+  // node to commit ~all of its RAM before the first write ever lands.
+  //
+  // The unsized-pool degradation above cannot catch that, because CTE resolves
+  // `capacity_limit: "0g"` to DefaultRamCapacityBytes() (80% of
+  // GetRamCapacity()) BEFORE the bdev sees it (core_config.cc, "0g" handling).
+  // total_size_ is then non-zero, so the pool looks explicitly sized and the
+  // guard passes it straight through.
+  //
+  // Apply the same half-budget clamp ipc_manager uses for the main/metadata
+  // segments (ServerInitShm): past that point the live set can only end in
+  // thrash, SIGBUS or OOM, so degrade to lazy rather than boot a time bomb.
+  // Lazy is safe here because EnsureRamPage() allocates on demand and
+  // AllocRamPage() zeroes what it hands back; capacity_limit stays a cap for
+  // placement either way, only the up-front commit changes.
+  //
+  // Measured on a 15.9 GiB win-10 host: GetRamCapacity() reported 20 GiB, so
+  // "0g" resolved to 16 GiB and this committed 16 x 1 GiB pages on the private
+  // heap (the SHM mapping having already failed with "MapViewOfFile: Access is
+  // denied" at that size). That wedged the worker inside Create and timed out
+  // 8 CAE/CTE tests at 300 s apiece, while Linux CI stayed green because its
+  // memfd mapping is sparse and never falls back to the heap.
+  if (preallocate) {
+    const size_t budget = ctp::SystemInfo::GetProcessMemoryBudget();
+    if (budget > 0 && static_cast<size_t>(ram_capacity_) > budget / 2) {
+      HLOG(kWarning,
+           "bdev: capacity {} bytes exceeds half the memory budget ({} bytes); "
+           "preallocating it would commit more memory than this host can hold, "
+           "so pages will be allocated lazily instead",
+           ram_capacity_, budget);
+      preallocate = false;
+    }
+  }
+
   if (preallocate) {
     PreallocateRamPages();
   }
@@ -208,15 +243,12 @@ void MemBdevTransport::PreallocateRamPages() {
   std::lock_guard<std::mutex> lock(ram_pages_mu_);
   ram_pages_.resize(num_pages);
   for (RamPage &page : ram_pages_) {
+    // AllocRamPage() zeroes each page it allocates, which is both the
+    // pre-fault and the read-as-zero guarantee: pageable pages are otherwise
+    // faulted in 4 KiB at a time by the first write inside the I/O path, and a
+    // GPU D2H into never-touched pageable memory is the slowest copy the
+    // driver offers. Zeroing here as well would just write every page twice.
     AllocRamPage(page);
-    if (page.data == nullptr) continue;
-    // Pre-fault (pageable) / zero (both). Pageable pages are otherwise faulted
-    // in 4 KiB at a time by the first write, inside the I/O path; a GPU D2H into
-    // never-touched pageable memory is the slowest copy the driver offers. The
-    // zeroing also preserves the read semantics below: a region that was never
-    // written must read back as zeros, and a preallocated page can no longer be
-    // detected by a null pointer.
-    memset(page.data, 0, kRamPageSize);
   }
 }
 
@@ -321,6 +353,15 @@ char* MemBdevTransport::AllocRamPage(RamPage &page) {
   if (page.data == nullptr) {
     page.data = new char[kRamPageSize];
     page.pinned = false;
+  }
+  // Zero every page we hand back. A region that was never written must read
+  // back as zeros, and neither `new char[]` nor MallocHost guarantees that.
+  // PreallocateRamPages() used to be the only thing zeroing these, so a page
+  // allocated on the I/O path could expose heap garbage for whatever parts of
+  // it nobody had written yet — already reachable for an unsized pool, and now
+  // for any pool whose eager preallocation the half-budget clamp degraded.
+  if (page.data != nullptr) {
+    std::memset(page.data, 0, kRamPageSize);
   }
   return page.data;
 }


### PR DESCRIPTION
Fixes #1018

## What

The RAM bdev eagerly committed its entire configured capacity before the first write. On a host where that capacity exceeds physical RAM, `PreallocateRamPages()` wedged the worker inside pool creation and eight CAE/CTE tests hung to their 300 s ctest limit.

Two changes, both in `mem_bdev_transport.cc`:

- **Eager preallocation now respects the memory budget.** This reuses the runtime's own guard — `GetProcessMemoryBudget()` with a half-budget threshold — the same one `ipc_manager::ServerInitShm` applies to the main and metadata segments, for the same reason. Over that threshold the pool degrades to lazy with a warning, mirroring how an unsized pool already degrades. `capacity_limit` stays a cap for placement; only the up-front commit changes.
- **`AllocRamPage()` zeroes what it returns**, and the now-redundant `memset` in `PreallocateRamPages()` is removed so pages are not written twice. The zeroing is required once preallocation can be skipped — `new char[]` does not zero, and that `memset` was the only thing guaranteeing "a region never written reads back as zeros". It also closes a latent bug: an **unsized** pool already allocated lazily, so it could expose heap garbage for the unwritten parts of an allocated 1 GiB page.

The existing safety check could not catch this: it only fires on `total_size_ == 0`, and CTE resolves `capacity_limit: "0g"` into concrete bytes before the bdev sees it, so the pool arrives looking explicitly sized. See #1018 for the full chain.

## Test plan

Built and run on win-10 against dev `fcbc503f` (`clio_dev_r.bat` configuration: Ninja + icx, Debug, `CLIO_CTP_LOG_LEVEL=0`).

All eight tests from #1018, previously 300 s timeouts:

| Test | Before | After |
| --- | --- | --- |
| `cte_tiered_dram_default_all` | Timeout 300.59 s | Passed 9.27 s |
| `cae_binary_assim` | Timeout 300.46 s | Passed 34.52 s |
| `cae_range_assim` | Timeout 300.33 s | Passed 3.14 s |
| `cae_error_handling` | Timeout 300.41 s | Passed 2.26 s |
| `cae_cloud_factory_guard` | Timeout 300.42 s | Passed 1.41 s |
| `cae_exportdata_task` | Timeout 300.24 s | Passed 1.58 s |
| `cae_exportdata_runtime` | Timeout 300.36 s | Passed 2.18 s |
| `cae_exportdata_force_net` | Timeout 300.50 s | Passed 4.02 s |

Full suite: **232/233 in 798 s**.

The clamp was confirmed to actually fire, rather than the tests passing for some other reason:

```
mem_bdev_transport.cc Init bdev: capacity 17179869184 bytes exceeds half the
memory budget (17078145024 bytes); preallocating it would commit more memory
than this host can hold, so pages will be allocated lazily instead
```

## The one remaining suite failure is not a regression

`cr_bdev_force_net` fails late in a full-suite run on this host, but it is a **full C: drive**, not this change:

- its failing `REQUIRE` is `createTestFile(100 * 1024 * 1024)`, a 100 MB file write that returns false when `file.good()` fails — nothing in this diff touches file I/O;
- it **passes in isolation in 23.63 s**, matching the dashboard's 23.1–23.4 s;
- C: fell from 2.24 GB to 1.37 GB *during* the run.

Worth flagging separately: the suite leaks ~0.8–1.7 GB into `%TEMP%` per run and the cleanup fixture only runs at the start and end, never between tests. On a host this tight that is enough to make unrelated tests fail mid-run, which is its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
