### PR TITLE
Fix the two CI failures that are not already in flight

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -463,7 +463,7 @@ jobs:
     # community-feed 503, silently building the package without the adapter.
     - name: Install WinFsp (FUSE adapter SDK)
       run: |
-        pwsh CI/Retry.ps1 -Attempts 3 -DelaySeconds 30 -- choco install winfsp -y --no-progress
+        pwsh CI/Retry.ps1 -Attempts 3 -DelaySeconds 30 choco install winfsp -y --no-progress
         if (-not (Test-Path "${env:ProgramFiles(x86)}\WinFsp\inc\fuse3\fuse.h")) {
           throw "WinFsp SDK missing after the install succeeded -- failing HERE rather than packaging without the FUSE adapter (#1004)"
         }
@@ -474,7 +474,7 @@ jobs:
     # package, so it reads as a packaging-config problem rather than a missing
     # tool. The runner image does not ship NSIS.
     - name: Install NSIS (installer generator for cpack -G NSIS)
-      run: pwsh CI/Retry.ps1 -- choco install nsis -y --no-progress
+      run: pwsh CI/Retry.ps1 choco install nsis -y --no-progress
 
     - name: Configure with CMake
       run: |
@@ -528,7 +528,7 @@ jobs:
     # Same hardening for the runtime install used by the smoke test (#1004).
     - name: Install WinFsp (FUSE adapter runtime)
       run: |
-        pwsh CI/Retry.ps1 -Attempts 3 -DelaySeconds 30 -- choco install winfsp -y --no-progress
+        pwsh CI/Retry.ps1 -Attempts 3 -DelaySeconds 30 choco install winfsp -y --no-progress
         if (-not (Test-Path "${env:ProgramFiles(x86)}\WinFsp\bin")) {
           throw "WinFsp runtime missing after the install succeeded -- failing HERE rather than smoke-testing without it (#1004)"
         }

--- a/.github/workflows/build-pip.yml
+++ b/.github/workflows/build-pip.yml
@@ -404,12 +404,28 @@ jobs:
               # AppStream module and put it ahead of the stock interpreter so
               # the venv below matches a wheel we actually ship. Newer distros
               # fall through to their default python3.
-              if dnf install -y -q python3.12 python3.12-pip >/dev/null 2>&1; then
+              #
+              # The expat package is not a typo and not optional. The
+              # rockylinux:8 base image ships expat 2.2.5, but the current
+              # python3.12-3.12.14-1.el8_10
+              # (built 2026-08-24) links pyexpat against 2.4+ symbols, so
+              # importing pyexpat dies with:
+              #   undefined symbol: XML_SetBillionLaughsAttackProtection...
+              # pip imports it, so ensurepip fails and python3 -m venv
+              # aborts -- which is how this arrived, as every test-wheels leg
+              # going red overnight with no change on our side. Naming expat
+              # explicitly upgrades it to 2.5.0 alongside the interpreter.
+              if dnf install -y -q python3.12 python3.12-pip expat >/dev/null 2>&1; then
                 ln -sf /usr/bin/python3.12 /usr/local/bin/python3
               else
-                dnf install -y -q python3 python3-pip >/dev/null 2>&1
+                dnf install -y -q python3 python3-pip expat >/dev/null 2>&1
               fi
             fi
+
+            # Fail loudly here rather than 20 lines down. Both branches above
+            # swallow their output, so a broken interpreter used to surface as
+            # an opaque ensurepip traceback from the venv step.
+            python3 -c "import pyexpat, ssl, sys; print(\"interpreter OK:\", sys.version)"
 
             # Create clean venv
             python3 -m venv /tmp/test-venv

--- a/.github/workflows/build-pip.yml
+++ b/.github/workflows/build-pip.yml
@@ -187,7 +187,7 @@ jobs:
     # test job, far from the cause (#1004).
     - name: Install WinFsp (FUSE adapter SDK)
       run: |
-        pwsh CI/Retry.ps1 -Attempts 3 -DelaySeconds 30 -- choco install winfsp -y --no-progress
+        pwsh CI/Retry.ps1 -Attempts 3 -DelaySeconds 30 choco install winfsp -y --no-progress
         if (-not (Test-Path "${env:ProgramFiles(x86)}\WinFsp\inc\fuse3\fuse.h")) {
           throw "WinFsp SDK missing after the install succeeded -- failing HERE instead of shipping a wheel without the FUSE adapter (#1004)"
         }
@@ -653,7 +653,7 @@ jobs:
     # install this from winfsp.dev. The DLL lives under
     # %ProgramFiles(x86)%\WinFsp\bin, which is not on PATH by default.
     - name: Install WinFsp (FUSE adapter runtime)
-      run: pwsh CI/Retry.ps1 -- choco install winfsp -y --no-progress
+      run: pwsh CI/Retry.ps1 choco install winfsp -y --no-progress
 
     - name: Test wheel in clean venv
       shell: pwsh

