### PR TITLE
Make AggregateOut merge OUT fields only, never whole-task Copy

### DIFF
--- a/context-assimilation-engine/core/include/clio_cae/core/core_tasks.h
+++ b/context-assimilation-engine/core/include/clio_cae/core/core_tasks.h
@@ -284,7 +284,23 @@ struct ParseOmniTask : public clio::run::Task {
    */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<ParseOmniTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<ParseOmniTask>();
+    // Each replica schedules its own share of the work, so the count is the
+    // SUM. result_code_ keeps the FIRST failure so a later success cannot mask
+    // it.
+    num_tasks_scheduled_ += replica->num_tasks_scheduled_;
+    if (result_code_ == 0) {
+      result_code_ = replica->result_code_;
+    }
+    // error_message_ is diagnostic: keep the FIRST replica that reported one,
+    // so the failure that set the collective return code is the one the caller
+    // sees (last-replica-wins would hide it behind a later success).
+    if (error_message_.size() == 0 && replica->error_message_.size() > 0) {
+      error_message_ = replica->error_message_;
+    }
   }
 };
 
@@ -437,7 +453,22 @@ struct ExportDataTask : public clio::run::Task {
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<ExportDataTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<ExportDataTask>();
+    // Each replica exports its own share, so the byte count is the SUM;
+    // result_code_ keeps the FIRST failure.
+    bytes_exported_ += replica->bytes_exported_;
+    if (result_code_ == 0) {
+      result_code_ = replica->result_code_;
+    }
+    // error_message_ is diagnostic: keep the FIRST replica that reported one,
+    // so the failure that set the collective return code is the one the caller
+    // sees (last-replica-wins would hide it behind a later success).
+    if (error_message_.size() == 0 && replica->error_message_.size() > 0) {
+      error_message_ = replica->error_message_;
+    }
   }
 };
 
@@ -509,7 +540,22 @@ struct ImportDataTask : public clio::run::Task {
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<ImportDataTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<ImportDataTask>();
+    // Each replica imports its own share, so the byte count is the SUM;
+    // result_code_ keeps the FIRST failure.
+    bytes_imported_ += replica->bytes_imported_;
+    if (result_code_ == 0) {
+      result_code_ = replica->result_code_;
+    }
+    // error_message_ is diagnostic: keep the FIRST replica that reported one,
+    // so the failure that set the collective return code is the one the caller
+    // sees (last-replica-wins would hide it behind a later success).
+    if (error_message_.size() == 0 && replica->error_message_.size() > 0) {
+      error_message_ = replica->error_message_;
+    }
   }
 };
 

--- a/context-assimilation-engine/test/unit/test_export_data.cc
+++ b/context-assimilation-engine/test/unit/test_export_data.cc
@@ -230,16 +230,29 @@ TEST_CASE("ExportData - Task AggregateOut", "[cae][export][task]") {
 
   auto replica = ipc->NewTask<ExportDataTask>(clio::run::CreateTaskId(),
                                               clio::cae::core::kCaePoolId,
-                                              clio::run::PoolQuery::Local(),
+                                              clio::run::PoolQuery::Broadcast(),
                                               "tag_agg", "/tmp/agg.bin", "binary");
   replica->bytes_exported_ = 200;
   replica->result_code_ = 5;
 
+  const clio::run::TaskId id_before = orig->task_id_;
+  const clio::run::PoolQuery query_before = orig->pool_query_;
+
   orig->AggregateOut(replica.template Cast<clio::run::Task>());
 
-  // AggregateOut calls Copy, so orig should now have replica's values
-  REQUIRE(orig->bytes_exported_ == 200);
-  REQUIRE(orig->result_code_ == 5);
+  // AggregateOut is an N->1 GATHER of OUT fields, not a whole-task copy
+  // (issue #915): each replica exports its own share, so the byte counts SUM.
+  REQUIRE(orig->bytes_exported_ == 300);
+  // result_code_ keeps the FIRST failure — a later replica must not be able to
+  // mask it (the old Copy() delegation let 5 overwrite 1).
+  REQUIRE(orig->result_code_ == 1);
+
+  // The origin's identity must survive aggregation untouched: the whole-task
+  // copy used to overwrite it with the replica's, which is what corrupted
+  // send_map_/completion bookkeeping mid-flight in #856.
+  REQUIRE(orig->task_id_ == id_before);
+  REQUIRE(memcmp(&orig->pool_query_, &query_before,
+                 sizeof(clio::run::PoolQuery)) == 0);
 
   orig.reset();
   replica.reset();
@@ -550,14 +563,26 @@ TEST_CASE("ParseOmni - Task AggregateOut", "[cae][export][task]") {
 
   auto rep = ipc->NewTask<ParseOmniTask>(clio::run::CreateTaskId(),
                                          clio::cae::core::kCaePoolId,
-                                         clio::run::PoolQuery::Local(), ctxs);
+                                         clio::run::PoolQuery::Broadcast(), ctxs);
   rep->num_tasks_scheduled_ = 5;
   rep->result_code_ = 9;
 
+  const clio::run::TaskId id_before = orig->task_id_;
+  const clio::run::PoolQuery query_before = orig->pool_query_;
+
   orig->AggregateOut(rep.template Cast<clio::run::Task>());
 
-  REQUIRE(orig->num_tasks_scheduled_ == 5);
+  // OUT fields only, merged with the semantics that suit them (issue #915):
+  // each replica schedules its own share, so the counts SUM...
+  REQUIRE(orig->num_tasks_scheduled_ == 6);
+  // ...and result_code_ takes the first failure. The origin was still clean
+  // (0), so the replica's 9 is adopted.
   REQUIRE(orig->result_code_ == 9);
+
+  // Identity is never touched by a gather.
+  REQUIRE(orig->task_id_ == id_before);
+  REQUIRE(memcmp(&orig->pool_query_, &query_before,
+                 sizeof(clio::run::PoolQuery)) == 0);
 
   orig.reset();
   rep.reset();

--- a/context-runtime/include/clio_runtime/task.h
+++ b/context-runtime/include/clio_runtime/task.h
@@ -743,6 +743,36 @@ class Task {
    * IMPORTANT: Derived classes that override AggregateOut MUST call
    * Task::AggregateOut(replica_task) first before aggregating their own fields.
    *
+   * THE CONTRACT (issue #915) — AggregateOut merges a REPLICA's OUT fields
+   * into THIS (origin) task, an N->1 gather. Two rules follow, and violating
+   * either corrupts a live runtime rather than merely returning bad data:
+   *
+   *   1. NEVER implement it by delegating to Copy(). Copy() is a WHOLE-TASK
+   *      assignment: it runs Task::Copy, overwriting this origin's task_id_,
+   *      pool_query_, method_, task_flags_, completer_ and task_group_ with
+   *      the REPLICA's — and the replica's task_id_ carries net_key/replica_id,
+   *      so the origin adopts a subtask's identity mid-flight while send_map_,
+   *      the replica accounting and the completion path still key off its own.
+   *      That is the `free(): invalid pointer` / SIGSEGV that killed
+   *      leader-election recovery in #856.
+   *   2. Touch OUT (and INOUT) fields ONLY, and never re-assign an shm-backed
+   *      member the CLIENT owns (a priv::string IN field, a ShmPtr payload
+   *      buffer). Doing so frees the origin's buffer through the replica's
+   *      allocator. Bulk-transferred payloads have already landed in the
+   *      origin's own buffer and must be left alone.
+   *
+   * Pick a reduction that suits each OUT field — SUM for partitioned counters,
+   * MAX for an owner-reported value that non-owners answer 0 for,
+   * first-non-empty for a diagnostic string, concatenation for a vector —
+   * and make sure a SINGLE-replica gather lands on the replica's value, since
+   * that is what almost every route actually does.
+   *
+   * Enforcement: `cr_aggregate_out_contract` lints every AggregateOut body in
+   * the tree for a Copy() call, the autogen sweep asserts the origin's identity
+   * survives a real container-dispatched aggregation for every method, and
+   * RecvOut (src/ipc/ipc_run2run.cc) checks and repairs it at run time for
+   * out-of-tree chimods.
+   *
    * @param replica_task The replica task to aggregate from
    */
   void AggregateOut(const ctp::ipc::FullPtr<Task>& replica_task) {

--- a/context-runtime/modules/admin/include/clio_runtime/admin/admin_tasks.h
+++ b/context-runtime/modules/admin/include/clio_runtime/admin/admin_tasks.h
@@ -524,7 +524,16 @@ struct DestroyPoolTask : public clio::run::Task {
   /** AggregateOut replica results into this task */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<DestroyPoolTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<DestroyPoolTask>();
+    // error_message_ is diagnostic: keep the FIRST replica that reported one,
+    // so the failure that set the collective return code is the one the caller
+    // sees (last-replica-wins would hide it behind a later success).
+    if (error_message_.size() == 0 && replica->error_message_.size() > 0) {
+      error_message_ = replica->error_message_;
+    }
   }
 };
 
@@ -606,7 +615,16 @@ struct StopRuntimeTask : public clio::run::Task {
   /** AggregateOut replica results into this task */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<StopRuntimeTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<StopRuntimeTask>();
+    // error_message_ is diagnostic: keep the FIRST replica that reported one,
+    // so the failure that set the collective return code is the one the caller
+    // sees (last-replica-wins would hide it behind a later success).
+    if (error_message_.size() == 0 && replica->error_message_.size() > 0) {
+      error_message_ = replica->error_message_;
+    }
   }
 };
 
@@ -668,7 +686,16 @@ struct FlushTask : public clio::run::Task {
   /** AggregateOut replica results into this task */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<FlushTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<FlushTask>();
+    // Flush is broadcast to every node and each reports the work IT did, so
+    // the collective figure is the SUM. This is the field the flush loop polls
+    // to decide whether the system is quiesced: clobbering it with the last
+    // replica's count (what the whole-task copy did) makes a busy system look
+    // idle as soon as one node happens to be.
+    total_work_done_ += replica->total_work_done_;
   }
 };
 
@@ -763,7 +790,16 @@ struct SendTask : public clio::run::Task {
   /** AggregateOut replica results into this task */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<SendTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<SendTask>();
+    // error_message_ is diagnostic: keep the FIRST replica that reported one,
+    // so the failure that set the collective return code is the one the caller
+    // sees (last-replica-wins would hide it behind a later success).
+    if (error_message_.size() == 0 && replica->error_message_.size() > 0) {
+      error_message_ = replica->error_message_;
+    }
   }
 };
 
