### PR TITLE
Stop the dashboard deadlocking the daemon's shutdown

### DIFF
--- a/context-runtime/src/viz/viz_server.cc
+++ b/context-runtime/src/viz/viz_server.cc
@@ -870,7 +870,19 @@ void VizServer::Stop() {
   // alive for the worker, and the process is seconds from exit anyway) and let
   // the rest of ServerFinalize proceed. Losing the dashboard's memory at exit
   // is strictly better than losing the graceful shutdown.
-  constexpr int kVizStopBudgetMs = 3000;
+  // Overridable with CLIO_VIZ_STOP_BUDGET_MS, the same env convention as
+  // CLIO_VIZ_ENABLE / _PORT / _BIND. An operator can shorten it on a node
+  // where a wedged handler must never delay shutdown, and the tests set 0 to
+  // exercise the abandon path deterministically instead of leaving it as a
+  // branch nothing ever takes.
+  int stop_budget_ms = 3000;
+  if (const char *env = clio::run::env::GetCompat("VIZ_STOP_BUDGET_MS")) {
+    char *end = nullptr;
+    long n = std::strtol(env, &end, 10);
+    if (end != env && n >= 0) {
+      stop_budget_ms = static_cast<int>(n);
+    }
+  }
   std::shared_ptr<Impl> impl(std::move(impl_));  // impl_ is null from here on
   auto finished = std::make_shared<std::promise<void>>();
   std::future<void> done = finished->get_future();
@@ -887,12 +899,12 @@ void VizServer::Stop() {
     finished->set_value();
   }).detach();
 
-  if (done.wait_for(std::chrono::milliseconds(kVizStopBudgetMs)) !=
+  if (done.wait_for(std::chrono::milliseconds(stop_budget_ms)) !=
       std::future_status::ready) {
     HLOG(kWarning,
          "Viz: dashboard teardown did not finish within {} ms; abandoning it "
          "so the shutdown can proceed",
-         kVizStopBudgetMs);
+         stop_budget_ms);
   }
 }
 

--- a/context-runtime/src/viz/viz_server.cc
+++ b/context-runtime/src/viz/viz_server.cc
@@ -40,10 +40,14 @@
 
 #include <algorithm>
 #include <cctype>
+#include <chrono>
 #include <filesystem>
 #include <fstream>
+#include <future>
+#include <memory>
 #include <set>
 #include <sstream>
+#include <thread>
 
 #include "clio_runtime/container.h"
 #include "clio_runtime/module_manager.h"
@@ -62,6 +66,7 @@
 #include <Poco/Net/ServerSocket.h>
 #include <Poco/Net/SocketAddress.h>
 #include <Poco/StreamCopier.h>
+#include <Poco/ThreadPool.h>
 #include <Poco/URI.h>
 #endif
 
