### PR TITLE
HDF5 VFD + VOL: fix exit-time hangs, per-process exit cost, and two VOL data-correctness bugs (netCDF-C suite 215/215)

### DIFF
--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -76,6 +76,27 @@
 // Global pointer variable definition for IPC manager singleton
 CLIO_RUN_DEFINE_GLOBAL_PTR_VAR_CC(clio::run::IpcManager, g_ipc_manager);
 
+/* Interruptible wait between liveness probes.
+ *
+ * The probe used to nap with a plain 1s sleep, which ClientFinalize's join()
+ * then had to sit through: EVERY client process paid up to a full second at
+ * exit, no matter how little work it did. That is invisible in a long-running
+ * application and lethal in a fan-out of short ones -- the netCDF-C tool tests
+ * spawn hundreds of one-file ncgen/ncdump processes, and a ~1s floor per
+ * process turned a 10s test into a ctest timeout (ncdump/tst_ncgen4 and
+ * friends). The condition variable lets the shutdown store wake the probe
+ * immediately while keeping the idle cost at one wakeup per second.
+ *
+ * Deliberately file-scope rather than IpcManager members: ipc_manager.h is
+ * included by every client of the runtime, and growing the class changes its
+ * layout -- any .so not rebuilt in the same pass then disagrees about where
+ * every following member lives, which shows up as a lock taken on the wrong
+ * address and a hang that looks nothing like its cause. There is one
+ * IpcManager per process (the g_ipc_manager global), so a process-wide pair is
+ * exactly as precise as members would be. */
+static std::mutex g_heartbeat_mtx;
+static std::condition_variable g_heartbeat_cv;
+
 namespace clio::run {
 
 // Bind address for the local server sockets (client ROUTER, response listener,
@@ -623,9 +644,16 @@ void IpcManager::ClientFinalize() {
                               static_cast<TaskCounter *>(nullptr));
   }
 
-  // Stop heartbeat thread
+  // Stop heartbeat thread. The store must be published under the same mutex
+  // the probe waits on, or the notify can slip into the gap between the
+  // predicate check and the wait and be missed -- which would put the full
+  // interval back into every process's exit path.
   if (heartbeat_running_.load()) {
-    heartbeat_running_.store(false);
+    {
+      std::lock_guard<std::mutex> lk(g_heartbeat_mtx);
+      heartbeat_running_.store(false);
+    }
+    g_heartbeat_cv.notify_all();
     if (heartbeat_thread_.joinable()) {
       heartbeat_thread_.join();
     }
@@ -3833,7 +3861,11 @@ void IpcManager::HeartbeatThread() {
   while (heartbeat_running_.load()) {
     bool alive = IsServerAlive();
     server_alive_.store(alive, std::memory_order_release);
-    CTP_THREAD_MODEL->SleepForUs(1000000);
+    // ClientFinalize clears heartbeat_running_ and notifies, so the join that
+    // follows returns at once instead of waiting out the probe interval.
+    std::unique_lock<std::mutex> lk(g_heartbeat_mtx);
+    g_heartbeat_cv.wait_for(lk, std::chrono::seconds(1),
+                            [this]() { return !heartbeat_running_.load(); });
   }
 }
 

--- a/context-transfer-engine/adapter/hdf5_vol/clio_vol.cc
+++ b/context-transfer-engine/adapter/hdf5_vol/clio_vol.cc
@@ -328,9 +328,62 @@ static void clio_tier_mark_accepting() {
   }
 }
 