@@ -832,7 +868,16 @@ struct RecvTask : public clio::run::Task {
   /** AggregateOut replica results into this task */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<RecvTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<RecvTask>();
+    // error_message_ is diagnostic: keep the FIRST replica that reported one,
+    // so the failure that set the collective return code is the one the caller
+    // sees (last-replica-wins would hide it behind a later success).
+    if (error_message_.size() == 0 && replica->error_message_.size() > 0) {
+      error_message_ = replica->error_message_;
+    }
   }
 };
 
@@ -989,7 +1034,46 @@ struct ClientConnectTask : public clio::run::Task {
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<ClientConnectTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<ClientConnectTask>();
+    // The handshake describes ONE runtime instance's shm layout — allocator
+    // ids, queue offsets, worker tids, GPU IPC handles. There is no meaningful
+    // N-to-1 merge of two different runtimes' layouts, so the first replica to
+    // answer wins and later ones are ignored (server_pid_ is 0 until a replica
+    // has filled the block). Aggregating instead of copying keeps the origin's
+    // identity intact either way.
+    if (server_pid_ != 0) {
+      return;
+    }
+    response_ = replica->response_;
+    server_generation_ = replica->server_generation_;
+    server_pid_ = replica->server_pid_;
+    worker_queues_off_ = replica->worker_queues_off_;
+    shm_in_shards_ = replica->shm_in_shards_;
+    main_alloc_id_ = replica->main_alloc_id_;
+    queue_alloc_id_ = replica->queue_alloc_id_;
+    metadata_dir_off_ = replica->metadata_dir_off_;
+    num_gpus_ = replica->num_gpus_;
+    gpu_queue_depth_ = replica->gpu_queue_depth_;
+    num_worker_tids_ = replica->num_worker_tids_;
+    for (clio::run::u32 i = 0; i < kMaxWorkerTids; ++i) {
+      worker_tids_[i] = replica->worker_tids_[i];
+    }
+    for (clio::run::u32 i = 0; i < kMaxGpuDevices; ++i) {
+      cpu2gpu_queue_off_[i] = replica->cpu2gpu_queue_off_[i];
+      gpu2cpu_queue_off_[i] = replica->gpu2cpu_queue_off_[i];
+      gpu2gpu_queue_off_[i] = replica->gpu2gpu_queue_off_[i];
+      cpu2gpu_backend_size_[i] = replica->cpu2gpu_backend_size_[i];
+      gpu2cpu_backend_size_[i] = replica->gpu2cpu_backend_size_[i];
+    }
+    for (clio::run::u32 i = 0; i < kMaxGpuDevices; ++i) {
+      const char *src = replica->gpu2gpu_ipc_handle_bytes_[i];
+      for (size_t b = 0; b < sizeof(gpu2gpu_ipc_handle_bytes_[i]); ++b) {
+        gpu2gpu_ipc_handle_bytes_[i][b] = src[b];
+      }
+    }
   }
 };
 
@@ -1040,7 +1124,13 @@ struct ClientRecvTask : public clio::run::Task {
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<ClientRecvTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<ClientRecvTask>();
+    // Each replica drains its own client queues, so the collective count is
+    // the SUM.
+    tasks_received_ += replica->tasks_received_;
   }
 };
 
@@ -1091,7 +1181,13 @@ struct ClientSendTask : public clio::run::Task {
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<ClientSendTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<ClientSendTask>();
+    // Each replica sends from its own client queues, so the collective count
+    // is the SUM.
+    tasks_sent_ += replica->tasks_sent_;
   }
 };
 
@@ -1158,7 +1254,12 @@ struct WreapDeadIpcsTask : public clio::run::Task {
   /** AggregateOut replica results into this task */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<WreapDeadIpcsTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<WreapDeadIpcsTask>();
+    // Each node reaps its own dead IPCs, so the collective count is the SUM.
+    reaped_count_ += replica->reaped_count_;
   }
 };
 
@@ -1396,7 +1497,19 @@ struct SubmitBatchTask : public clio::run::Task {
    */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<SubmitBatchTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<SubmitBatchTask>();
+    // Each replica completes its own slice of the batch, so the collective
+    // count is the SUM.
+    tasks_completed_ += replica->tasks_completed_;
+    // error_message_ is diagnostic: keep the FIRST replica that reported one,
+    // so the failure that set the collective return code is the one the caller
+    // sees (last-replica-wins would hide it behind a later success).
+    if (error_message_.size() == 0 && replica->error_message_.size() > 0) {
+      error_message_ = replica->error_message_;
+    }
   }
 };
 
@@ -1523,7 +1636,21 @@ struct RegisterMemoryTask : public clio::run::Task {
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<RegisterMemoryTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<RegisterMemoryTask>();
+    // Registration must hold on EVERY node, so one failure fails the
+    // collective and is sticky: a failing replica also forces a non-zero
+    // return code, which stops any later success from setting the flag again.
+    if (!replica->success_) {
+      success_ = false;
+      if (GetReturnCode() == 0) {
+        SetReturnCode(1);
+      }
+    } else if (GetReturnCode() == 0) {
+      success_ = true;
+    }
   }
 };
 
@@ -1572,7 +1699,19 @@ struct RestartContainersTask : public clio::run::Task {
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<RestartContainersTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<RestartContainersTask>();
+    // Each node restarts the containers IT hosts, so the collective count is
+    // the SUM.
+    containers_restarted_ += replica->containers_restarted_;
+    // error_message_ is diagnostic: keep the FIRST replica that reported one,
+    // so the failure that set the collective return code is the one the caller
+    // sees (last-replica-wins would hide it behind a later success).
+    if (error_message_.size() == 0 && replica->error_message_.size() > 0) {
+      error_message_ = replica->error_message_;
+    }
   }
 };
 
@@ -1685,7 +1824,20 @@ struct AddNodeTask : public clio::run::Task {
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<AddNodeTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<AddNodeTask>();
+    // Exactly one replica (the leader) allocates the id; the rest answer 0.
+    if (new_node_id_ == 0) {
+      new_node_id_ = replica->new_node_id_;
+    }
+    // error_message_ is diagnostic: keep the FIRST replica that reported one,
+    // so the failure that set the collective return code is the one the caller
+    // sees (last-replica-wins would hide it behind a later success).
+    if (error_message_.size() == 0 && replica->error_message_.size() > 0) {
+      error_message_ = replica->error_message_;
+    }
   }
 };
 
@@ -1812,7 +1964,19 @@ struct MigrateContainersTask : public clio::run::Task {
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<MigrateContainersTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<MigrateContainersTask>();
+    // Migration is partitioned across nodes: each reports what IT moved, so
+    // the collective figure is the SUM.
+    num_migrated_ += replica->num_migrated_;
+    // error_message_ is diagnostic: keep the FIRST replica that reported one,
+    // so the failure that set the collective return code is the one the caller
+    // sees (last-replica-wins would hide it behind a later success).
+    if (error_message_.size() == 0 && replica->error_message_.size() > 0) {
+      error_message_ = replica->error_message_;
+    }
   }
 };
 