@@ -672,6 +677,18 @@ bool VizServer::Dispatch(const Request &req, Response &resp) {
 /** Poco server state. Lives here so no Poco type reaches an installed header. */
 struct VizServer::Impl {
   Poco::Net::ServerSocket socket;
+  // A PRIVATE thread pool, deliberately NOT Poco's ThreadPool::defaultPool().
+  //
+  // The HTTPServer(factory, socket, params) overload silently borrows the
+  // process-wide default pool, and tearing the server down then joins THAT
+  // pool -- i.e. it waits on threads this dashboard never owned and cannot
+  // finish. stopAll() then never returns, ServerFinalize() stalls behind it,
+  // and the RequestStop watchdog force-exits the daemon with code 2. That is
+  // the 2026-08-19 regression in cr_shutdown_bt_churn (issue #990's dashboard).
+  //
+  // Declared BEFORE `server` so it is destroyed after it (members die in
+  // reverse declaration order): the server must not outlive its pool.
+  std::unique_ptr<Poco::ThreadPool> pool;
   std::unique_ptr<Poco::Net::HTTPServer> server;
   std::string bind_addr;
   u32 port = 0;
@@ -797,8 +814,11 @@ bool VizServer::StartOn(const std::string &bind_addr, u32 port,
     // misbehaving client cannot own a thread forever.
     params->setKeepAliveTimeout(Poco::Timespan(2, 0));
     params->setMaxKeepAliveRequests(100);
+    // Own the thread pool (see Impl) so teardown only ever joins our threads.
+    const int pool_max = static_cast<int>(std::max<u32>(max_threads, 2));
+    impl->pool = std::make_unique<Poco::ThreadPool>(/*minCapacity=*/1, pool_max);
     impl->server = std::make_unique<Poco::Net::HTTPServer>(
-        new PocoVizHandlerFactory(this), impl->socket, params);
+        new PocoVizHandlerFactory(this), *impl->pool, impl->socket, params);
     impl->server->start();
     impl->bind_addr = bind_addr;
     impl->port = impl->socket.address().port();
@@ -824,19 +844,56 @@ void VizServer::Stop() {
   }
   HLOG(kInfo, "Viz: stopping dashboard on {}:{}", impl_->bind_addr,
        impl_->port);
+  // Close the LISTENING SOCKET FIRST, before asking Poco to stop. Poco is
+  // thread-per-connection: TCPServer::start() spawns an acceptor parked in
+  // ServerSocket::poll() on this socket, and the stop path joins it. Closing
+  // first makes that poll return so the acceptor can observe the stop flag.
+  //
+  // (The old comment here also had Poco's flag backwards: per
+  // HTTPServer::stopAll's contract abortCurrent=TRUE shuts the client sockets
+  // down, aborting requests, and FALSE lets current requests finish. Waiting
+  // is the risky one, so keep true.)
   try {
-    if (impl_->server) {
-      // true = wait for in-flight requests. A handler blocked on a task Future
-      // uses a bounded timeout, so this cannot wait forever.
-      impl_->server->stopAll(true);
-      impl_->server.reset();
-    }
     impl_->socket.close();
   } catch (const Poco::Exception &e) {
-    HLOG(kWarning, "Viz: error while stopping the dashboard: {}",
+    HLOG(kWarning, "Viz: error closing the dashboard socket: {}",
          e.displayText());
   }
-  impl_.reset();
+
+  // Belt and braces. With the private pool (see Impl) stopAll() returns
+  // promptly, so this budget is never actually spent -- measured: teardown is
+  // instant and cr_shutdown_bt_churn is back to its pre-dashboard 58 s, versus
+  // 130 s when every cycle burned the timeout below. It stays as a backstop
+  // because a request handler is ChiMod code that can block on a task, and the
+  // dashboard is a debugging aid: it must never be the reason a daemon cannot
+  // exit. On timeout, abandon the Poco objects (the shared_ptr keeps them
+  // alive for the worker, and the process is seconds from exit anyway) and let
+  // the rest of ServerFinalize proceed. Losing the dashboard's memory at exit
+  // is strictly better than losing the graceful shutdown.
+  constexpr int kVizStopBudgetMs = 3000;
+  std::shared_ptr<Impl> impl(std::move(impl_));  // impl_ is null from here on
+  auto finished = std::make_shared<std::promise<void>>();
+  std::future<void> done = finished->get_future();
+  std::thread([impl, finished]() mutable {
+    try {
+      if (impl->server) {
+        impl->server->stopAll(true);
+        impl->server.reset();
+      }
+    } catch (const Poco::Exception &e) {
+      HLOG(kWarning, "Viz: error while stopping the dashboard: {}",
+           e.displayText());
+    }
+    finished->set_value();
+  }).detach();
+
+  if (done.wait_for(std::chrono::milliseconds(kVizStopBudgetMs)) !=
+      std::future_status::ready) {
+    HLOG(kWarning,
+         "Viz: dashboard teardown did not finish within {} ms; abandoning it "
+         "so the shutdown can proceed",
+         kVizStopBudgetMs);
+  }
 }
 
 bool VizServer::IsRunning() const { return impl_ != nullptr; }

--- a/context-runtime/test/unit/test_viz_server.cc
+++ b/context-runtime/test/unit/test_viz_server.cc
@@ -49,10 +49,12 @@
 
 #include "../simple_test.h"
 
+#include <chrono>
 #include <cmath>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <limits>
 #include <string>
 
@@ -953,6 +955,72 @@ TEST_CASE("Viz pools can be shut down from the dashboard", "[viz]") {
     REQUIRE(Contains(std::string(buf, static_cast<size_t>(n)), "404"));
     REQUIRE(sec < 5.0);
   }
+}
+
+// ===========================================================================
+// Dashboard teardown (issue #1020)
+//
+// Stop() used to deadlock: the HTTPServer(factory, socket, params) overload
+// borrows Poco's process-wide ThreadPool::defaultPool(), so tearing the
+// dashboard down joined threads it never owned and stopAll() never returned.
+// ServerFinalize() stalled behind it and the RequestStop watchdog force-exited
+// the daemon with code 2.
+//
+// These cases drive Stop() directly, on a private VizServer rather than the
+// runtime's singleton, so the teardown is exercised as its own unit instead of
+// only incidentally at process exit.
+// ===========================================================================
+
+TEST_CASE("Viz dashboard starts and stops without wedging", "[viz][shutdown]") {
+  clio::run::viz::VizServer server;
+  // Port 0: an ephemeral port, so this never collides with the singleton
+  // dashboard the other cases in this file are talking to.
+  REQUIRE(server.StartOn("127.0.0.1", 0, /*max_threads=*/4));
+  REQUIRE(server.IsRunning());
+  REQUIRE(server.GetPort() != 0);
+  REQUIRE(server.GetBindAddr() == "127.0.0.1");
+
+  // The regression: this call is what used to never return. Time it, and hold
+  // it to a budget far below the watchdog's, so a reintroduced deadlock fails
+  // the test instead of quietly slowing every shutdown down.
+  auto t0 = std::chrono::steady_clock::now();
+  server.Stop();
+  double ms = std::chrono::duration<double, std::milli>(
+                  std::chrono::steady_clock::now() - t0)
+                  .count();
+  std::cout << "  Stop() took " << ms << " ms" << std::endl;
+  REQUIRE(!server.IsRunning());
+  REQUIRE(server.GetPort() == 0);
+  REQUIRE(ms < 3000.0);  // the teardown budget; a deadlock would spend it all
+
+  // Idempotent: stopping an already-stopped dashboard is a no-op, not a crash.
+  server.Stop();
+  REQUIRE(!server.IsRunning());
+}
+
+TEST_CASE("Viz teardown abandons a slow dashboard instead of blocking",
+          "[viz][shutdown]") {
+  // CLIO_VIZ_STOP_BUDGET_MS=0 forces the abandon path: Stop() must give up on
+  // the Poco teardown immediately and return, leaving the server logically
+  // stopped. This is the backstop that keeps a blocked request handler from
+  // holding the whole daemon's shutdown hostage -- without a knob it would be
+  // a branch no test could reach.
+  SIMPLE_TEST_SETENV("CLIO_VIZ_STOP_BUDGET_MS", "0");
+
+  clio::run::viz::VizServer server;
+  REQUIRE(server.StartOn("127.0.0.1", 0, /*max_threads=*/4));
+  REQUIRE(server.IsRunning());
+
+  auto t0 = std::chrono::steady_clock::now();
+  server.Stop();
+  double ms = std::chrono::duration<double, std::milli>(
+                  std::chrono::steady_clock::now() - t0)
+                  .count();
+  std::cout << "  Stop() with a 0 ms budget took " << ms << " ms" << std::endl;
+  REQUIRE(!server.IsRunning());
+  REQUIRE(ms < 1000.0);  // must not wait out anything
+
+  SIMPLE_TEST_SETENV("CLIO_VIZ_STOP_BUDGET_MS", "");
 }
 
 SIMPLE_TEST_MAIN()

--- a/context-runtime/util/clio_run_cmd_runtime_start.cc
+++ b/context-runtime/util/clio_run_cmd_runtime_start.cc
@@ -75,25 +75,31 @@ bool InitializeAdminChiMod() {
   }
 }
 
