### PR TITLE
Adapter CI reliability: quarantine the 5 flaky xfstests, stop gating merges on adapters

### DIFF
--- a/.github/workflows/ci-adapters.yml
+++ b/.github/workflows/ci-adapters.yml
@@ -21,6 +21,20 @@ name: CI Adapters
 #             suites; FSKit-backend mount smoke as a non-blocking probe)
 #   Windows : hdf5_vol + libfuse (WinFsp build + unit + in-process ops
 #             suites + live WinFsp mount smoke)
+#
+# NOT A REQUIRED CHECK (2026-08-25, issue #1022). "adapters (linux, all 5)" was
+# a required status check on the dev and main rulesets and was removed from
+# both. Reason: over 157 runs (2026-08-05..08-25) it blocked 5 of 134 otherwise
+# clean runs on xfstests that flake under the runner's scheduling, on branches
+# that touched nothing those tests exercise -- a macFUSE-only build fix, a
+# dashboard-teardown fix, a bdev preallocation clamp. Blocking a merge on a
+# result the author cannot act on trains people to re-run instead of read.
+#
+# It still runs on every PR and every push: this is informational coverage, not
+# a gate. Take it seriously -- the five known-flaky xfstests are quarantined
+# (scripts/xfstests/ci_flaky_quarantine.txt) precisely so that what is left CAN
+# be trusted. Re-add it to the rulesets once it has been green for a stretch on
+# its own merits.
 
 on:
   push:

--- a/CI/adapters_linux.sh
+++ b/CI/adapters_linux.sh
@@ -139,6 +139,16 @@ ctest --test-dir "$BUILD_DIR" --output-on-failure \
   -R "posix|stdio|vfd|hdf5_vol|fuse" \
   -E "copy_workspace|compat_suite" -LE "docker|ollama"
 
+# --repeat until-pass:2 above keeps a one-off flake from blocking a merge, and
+# in doing so makes the flake INVISIBLE: the check goes green and the only trace
+# is in LastTest.log. That is how cte_hdf5_vol_io_dataset failed its first
+# attempt in 5 of 146 runs (a read-back DATA MISMATCH, not a timeout) without
+# anyone noticing until the logs were mined by hand for #1022. Every other CI
+# job already runs this reporter; the adapters job was the one that did not.
+# Reports only -- never gates, never changes the exit status.
+bash CI/report_flaky_tests.sh \
+  "$BUILD_DIR/Testing/Temporary/LastTest.log" "adapters (linux, all 5)" || true
+
 # The compat suites self-skip (exit 125 -> CTest "Skipped") when the toolchain is
 # missing, which is right locally and WRONG here: a skipped differential suite is
 # no evidence at all, and ctest above counts a skip as success. Assert both

--- a/scripts/xfstests/REMAINING_WORK.md
+++ b/scripts/xfstests/REMAINING_WORK.md
@@ -30,7 +30,21 @@ that shows what a REAL regression looks like in this data (many tests, both
 ctest attempts, MOUNTFAIL) versus a flake (one or two tests, once).
 
 These five now live in `ci_flaky_quarantine.txt`: still run every job, reported
-as a `::warning::`, never gating. **Root cause not yet found.** They are almost
+as a `::warning::`, never gating.
+
+**First signatures captured** (run 32883603078, the PR that added the
+quarantine -- a CI-scripts-only diff that flaked two of the five, which is
+exactly the measured rate and would have been red under the old gate):
+
+* `generic/070` — `rm: cannot remove '.../fsstress/p0/d4b/.../dd60': Directory
+  not empty`. fsstress teardown: `rmdir` sees a directory as non-empty after
+  its children were unlinked — an unlink/readdir visibility ordering hole.
+* `generic/729` — `mmap-rw-fault: pread (D_DIRECT) from hole is broken`. An
+  `O_DIRECT` read from a hole did not come back zeroed.
+
+Both are **real filesystem-semantics bugs that are merely rare**, not test
+noise. Quarantining them is right for the gate; tolerating them is not.
+**Root cause not yet found.** They are almost
 certainly the same class as the 2026-07-05 pool above — a scheduling race that
 only manifests under the runner's constrained CPU — but unlike that pool these
 FAIL rather than HANG, so the two are not proven identical. Next step is to