@@ -2185,7 +2349,11 @@ struct SystemMonitorTask : public clio::run::Task {
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<SystemMonitorTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    // This task declares no OUT fields, so the base call above (return code +
+    // completer) is the entire merge.
   }
 };
 
@@ -2233,7 +2401,11 @@ struct AnnounceShutdownTask : public clio::run::Task {
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<AnnounceShutdownTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    // This task declares no OUT fields, so the base call above (return code +
+    // completer) is the entire merge.
   }
 };
 

--- a/context-runtime/modules/bdev/include/clio_runtime/bdev/bdev_tasks.h
+++ b/context-runtime/modules/bdev/include/clio_runtime/bdev/bdev_tasks.h
@@ -475,7 +475,17 @@ struct AllocateBlocksTask : public clio::run::Task {
   /** AggregateOut replica results into this task */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<AllocateBlocksTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<AllocateBlocksTask>();
+    // Allocation is partitioned across the replicas: each contributes the
+    // blocks IT reserved, so the origin accumulates the union. Element-wise
+    // push_back keeps every Block in the ORIGIN's allocator — assigning the
+    // replica's vector would adopt a foreign segment's buffer.
+    for (size_t i = 0; i < replica->blocks_.size(); ++i) {
+      blocks_.push_back(replica->blocks_[i]);
+    }
   }
 };
 
@@ -545,7 +555,11 @@ struct FreeBlocksTask : public clio::run::Task {
   /** AggregateOut replica results into this task */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<FreeBlocksTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    // This task declares no OUT fields, so the base call above (return code +
+    // completer) is the entire merge.
   }
 };
 
@@ -608,7 +622,16 @@ struct WriteTask : public clio::run::Task {
   /** AggregateOut */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<WriteTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<WriteTask>();
+    // Each replica writes its own slice, so bytes are SUMMED; the first
+    // non-zero io_error_ wins so a later success cannot mask a failure.
+    bytes_written_ += replica->bytes_written_;
+    if (io_error_ == 0) {
+      io_error_ = replica->io_error_;
+    }
   }
 
   /**
@@ -688,7 +711,21 @@ struct ReadTask : public clio::run::Task {
   /** AggregateOut */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<ReadTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<ReadTask>();
+    // data_ is a ShmPtr into the ORIGIN's buffer and the payload already
+    // landed there via the bulk transfer — never take the replica's pointer,
+    // which addresses a foreign segment.
+    // length_ is INOUT: it goes out as the requested length and comes back as
+    // the length actually read, so it is adopted rather than reduced (reading
+    // one range from several replicas is not a meaningful collective).
+    length_ = replica->length_;
+    bytes_read_ += replica->bytes_read_;
+    if (io_error_ == 0) {
+      io_error_ = replica->io_error_;
+    }
   }
 
   /**
@@ -762,7 +799,23 @@ struct GetStatsTask : public clio::run::Task {
   /** AggregateOut replica results into this task */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<GetStatsTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<GetStatsTask>();
+    // Stats are per-device and partitioned: a replica that does not host the
+    // bdev answers zeros. Capacity SUMS, the predicted lifetime keeps the
+    // WORST (smallest) figure — 999999 is the "healthy" sentinel the origin
+    // starts at — and the throughput model is taken from the first replica
+    // that actually measured one.
+    if (metrics_.read_bandwidth_mbps_ == 0.0 &&
+        metrics_.write_bandwidth_mbps_ == 0.0) {
+      metrics_ = replica->metrics_;
+    }
+    remaining_size_ += replica->remaining_size_;
+    if (replica->predicted_ttl_days_ < predicted_ttl_days_) {
+      predicted_ttl_days_ = replica->predicted_ttl_days_;
+    }
   }
 };
 
@@ -809,7 +862,11 @@ struct SetLifespanTask : public clio::run::Task {
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<SetLifespanTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    // This task declares no OUT fields, so the base call above (return code +
+    // completer) is the entire merge.
   }
 };
 
@@ -854,7 +911,11 @@ struct FlushAllocLogTask : public clio::run::Task {
   /** AggregateOut replica results into this task */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<FlushAllocLogTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    // This task declares no OUT fields, so the base call above (return code +
+    // completer) is the entire merge.
   }
 };
 
@@ -919,7 +980,11 @@ struct UpdateTask : public clio::run::Task {
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<UpdateTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    // This task declares no OUT fields, so the base call above (return code +
+    // completer) is the entire merge.
   }
 };
 

--- a/context-runtime/modules/safe-bdev/include/clio_runtime/safe_bdev/safe_bdev_tasks.h
+++ b/context-runtime/modules/safe-bdev/include/clio_runtime/safe_bdev/safe_bdev_tasks.h
@@ -280,7 +280,11 @@ struct AddBdevTask : public clio::run::Task {
   /** Aggregate replica results into this task */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<AddBdevTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    // This task declares no OUT fields, so the base call above (return code +
+    // completer) is the entire merge.
   }
 };
 
@@ -328,7 +332,11 @@ struct RemoveBdevTask : public clio::run::Task {
   /** Aggregate replica results into this task */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<RemoveBdevTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    // This task declares no OUT fields, so the base call above (return code +
+    // completer) is the entire merge.
   }
 };
 
@@ -388,7 +396,11 @@ struct RecoverBdevTask : public clio::run::Task {
   /** Aggregate replica results into this task */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<RecoverBdevTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    // This task declares no OUT fields, so the base call above (return code +
+    // completer) is the entire merge.
   }
 };
 
@@ -433,7 +445,11 @@ struct BuildParityTask : public clio::run::Task {
   /** Aggregate replica results into this task */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<BuildParityTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    // This task declares no OUT fields, so the base call above (return code +
+    // completer) is the entire merge.
   }
 };
 
@@ -479,7 +495,11 @@ struct FlushAllocLogTask : public clio::run::Task {
   /** Aggregate replica results into this task */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<FlushAllocLogTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    // This task declares no OUT fields, so the base call above (return code +
+    // completer) is the entire merge.
   }
 };
 

--- a/context-runtime/src/ipc/ipc_run2run.cc
+++ b/context-runtime/src/ipc/ipc_run2run.cc
@@ -31,6 +31,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <cstring>
+
 #include <clio_runtime/ipc/ipc_run2run.h>
 #include <clio_runtime/ipc_manager.h>
 #include <clio_runtime/pool_manager.h>