+/*---------------------------------------------------------------------------
+ * Process-exit guard.
+ *
+ * HDF5 installs atexit(H5_term_library) the first time the library is
+ * initialized, and H5_term_library closes every file the application left
+ * open -- which reaches clio_file_close, and through it drain_dataset_puts and
+ * the coherence stamp, LONG AFTER main() has returned.
+ *
+ * The CLIO client, by contrast, is a set of process-global objects whose
+ * teardown runs as ordinary static destructors: the shared ZeroMQ context
+ * (whose destructor zmq_ctx_shutdown()s every socket), the IPC manager's
+ * receive threads, the deferred-write registry. Every one of those is
+ * registered LATER than HDF5's atexit handler -- the client is first
+ * constructed on the first H5Fopen, long after H5open() -- and exit handlers
+ * run last-registered-first. So by the time H5_term_library asks this
+ * connector to close a file, CLIO is already gone, and the Wait() inside
+ * clio_write_stamp blocks forever on a future no surviving receive thread can
+ * ever complete. That is an unkillable hang at exit, and it is what made the
+ * netCDF-C suite's short-lived tool processes (ncdump, ncgen, nctest, and
+ * every nc_test4 binary that leaves a file open) sit at their ctest timeout
+ * instead of exiting.
+ *
+ * The fix is to stop calling into CLIO once teardown has begun. The guard is
+ * armed from every entry point HDF5 can reach this connector through, all of
+ * which run after H5open(), so LIFO ordering guarantees it is set before
+ * H5_term_library runs. Nothing is lost by skipping the tier there: the native
+ * file is authoritative and already closed correctly by the under-VOL, and a
+ * coherence stamp that is not written simply makes the next open see kAbsent
+ * and re-read from the file -- the fail-closed direction.
+ *
+ * Not atomic on purpose: written once by the thread running exit handlers, at
+ * a point where the C runtime has already serialized teardown.
+ *---------------------------------------------------------------------------*/
+static bool clio_vol_exiting_g = false;
+
+static void clio_vol_note_exit() { clio_vol_exiting_g = true; }
+
+static void clio_vol_install_exit_guard() {
+  static bool installed = false;
+  if (!installed) {
+    installed = true;
+    std::atexit(clio_vol_note_exit);
+  }
+}
+
 static bool drain_dataset_puts(clio_dataset_t *dset) {
   bool ok = true;
   int first_rc = 0;
+  /* Exit handlers are running and the client that would retire these puts is
+     gone; waiting is waiting forever. Report success so the caller does not
+     then try to invalidate (another round trip into the same dead client) --
+     the native file is authoritative and unaffected either way. */
+  if (clio_vol_exiting_g) {
+    dset->pending_puts.clear();
+    return true;
+  }
   for (auto &future : dset->pending_puts) {
     future.Wait();
     const int rc = future->GetReturnCode();
@@ -388,6 +441,11 @@ struct clio_wrap_ctx_t {
  * ======================================================================== */
 
 static clio::cte::core::Client *get_cte_client() {
+  /* Checked before the cached answer, and here rather than at each call site:
+     this is the one door to the tier, so a caller cannot forget the guard.
+     Returning nullptr is a state every caller already handles -- it is the
+     same answer they get when the runtime was never reachable. */
+  if (clio_vol_exiting_g) return nullptr;
   /* Lazily attach this process to the running clio/CTE runtime on first
      use. When HDF5 dlopen()s the connector via HDF5_VOL_CONNECTOR there is no
      LD_PRELOAD constructor to do it (the POSIX adapter inits in
@@ -1126,6 +1184,10 @@ static clio_file_t *clio_make_file(void *under_file, const char *name,
 static void *clio_file_create(const char *name, unsigned flags,
                                 hid_t fcpl_id, hid_t fapl_id,
                                 hid_t dxpl_id, void **req) {
+  /* Belt and braces: whatever route selected this connector, a file open is
+     unconditionally after H5open(), so the guard is armed no later than the
+     first file that could still be open when exit handlers start running. */
+  clio_vol_install_exit_guard();
   size_t chunk_size = 0;
   bool cache_on = true;
   clio_resolve_config(fapl_id, &chunk_size, &cache_on);
@@ -1154,6 +1216,7 @@ static void *clio_file_create(const char *name, unsigned flags,
 
 static void *clio_file_open(const char *name, unsigned flags,
                               hid_t fapl_id, hid_t dxpl_id, void **req) {
+  clio_vol_install_exit_guard();
   size_t chunk_size = 0;
   bool cache_on = true;
   clio_resolve_config(fapl_id, &chunk_size, &cache_on);
@@ -1279,6 +1342,13 @@ static herr_t clio_file_close(void *obj, hid_t dxpl_id, void **req) {
                        file->trace);
     }
   }
+
+  /* See clio_group_close: a failed native close leaves the file open, and
+     HDF5 will call this callback again with the same wrapper -- so stop here,
+     before anything is released or the trace is closed out. The drain above
+     is idempotent and the stamp was already skipped (it is guarded on
+     ret >= 0), so the retry does the whole job. */
+  if (ret < 0) return ret;
 
   clio::trace::close_file(file->trace);  /* writes the summary; no-op if null */
   file->trace = nullptr;
@@ -1479,6 +1549,55 @@ static bool clio_type_matches_file(clio_dataset_t *dataset, hid_t mem_type_id,
   return H5Tget_size(mem_type_id) == dataset->file_type_size;
 }
 
+/* The dataset's FULL path inside the file, e.g. "/g1/g2/var".
+ *
+ * Every CTE blob this connector writes is keyed by this string, so it has to
+ * identify the dataset uniquely within the file. The `name` argument HDF5
+ * hands to dataset_create/open does NOT: it is relative to `obj`, so a
+ * dataset opened through its parent group arrives as bare "var", and two
+ * datasets called "var" in different groups shared one key. The second one
+ * opened then read the first one's bytes -- zero-padded when it was shorter,
+ * which is exactly how it surfaced: ncdump printing `var = 1, 0, 0` for a
+ * variable holding 1, 2, 3 (ncdump/tst_netcdf4 and tst_grp_spec).
+ *
+ * Asked of the under-VOL rather than composed here, because `name` may also be
+ * absolute, may be relative to the file, and may reach us by token from
+ * H5Oopen or a reference -- one query answers all of those the way HDF5 itself
+ * would (this is what H5Iget_name does).
+ *
+ * Returns "" when the name cannot be had, which make_dataset_wrapper() treats
+ * as not cacheable: no key at all is the only safe answer, since a guessed one
+ * is how the collision above happened. */
+static std::string clio_object_full_path(void *under_obj, hid_t under_vol_id,
+                                         H5I_type_t obj_type, hid_t dxpl_id) {
+  if (!under_obj) return std::string();
+  H5VL_loc_params_t loc{};
+  loc.type = H5VL_OBJECT_BY_SELF;
+  loc.obj_type = obj_type;
+
+  size_t name_len = 0;
+  H5VL_object_get_args_t args{};
+  args.op_type = H5VL_OBJECT_GET_NAME;
+  args.args.get_name.buf_size = 0;
+  args.args.get_name.buf = nullptr;
+  args.args.get_name.name_len = &name_len;
+  if (H5VLobject_get(under_obj, &loc, under_vol_id, &args, dxpl_id,
+                     nullptr) < 0 || name_len == 0) {
+    return std::string();
+  }
+
+  std::string path(name_len + 1, '\0');
+  args.args.get_name.buf_size = name_len + 1;
+  args.args.get_name.buf = &path[0];
+  args.args.get_name.name_len = &name_len;
+  if (H5VLobject_get(under_obj, &loc, under_vol_id, &args, dxpl_id,
+                     nullptr) < 0) {
+    return std::string();
+  }
+  path.resize(name_len);
+  return path;
+}
+
 static void *clio_dataset_create(void *obj,
                                    const H5VL_loc_params_t *loc_params,
                                    const char *name, hid_t lcpl_id,
@@ -1493,8 +1612,11 @@ static void *clio_dataset_create(void *obj,
       lcpl_id, type_id, space_id, dcpl_id, dapl_id, dxpl_id, req);
   if (!under_dset) return nullptr;
 
+  const std::string path = clio_object_full_path(under_dset, o->under_vol_id,
+                                                 H5I_DATASET, dxpl_id);
   return make_dataset_wrapper(under_dset, o->under_vol_id,
-                              find_parent_file(obj), name);
+                              find_parent_file(obj),
+                              path.empty() ? nullptr : path.c_str());
 }
 
 static void *clio_dataset_open(void *obj,
@@ -1508,8 +1630,11 @@ static void *clio_dataset_open(void *obj,
       dapl_id, dxpl_id, req);
   if (!under_dset) return nullptr;
 
+  const std::string path = clio_object_full_path(under_dset, o->under_vol_id,
+                                                 H5I_DATASET, dxpl_id);
   return make_dataset_wrapper(under_dset, o->under_vol_id,
-                              find_parent_file(obj), name);
+                              find_parent_file(obj),
+                              path.empty() ? nullptr : path.c_str());
 }
 
 /* ---- Access telemetry helpers (observe-only; active only under CLIO_VOL_TRACE) */
@@ -2299,9 +2424,14 @@ static herr_t clio_dataset_close(void *obj, hid_t dxpl_id, void **req) {
     clio_invalidate_dataset(dset);
   }
 
-  if (dset->file_type >= 0) H5Tclose(dset->file_type);
   herr_t ret = H5VLdataset_close(dset->obj.under_object,
                                   dset->obj.under_vol_id, dxpl_id, req);
+  /* See clio_group_close: on failure HDF5 keeps the object and will close it
+     again through this same wrapper, so nothing may be released. The drain
+     above has already run, which is correct either way -- it is idempotent
+     (pending_puts is emptied) and a retry must not re-wait on retired puts. */
+  if (ret < 0) return ret;
+  if (dset->file_type >= 0) H5Tclose(dset->file_type);
   delete dset;
   /* Last, and only after everything above has finished reading through
      dset->file (drain and invalidate both use its tag and trace). */
@@ -2365,7 +2495,15 @@ static herr_t clio_group_close(void *obj, hid_t dxpl_id, void **req) {
   auto *o = static_cast<clio_obj_t *>(obj);
   herr_t ret = H5VLgroup_close(o->under_object, o->under_vol_id,
                                 dxpl_id, req);
-  delete o;
+  /* Free the wrapper ONLY when the underlying close succeeded. A failed close
+     leaves the object open, and HDF5 hands the SAME VOL object back on the
+     caller's next attempt -- freeing it here made that retry a use-after-free.
+     H5F_CLOSE_SEMI is the everyday way to see it: H5Fclose fails while anything
+     in the file is still open, and h5_test/tst_h_files sets exactly that degree
+     and then closes twice, which aborted the process inside malloc rather than
+     reporting the failure. Mirrors H5VLpassthru, which guards every one of its
+     free_obj calls the same way. */
+  if (ret >= 0) delete o;
   return ret;
 }
 
@@ -2433,7 +2571,9 @@ static herr_t clio_attr_specific(void *obj, const H5VL_loc_params_t *lp,
 static herr_t clio_attr_close(void *attr, hid_t dxpl_id, void **req) {
   auto *o = static_cast<clio_obj_t *>(attr);
   herr_t ret = H5VLattr_close(o->under_object, o->under_vol_id, dxpl_id, req);
-  delete o;
+  /* See clio_group_close: a failed close means HDF5 will hand this same
+     wrapper back on the next attempt. */
+  if (ret >= 0) delete o;
   return ret;
 }
 
@@ -2526,14 +2666,16 @@ static void *clio_object_open(void *obj,
      the dataset_read/write/close callbacks to this wrapper and cast it to
      clio_dataset_t. h5py opens datasets through H5Oopen, so returning a bare
      clio_obj_t here would be mis-cast and corrupt the heap. Build the right
-     wrapper type. The dataset path is recovered from a by-name location when
-     available; otherwise the dataset is marked non-cacheable. */
+     wrapper type. A dataset whose path cannot be resolved is marked
+     non-cacheable. */
   if (opened_type && *opened_type == H5I_DATASET) {
-    const char *name = nullptr;
-    if (loc_params && loc_params->type == H5VL_OBJECT_BY_NAME) {
-      name = loc_params->loc_data.loc_by_name.name;
-    }
-    return make_dataset_wrapper(under, o->under_vol_id, o->parent_file, name);
+    /* The full path, asked of the under-VOL -- not loc_params' name, which is
+       relative to `obj` and absent entirely for a by-token open. See
+       clio_object_full_path() for why a relative name cannot be a cache key. */
+    const std::string path = clio_object_full_path(under, o->under_vol_id,
+                                                   H5I_DATASET, dxpl_id);
+    return make_dataset_wrapper(under, o->under_vol_id, o->parent_file,
+                                path.empty() ? nullptr : path.c_str());
   }
 
   auto *wrapped = new clio_obj_t;
@@ -2630,7 +2772,8 @@ static herr_t clio_datatype_close(void *obj, hid_t dxpl_id, void **req) {
   auto *o = static_cast<clio_obj_t *>(obj);
   herr_t ret = H5VLdatatype_close(o->under_object, o->under_vol_id, dxpl_id,
                                    req);
-  delete o;
+  /* See clio_group_close. */
+  if (ret >= 0) delete o;
   return ret;
 }
 
@@ -2638,9 +2781,30 @@ static herr_t clio_datatype_close(void *obj, hid_t dxpl_id, void **req) {
 static herr_t clio_introspect_get_conn_cls(void *obj,
                                              H5VL_get_conn_lvl_t lvl,
                                              const H5VL_class_t **conn_cls) {
-  (void)obj; (void)lvl;
-  *conn_cls = &H5VL_clio_cls;
-  return 0;
+  /* Only H5VL_GET_CONN_LVL_CURR asks about THIS connector. Every other level --
+     H5VL_GET_CONN_LVL_TERMINAL above all -- asks about the connector at the
+     bottom of the stack, and this one is a pass-through: the terminal
+     connector is the native VOL underneath, not us.
+
+     Answering "clio" for every level made H5VLobject_is_native() report false
+     for every object in a clio-backed file. HDF5's own dimension-scale code
+     branches on exactly that: H5DSwith_new_ref() sets
+     is_new_ref = (config_flag || !native), so a false answer diverted
+     H5DSattach_scale onto its new-style-reference path, which attaches a held
+     file ID to each reference it builds. One of those holds is never released
+     (the H5Treclaim after the write is sized by the OLD dataspace, one element
+     short of the buffer), so the file ID outlived H5Fclose and the next
+     H5Fcreate(H5F_ACC_TRUNC) on the same name failed with "unable to truncate
+     a file which is already open" -- h5_test/tst_h_dimscales, with nothing in
+     the error to point back here. Delegating puts a clio-backed file on the
+     same path as a native one. Mirrors H5VLpassthru. */
+  auto *o = static_cast<clio_obj_t *>(obj);
+  if (H5VL_GET_CONN_LVL_CURR == lvl || !o) {
+    *conn_cls = &H5VL_clio_cls;
+    return 0;
+  }
+  return H5VLintrospect_get_conn_cls(o->under_object, o->under_vol_id, lvl,
+                                     conn_cls);
 }
 
 static herr_t clio_introspect_get_cap_flags(const void *info,
@@ -2922,6 +3086,7 @@ const H5VL_class_t H5VL_clio_cls = {
 };
 
 hid_t H5VL_clio_register(void) {
+  clio_vol_install_exit_guard();
   return H5VLregister_connector(&H5VL_clio_cls, H5P_DEFAULT);
 }
 
@@ -2941,4 +3106,11 @@ hid_t H5VL_clio_register(void) {
  * H5VL_clio_register() + H5Pset_vol() itself.
  * ======================================================================== */
 extern "C" H5PL_type_t H5PLget_plugin_type(void) { return H5PL_TYPE_VOL; }
-extern "C" const void *H5PLget_plugin_info(void) { return &H5VL_clio_cls; }
+extern "C" const void *H5PLget_plugin_info(void) {
+  /* The plugin path does NOT go through H5VL_clio_register(): HDF5 asks for
+     the class here and registers the connector itself. This is therefore the
+     entry point that must arm the process-exit guard for every
+     HDF5_VOL_CONNECTOR=clio application. */
+  clio_vol_install_exit_guard();
+  return &H5VL_clio_cls;
+}

--- a/context-transfer-engine/adapter/vfd/H5FDclio.cc
+++ b/context-transfer-engine/adapter/vfd/H5FDclio.cc
@@ -149,6 +149,69 @@ static size_t H5FD__clio_max_io_bytes(void) {
   return limit;
 }
 
+/*---------------------------------------------------------------------------
+ * Process-exit guard.
+ *
+ * HDF5 installs atexit(H5_term_library) the first time the library is
+ * initialized, and H5_term_library closes every file, datatype and group the
+ * application left open -- which reaches this driver's write, flush, truncate
+ * and close callbacks LONG AFTER main() has returned.
+ *
+ * The CLIO client, by contrast, is a set of process-global objects whose
+ * teardown runs as ordinary static destructors: the shared ZeroMQ context
+ * (whose destructor zmq_ctx_shutdown()s every socket, so RecvZmqClientThread
+ * exits), the deferred-write registry, the IPC manager's receive threads.
+ * Every one of those is registered LATER than HDF5's atexit handler -- the
+ * client is first constructed on the first H5Fopen, long after H5open() -- and
+ * exit handlers run last-registered-first. So by the time H5_term_library asks
+ * this driver to close a file, CLIO is already gone. Calling into it then does
+ * one of two things, both observed in the netCDF-C suite:
+ *
+ *   - SIGSEGV inside Client::DeferRegisterWrite, dereferencing the destroyed
+ *     DeferRegistry hash table (h5_test/tst_h_dimscales, at exit, after the
+ *     test itself printed "Tests successful!");
+ *   - an unkillable hang in Client::CloseFd, waiting on a future that no
+ *     surviving receive thread will ever complete (h5_test/tst_h_compounds2,
+ *     tst_h_strings2, and every ncdump shell test whose child processes never
+ *     exit).
+ *
+ * The fix is to stop calling into CLIO once teardown has begun. The guard is
+ * armed from every entry point HDF5 can reach this driver through --
+ * H5PLget_plugin_info() for the HDF5_DRIVER=clio_vfd path, H5FD_clio_init()
+ * for an application that registers the driver itself, and open() as a
+ * backstop -- all of which run AFTER H5open() has installed H5_term_library,
+ * so LIFO ordering guarantees it runs BEFORE H5_term_library: the flag is
+ * always set by the time the late callbacks arrive. Nothing is lost by
+ * skipping the tier there -- it is populate-only and
+ * best-effort, and every byte has already been written through to the
+ * authoritative native file, so the on-disk image is complete and valid either
+ * way.
+ *
+ * Not atomic on purpose: it is written once by the thread running exit
+ * handlers, at a point where the C runtime has already serialized teardown.
+ *---------------------------------------------------------------------------*/
+static bool H5FDclio_exiting_g = false;
+
+static void H5FD__clio_note_exit(void) { H5FDclio_exiting_g = true; }
+
+/* Register the guard once, from driver init. Separate from the flag so the
+ * registration cannot be duplicated by a re-register of the driver. */
+static void H5FD__clio_install_exit_guard(void) {
+  static bool installed = false;
+  if (!installed) {
+    installed = true;
+    atexit(H5FD__clio_note_exit);
+  }
+}
+
+/* True when it is still safe to call into the CTE cache tier: this file has a
+ * handle AND the process has not begun running exit handlers. Every cache-tier
+ * call site goes through this -- a call site that tests `fd >= 0` alone is the
+ * bug described above. */
+static inline bool H5FD__clio_cache_live(int fd) {
+  return fd >= 0 && !H5FDclio_exiting_g;
+}
+
 /* Attach to the CLIO runtime, at most once per process, and remember the
  * answer. Attaching to an absent runtime retries for CLIO_CLIENT_RETRY_TIMEOUT
  * seconds (60 by default), so asking per H5Fopen would make a down runtime
@@ -158,6 +221,10 @@ static size_t H5FD__clio_max_io_bytes(void) {
  * picked up for the life of the process. Files stay native-only, which is
  * correct, just unaccelerated. */
 static bool H5FD__clio_cache_available(void) {
+  /* Checked before the cached answer: a file opened while exit handlers are
+     running (HDF5 reopens nothing, but H5FD__clio_del does open a FAPL path)
+     must not attach to a client that is being torn down. */
+  if (H5FDclio_exiting_g) return false;
   static const bool available = clio::cte::core::CLIO_CTE_CLIENT_INIT();
   return available;
 }
@@ -180,6 +247,21 @@ static bool H5FD__clio_cache_env_enabled(void) {
            strcmp(v, "false") == 0 || strcmp(v, "no") == 0);
 }
 
+/* Read the CLIO_VFD_FSYNC opt-IN for the flush callback. Default off; any of
+ * "1"/"on"/"true"/"yes" turns it on for every file in the process. The mirror
+ * image of CLIO_VFD_CACHE: that one can only DISABLE what the FAPL asked for,
+ * this one can only ENABLE what the FAPL left off -- in both cases the
+ * environment moves the knob in the safe direction (fail-closed for the cache,
+ * more-durable for fsync), so neither can silently weaken an explicit choice
+ * made in code. */
+static bool H5FD__clio_fsync_env_forced(void) {
+  const char *v = getenv("CLIO_VFD_FSYNC");
+  if (!v || !*v) return false;
+  return strcmp(v, "1") == 0 || strcmp(v, "on") == 0 ||
+         strcmp(v, "true") == 0 || strcmp(v, "yes") == 0;
+}
+
+
 /* True when addr/size cannot be expressed as a POSIX file region: an undefined
  * address, an address past the driver's advertised maxaddr, or a length that
  * wraps when added to the address. sec2 performs the equivalent checks; without
@@ -198,6 +280,7 @@ extern "C" {
  * read tier makes them meaningful. */
 typedef struct H5FD_clio_fapl_t {
   hbool_t cache_enabled; /* populate the CTE cache tier (default on) */
+  hbool_t fsync_on_flush; /* fsync(2) the native file in flush (default off) */
   size_t sieve_max;      /* vector-I/O coalescing window, bytes (0 = off) */
 } H5FD_clio_fapl_t;
 
@@ -224,7 +307,8 @@ static inline bool H5FD__clio_sieve_valid(size_t v) {
 /* Default policy when a file is opened without a driver-specific FAPL
  * (e.g. H5Pset_driver(fapl, driver, NULL)): cache on, coalescing on. */
 static const H5FD_clio_fapl_t H5FD_clio_fapl_default_g = {
-    /*cache_enabled*/ 1, /*sieve_max*/ H5FD_CLIO_SIEVE_MAX_DEF};
+    /*cache_enabled*/ 1, /*fsync_on_flush*/ 0,
+    /*sieve_max*/ H5FD_CLIO_SIEVE_MAX_DEF};
 
 /*
  * Apply the driver config string, if the FAPL carries one.
@@ -236,6 +320,8 @@ static const H5FD_clio_fapl_t H5FD_clio_fapl_default_g = {
  *
  * Recognised keys:
  *   cache=0|1|on|off|true|false|yes|no   the CTE tier
+ *   fsync=0|1|on|off|true|false|yes|no   fsync(2) inside the flush callback
+ *                                        (default off; see H5FD__clio_flush)
  *   sieve=<bytes>                        vector-I/O coalescing window
  *                                        (0 disables; default 65536)
  *
@@ -271,6 +357,15 @@ static bool H5FD__clio_apply_config_str(hid_t fapl_id, H5FD_clio_fapl_t *fa) {
         return false;
       }
       fa->cache_enabled = on ? 1 : 0;
+    } else if (e.first == "fsync") {
+      bool on = false;
+      if (!clio::cte::adapter::ConfigParseBool(e.second, &on)) {
+        H5FD_CLIO_ERROR(("driver config: fsync='" + e.second +
+                         "' is not a boolean (use 0/1/on/off/true/false)")
+                            .c_str());
+        return false;
+      }
+      fa->fsync_on_flush = on ? 1 : 0;
     } else if (e.first == "sieve") {
       /* strtoull WRAPS a negative instead of rejecting it -- "-1" parses as
          ULLONG_MAX with errno untouched, which would install a SIZE_MAX
@@ -306,7 +401,7 @@ static bool H5FD__clio_apply_config_str(hid_t fapl_id, H5FD_clio_fapl_t *fa) {
       fa->sieve_max = (size_t)v;
     } else {
       H5FD_CLIO_ERROR(("driver config: unknown key '" + e.first +
-                       "' (this driver accepts: cache, sieve)")
+                       "' (this driver accepts: cache, fsync, sieve)")
                           .c_str());
       return false;
     }
@@ -430,6 +525,12 @@ static const H5FD_class_t H5FD_clio_g = {
 hid_t H5FD_clio_init(void) {
   hid_t ret_value = H5I_INVALID_HID; /* Return value */
 
+  /* The ordering argument that makes the guard work is that this atexit()
+     call follows the one H5open() already made for H5_term_library. Every
+     entry point that arms it is reached after H5open(), so arming it at all
+     of them is safe and none of them can be the one that gets missed. */
+  H5FD__clio_install_exit_guard();
+
   /* Register the driver's HDF5 error class + messages once. Without this,
    * term() unregistered a class that init() never registered, so the error
    * path was dead and failures were silent. */
@@ -495,6 +596,11 @@ static herr_t H5FD__clio_term(void) {
  */
 static H5FD_t *H5FD__clio_open(const char *name, unsigned flags,
                                  hid_t fapl_id, haddr_t maxaddr) {
+  /* Belt and braces. Whatever route selected this driver, a file open is
+     unconditionally after H5open(), so the guard is armed no later than the
+     first file that could still be open when exit handlers start running. */
+  H5FD__clio_install_exit_guard();
+
   // Argument validation, sec2 parity. Without these a NULL name dereferences in
   // HasClioPrefix below, and an out-of-range maxaddr is accepted despite the
   // class advertising MAXADDR.
@@ -557,6 +663,12 @@ static H5FD_t *H5FD__clio_open(const char *name, unsigned flags,
      therefore its retry timeout) rather than attaching and then not using it. */
   if (fa.cache_enabled && !H5FD__clio_cache_env_enabled()) {
     fa.cache_enabled = 0;
+  }
+
+  /* Same shape, opposite direction: the environment can turn the flush-time
+     durability barrier ON for a file whose FAPL did not ask for it. */
+  if (!fa.fsync_on_flush && H5FD__clio_fsync_env_forced()) {
+    fa.fsync_on_flush = 1;
   }
 
   // Attach to the CLIO runtime ONLY when this file wants the cache tier: the
@@ -719,8 +831,11 @@ static herr_t H5FD__clio_close(H5FD_t *_file) {
       ret_value = FAIL;
     }
   }
-  // Release the CTE cache handle, if this session had one.
-  if (file->fd >= 0) {
+  // Release the CTE cache handle, if this session had one -- unless the
+  // process is already running its exit handlers, in which case the client
+  // that would service the close no longer has a receive thread and the wait
+  // never returns. The handle goes down with the process.
+  if (H5FD__clio_cache_live(file->fd)) {
     CLIO_CFS_CLIENT->CloseFd(file->fd);
     HLOG(kDebug, "");
   }
@@ -958,7 +1073,7 @@ static herr_t H5FD__clio_do_write(H5FD_clio_t *file, haddr_t addr, size_t size,
   // already succeeded), but NOT silent: a dropped populate is a range the tier
   // does not hold, which the future read tier must not mistake for resident
   // data. Count it and log once per failure so residency work has a signal.
-  if (file->fd >= 0) {
+  if (H5FD__clio_cache_live(file->fd)) {
     if (CLIO_CFS_CLIENT->PwriteFd(file->fd, buf, size, static_cast<off_t>(addr)) < 0) {
       H5FDclio_cache_write_failures_g++;
       HLOG(kWarning,
@@ -1345,9 +1460,33 @@ static herr_t H5FD__clio_get_handle(H5FD_t *_file, hid_t fapl,
 /*-------------------------------------------------------------------------
  * Function:    H5FD__clio_flush
  *
- * Purpose:     Durability barrier: fsync the authoritative native file so a
- *              successful H5Fflush/H5Dflush leaves no pending dirty state on
- *              disk. Fail-closed if the fsync fails.
+ * Purpose:     Push this driver's buffers out to the file. There are none:
+ *              every write is written through to the authoritative native file
+ *              by pwrite(2) before the write callback returns, so by the time
+ *              flush is called the data is already in the page cache and
+ *              visible to every other process on the machine. That is what
+ *              HDF5 asks a flush callback for, and it is what sec2 -- the
+ *              reference driver this one is byte-for-byte compatible with --
+ *              provides by having no flush callback at all.
+ *
+ *              This used to fsync(2) unconditionally, which is a DURABILITY
+ *              barrier (survive a power cut), not a visibility one, and is
+ *              strictly stronger than the callback's contract. It is also
+ *              ruinously expensive at netCDF-4's call rate: netCDF calls
+ *              H5Fflush from nc_enddef, so nc_test4/tst_atts -- which
+ *              re-enters define mode 3 x 2^16 times -- issued ~200k fsyncs and
+ *              went from 0.9s on sec2 to over 300s here (ctest timeout).
+ *              tst_h_strings2, tst_h_compounds2 and the ncdump shell tests
+ *              were the same shape.
+ *
+ *              The barrier is still available, because "my writes are on
+ *              stable storage when H5Fflush returns" is a real requirement for
+ *              some callers -- it is just opt-in now: fsync=1 in the driver
+ *              config string (HDF5_DRIVER_CONFIG="fsync=1"), or
+ *              CLIO_VFD_FSYNC=1 in the environment for a process that cannot
+ *              reach the FAPL. close() fsyncs unconditionally either way, so
+ *              a file that is closed normally is always durable; only the
+ *              per-flush barrier is a choice.
  *
  * Return:      SUCCEED/FAIL
  *
@@ -1357,9 +1496,12 @@ static herr_t H5FD__clio_flush(H5FD_t *_file, hid_t dxpl_id, bool closing) {
   (void)dxpl_id;
   (void)closing;
   H5FD_clio_t *file = (H5FD_clio_t *)_file;
-  // Persist the authoritative native file; fail-closed so a flush that did not
-  // reach disk never reports success. Writes are write-through, so the native
-  // file is the only store holding data to flush.
+  if (!file->fa.fsync_on_flush) {
+    return SUCCEED;
+  }
+  // Opt-in durability barrier; fail-closed so a flush that did not reach disk
+  // never reports success. Writes are write-through, so the native file is the
+  // only store holding data to flush.
   if (file->posix_fd >= 0 && fsync(file->posix_fd) < 0) {
     H5FD_CLIO_ERROR("fsync() in flush failed");
     return FAIL;
@@ -1391,7 +1533,7 @@ static herr_t H5FD__clio_truncate(H5FD_t *_file, hid_t dxpl_id, bool closing) {
     // Keep the CTE cache's logical size in step (best-effort; populate-only
     // tier, see the write callback). Counted on failure for the same reason:
     // a tier that did not shrink still holds bytes past the new EOF.
-    if (file->fd >= 0) {
+    if (H5FD__clio_cache_live(file->fd)) {
       if (CLIO_CFS_CLIENT->FtruncateFd(file->fd, (off_t)file->eoa) < 0) {
         H5FDclio_cache_truncate_failures_g++;
         HLOG(kWarning,
@@ -1597,6 +1739,14 @@ static herr_t H5FD__clio_del(const char *name, hid_t fapl) {
  */
 H5PL_type_t H5PLget_plugin_type(void) { return H5PL_TYPE_VFD; }
 
-const void *H5PLget_plugin_info(void) { return &H5FD_clio_g; }
+const void *H5PLget_plugin_info(void) {
+  /* The plugin path does NOT go through H5FD_clio_init(): HDF5 asks for the
+     class struct here and registers the driver itself. So this is the entry
+     point that must arm the process-exit guard -- arming it only in
+     H5FD_clio_init() left the guard disarmed for every HDF5_DRIVER=clio_vfd
+     application, which is all of them. */
+  H5FD__clio_install_exit_guard();
+  return &H5FD_clio_g;
+}
 
 } // extern C


### PR DESCRIPTION
Fixes #1024.

Six defects in the HDF5 VFD and VOL adapters (plus the runtime's heartbeat
thread), all found by running the **whole netCDF-C test suite** — 215 tests:
unit tests, the ncdump/ncgen/nccopy tool tests and nc_perf — against
clio-core `dev`.

Every variant uses the same netCDF-C and HDF5 build; only the HDF5 plugin
environment differs, so a test that passes on the baseline and fails under a
CLIO variant is attributable to the adapter.

| variant | before | after |
| --- | --- | --- |
| baseline (sec2 / native VOL) | 215/215, 41s | 215/215, 42s |
| `HDF5_DRIVER=clio_vfd` | **9 failed** / 215, 1128s | **215/215**, 123s |
| `HDF5_VOL_CONNECTOR=clio` | **48 failed** of the 94 it reached before being killed at 60m | **215/215**, 174s |

Three commits, one per area.

---

### `runtime: make the heartbeat wait interruptible`

`HeartbeatThread` napped with an uninterruptible 1s `SleepForUs`, and
`ClientFinalize()` clears the flag and then `join()`s — so **every** client
process sat through up to a full second on its way out. Measured: `ncdump -h`
took 1.02s against 0.011s on stock HDF5. `ncdump/tst_ncgen4` spawns hundreds of
one-file processes and hit its 300s timeout on that alone.

A condition variable makes the join immediate; idle cost is unchanged at one
wakeup per second.

The mutex/CV are **file-scope, not `IpcManager` members**, deliberately:
`ipc_manager.h` is included by every client of the runtime, so growing the class
changes its layout and any `.so` not rebuilt in the same pass disagrees about
where the following members live. Not hypothetical — it first showed up here as
a lock taken on an address inside the new CV and a hang that looked nothing like
its cause.

### `vfd: stop calling CLIO after its own teardown, and make flush's fsync opt-in`

**Exit-time hang / SIGSEGV.** HDF5 installs `atexit(H5_term_library)`, which
closes every file left open — reaching the VFD's callbacks long after `main()`
returned. The CLIO client is torn down by static destructors registered *later*
than that handler (the client is first constructed on the first `H5Fopen`, long
after `H5open()`), and exit handlers run last-registered-first, so CLIO is
always already gone:

```
#1  Client::DeferRegisterWrite<WriteTask>   <-- destroyed DeferRegistry
#3  Client::PwriteFd
#4  H5FD__clio_do_write
#17 H5_term_library
```
SIGSEGV in `tst_h_dimscales` — *after* it printed `*** Tests successful!`.

```
#1  IpcCpu2Cpu::RecvOut<CloseTask>          <-- no receive thread left
#3  Client::CloseFd
#4  H5FD__clio_close
#15 H5_term_library
```
Unkillable hang in `tst_h_compounds2`, `tst_h_strings2` and every `ncdump` shell
test. An `atexit`-set flag now gates every cache-tier call site. Note it is
armed from `H5PLget_plugin_info()` too — the plugin path never calls
`H5FD_clio_init()`, so arming only there leaves the guard disarmed for every
`HDF5_DRIVER=clio_vfd` application.

**`fsync(2)` per flush.** `H5FD__clio_flush` fsynced unconditionally — a
*durability* barrier, not the *visibility* one HDF5 asks a flush callback for
(sec2 has no flush callback at all) — and netCDF calls `H5Fflush` from
`nc_enddef`. `nc_test4/tst_atts` re-enters define mode 3 × 2¹⁶ times: ~200k
fsyncs, **0.9s on sec2 vs over 300s here**. Now opt-in via `fsync=1` in the
driver config string or `CLIO_VFD_FSYNC=1`; `close()` still fsyncs
unconditionally, so a normally-closed file is always durable.

### `hdf5_vol: four fixes found by the netCDF-C suite`

1. **Same exit-teardown hang**, via `clio_write_stamp`'s `Wait()` and
   `drain_dataset_puts`. `get_cte_client()` returns `nullptr` once teardown has
   begun — a state every caller already handles. Skipping the stamp is the
   fail-closed direction (next open sees `kAbsent` and re-reads).

2. **`introspect_get_conn_cls` ignored `lvl`.** `H5VL_GET_CONN_LVL_TERMINAL`
   asks about the connector at the *bottom* of the stack, which for a
   pass-through is native. Answering `clio` made `H5VLobject_is_native()` false
   for every object in a clio-backed file, and HDF5's dimension-scale code
   branches on exactly that (`H5DSwith_new_ref` sets
   `is_new_ref = (config_flag || !native)`). The diverted path leaks a held file
   ID, so a later `H5Fcreate(H5F_ACC_TRUNC)` failed with *"unable to truncate a
   file which is already open"* — `tst_h_dimscales`, with nothing in the error
   to suggest a dimension scale. Now delegates for every level but `CURR`, as
   `H5VLpassthru` does.

3. **CTE blobs keyed by a relative name.** `make_dataset_wrapper()` got the
   `name` HDF5 passes to `dataset_create`/`open`, which is relative to `obj` —
   so `/var` and `/g/var` both keyed `"var/chunk_0"` and the second one opened
   read the first one's bytes, zero-padded when shorter:

   ```
   $ ncdump tst_grp_spec.nc      # expected 1, 2, 3, 4
      var = 1, 0, 0, 0 ;
   ```

   `tst_netcdf4`, `tst_grp_spec`, `tst_ncgen4` and `tst_nccopy4` all failed this
   way, and all four passed with `CLIO_VOL_CACHE=0` — which is what identified
   the tier. The full path is now asked of the under-VOL, since `name` may also
   be absolute, may be relative to the file, and is absent entirely for a
   by-token open (`H5Oopen`, a reference). A dataset whose path cannot be
   resolved is marked non-cacheable: no key at all is the only safe answer.

4. **Wrappers freed even when the underlying close failed.** A failed close
   leaves the object open and HDF5 hands the *same* VOL object back on the next
   attempt. `tst_h_files` sets `H5F_CLOSE_SEMI` and closes twice, which aborted
   the process inside malloc (`double free detected in tcache 2`) instead of
   reporting the failure. Every free is now guarded on `ret >= 0`, as
   `H5VLpassthru` does.

---

### Testing

Linux, 20 cores, HDF5 `develop` @ `562e6028`, netCDF-C `main` @ `4e403969`,
driven by [`nc4_clio_test.sh`](https://github.com/hyoklee/actions/blob/main/.github/scripts/nc4_clio_test.sh).
All three variants run the full suite to completion with zero failures, in one
pass, on the tip of this branch.

Two fixes outside this repo were needed to get a clean board and are **not** in
this PR:

- `H5DSattach_scale` never closes the ID from `H5Ropen_object` on the success
  path, while `H5DSdetach_scale`'s identical loop always has — a genuine HDF5
  leak, reachable only through a non-native VOL. Fix 2 above means clio-backed
  files no longer take that path, so this PR does not depend on it.
- The test harness now puts the HDF5 under test first on `PATH`, so tests that
  shell out to `h5dump` don't hand a foreign HDF5 an `HDF5_VOL_CONNECTOR=clio`
  it cannot load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