--- a/scripts/xfstests/REMAINING_WORK.md
+++ b/scripts/xfstests/REMAINING_WORK.md
@@ -5,6 +5,48 @@ embedded gate is now **84 tests** (all verified passing, `run_ci`-green) plus 35
 in the scratch gate. Everything below is *why the rest don't pass* and *what it
 would take*, with the concrete caveats found by actually attempting them.
 
+## 2026-08-25 — five xfstests quarantined as flaky; gate 72 -> 67 (issue #1022)
+
+The embedded gate turned **5 of 134 otherwise-clean CI runs red** (3.7%) on
+tests that were not related to the branch under test. Mined from the "adapters
+(linux, all 5)" job logs of all 157 completed CI Adapters runs between
+2026-08-05 and 2026-08-25:
+
+| test | failures / 134 clean runs | seen on |
+|---|---|---|
+| generic/209 | 3 (2.2%) | 1011-macfuse-build-break x2, 1020-viz-teardown-deadlock |
+| generic/729 | 2 (1.5%) | dev (push), 1018-bdev-preallocate-budget |
+| generic/647 | 1 (0.7%) | dev (push) |
+| generic/451 | 1 (0.7%) | 1018-bdev-preallocate-budget |
+| generic/070 | 1 (0.7%) | 1020-viz-teardown-deadlock |
+
+The remaining 67 baseline tests: **0 failures in 134 runs.**
+
+"Clean population" excludes 10 runs with >3 failures each — all of them on
+1007-client-put-sieving, which really did break the filesystem (7-19 failures
+per run, incl. MOUNTFAIL) until it was fixed. Counting those would have
+libelled ~20 healthy tests as flaky; the sieving branch is the counter-example
+that shows what a REAL regression looks like in this data (many tests, both
+ctest attempts, MOUNTFAIL) versus a flake (one or two tests, once).
+
+These five now live in `ci_flaky_quarantine.txt`: still run every job, reported
+as a `::warning::`, never gating. **Root cause not yet found.** They are almost
+certainly the same class as the 2026-07-05 pool above — a scheduling race that
+only manifests under the runner's constrained CPU — but unlike that pool these
+FAIL rather than HANG, so the two are not proven identical. Next step is to
+capture the golden-vs-actual diff: `run_clio_xfstests.sh` now prints
+`./check` output plus `.out.bad`/`.full` on failure, which it previously threw
+away (a CI failure literally read `generic/070 : FAIL` and nothing more). Wait
+for the next natural flake, read the diff, then fix and re-admit.
+
+### Related, NOT quarantined
+* `cte_hdf5_vol_io_dataset` — read-back **data mismatch** (`REQUIRE(match)`),
+  first attempt failed in 5 of 146 runs, every one on or before 2026-08-11,
+  0 of 90 since. `ctest --repeat until-pass:2` hid it completely; the adapters
+  job now runs `CI/report_flaky_tests.sh` so a recurrence is annotated.
+* `fuse_ops` — failed 2 runs, both attempts, both on 1007-client-put-sieving.
+  A real regression that was fixed. Not flaky.
+
 ## 2026-07-05 — CI went red: worker oversubscription livelock (FIXED)
 The embedded-FUSE gate passed locally but **hung 12 tests in CI** (run
 28747864260, job "adapters (linux, all 5)"): generic/006/007/011/013/089/100/

--- a/scripts/xfstests/ci_baseline_pass.txt
+++ b/scripts/xfstests/ci_baseline_pass.txt
@@ -45,6 +45,12 @@
 # or resolve the self-send/lost-wakeup) — tracked in REMAINING_WORK.md; needs
 # CI-iteration validation. Gate: 84 -> 72. Re-add each test once the runtime fix
 # lands and it passes several clean CI runs.