@@ -661,25 +663,37 @@ int IpcManagerRun2Run::RecvOutAggregate(
     // Contract guard (issue #915). AggregateOut merges a REPLICA's OUT fields
     // into the origin; it must never touch the origin's IDENTITY. Tasks that
     // implement it by delegating to Copy() — a whole-task assignment — run
-    // Task::Copy and overwrite task_id_/pool_query_/completer_ with the
-    // replica's while send_map_ and the completion path still reference the
-    // origin, and re-assign IN shm strings across segments. That corrupted the
-    // runtime in production (#856) and ~26 such implementations still exist in
-    // tasks that are currently only routed single-replica. This catches any of
-    // them the instant someone routes that task multi-replica, naming the
-    // method, instead of letting it corrupt memory silently.
+    // Task::Copy and overwrite task_id_/pool_query_/method_/completer_ with
+    // the replica's while send_map_ and the completion path still reference
+    // the origin, and re-assign IN shm strings across segments. That corrupted
+    // the runtime in production (#856). Every in-tree AggregateOut now merges
+    // OUT fields only, and this guard keeps it that way: an out-of-tree chimod
+    // (or a new one that copy-pastes the old shape) is caught here, named by
+    // method, instead of corrupting memory silently.
+    //
+    // pool_query_ has no operator== and is deliberately trivially copyable and
+    // raw-byte compared elsewhere in the tree, so memcmp is the right test.
     const clio::run::TaskId id_before = origin_task->task_id_;
+    const clio::run::PoolQuery query_before = origin_task->pool_query_;
+    const clio::run::u32 method_before = origin_task->method_;
     container->AggregateOut(origin_task->method_, origin_task, replica);
-    if (!(origin_task->task_id_ == id_before)) {
+    const bool id_changed = !(origin_task->task_id_ == id_before);
+    const bool query_changed = memcmp(&origin_task->pool_query_, &query_before,
+                                      sizeof(clio::run::PoolQuery)) != 0;
+    const bool method_changed = origin_task->method_ != method_before;
+    if (id_changed || query_changed || method_changed) {
       HLOG(kError,
            "[AggregateOut CONTRACT VIOLATION] pool={} method={}: the origin's "
-           "task_id_ changed during aggregation ({} -> {}). This task's "
+           "identity changed during aggregation (task_id {} -> {}; "
+           "pool_query changed={}; method changed={}). This task's "
            "AggregateOut is copying the whole replica (almost certainly "
            "`Copy(other_base...)`) instead of merging OUT fields only. See "
            "issue #915. Restoring the origin's identity to avoid corruption.",
-           origin_task->pool_id_, origin_task->method_, id_before,
-           origin_task->task_id_);
+           origin_task->pool_id_, method_before, id_before,
+           origin_task->task_id_, query_changed, method_changed);
       origin_task->task_id_ = id_before;
+      origin_task->pool_query_ = query_before;
+      origin_task->method_ = method_before;
     }
 
     HLOG(kDebug, "[RecvOut] Task {}", origin_task->task_id_);

--- a/context-runtime/test/unit/CMakeLists.txt
+++ b/context-runtime/test/unit/CMakeLists.txt
@@ -34,6 +34,15 @@ set(SAVE_LOAD_TASK_TEST_SOURCES
   test_save_load_task.cc
 )
 
+# AggregateOut contract lint (issue #915). Source-level guard: fails if any
+# AggregateOut implementation anywhere in the tree delegates to Copy(), which
+# is a whole-task assignment that destroys the origin task's identity. Reads
+# sources only — no runtime, no links beyond ctp::cxx.
+set(AGGREGATE_OUT_CONTRACT_TEST_TARGET clio_run_aggregate_out_contract_tests)
+set(AGGREGATE_OUT_CONTRACT_TEST_SOURCES
+  test_aggregate_out_contract.cc
+)
+
 # Local Task Archive test executable
 set(LOCAL_TASK_ARCHIVE_TEST_TARGET clio_run_local_task_archive_tests)
 set(LOCAL_TASK_ARCHIVE_TEST_SOURCES
@@ -208,6 +217,33 @@ set_target_properties(${SAVE_LOAD_TASK_TEST_TARGET} PROPERTIES
 )
 
 set_target_properties(${SAVE_LOAD_TASK_TEST_TARGET} PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
+# Create AggregateOut contract lint executable (issue #915)
+add_executable(${AGGREGATE_OUT_CONTRACT_TEST_TARGET}
+  ${AGGREGATE_OUT_CONTRACT_TEST_SOURCES})
+
+target_include_directories(${AGGREGATE_OUT_CONTRACT_TEST_TARGET} PRIVATE
+  ${CLIO_RUN_ROOT}/include
+  ${CLIO_RUN_ROOT}/test  # For simple_test.h
+)
+
+# The lint reads the repository's sources, so it needs to know where they are.
+# When the binary is run from an install tree the directory is gone and the
+# test reports a skip instead of failing.
+target_compile_definitions(${AGGREGATE_OUT_CONTRACT_TEST_TARGET} PRIVATE
+  CLIO_REPO_SOURCE_DIR="${CMAKE_SOURCE_DIR}"
+)
+
+target_link_libraries(${AGGREGATE_OUT_CONTRACT_TEST_TARGET}
+  ctp::cxx
+  ${CMAKE_THREAD_LIBS_INIT}
+)
+
+set_target_properties(${AGGREGATE_OUT_CONTRACT_TEST_TARGET} PROPERTIES
+  CXX_STANDARD 20
+  CXX_STANDARD_REQUIRED ON
   RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
 )
 
@@ -884,6 +920,17 @@ if(CLIO_CORE_ENABLE_TESTS)
   set_tests_properties(cr_unit_tests PROPERTIES
     ENVIRONMENT "CLIO_REPO_PATH=${CMAKE_BINARY_DIR}/bin;CLIO_TEST_MODE=1;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CLIO_BIND_ADDR=127.0.0.1;CLIO_PORT=10500"
     TIMEOUT 600
+  )
+
+  # AggregateOut contract lint (issue #915). Pure source scan: fast, no
+  # runtime, no ports, safe under every sanitizer.
+  add_test(
+    NAME cr_aggregate_out_contract
+    COMMAND ${AGGREGATE_OUT_CONTRACT_TEST_TARGET}
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  )
+  set_tests_properties(cr_aggregate_out_contract PROPERTIES
+    TIMEOUT 120
   )
 
   # IPC AllocateBuffer Tests

--- a/context-runtime/test/unit/autogen_more/test_autogen_methods_sweep.cc
+++ b/context-runtime/test/unit/autogen_more/test_autogen_methods_sweep.cc
@@ -19,6 +19,7 @@
 
 #include "simple_test.h"
 
+#include <cstring>
 #include <string>
 #include <vector>
 
@@ -141,10 +142,48 @@ void SweepMethod(clio::run::Container &container, clio::run::u32 method) {
 
   // --- AggregateOut via the container dispatch switch (the per-method tests
   // call task->AggregateOut directly, leaving the dispatch arms uncovered).
+  //
+  // This is also the identity regression for issue #915. AggregateOut merges
+  // a REPLICA's OUT fields into the ORIGIN; it must NEVER touch the origin's
+  // identity. The 77 implementations that delegated to Copy() ran Task::Copy
+  // and made the origin adopt the replica's task_id_/pool_query_/method_
+  // mid-flight while send_map_, the replica accounting and the completion
+  // path still keyed off the origin's — the `free(): invalid pointer` that
+  // killed leader-election recovery (#856). Stamping the origin and the
+  // replica with DIFFERENT identities makes any whole-task copy fail here
+  // instead of corrupting a live runtime.
   {
     auto replica = container.NewTask(method);
     if (!replica.IsNull()) {
+      task->task_id_ =
+          clio::run::TaskId(1111, 2222, 3333, /*replica_id=*/0, 4444, 55, 6666);
+      task->pool_query_ = clio::run::PoolQuery::Local();
+      task->method_ = method;
+
+      replica->task_id_ =
+          clio::run::TaskId(7777, 8888, 9999, /*replica_id=*/1, 1010, 11, 1212);
+      replica->pool_query_ = clio::run::PoolQuery::Broadcast();
+      replica->method_ = method;
+
+      const clio::run::TaskId id_before = task->task_id_;
+      const clio::run::PoolQuery query_before = task->pool_query_;
+      const clio::run::u32 method_before = task->method_;
+
       container.AggregateOut(method, task, replica);
+
+      // PoolQuery has no operator== and is deliberately trivially copyable
+      // (it is raw-byte compared elsewhere in the tree), so memcmp is the
+      // right test here.
+      if (!(task->task_id_ == id_before) ||
+          memcmp(&task->pool_query_, &query_before,
+                 sizeof(clio::run::PoolQuery)) != 0 ||
+          task->method_ != method_before) {
+        FAIL("AggregateOut changed the ORIGIN task's identity for method "
+             << method
+             << ": its AggregateOut is copying the whole replica (almost "
+                "certainly `Copy(other_base...)`) instead of merging OUT "
+                "fields only. See issue #915.");
+      }
     }
   }
 
@@ -458,6 +497,105 @@ TEST_CASE("AutogenSweep - CAE core all methods full dispatch battery",
     SweepMethod(cae_runtime, method);
   }
   REQUIRE(true);
+}
+
+//==============================================================================
+// Issue #915 — AggregateOut must merge OUT fields only.
+//
+// The per-method sweep above stamps distinct identities on origin and replica
+// for EVERY method of every module linked here, so a whole-task copy fails
+// immediately. This case pins the two specifics the issue calls out, on the
+// task where they actually bit: an shm-allocated IN/INOUT string, and the
+// OUT-field merge semantics.
+//
+// PutBlobTask::blob_name_ is a priv::string owned by the CLIENT's allocator.
+// A whole-task copy re-assigns it from the replica's segment, freeing the
+// client's buffer through the wrong allocator — the `free(): invalid pointer`
+// abort of #856/#500. AggregateOut must leave it untouched.
+//==============================================================================
+
+TEST_CASE("AggregateOut merges OUT fields only, never the whole task (#915)",
+          "[autogen][cte][aggregate_out][contract]") {
+  EnsureInitialized();
+
+  clio::cte::core::Runtime cte_runtime;
+  namespace ct = clio::cte::core;
+
+  SECTION("PutBlobTask: shm string IN field and identity survive");
+  {
+    auto origin_base = cte_runtime.NewTask(ct::Method::kPutBlob);
+    auto replica_base = cte_runtime.NewTask(ct::Method::kPutBlob);
+    REQUIRE(!origin_base.IsNull());
+    REQUIRE(!replica_base.IsNull());
+
+    auto *origin = static_cast<ct::PutBlobTask *>(origin_base.get());
+    auto *replica = static_cast<ct::PutBlobTask *>(replica_base.get());
+
+    origin->blob_name_ = "origin-blob";
+    origin->task_id_ =
+        clio::run::TaskId(4242, 4343, 4444, /*replica_id=*/0, 4545, 7, 0xABCD);
+    origin->pool_query_ = clio::run::PoolQuery::Broadcast();
+    origin->context_.emulated_time_ns_ = 0;
+
+    // A REPLICA looks exactly like the subtask that comes back off the wire:
+    // same method, different task_id_ (carrying replica_id/net_key), its own
+    // shm string, and the OUT state the remote handler produced.
+    replica->blob_name_ = "replica-blob";
+    replica->task_id_ =
+        clio::run::TaskId(9999, 9898, 9797, /*replica_id=*/1, 9696, 3, 0x1234);
+    replica->pool_query_ = clio::run::PoolQuery::Physical(3);
+    replica->context_.emulated_time_ns_ = 12345;
+    replica->context_.transform_flags_ = 0x2;
+
+    const clio::run::TaskId id_before = origin->task_id_;
+    const clio::run::PoolQuery query_before = origin->pool_query_;
+    const clio::run::u32 method_before = origin->method_;
+
+    cte_runtime.AggregateOut(ct::Method::kPutBlob, origin_base, replica_base);
+
+    // Identity is untouched.
+    REQUIRE(origin->task_id_ == id_before);
+    REQUIRE(memcmp(&origin->pool_query_, &query_before,
+                   sizeof(clio::run::PoolQuery)) == 0);
+    REQUIRE(origin->method_ == method_before);
+
+    // The client's shm string is untouched: a whole-task copy would have made
+    // this "replica-blob" and freed the origin's buffer through the replica's
+    // allocator.
+    REQUIRE(origin->blob_name_.str() == "origin-blob");
+
+    // The OUT state DID come across (this is what AggregateOut is for).
+    REQUIRE(origin->context_.emulated_time_ns_ == 12345);
+    REQUIRE((origin->context_.transform_flags_ & 0x2) != 0);
+  }
+
+  SECTION("FlushDataTask: OUT counters SUM across replicas");
+  {
+    auto origin_base = cte_runtime.NewTask(ct::Method::kFlushData);
+    auto r1 = cte_runtime.NewTask(ct::Method::kFlushData);
+    auto r2 = cte_runtime.NewTask(ct::Method::kFlushData);
+    REQUIRE(!origin_base.IsNull());
+    REQUIRE(!r1.IsNull());
+    REQUIRE(!r2.IsNull());
+
+    auto *origin = static_cast<ct::FlushDataTask *>(origin_base.get());
+    auto *rep1 = static_cast<ct::FlushDataTask *>(r1.get());
+    auto *rep2 = static_cast<ct::FlushDataTask *>(r2.get());
+
+    origin->bytes_flushed_ = 0;
+    origin->blobs_flushed_ = 0;
+    rep1->bytes_flushed_ = 100;
+    rep1->blobs_flushed_ = 1;
+    rep2->bytes_flushed_ = 250;
+    rep2->blobs_flushed_ = 4;
+
+    cte_runtime.AggregateOut(ct::Method::kFlushData, origin_base, r1);
+    cte_runtime.AggregateOut(ct::Method::kFlushData, origin_base, r2);
+
+    // Last-replica-wins (what the whole-task copy did) would leave 250/4.
+    REQUIRE(origin->bytes_flushed_ == 350);
+    REQUIRE(origin->blobs_flushed_ == 5);
+  }
 }
 
 SIMPLE_TEST_MAIN()

--- a/context-runtime/test/unit/external-chimod/modules/simple_mod/include/external_test/simple_mod/simple_mod_tasks.h
+++ b/context-runtime/test/unit/external-chimod/modules/simple_mod/include/external_test/simple_mod/simple_mod_tasks.h
@@ -142,7 +142,13 @@ struct FlushTask : public clio::run::Task {
    */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<FlushTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<FlushTask>();
+    // Each replica reports the work IT did, so the collective figure is the
+    // SUM (see admin FlushTask::AggregateOut).
+    total_work_done_ += replica->total_work_done_;
   }
 };
 

--- a/context-runtime/test/unit/test_aggregate_out_contract.cc
+++ b/context-runtime/test/unit/test_aggregate_out_contract.cc
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ * This file is part of IOWarp Core.
+ * BSD 3-Clause License. See LICENSE file.
+ */
+
+/**
+ * AggregateOut contract lint (issue #915).
+ *
+ * `Task::AggregateOut` merges a REPLICA's OUT fields into the ORIGIN task
+ * (an N->1 gather). `Copy()` is a WHOLE-TASK assignment. Implementing the
+ * former with the latter does two illegal things:
+ *
+ *   1. It runs `Task::Copy`, overwriting the ORIGIN's task_id_, pool_query_,
+ *      method_, task_flags_, completer_ and task_group_ with the REPLICA's --
+ *      destroying the origin's identity while send_map_, the replica
+ *      accounting and the completion path still reference it. The replica's
+ *      task_id_ carries net_key/replica_id, so the origin adopts a subtask's
+ *      identity mid-flight.
+ *   2. It re-assigns IN fields, including priv::string / shm-allocated
+ *      members, from the replica's shared-memory segment -- freeing the
+ *      origin's buffer through the wrong allocator.
+ *
+ * That is the `free(): invalid pointer` / SIGSEGV that killed leader-election
+ * recovery in #856, plus silently wrong OUT values (last-replica-wins instead
+ * of a real merge) everywhere else.
+ *
+ * The shape is trivially copy-pasteable and was present in 77 task types
+ * across the tree, so a runtime assertion alone is not enough: a latent
+ * instance only detonates once someone routes that task Broadcast/multi-
+ * replica, which may be years later and in a different module. This test is
+ * the cheap, total guard -- it reads the SOURCE and fails the build's test
+ * suite the moment any AggregateOut body calls Copy() again, including in
+ * modules that no test binary links.
+ *
+ * The complementary runtime checks live in
+ * test/unit/autogen_more/test_autogen_methods_sweep.cc (identity survives a
+ * real container-dispatched aggregation) and in RecvOut's contract guard in
+ * src/ipc/ipc_run2run.cc (catches out-of-tree chimods at run time).
+ */
+
+#include "simple_test.h"
+
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+/** Directory names that are never part of this repository's own sources. */
+bool IsSkippedDir(const std::string &name) {
+  static const std::vector<std::string> kSkipped = {
+      ".git",   "external", "third-party", "third_party",
+      "node_modules", "venv", ".venv", "docs"};
+  if (std::find(kSkipped.begin(), kSkipped.end(), name) != kSkipped.end()) {
+    return true;
+  }
+  // build/, build-cpu/, cmake-build-debug/, ...
+  return name.rfind("build", 0) == 0 || name.rfind("cmake-build", 0) == 0;
+}
+
+bool IsSourceFile(const fs::path &p) {
+  const std::string ext = p.extension().string();
+  return ext == ".h" || ext == ".hpp" || ext == ".cc" || ext == ".cpp" ||
+         ext == ".cu" || ext == ".cuh";
+}
+
+/** Replace // and comments with spaces so the scan only sees real code. */
+std::string StripComments(const std::string &src) {
+  std::string out = src;
+  for (size_t i = 0; i + 1 < out.size(); ++i) {
+    if (out[i] == '/' && out[i + 1] == '/') {
+      while (i < out.size() && out[i] != '\n') {
+        out[i++] = ' ';
+      }
+    } else if (out[i] == '/' && out[i + 1] == '*') {
+      out[i] = out[i + 1] = ' ';
+      i += 2;
+      while (i + 1 < out.size() && !(out[i] == '*' && out[i + 1] == '/')) {
+        if (out[i] != '\n') {
+          out[i] = ' ';
+        }
+        ++i;
+      }
+      if (i + 1 < out.size()) {
+        out[i] = out[i + 1] = ' ';
+        ++i;
+      }
+    }
+  }
+  return out;
+}
+
+bool IsIdentChar(char c) {
+  return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+         (c >= '0' && c <= '9') || c == '_';
+}
+
+/**
+ * True if `body` contains a call to Copy(...) that is not a qualified name
+ * (Task::Copy / Base::Copy) and not the tail of a longer identifier
+ * (NewCopyTask, DeepCopy, ...).
+ */
+bool CallsCopy(const std::string &body) {
+  const std::string kNeedle = "Copy";
+  size_t pos = 0;
+  while ((pos = body.find(kNeedle, pos)) != std::string::npos) {
+    size_t after = pos + kNeedle.size();
+    // Skip whitespace between the name and '('.
+    size_t paren = after;
+    while (paren < body.size() && std::isspace((unsigned char)body[paren])) {
+      ++paren;
+    }
+    const bool is_call = paren < body.size() && body[paren] == '(';
+    bool qualified = false;
+    bool suffix_of_ident = false;
+    if (pos > 0) {
+      suffix_of_ident = IsIdentChar(body[pos - 1]);
+    }
+    if (pos >= 2) {
+      qualified = body[pos - 1] == ':' && body[pos - 2] == ':';
+    }
+    if (is_call && !qualified && !suffix_of_ident) {
+      return true;
+    }
+    pos = after;
+  }
+  return false;
+}
+
+/** Extract the {...} block starting at or after `from`. Empty if none. */
+std::string BraceBlock(const std::string &src, size_t from) {
+  size_t open = src.find('{', from);
+  if (open == std::string::npos) {
+    return "";
+  }
+  int depth = 0;
+  for (size_t i = open; i < src.size(); ++i) {
+    if (src[i] == '{') {
+      ++depth;
+    } else if (src[i] == '}') {
+      --depth;
+      if (depth == 0) {
+        return src.substr(open, i - open + 1);
+      }
+    }
+  }
+  return "";
+}
+
+size_t LineOf(const std::string &src, size_t pos) {
+  return 1 + (size_t)std::count(src.begin(), src.begin() + (long)pos, '\n');
+}
+
+/** One offending AggregateOut implementation. */
+struct Violation {
+  std::string file;
+  size_t line;
+};
+
+void ScanFile(const fs::path &path, const std::string &rel,
+              std::vector<Violation> &out) {
+  std::ifstream in(path, std::ios::binary);
+  if (!in) {
+    return;
+  }
+  std::ostringstream ss;
+  ss << in.rdbuf();
+  const std::string raw = ss.str();
+  if (raw.find("AggregateOut") == std::string::npos) {
+    return;
+  }
+  const std::string src = StripComments(raw);
+
+  size_t pos = 0;
+  const std::string kName = "AggregateOut";
+  while ((pos = src.find(kName, pos)) != std::string::npos) {
+    size_t after = pos + kName.size();
+    size_t paren = after;
+    while (paren < src.size() && std::isspace((unsigned char)src[paren])) {
+      ++paren;
+    }
+    // A definition: `... AggregateOut(...) { ... }`, not a call and not a
+    // qualified invocation such as `Task::AggregateOut(x);`.
+    const bool qualified =
+        pos >= 2 && src[pos - 1] == ':' && src[pos - 2] == ':';
+    if (paren >= src.size() || src[paren] != '(' || qualified) {
+      pos = after;
+      continue;
+    }
+    // Match the parameter list's closing paren (parameters may themselves
+    // contain parens, e.g. a defaulted argument).
+    size_t close = std::string::npos;
+    int pdepth = 0;
+    for (size_t i = paren; i < src.size(); ++i) {
+      if (src[i] == '(') {
+        ++pdepth;
+      } else if (src[i] == ')') {
+        if (--pdepth == 0) {
+          close = i;
+          break;
+        }
+      }
+    }
+    if (close == std::string::npos) {
+      break;
+    }
+    size_t brace = close + 1;
+    while (brace < src.size() && std::isspace((unsigned char)src[brace])) {
+      ++brace;
+    }
+    if (brace >= src.size() || src[brace] != '{') {
+      pos = after;  // declaration, or a call -- not a definition
+      continue;
+    }
+    const std::string body = BraceBlock(src, close);
+    if (!body.empty() && CallsCopy(body)) {
+      out.push_back({rel, LineOf(src, pos)});
+    }
+    pos = brace + body.size();
+  }
+}
+
+}  // namespace
+
+TEST_CASE("AggregateOut never delegates to Copy (issue #915)",
+          "[aggregate_out][contract][lint]") {
+#ifndef CLIO_REPO_SOURCE_DIR
+  INFO("CLIO_REPO_SOURCE_DIR not defined - skipping source lint");
+  REQUIRE(true);
+#else
+  const fs::path root(CLIO_REPO_SOURCE_DIR);
+  if (!fs::is_directory(root)) {
+    // Installed/relocated test binary: the source tree is not present. The
+    // lint is a build-time guard, so there is nothing to check here.
+    INFO("Source tree not present at " + root.string() + " - skipping lint");
+    REQUIRE(true);
+    return;
+  }
+
+  std::vector<Violation> violations;
+  size_t files_scanned = 0;
+  for (auto it = fs::recursive_directory_iterator(
+           root, fs::directory_options::skip_permission_denied);
+       it != fs::recursive_directory_iterator(); ++it) {
+    const fs::path &p = it->path();
+    if (it->is_directory()) {
+      if (IsSkippedDir(p.filename().string())) {
+        it.disable_recursion_pending();
+      }
+      continue;
+    }
+    if (!it->is_regular_file() || !IsSourceFile(p)) {
+      continue;
+    }
+    ++files_scanned;
+    ScanFile(p, fs::relative(p, root).generic_string(), violations);
+  }
+
+  // Sanity: the walk must actually have found this repository's sources. A
+  // silently empty scan would make the lint vacuously pass forever.
+  INFO("scanned " + std::to_string(files_scanned) + " source files");
+  REQUIRE(files_scanned > 100);
+
+  if (!violations.empty()) {
+    std::ostringstream msg;
+    msg << violations.size()
+        << " AggregateOut implementation(s) delegate to Copy(), which is a "
+           "WHOLE-TASK assignment and corrupts the origin task's identity "
+           "(issue #915). Merge OUT fields only:\n";
+    for (const Violation &v : violations) {
+      msg << "  " << v.file << ":" << v.line << "\n";
+    }
+    INFO(msg.str());
+  }
+  REQUIRE(violations.empty());
+#endif
+}
+
+SIMPLE_TEST_MAIN()

--- a/context-transfer-engine/cache/include/clio_cte/cache/cache_tasks.h
+++ b/context-transfer-engine/cache/include/clio_cte/cache/cache_tasks.h
@@ -96,7 +96,11 @@ struct DestroyTask : public clio::run::Task {
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<DestroyTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    // This task declares no OUT fields, so the base call above (return code +
+    // completer) is the entire merge.
   }
 
   void Copy(const ctp::ipc::FullPtr<DestroyTask>& other) {

--- a/context-transfer-engine/compressor/include/clio_cte/compressor/compressor_tasks.h
+++ b/context-transfer-engine/compressor/include/clio_cte/compressor/compressor_tasks.h
@@ -144,7 +144,11 @@ struct DestroyTask : public clio::run::Task {
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<DestroyTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    // This task declares no OUT fields, so the base call above (return code +
+    // completer) is the entire merge.
   }
 
   void Copy(const ctp::ipc::FullPtr<DestroyTask>& other) {
@@ -274,7 +278,18 @@ struct DynamicScheduleTask : public clio::run::Task {
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<DynamicScheduleTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<DynamicScheduleTask>();
+    // blob_name_ is INOUT only because the wire protocol echoes it back; the
+    // server never writes it and it is the CLIENT's shm string, so assigning
+    // the replica's would free the client's buffer through the wrong
+    // allocator. blob_data_ is bulk-transferred, never merged.
+    context_.AggregateOut(replica->context_);
+    if (replica->tier_score_ > tier_score_) {
+      tier_score_ = replica->tier_score_;
+    }
   }
 
   void Copy(const ctp::ipc::FullPtr<DynamicScheduleTask>& other) {
@@ -353,7 +368,16 @@ struct CompressTask : public clio::run::Task {
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<CompressTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<CompressTask>();
+    // See DynamicScheduleTask::AggregateOut — blob_name_/blob_data_ belong to
+    // the client and never merge; context_ and tier_score_ are the OUT state.
+    context_.AggregateOut(replica->context_);
+    if (replica->tier_score_ > tier_score_) {
+      tier_score_ = replica->tier_score_;
+    }
   }
 
   void Copy(const ctp::ipc::FullPtr<CompressTask>& other) {
@@ -429,7 +453,15 @@ struct DecompressTask : public clio::run::Task {
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<DecompressTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<DecompressTask>();
+    // blob_data_ is bulk-transferred into the ORIGIN's buffer. Each replica
+    // decompresses its own slice, so both the produced bytes and the CPU time
+    // spent are SUMS.
+    output_size_ += replica->output_size_;
+    decompress_time_ms_ += replica->decompress_time_ms_;
   }
 
   void Copy(const ctp::ipc::FullPtr<DecompressTask>& other) {
@@ -505,7 +537,16 @@ struct PollNodeLoadTask : public clio::run::Task {
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<PollNodeLoadTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<PollNodeLoadTask>();
+    // The sample describes ONE node (the task is Physical-routed), so there is
+    // nothing to reduce: the first replica that actually sampled wins.
+    // num_workers_ is 0 until a replica has filled the sample.
+    if (sample_.num_workers_ == 0) {
+      sample_ = replica->sample_;
+    }
   }
 
   void Copy(const ctp::ipc::FullPtr<PollNodeLoadTask> &other) {
@@ -540,7 +581,11 @@ struct PollConsumersTask : public clio::run::Task {
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<PollConsumersTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    // This task declares no OUT fields, so the base call above (return code +
+    // completer) is the entire merge.
   }
 
   void Copy(const ctp::ipc::FullPtr<PollConsumersTask> &other) {

--- a/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
@@ -422,7 +422,11 @@ struct RegisterTargetTask : public clio::run::Task {
    */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<RegisterTargetTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    // This task declares no OUT fields, so the base call above (return code +
+    // completer) is the entire merge.
   }
 };
 
@@ -483,7 +487,11 @@ struct UnregisterTargetTask : public clio::run::Task {
    */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<UnregisterTargetTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    // This task declares no OUT fields, so the base call above (return code +
+    // completer) is the entire merge.
   }
 };
 
@@ -602,7 +610,11 @@ struct StatTargetsTask : public clio::run::Task {
    */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<StatTargetsTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    // This task declares no OUT fields, so the base call above (return code +
+    // completer) is the entire merge.
   }
 };
 
@@ -688,8 +700,22 @@ struct GetTargetInfoTask : public clio::run::Task {
    */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    // For target info, just copy (should be same across replicas)
-    Copy(other_base.template Cast<GetTargetInfoTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<GetTargetInfoTask>();
+    // Target info is PARTITIONED across nodes: only the node that owns the
+    // target has real numbers, every other replica answers zeros. Summing the
+    // counters and taking the best score therefore reproduces the owner's
+    // answer for one replica and a true collective total for many.
+    if (replica->target_score_ > target_score_) {
+      target_score_ = replica->target_score_;
+    }
+    remaining_space_ += replica->remaining_space_;
+    bytes_read_ += replica->bytes_read_;
+    bytes_written_ += replica->bytes_written_;
+    ops_read_ += replica->ops_read_;
+    ops_written_ += replica->ops_written_;
   }
 };
 
@@ -1649,6 +1675,46 @@ struct Context {
         actual_psnr_db_(0.0) {
   }
 
+  /**
+   * Merge a REPLICA's OUT state into this (origin) Context. Issue #915.
+   *
+   * Context is INOUT on every Put/Get task, so a task's AggregateOut may not
+   * simply assign it: the IN half (persistence targets, emulate_, replica_,
+   * origin_node_, the compression controls) belongs to the CALLER and has to
+   * survive the gather untouched. Only the fields the RUNTIME writes are
+   * merged here, with reductions chosen so that a single-replica gather --
+   * which is what almost every route does -- lands on exactly the replica's
+   * values, the same result the old whole-task copy produced.
+   */
+  CTP_CROSS_FUN void AggregateOut(const Context &replica) {
+    // Modeled I/O time and compression cost are per-replica WORK: they sum.
+    emulated_time_ns_ += replica.emulated_time_ns_;
+    actual_original_size_ += replica.actual_original_size_;
+    actual_compressed_size_ += replica.actual_compressed_size_;
+    actual_compress_time_ms_ += replica.actual_compress_time_ms_;
+    // transform_flags_ is a bit set describing the STORED bytes; every replica
+    // that transformed its share contributes its bits.
+    transform_flags_ |= replica.transform_flags_;
+    // Coherence version (#894): newest wins. A stale replica must never roll
+    // the origin's view of the content backwards.
+    if (replica.version_ > version_) {
+      version_ = replica.version_;
+    }
+    // PSNR is a quality bound, not a total: keep the WORST (lowest) figure any
+    // replica reported. 0 means "lossless / not measured", hence the guard.
+    if (replica.actual_psnr_db_ > 0.0 &&
+        (actual_psnr_db_ == 0.0 || replica.actual_psnr_db_ < actual_psnr_db_)) {
+      actual_psnr_db_ = replica.actual_psnr_db_;
+    }
+    // Derive the ratio from the merged totals so it stays consistent with
+    // them. It defaults to 1.0, so a first-non-zero rule could not work.
+    if (actual_compressed_size_ > 0) {
+      actual_compression_ratio_ =
+          static_cast<double>(actual_original_size_) /
+          static_cast<double>(actual_compressed_size_);
+    }
+  }
+
   template <class Archive>
   CTP_CROSS_FUN void serialize(Archive &ar) {
     // ONE unconditional range = ONE wire format in every build (see the
@@ -1838,7 +1904,23 @@ struct GetOrCreateTagTask : public clio::run::Task {
    */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<GetOrCreateTagTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<GetOrCreateTagTask>();
+    // tag_id_ is INOUT and every replica resolves the SAME tag, so the first
+    // non-null id wins. created_ is a one-shot flag (the tag is created once,
+    // by one node). tag_size_ lives on the owning shard, the only replica that
+    // answers non-zero.
+    if (tag_id_.IsNull()) {
+      tag_id_ = replica->tag_id_;
+    }
+    if (replica->created_) {
+      created_ = replica->created_;
+    }
+    if (replica->tag_size_ > tag_size_) {
+      tag_size_ = replica->tag_size_;
+    }
   }
 };
 
@@ -2090,7 +2172,16 @@ struct PutBlobTask : public clio::run::Task {
    */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<PutBlobTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<PutBlobTask>();
+    // blob_name_ is INOUT only because the wire protocol echoes it; the server
+    // never modifies it, so the origin's copy is already correct. Do NOT assign
+    // it: it is the CLIENT's shm string, and taking the replica's would free
+    // the client's buffer through the runtime's allocator (the #500 class of
+    // corruption). context_ is the only field carrying real OUT state.
+    context_.AggregateOut(replica->context_);
   }
 };
 
@@ -2341,7 +2432,15 @@ struct GetBlobTask : public clio::run::Task {
    */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<GetBlobTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<GetBlobTask>();
+    // blob_data_ is never merged: the payload is bulk-transferred straight into
+    // the ORIGIN's buffer, and the replica's ShmPtr points into a foreign
+    // segment. context_ carries the OUT state (emulated time, transform flags,
+    // coherence version).
+    context_.AggregateOut(replica->context_);
   }
 };
 
@@ -2419,7 +2518,11 @@ struct ReorganizeBlobTask : public clio::run::Task {
    */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<ReorganizeBlobTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    // This task declares no OUT fields, so the base call above (return code +
+    // completer) is the entire merge.
   }
 };
 
@@ -2766,7 +2869,13 @@ struct PodPutBlobTask : public clio::run::Task {
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<PodPutBlobTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<PodPutBlobTask>();
+    // blob_name_ round-trips unchanged (the server never writes it), so the
+    // origin's copy is already correct. See PutBlobTask::AggregateOut.
+    context_.AggregateOut(replica->context_);
   }
 };
 
@@ -2884,7 +2993,13 @@ struct PodGetBlobTask : public clio::run::Task {
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<PodGetBlobTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<PodGetBlobTask>();
+    // blob_data_ is bulk-transferred into the ORIGIN's buffer; never merge the
+    // replica's pointer. See GetBlobTask::AggregateOut.
+    context_.AggregateOut(replica->context_);
   }
 };
 
@@ -2955,7 +3070,11 @@ struct PodReorganizeBlobTask : public clio::run::Task {
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<PodReorganizeBlobTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    // This task declares no OUT fields, so the base call above (return code +
+    // completer) is the entire merge.
   }
 };
 