-void ShutdownAdminChiMod() {
-  HLOG(kDebug, "Shutting down admin ChiMod...");
-
-  try {
-    auto* pool_manager = CLIO_POOL_MANAGER;
-    if (pool_manager && pool_manager->HasPool(clio::run::kAdminPoolId)) {
-      if (pool_manager->DestroyLocalPool(clio::run::kAdminPoolId)) {
-        HLOG(kDebug, "Admin pool destroyed successfully");
-      } else {
-        HLOG(kError, "Failed to destroy admin pool");
-      }
-    }
-
-  } catch (const std::exception& e) {
-    HLOG(kError, "Exception during admin ChiMod shutdown: {}", e.what());
-  }
-
-  HLOG(kDebug, "Admin ChiMod shutdown complete");
-}
+// NOTE: there is deliberately no ShutdownAdminChiMod() here any more.
+//
+// This used to call PoolManager::DestroyLocalPool(kAdminPoolId) right after
+// RunUntilStopped() returned — i.e. while every worker was still running. The
+// admin container owns the periodic service pumps (kSend=14, kClientSend=21,
+// kHeartbeatProbe=28, kSystemMonitor=31); once its container is gone, each
+// reschedule routes to a pool that no longer exists, RouteTask gets
+// RouteResult::Dne, and Worker::AddToRetryQueue parks it. ProcessRetryQueue
+// then re-routes it, gets Dne again, and re-parks it: an unbounded spin that
+// DrainPendingTasks() can never drain, so the RequestStop watchdog force-exits
+// the daemon with code 2 instead of a clean 0.
+//
+// The race was always here but the window was microseconds wide (destroy →
+// return → atexit → StopWorkers), so nothing ever landed in it. Issue #990's
+// dashboard put VizServer::Stop() at the top of ServerFinalize(), between the
+// destroy and StopWorkers(); stopAll(true) drains in-flight HTTP requests and
+// takes real time, holding the window open long enough for the pumps to fire.
+// That is what broke cr_shutdown_bt_churn and
+// cte_replication_persist_integration on 2026-08-19.
+//
+// Destroying the admin pool early was never necessary: ServerFinalize() calls
+// PoolManager::DestroyAllContainers() after StopWorkers(), and that walks all
+// of pool_metadata_ — admin included. Letting admin live exactly as long as
+// every other pool restores the invariant that no container is torn down while
+// a worker can still route to it.
 
 bool InductNode() {
   auto* ipc_manager = CLIO_IPC;
@@ -305,7 +311,10 @@ int RuntimeStart(int argc, char* argv[]) {
   RunUntilStopped();
 
   HLOG(kDebug, "Shutting down Clio runtime...");
-  ShutdownAdminChiMod();
+  // The admin pool is NOT destroyed here — ServerFinalize()'s
+  // DestroyAllContainers() does it after StopWorkers(). See the
+  // "no ShutdownAdminChiMod()" note near the top of this file for why tearing
+  // it down while the workers still run wedges the shutdown.
   HLOG(kDebug, "Clio runtime stopped (finalization will happen automatically)");
   return 0;
 }
@@ -366,7 +375,10 @@ int RuntimeRestart(int argc, char* argv[]) {
   RunUntilStopped();
 
   HLOG(kDebug, "Shutting down Clio runtime...");
-  ShutdownAdminChiMod();
+  // The admin pool is NOT destroyed here — ServerFinalize()'s
+  // DestroyAllContainers() does it after StopWorkers(). See the
+  // "no ShutdownAdminChiMod()" note near the top of this file for why tearing
+  // it down while the workers still run wedges the shutdown.
   HLOG(kDebug, "Clio runtime stopped (finalization will happen automatically)");
   return 0;
 }


### PR DESCRIPTION
## Summary
- Give the web dashboard its **own** `Poco::ThreadPool` instead of the process-wide `ThreadPool::defaultPool()` it was silently borrowing. That is the fix: teardown was joining threads the dashboard never owned, so `stopAll()` never returned and `ServerFinalize()` stalled until the `RequestStop` watchdog force-exited the daemon with code 2.
- Close the listening socket before `stopAll()`, and keep a bounded teardown budget as a backstop (with the pool fix it never fires).
- Stop destroying the admin pool while workers are still running — `ServerFinalize()`'s `DestroyAllContainers()` already does it after `StopWorkers()`.

## Motivation
Fixes #1020.

Bisected from the CDash logs by the revision each build recorded: `48b2250` (Aug 18) was clean at 0 failed / 381; `35678b8` (Aug 19) had 3 failed / 382. That range is exactly PR #993. The last clean build has zero `RouteLocal returned 4` and zero watchdog fires; the first bad one has both.

## Why the private pool is the fix, not the timeout

This is the part worth reviewing, because a bounded timeout *also* makes the test pass — and would have been the wrong fix:

| Variant | `cr_shutdown_bt_churn` | teardown |
|---|---|---|
| broken | FAILED 23 s | `stopAll` never returns |
| timeout backstop only | Passed **130 s** | 3 s bail-out every cycle |
| **private thread pool** | Passed **58.75 s** | returns instantly |
| pre-regression baseline | Passed 58.16 s | no dashboard existed |

An instrumented build confirms it directly — before, `calling stopAll(true)` with no matching return, ever; after, `stopAll returned` → `server reset done`.

Diagnosis came from `/proc` sampling of a wedged daemon (gdb can't attach: `ptrace_scope=2` on these nodes): main thread in `futex_wait_queue`, acceptor in `poll_schedule_timeout`, `:8080` still `LISTEN`.

## Knock-on fix

While `Stop()` was wedged the workers were still running, and the admin pool had already been destroyed by `ShutdownAdminChiMod()`. Admin owns the periodic pumps (`kSend`, `kClientSend`, `kHeartbeatProbe`, `kSystemMonitor`), so every reschedule routed to a destroyed container, hit `RouteResult::Dne`, and was parked and re-routed forever — **8,984** retries in one run. The race predates the dashboard but its window used to be microseconds wide; `Stop()` held it open for the full 20 s.

## Test plan
Verified on TACC Vista (GH200, `sm_90`, CUDA 12.5, Poco 1.15.3), Release + CUDA, from a clean build:

- [x] `cr_shutdown_bt_churn` — **Passed 58.55 s** (baseline 58.16 s), not via timeout
- [x] `clio_cte_posix_unit_tests` — Passed
- [x] `cte_query_local_poolquery` — Passed
- [x] 0 watchdog force-exits, 0 `RouteLocal returned 4`, 0 teardown-budget bail-outs
- [x] 0 compiler errors
- [x] Reproduced the failures on the unmodified tree first (churn FAILED 23.16 s, replication FAILED 57.10 s — matching the dashboard's 22.43 s / 57.10 s), so the before/after is measured rather than assumed

## Not fixed by this PR

`cte_replication_persist_integration` still fails, and this PR does not claim it. It fails identically with the dashboard disabled entirely and a verifiably clean shutdown (0 watchdog, 0 `Dne`, segments reaped):

```
Phase 2: blob 0 primary survived reboot?! size=4096 rc=0
```

The DRAM primary is supposed to die with the reboot, leaving only the disk replica. The deadlock had been masking this behind a 57 s timeout. It needs its own investigation.

## Breaking changes
None. The dashboard's observable behaviour is unchanged; it just no longer shares a thread pool with the rest of the process, and shutdown no longer depends on Poco's teardown completing.

## Note for the reviewer
The `Impl` comment references issue #990 (the dashboard's own issue, taken from the surrounding code comments) alongside #1020 for this regression — happy to normalise those references if you'd prefer only one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