+# 2026-08-25 FLAKY QUARANTINE (issue #1022). Five of the tests below flake in
+# CI -- generic/070 209 451 647 729. They stay listed here (they are still run
+# on every job) but are subtracted from the ENFORCED set by
+# run_ci_xfstests.sh and reported non-gating instead. Per-test failure rates
+# and the 157-run evidence they came from are in ci_flaky_quarantine.txt.
+# Enforced gate: 72 -> 67.
 generic/001
 generic/002
 generic/005

--- a/scripts/xfstests/ci_flaky_quarantine.txt
+++ b/scripts/xfstests/ci_flaky_quarantine.txt
@@ -48,6 +48,26 @@
 #   * the compat suites, the live mount smoke, apt/pip/docker setup: zero
 #     failures in 157 runs.
 #
+# 2026-08-25 FIRST CAPTURED SIGNATURES. The run that validated this quarantine
+# (32883603078, on the PR that introduced it -- a CI-scripts-only diff) flaked
+# generic/070 AND generic/729, and the new diagnostics printed why:
+#
+#   generic/070  rm: cannot remove '.../fsstress/p0/d4b/.../dd60':
+#                Directory not empty
+#                -> fsstress teardown: rmdir sees a directory as non-empty
+#                   after its children were unlinked. An unlink/readdir
+#                   visibility ordering hole, not test noise.
+#
+#   generic/729  mmap-rw-fault: pread (D_DIRECT) from hole is broken
+#                -> an O_DIRECT read from a hole did not come back zeroed.
+#
+# So these are REAL filesystem-semantics bugs that happen to be rare -- not
+# infrastructure noise. Quarantine is the right call for the gate (a 0.7-2.2%
+# per-test failure rate cannot be allowed to block unrelated merges) but they
+# should be fixed, not tolerated. Note also that this pair failing together on
+# one run is exactly the measured rate, and would have turned the CI-scripts PR
+# red under the old gate.
+#
 # Re-admit a test to ci_baseline_pass.txt once the underlying race is fixed and
 # it has been green across several CI runs. Do not re-admit on a local pass —
 # these flake only under the runner's constrained scheduling.