@@ -3020,7 +3139,11 @@ struct DelBlobTask : public clio::run::Task {
    */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<DelBlobTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    // This task declares no OUT fields, so the base call above (return code +
+    // completer) is the entire merge.
   }
 };
 
@@ -3079,7 +3202,11 @@ struct TruncateBlobTask : public clio::run::Task {
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<TruncateBlobTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    // This task declares no OUT fields, so the base call above (return code +
+    // completer) is the entire merge.
   }
 };
 
@@ -3166,7 +3293,15 @@ struct DelTagTask : public clio::run::Task {
    */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<DelTagTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<DelTagTask>();
+    // tag_id_ is INOUT (input, or the result of a name lookup). Every replica
+    // resolves the same tag, so the first non-null id wins.
+    if (tag_id_.IsNull()) {
+      tag_id_ = replica->tag_id_;
+    }
   }
 };
 
@@ -3700,7 +3835,18 @@ struct PollTelemetryLogTask : public clio::run::Task {
    */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<PollTelemetryLogTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<PollTelemetryLogTask>();
+    // The log is partitioned per node: concatenate the entries and keep the
+    // highest logical time any replica scanned to.
+    if (replica->last_logical_time_ > last_logical_time_) {
+      last_logical_time_ = replica->last_logical_time_;
+    }
+    for (size_t i = 0; i < replica->entries_.size(); ++i) {
+      entries_.push_back(replica->entries_[i]);
+    }
   }
 };
 