--- a/CI/Retry.ps1
+++ b/CI/Retry.ps1
@@ -5,8 +5,20 @@
 # install, never the build or the test.
 #
 # Usage:
-#   pwsh CI/Retry.ps1 -- choco install winfsp -y --no-progress
-#   pwsh CI/Retry.ps1 -Attempts 5 -DelaySeconds 10 -- <command> [args...]
+#   pwsh CI/Retry.ps1 choco install winfsp -y --no-progress
+#   pwsh CI/Retry.ps1 -Attempts 5 -DelaySeconds 10 <command> [args...]
+#
+# Do NOT put a '--' separator before the command. Unlike the bash half, this
+# is an advanced function ([CmdletBinding()]), and PowerShell's parameter
+# binder reads '--' as a parameter whose name is empty -- so it fails with
+# "the parameter name '' is ambiguous" BEFORE a single line of this script
+# runs, and the wrapped command never executes at all. That took every
+# Windows wheel build red the day this helper landed: the WinFsp install
+# silently never ran, and the #1004 SDK assertion downstream was what
+# actually reported the failure.
+#
+# The command's own dashed flags need no protection -- ValueFromRemaining-
+# Arguments collects '-y' and '--no-progress' into $Command unharmed.
 
 [CmdletBinding()]
 param(
@@ -26,10 +38,6 @@ $ErrorActionPreference = 'Continue'
 # so this script -- and only this script -- decides what a non-zero exit means.
 $PSNativeCommandUseErrorActionPreference = $false
 
-# Strip the '--' separator if the caller used one.
-if ($Command.Count -gt 0 -and $Command[0] -eq '--') {
-    $Command = $Command[1..($Command.Count - 1)]
-}
 if ($Command.Count -eq 0) {
     Write-Error 'CI/Retry.ps1: no command given'
     exit 2


### PR DESCRIPTION
`dev` is red on four counts right now. Two of them had no fix anywhere; this PR is those two. Both were reproduced locally and the fixes verified against the real environments, not reasoned about.

## 1. Windows wheels: the retry wrapper never ran its command

Every Windows wheel and package build has failed since `CI/Retry.ps1` landed, and **chocolatey was never the problem**:

```
pwsh CI/Retry.ps1 -Attempts 3 -DelaySeconds 30 -- choco install winfsp -y --no-progress
Retry.ps1: Parameter cannot be processed because the parameter name '' is ambiguous.
Possible matches include: -Attempts -DelaySeconds -Command ...
```

`Retry.ps1` is an advanced function (`[CmdletBinding()]`), so PowerShell's parameter binder reads `--` as a parameter whose name is empty and fails *before* the script body runs. The body's own "strip a leading `--`" branch could never fire — binding happens first. So WinFsp never installed, and what reported the failure was the #1004 SDK assertion two lines later, pointing at the CDN instead of at the caller.

Fix: drop the separator at all five call sites, delete the unreachable strip, and document why `--` must not come back. The command's own dashed flags are safe — `ValueFromRemainingArguments` collects `-y` and `--no-progress` unharmed.

**Verified** in `mcr.microsoft.com/powershell` against the real script: the `--` form reproduces the CI error verbatim, the fixed form passes flags through intact, and the retry path still backs off and exits non-zero after exhausting attempts.

## 2. test-wheels: rockylinux:8 cannot build a venv

Both `test-wheels` legs went red overnight with no change on our side. `python3 -m venv` dies in `ensurepip`, and the real cause is one layer down:

```
ImportError: .../pyexpat.cpython-312-x86_64-linux-gnu.so: undefined symbol:
XML_SetBillionLaughsAttackProtectionMaximumAmplification
```

`rockylinux:8` ships expat 2.2.5, but `python3.12-3.12.14-1.el8_10` — built 2026-08-24, hours before the first red run — links pyexpat against 2.4+ symbols. pip imports pyexpat, so ensurepip fails and the venv aborts.

Fix: name `expat` in the same `dnf` transaction (upgrades it to 2.5.0), and probe the interpreter right where the install happens — both install branches discard their output, so a broken interpreter used to surface twenty lines later as an opaque traceback.

**Verified** against the real `rockylinux:8` image, then re-run with the install prologue extracted verbatim from the patched YAML: interpreter OK, venv created, pip working.

## What this PR deliberately does not fix

- **`adapters (macos, hdf5_vol + macfuse)`** — this is #1011, and #1012 already carries the fix. Duplicating it here would just create a conflict. #1012's own `adapters (linux, all 5)` leg predates the xfstests quarantine in #1023, so a rebase on current `dev` should clear it.
- **`Cluster Tests`** — a separate regression, first red at `f8f6fad9` (#1025), green at the commit before. The 4-node coherence cluster starts, then `node 1 exit 1` and the step sits until its 20-minute timeout; the cross-node SHM gate failure after it is a cascade, because the timed-out step leaks its docker network and the next `compose up` cannot allocate a subnet. Needs a local 4-node repro to diagnose, and it is unrelated to the CI plumbing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U95XdU4TKKpSsDN9JJH4Nu