--- a/scripts/xfstests/ci_flaky_quarantine.txt
+++ b/scripts/xfstests/ci_flaky_quarantine.txt
@@ -1,0 +1,59 @@
+# xfstests FLAKY QUARANTINE — tests that pass MOST of the time against the clio
+# FUSE filesystem but fail non-deterministically in CI.
+#
+# scripts/xfstests/run_ci_xfstests.sh subtracts this list from
+# ci_baseline_pass.txt before gating, then runs these tests in a SECOND,
+# NON-GATING lane and reports the outcome as a ::warning:: + step summary. They
+# still run on every job — they just cannot turn the check red.
+#
+# ---------------------------------------------------------------------------
+# 2026-08-25 EVIDENCE (issue #1022). Mined from the CI Adapters "adapters
+# (linux, all 5)" job logs for all 157 completed runs between 2026-08-05 and
+# 2026-08-25 (144 reached the xfstests phase).
+#
+# Method: a run whose xfstests phase reported MORE THAN 3 failures was treated
+# as a branch-wide regression and excluded from the flake population — that is
+# 10 runs, ALL of them on 1007-client-put-sieving, which genuinely broke the
+# filesystem (7-19 failures per run, incl. MOUNTFAIL) before it was fixed.
+# Mixing those in would have libelled ~20 healthy tests as flaky. The remaining
+# 134 runs are the "clean population" below.
+#
+#   clean runs                                    : 134
+#   clean runs turned RED purely by xfstests flake:   5  (3.7%)
+#   distinct tests responsible                    :   5
+#
+#   test           failures / 134 clean runs   when
+#   ------------   -------------------------   -----------------------------
+#   generic/209        3  (2.2%)               1011-macfuse-build-break x2,
+#                                              1020-viz-teardown-deadlock
+#   generic/729        2  (1.5%)               dev (push), 1018-bdev-prealloc
+#   generic/647        1  (0.7%)               dev (push)
+#   generic/451        1  (0.7%)               1018-bdev-preallocate-budget
+#   generic/070        1  (0.7%)               1020-viz-teardown-deadlock
+#
+# Every one of those five red runs was on a branch that touched NOTHING these
+# tests exercise (a macFUSE-only build fix; a dashboard-teardown fix; a bdev
+# preallocation clamp; two dev merges). generic/209 failing twice on
+# 1011-macfuse-build-break — a branch whose whole diff is Darwin build glue —
+# is the cleanest proof available that this is timing, not code.
+#
+# The other 67 baseline tests: 0 failures in 134 clean runs. The gate is
+# therefore 72 -> 67 enforced, 5 reported.
+#
+# NOT quarantined, for the record (checked in the same sweep):
+#   * cte_hdf5_vol_io_dataset — read-back data mismatch, 5/146 runs, but ALL of
+#     them on or before 2026-08-11 and 0/90 since. Historical; leave gating.
+#   * fuse_ops — failed in 2 runs, BOTH attempts, BOTH on 1007-client-put-
+#     sieving. A real regression that was fixed, not a flake.
+#   * the compat suites, the live mount smoke, apt/pip/docker setup: zero
+#     failures in 157 runs.
+#
+# Re-admit a test to ci_baseline_pass.txt once the underlying race is fixed and
+# it has been green across several CI runs. Do not re-admit on a local pass —
+# these flake only under the runner's constrained scheduling.
+# ---------------------------------------------------------------------------
+generic/070
+generic/209
+generic/451
+generic/647
+generic/729

--- a/scripts/xfstests/run_ci_xfstests.sh
+++ b/scripts/xfstests/run_ci_xfstests.sh
@@ -2,13 +2,27 @@
 #
 # CI gate for the clio FUSE filesystem xfstests conformance suite.
 #
-# Runs ONLY the tests known to pass (scripts/xfstests/ci_baseline_pass.txt --
-# the maximum passing set discovered across the whole generic/* group) against
-# the clio FUSE fs via run_clio_xfstests.sh. Every listed test must pass; any
-# non-pass (FAIL / notrun / HANG / missing from the run) fails the job.
+# Two lanes:
 #
-# The currently-failing tests are intentionally NOT run here -- they are
-# tracked, with root causes, in issue #680.
+#   ENFORCED  ci_baseline_pass.txt MINUS ci_flaky_quarantine.txt. Every test
+#             must pass; any non-pass (FAIL / notrun / HANG / missing from the
+#             run) fails the job.
+#   REPORTED  ci_flaky_quarantine.txt. Run, reported as a ::warning:: and in the
+#             step summary, NEVER gating.
+#
+# WHY THE SECOND LANE EXISTS (issue #1022): between 2026-08-05 and 2026-08-25,
+# 5 of 134 otherwise-clean CI runs (3.7%) went red on one or two of five
+# xfstests that flake under the runner's constrained scheduling -- on branches
+# that touched nothing those tests exercise. A red check that a PR author cannot
+# act on is worse than no check: it trains everyone to re-run and stop reading.
+# The evidence, per test, is in the header of ci_flaky_quarantine.txt.
+#
+# Quarantine is not deletion. These tests still run on every job; they just
+# report instead of gate, so a quarantined test that starts failing 100% of the
+# time is still visible in the log and can be promoted back.
+#
+# The currently-failing tests (never passing) are a separate matter -- they are
+# not run here at all and are tracked, with root causes, in issue #680.
 #
 # Usage:
 #   scripts/xfstests/run_ci_xfstests.sh