@@ -3771,7 +3917,15 @@ struct GetBlobScoreTask : public clio::run::Task {
    */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<GetBlobScoreTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<GetBlobScoreTask>();
+    // The blob lives on one shard; every other replica answers 0, so max
+    // yields the owner's score for one replica and for many.
+    if (replica->score_ > score_) {
+      score_ = replica->score_;
+    }
   }
 };
 
@@ -3848,7 +4002,15 @@ struct GetBlobSizeTask : public clio::run::Task {
    */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<GetBlobSizeTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<GetBlobSizeTask>();
+    // The blob lives on one shard; non-owners answer 0, so max yields the
+    // owner's size for one replica and for many.
+    if (replica->size_ > size_) {
+      size_ = replica->size_;
+    }
   }
 };
 
@@ -3950,7 +4112,20 @@ struct GetBlobInfoTask : public clio::run::Task {
    */
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<GetBlobInfoTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<GetBlobInfoTask>();
+    // Score/size live on the owning shard (non-owners answer 0), while block
+    // placement is genuinely partitioned across the nodes holding the data.
+    if (replica->score_ > score_) {
+      score_ = replica->score_;
+    }
+    if (replica->total_size_ > total_size_) {
+      total_size_ = replica->total_size_;
+    }
+    blocks_.insert(blocks_.end(), replica->blocks_.begin(),
+                   replica->blocks_.end());
   }
 };
 