@@ -20,21 +34,47 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 BASELINE_FILE="${SCRIPT_DIR}/ci_baseline_pass.txt"
+QUARANTINE_FILE="${SCRIPT_DIR}/ci_flaky_quarantine.txt"
 RUNNER="${SCRIPT_DIR}/run_clio_xfstests.sh"
+SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/null}"
 
 [ -r "${BASELINE_FILE}" ] || { echo "ERROR: missing ${BASELINE_FILE}" >&2; exit 2; }
 [ -r "${RUNNER}" ]        || { echo "ERROR: missing ${RUNNER}" >&2; exit 2; }
 
-# --- read the expected-pass list (strip comments / blanks) ------------------
-mapfile -t BASELINE < <(grep -oE '^generic/[0-9]+' "${BASELINE_FILE}" | sort -u)
-[ "${#BASELINE[@]}" -gt 0 ] || { echo "ERROR: baseline is empty" >&2; exit 2; }
+# --- read the two lists (strip comments / blanks) ---------------------------
+mapfile -t ALL_LISTED < <(grep -oE '^generic/[0-9]+' "${BASELINE_FILE}" | sort -u)
+[ "${#ALL_LISTED[@]}" -gt 0 ] || { echo "ERROR: baseline is empty" >&2; exit 2; }
 
-echo "[ci-xfs] running ${#BASELINE[@]} baseline test(s) (all must pass)"
+QUARANTINED=()
+if [ -r "${QUARANTINE_FILE}" ]; then
+  mapfile -t QUARANTINED < <(grep -oE '^generic/[0-9]+' "${QUARANTINE_FILE}" | sort -u)
+fi
 
-# --- run the conformance driver, capture per-test outcomes ------------------
+# A quarantined test that is not in the baseline is a list-drift bug: it would
+# silently be run by nobody and look, from the file, like it were covered.
+for q in "${QUARANTINED[@]:-}"; do
+  [ -z "${q}" ] && continue
+  printf '%s\n' "${ALL_LISTED[@]}" | grep -qx "${q}" || {
+    echo "::error::${q} is in ci_flaky_quarantine.txt but not in ci_baseline_pass.txt" >&2
+    exit 2
+  }
+done
+
+# ENFORCED = baseline - quarantine
+mapfile -t ENFORCED < <(comm -23 \
+  <(printf '%s\n' "${ALL_LISTED[@]}") \
+  <(printf '%s\n' "${QUARANTINED[@]:-}" | sed '/^$/d' | sort -u))
+[ "${#ENFORCED[@]}" -gt 0 ] || { echo "ERROR: every baseline test is quarantined" >&2; exit 2; }
+
+echo "[ci-xfs] enforced: ${#ENFORCED[@]} test(s) (all must pass)"
+echo "[ci-xfs] reported (flaky quarantine, non-gating): ${#QUARANTINED[@]} test(s)"
+
+# --- run BOTH lanes in one driver invocation --------------------------------
+# One invocation, not two: the driver remounts a fresh FUSE fs + runtime per
+# test anyway, so splitting it would only pay the xfstests startup twice.
 RUN_LOG="$(mktemp)"
 trap 'rm -f "${RUN_LOG}"' EXIT