@@ -4251,7 +4426,13 @@ struct FlushMetadataTask : public clio::run::Task {
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<FlushMetadataTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<FlushMetadataTask>();
+    // Each node flushes its own metadata shard, so the collective total is the
+    // SUM (a whole-task copy clobbered it with the last replica's count).
+    entries_flushed_ += replica->entries_flushed_;
   }
 };
 
@@ -4308,7 +4489,13 @@ struct FlushDataTask : public clio::run::Task {
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<FlushDataTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<FlushDataTask>();
+    // Each node flushes its own data, so the collective totals are SUMS.
+    bytes_flushed_ += replica->bytes_flushed_;
+    blobs_flushed_ += replica->blobs_flushed_;
   }
 };
 
@@ -4361,7 +4548,11 @@ struct DynamicReorganizeTask : public clio::run::Task {
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<DynamicReorganizeTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    // This task declares no OUT fields, so the base call above (return code +
+    // completer) is the entire merge.
   }
 };
 

--- a/context-transfer-engine/indexer/include/clio_cte/indexer/indexer_tasks.h
+++ b/context-transfer-engine/indexer/include/clio_cte/indexer/indexer_tasks.h
@@ -165,7 +165,11 @@ struct DestroyTask : public clio::run::Task {
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<DestroyTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    // This task declares no OUT fields, so the base call above (return code +
+    // completer) is the entire merge.
   }
 
   void Copy(const ctp::ipc::FullPtr<DestroyTask>& other) {

--- a/context-transfer-engine/replication/include/clio_cte/replication/replication_tasks.h
+++ b/context-transfer-engine/replication/include/clio_cte/replication/replication_tasks.h
@@ -121,7 +121,11 @@ struct DestroyTask : public clio::run::Task {
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<DestroyTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    // This task declares no OUT fields, so the base call above (return code +
+    // completer) is the entire merge.
   }
 
   void Copy(const ctp::ipc::FullPtr<DestroyTask>& other) {
@@ -167,7 +171,12 @@ struct ReplicateSweepTask : public clio::run::Task {
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<ReplicateSweepTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<ReplicateSweepTask>();
+    // Each replica sweeps its own shard, so the collective count is the SUM.
+    blobs_swept_ += replica->blobs_swept_;
   }
 
   void Copy(const ctp::ipc::FullPtr<ReplicateSweepTask> &other) {
@@ -207,7 +216,13 @@ struct ReplicateBlobTask : public clio::run::Task {
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<ReplicateBlobTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<ReplicateBlobTask>();
+    // Each replica copies its own share of the bytes, so the collective figure
+    // is the SUM.
+    bytes_copied_ += replica->bytes_copied_;
   }
 
   void Copy(const ctp::ipc::FullPtr<ReplicateBlobTask>& other) {
@@ -261,7 +276,13 @@ struct FlushTagTask : public clio::run::Task {
 
   void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
     Task::AggregateOut(other_base);
-    Copy(other_base.template Cast<FlushTagTask>());
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<FlushTagTask>();
+    // Each replica flushes its own share of the tag, so both totals are SUMS.
+    blobs_replicated_ += replica->blobs_replicated_;
+    bytes_copied_ += replica->bytes_copied_;
   }
 
   void Copy(const ctp::ipc::FullPtr<FlushTagTask>& other) {


### PR DESCRIPTION
## Summary
- Rewrote all **66** remaining `AggregateOut` implementations that delegated to `Copy()` so they merge **OUT fields only**, with a reduction chosen per field.
- Added `Context::AggregateOut` — `Context` is INOUT on every Put/Get task, so its IN half belongs to the caller and must survive the gather.
- Added three guards so the mistake cannot come back, including in modules no test binary links.

## Motivation
Fixes #915.

`AggregateOut` merges a **replica's** OUT fields into the **origin** (N→1 gather). Implementing it as `Copy(other.Cast<XTask>())` is a *whole-task* assignment, which does two illegal things:

1. It runs `Task::Copy`, overwriting the origin's `task_id_`/`pool_query_`/`method_`/`task_flags_`/`completer_`/`task_group_` with the replica's — while `send_map_`, the replica accounting and the completion path still reference the origin. The replica's `task_id_` carries `net_key`/`replica_id`, so the origin adopts a subtask's identity mid-flight.
2. It re-assigns IN fields, including shm `priv::string`s, from the replica's segment.

That is the `free(): invalid pointer` that killed leader-election recovery in #856, plus silently wrong OUT values (last-replica-wins instead of a real merge) everywhere else.

The 4 broadcast-reachable instances and the `MOD_NAME` module template were already fixed on the #856 branch. This PR closes out the remaining 66 latent ones.

## Merge semantics
Each task now merges exactly the fields its OUT-path serializer sends:

| Reduction | Used for |
|---|---|
| SUM | counters partitioned across nodes (`bytes_flushed_`, `num_migrated_`, `total_work_done_`, …) |
| MAX | a value only the owning shard reports, non-owners answer 0 (`GetBlobSizeTask::size_`, `score_`, …) |
| first-non-empty | diagnostic strings (`error_message_`) and first-failure codes (`result_code_`, `io_error_`) |
| concatenate | vectors (`AllocateBlocksTask::blocks_`, telemetry `entries_`) |
| first-writer-wins | values with no meaningful N→1 merge (`ClientConnectTask`'s shm layout, `PollNodeLoadTask::sample_`) |

Every reduction is picked so a **single-replica** gather — what nearly every route actually does — lands on exactly the replica's value, keeping today's behaviour bit for bit.

Deliberately **not** merged: client-owned shm members (`PutBlobTask::blob_name_`) and bulk-transfer targets (`ReadTask::data_`, `blob_data_`). The payload has already landed in the origin's own buffer, and the replica's pointer addresses a foreign segment — assigning it is the #500 class of corruption.

## Guards
- **`cr_aggregate_out_contract`** (new) — scans all 788 tree sources and fails if any `AggregateOut` body calls `Copy()`. Catches modules no test binary links, which is where the latent instances live.
- **Autogen sweep** — now stamps origin and replica with *different* identities for every method of admin/bdev/MOD_NAME/CTE/CAE and requires the origin's `task_id_`/`pool_query_`/`method_` to survive a real container-dispatched aggregation.
- **RecvOut runtime check** — extended from `task_id_` only to also cover `pool_query_` and `method_`, for out-of-tree chimods.
- The full contract is now written out on `Task::AggregateOut` in `task.h`.

Both new guards were verified with a **negative control**: reintroducing `Copy()` in one task made each fail independently and name the offender (`cache_tasks.h:97`; "method 20"), and reverting made them pass.

## Test plan
- [x] New lint passes: `ctest -R cr_aggregate_out_contract` (scans 788 files)
- [x] Autogen sweep passes incl. the new #915 case: `ctest -R cr_autogen_sweep_tests` (7/7)
- [x] Negative control confirmed for both guards
- [x] Full suite: **305/306**, the one failure being `cte_replication_persist_integration` — a **pre-existing bug, now filed as #1030**. Ruled out as a regression by A/B on this box, 12 runs each, rebuilding both ways: baseline `origin/dev` 5 pass / 7 fail, this branch 7 pass / 5 fail. It also cannot be related mechanically: that test is single-node, and `AggregateOut` only runs in the cross-node `RecvOut` path.
- [x] No new compiler warnings in the touched files
- [x] cpplint clean on the new file; all added lines ≤ 80 cols
- [x] BSD 3-Clause header on the new file

Two CAE tests asserted the old last-replica-wins result (the comment literally read *"AggregateOut calls Copy, so orig should now have replica's values"*); they now assert the gather semantics and that the origin's identity is intact.

## Breaking changes
None for single-replica routes, which is every route in the tree today — the reductions were chosen to reproduce the previous result exactly for one replica. Multi-replica gathers now return correct merged values instead of the last replica's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDiKNSC9JSFvmm65euScwP