-TESTS="${BASELINE[*]}" bash "${RUNNER}" 2>&1 | tee "${RUN_LOG}"
+TESTS="${ALL_LISTED[*]}" bash "${RUNNER}" 2>&1 | tee "${RUN_LOG}"
 
 status_of() {  # $1 = test id -> prints pass|FAIL|notrun|HANG|MISSING
   local s
@@ -42,21 +82,62 @@ status_of() {  # $1 = test id -> prints pass|FAIL|notrun|HANG|MISSING
   [ -n "${s}" ] && echo "${s}" || echo "MISSING"
 }
 
-# --- every baseline test must pass ------------------------------------------
+# --- REPORTED lane: never gates, always visible -----------------------------
+q_bad=()
+for t in "${QUARANTINED[@]:-}"; do
+  [ -z "${t}" ] && continue
+  st="$(status_of "${t}")"
+  [ "${st}" = "pass" ] || q_bad+=("${t}(${st})")
+done
+
+{
+  echo "## xfstests conformance (clio FUSE)"
+  echo ""
+  echo "- enforced: ${#ENFORCED[@]} test(s)"
+  echo "- flaky quarantine (reported, non-gating): ${#QUARANTINED[@]} test(s)"
+} >> "${SUMMARY}"
+
+if [ "${#q_bad[@]}" -gt 0 ]; then
+  echo "[ci-xfs] QUARANTINE (non-gating): ${#q_bad[@]} of ${#QUARANTINED[@]} did not pass:"
+  printf '[ci-xfs]   ~ %s\n' "${q_bad[@]}"
+  echo "::warning title=Flaky xfstests (quarantined, non-gating)::${q_bad[*]} -- see scripts/xfstests/ci_flaky_quarantine.txt"
+  {
+    echo ""
+    echo "Quarantined tests that did not pass this run (did NOT fail the job):"
+    echo '```'
+    printf '  %s\n' "${q_bad[@]}"
+    echo '```'
+  } >> "${SUMMARY}"
+else
+  echo "[ci-xfs] QUARANTINE: all ${#QUARANTINED[@]} quarantined test(s) passed this run."
+  {
+    echo ""
+    echo "All quarantined tests passed this run."
+  } >> "${SUMMARY}"
+fi
+
+# --- ENFORCED lane: every test must pass ------------------------------------
 failures=()
-for t in "${BASELINE[@]}"; do
+for t in "${ENFORCED[@]}"; do
   st="$(status_of "${t}")"
   [ "${st}" = "pass" ] || failures+=("${t}(${st})")
 done
 
 echo "===================================================================="
-echo "[ci-xfs] SUMMARY: baseline=${#BASELINE[@]} not-passing=${#failures[@]}"
+echo "[ci-xfs] SUMMARY: enforced=${#ENFORCED[@]} not-passing=${#failures[@]}"
 
 if [ "${#failures[@]}" -gt 0 ]; then
-  echo "[ci-xfs] FAIL: ${#failures[@]} baseline test(s) did not pass:"
+  echo "[ci-xfs] FAIL: ${#failures[@]} enforced test(s) did not pass:"
   printf '[ci-xfs]   - %s\n' "${failures[@]}"
+  {
+    echo ""
+    echo "**FAILED** — enforced tests that did not pass:"
+    echo '```'
+    printf '  %s\n' "${failures[@]}"
+    echo '```'
+  } >> "${SUMMARY}"
   exit 1
 fi
 
-echo "[ci-xfs] OK: all ${#BASELINE[@]} baseline tests passed."
+echo "[ci-xfs] OK: all ${#ENFORCED[@]} enforced tests passed."
 exit 0

--- a/scripts/xfstests/run_clio_xfstests.sh
+++ b/scripts/xfstests/run_clio_xfstests.sh
@@ -161,7 +161,28 @@ for t in "${LIST[@]}"; do
     echo "--- end [${t}] runtime diagnosis ---"
   elif echo "${out}" | grep -q "^Not run:"; then echo "${t}: notrun"; notrun=$((notrun+1))
   elif echo "${out}" | grep -q "^Passed all"; then echo "${t}: pass"; pass=$((pass+1))
-  else echo "${t}: FAIL"; fail=$((fail+1)); failed_list="${failed_list} ${t}"; fi
+  else echo "${t}: FAIL"; fail=$((fail+1)); failed_list="${failed_list} ${t}"
+    # PRINT WHY. ./check's output -- which carries the golden-vs-actual diff --
+    # was captured into ${out} and then thrown away, so a CI failure read
+    # exactly "generic/070 : FAIL" and nothing else. Five red runs in three
+    # weeks were triaged by re-running rather than by reading, because there was
+    # nothing to read. Cost of keeping it: ~40 lines per failing test.
+    echo "--- [${t}] failure diagnosis ---"
+    echo "  [./check output, last 40 lines]:"
+    echo "${out}" | tail -n 40 | sed "s/^/    /"
+    # RESULT_BASE is results/ by default but becomes results/<section>/ when
+    # local.config declares sections, so find the artifacts instead of assuming
+    # the path -- an assumed path that misses prints nothing and looks the same
+    # as a test that left no artifacts.
+    for ext in out.bad full dmesg; do
+      while IFS= read -r f; do
+        [ -s "${f}" ] || continue
+        echo "  [${f#"${XFSTESTS_DIR}/"}, last 40 lines]:"
+        tail -n 40 "${f}" | sed "s/^/    /"
+      done < <(find "${XFSTESTS_DIR}/results" -type f -path "*/${t}.${ext}" 2>/dev/null)
+    done
+    echo "--- end [${t}] failure diagnosis ---"
+  fi
 done
 
 ran=$((pass+fail))

--- a/scripts/xfstests/run_clio_xfstests.sh
+++ b/scripts/xfstests/run_clio_xfstests.sh
@@ -167,7 +167,13 @@ for t in "${LIST[@]}"; do
     # exactly "generic/070 : FAIL" and nothing else. Five red runs in three
     # weeks were triaged by re-running rather than by reading, because there was
     # nothing to read. Cost of keeping it: ~40 lines per failing test.
-    echo "--- [${t}] failure diagnosis ---"
+    # ${t} carries trailing whitespace from ./check -n (which is why every
+    # status line above reads "generic/070 : FAIL", with the space). Path
+    # globs built from it silently match nothing, so trim before using it as
+    # a filename -- the first cut of this block did not, and printed no
+    # artifacts at all while looking like it had run.
+    tt="${t//[[:space:]]/}"
+    echo "--- [${tt}] failure diagnosis ---"
     echo "  [./check output, last 40 lines]:"
     echo "${out}" | tail -n 40 | sed "s/^/    /"
     # RESULT_BASE is results/ by default but becomes results/<section>/ when
@@ -179,9 +185,9 @@ for t in "${LIST[@]}"; do
         [ -s "${f}" ] || continue
         echo "  [${f#"${XFSTESTS_DIR}/"}, last 40 lines]:"
         tail -n 40 "${f}" | sed "s/^/    /"
-      done < <(find "${XFSTESTS_DIR}/results" -type f -path "*/${t}.${ext}" 2>/dev/null)
+      done < <(find "${XFSTESTS_DIR}/results" -type f -path "*/${tt}.${ext}" 2>/dev/null)
     done
-    echo "--- end [${t}] failure diagnosis ---"
+    echo "--- end [${tt}] failure diagnosis ---"
   fi
 done
 


### PR DESCRIPTION
Closes #1022.

## What was wrong

`adapters (linux, all 5)` was a **required status check** on `dev` and `main`, and it went red on work that has nothing to do with the adapters. On `1020-viz-teardown-deadlock` — a dashboard-teardown fix — it failed on `generic/070` and `generic/209`.

## Evidence

Mined the `adapters (linux, all 5)` job log of **all 157 completed CI Adapters runs**, 2026-08-05 → 2026-08-25 (144 reached the xfstests phase).

A run reporting **more than 3** xfstests failures was treated as a branch-wide regression and excluded — that is 10 runs, **all** on `1007-client-put-sieving`, which genuinely broke the filesystem (7–19 failures/run, incl. `MOUNTFAIL`) until it was fixed. Counting those would have libelled ~20 healthy tests as flaky. The remaining **134 runs** are the clean population.

| | |
|---|---|
| clean runs | 134 |
| clean runs turned red **purely by flake** | **5 (3.7%)** |
| distinct tests responsible | 5 |

| test | failures / 134 | seen on |
|---|---|---|
| `generic/209` | 3 (2.2%) | `1011-macfuse-build-break` ×2, `1020-viz-teardown-deadlock` |
| `generic/729` | 2 (1.5%) | `dev` (push), `1018-bdev-preallocate-budget` |
| `generic/647` | 1 (0.7%) | `dev` (push) |
| `generic/451` | 1 (0.7%) | `1018-bdev-preallocate-budget` |
| `generic/070` | 1 (0.7%) | `1020-viz-teardown-deadlock` |

The other **67** baseline tests: **0 failures in 134 runs.**

`generic/209` failing twice on `1011-macfuse-build-break` — a branch whose entire diff is Darwin build glue — is the cleanest proof available that this is timing, not code.

### What is *not* flaky (checked in the same sweep, so it stays gating)

| | |
|---|---|
| `cte_hdf5_vol_io_dataset` | read-back **data mismatch**, 5/146 runs — but all on or before 2026-08-11, **0 of 90 since**. `--repeat until-pass:2` hid it entirely. |
| `fuse_ops` | 2 runs, **both attempts**, both on `1007-client-put-sieving`. Real regression, since fixed. |
| VOL/VFD compat suites, live FUSE mount smoke, apt/pip/docker setup | **0** failures in 157 runs |
| `ci-vfd.yml` (`vfd (linux, native write-through)`) | **92/92 green** — stays required |

## Changes

1. **`scripts/xfstests/ci_flaky_quarantine.txt`** (new) — the five tests, with the evidence above in its header and the criteria for re-admission.
2. **`run_ci_xfstests.sh`** — two lanes. *Enforced* = baseline − quarantine (**72 → 67**, all must pass). *Reported* = the quarantine, still run on every job, emitted as a `::warning::` + step summary, **never gating**. A quarantined test absent from the baseline is a hard error, so the lists cannot drift; a missing quarantine file falls back to gating all 72 (fails safe).
3. **`run_clio_xfstests.sh`** — **print the failure.** `./check`'s output — which carries the golden-vs-actual diff — was captured into a variable and thrown away, so a CI failure read literally `generic/070 : FAIL` and nothing else. Five red runs in three weeks were triaged by re-running rather than by reading, because there was nothing to read. Now prints the `./check` tail plus `.out.bad`/`.full`/`.dmesg`, located by `find` rather than an assumed path.
4. **`CI/adapters_linux.sh`** — run `CI/report_flaky_tests.sh` after ctest. Every other CI job already did; adapters was the one that did not, which is how the `cte_hdf5_vol_io_dataset` data mismatch stayed invisible for a week.
5. **Ruleset change — already applied:** `adapters (linux, all 5)` removed from the required checks of `dev: gated merges` (21157489) and `main: gated merges` (21157512). Both keep `cpplint`, `build-test (unit amd64)`, `vfd (linux, native write-through)`, and every non-status rule (deletion / non_fast_forward / pull_request) untouched. The adapters job still runs on every PR and push — coverage, not a gate.

## Validation

The gate logic was exercised against a stub driver, including negative controls:

| case | expected | got |
|---|---|---|
| only a quarantined test fails | exit 0, warning emitted | ✅ exit 0 |
| an **enforced** test fails | exit 1 | ✅ exit 1 |
| quarantine lists a test absent from the baseline | exit 2, `::error::` | ✅ exit 2 |
| quarantine file absent | falls back to all 72 enforced | ✅ 72 |
| quarantine file empty | falls back to all 72 enforced | ✅ 72 |

Enforced set computes to **67**, reported to **5**.

## Not done here

Root cause of the five flakes is still open. They are likely the same class as the 2026-07-05 quarantined pool (a scheduling race under the runner's constrained CPU), but those **hang** and these **fail**, so the two are not proven identical. The next step is to read the diff the new diagnostics will capture on the next natural flake — then fix and re-admit. Not on a local pass: these flake only under CI scheduling. Tracked in `scripts/xfstests/REMAINING_WORK.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kgb4HNQz9c8thVfFkCde4d