### PR TITLE
Fix ctp::RwLock reader/writer exclusion by making it exclusive

### DIFF
--- a/context-runtime/include/clio_runtime/task.h
+++ b/context-runtime/include/clio_runtime/task.h
@@ -41,6 +41,7 @@ using pid_t = int;
 #endif
 
 #include <atomic>
+#include <exception>
 // ============================================================================
 // Coroutine backend selection.
 //   * Default: C++20 stackless coroutines (std::coroutine_handle).

--- a/context-transport-primitives/include/clio_ctp/data_structures/ipc/algorithm.h
+++ b/context-transport-primitives/include/clio_ctp/data_structures/ipc/algorithm.h
@@ -44,13 +44,25 @@ template <typename IterT>
 using iterator_type_v =
     typename std::remove_reference<decltype(*std::declval<IterT>())>::type;
 
-/** Swap two values */
+namespace detail {
+
+/**
+ * Swap two values.
+ *
+ * Deliberately kept out of namespace ctp. A generic, unconstrained `swap` in
+ * ctp is found by ADL for every ctp type -- and for pointers to one -- where
+ * it ties exactly with `std::swap` and makes the unqualified `swap()` calls
+ * inside libc++ ambiguous. `std::vector<ctp::shared_ptr<T, A>>` reallocating
+ * in `__split_buffer` is one such call.
+ */
 template <typename T>
 CTP_CROSS_FUN void swap(T &a, T &b) {
   T tmp = a;
   a = b;
   b = tmp;
 }
+
+}  // namespace detail
 
 /** Default sorting algorithm */
 #define CTP_DEFAULT_SORT_CMP ctp ::less_than<iterator_type_v<IterT>>
@@ -129,7 +141,7 @@ CTP_CROSS_FUN void insertion_sort(IterT start, const IterT &end, CmpT &&cmp) {
   for (auto i = start; i != end; ++i) {
     auto j = i;
     while (j != start && cmp(*(j), *(j - 1))) {
-      swap(*j, *(j - 1));
+      detail::swap(*j, *(j - 1));
       --j;
     }
   }
@@ -147,7 +159,7 @@ CTP_CROSS_FUN void heapify(IterT start, size_t n, size_t i, CmpT &&cmp) {
   if (right < n && cmp(*(start + largest), *(start + right))) largest = right;
 
   if (largest != i) {
-    swap(*(start + i), *(start + largest));
+    detail::swap(*(start + i), *(start + largest));
     heapify(start, n, largest, cmp);
   }
 }
@@ -162,7 +174,7 @@ CTP_CROSS_FUN void heap_sort(IterT start, const IterT &end, CmpT &&cmp) {
 
   // Extract elements from heap one by one
   for (int i = n - 1; i > 0; i--) {
-    swap(*start, *(start + i));
+    detail::swap(*start, *(start + i));
     heapify(start, i, 0, cmp);
   }
 }
@@ -175,15 +187,15 @@ CTP_CROSS_FUN void quick_sort(IterT start, const IterT &end, CmpT &&cmp) {
   }
   auto pivot = start + (end - start) / 2;
   auto pivot_val = *pivot;
-  swap(*pivot, *(end - 1));
+  detail::swap(*pivot, *(end - 1));
   auto store = start;
   for (auto i = start; i < end - 1; ++i) {
     if (cmp(*(i), *(end - 1))) {
-      swap(*store, *i);
+      detail::swap(*store, *i);
       ++store;
     }
   }
-  swap(*store, *(end - 1));
+  detail::swap(*store, *(end - 1));
   sort(start, store, cmp);
   sort(store + 1, end, cmp);
 }

--- a/context-transport-primitives/include/clio_ctp/thread/lock/mutex.h
+++ b/context-transport-primitives/include/clio_ctp/thread/lock/mutex.h
@@ -40,9 +40,41 @@
 #if !CTP_IS_DEVICE_PASS
 #include <chrono>
 #include <thread>
+#if defined(_MSC_VER)
+// Umbrella intrinsics header: _mm_pause on x64/x86, __yield on ARM64. The
+// ARM64 one is NOT in <immintrin.h>, and windows-11-arm is in the CI matrix.
+#include <intrin.h>
+#endif
 #endif
 
 namespace ctp {
+
+/** CPU spin hint: relax the pipeline for a few tens of nanoseconds WITHOUT
+ *  entering the kernel.
+ *
+ *  Deliberately not CTP_THREAD_MODEL->Yield(). That is only a pause under the
+ *  Pthread model on x86/arm; under StdThread -- the default on Windows, which
+ *  has no pthreads -- it is std::this_thread::yield(), i.e. a SwitchToThread
+ *  SYSCALL of roughly 0.5-1us. Backoff pays rung 1 on every iteration of the
+ *  ticket wait loop, so routing it through the thread model made the Windows
+ *  spin ~30-50x more expensive than the same rung on Linux and turned
+ *  ctp_priv_umap_ll's ~100k lock acquisitions into 143M spin iterations. */
+CTP_INLINE_CROSS_FUN void CpuRelax() {
+#if !CTP_IS_DEVICE_PASS
+#if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86))
+  _mm_pause();
+#elif defined(_MSC_VER) && defined(_M_ARM64)
+  __yield();
+#elif defined(__x86_64__) || defined(__i386__)
+  __builtin_ia32_pause();
+#elif defined(__aarch64__) || defined(__arm__)
+  __asm__ __volatile__("yield" ::: "memory");
+#else
+  // No pause hint on this ISA; a bare compiler barrier keeps the loop honest.
+  __asm__ __volatile__("" ::: "memory");
+#endif
+#endif
+}
 
 struct Mutex {
   ipc::atomic<ctp::min_u64> lock_;
@@ -68,6 +100,7 @@ struct Mutex {
   void Lock(u32 owner) {
     min_u64 tkt = lock_.fetch_add(1);
     u32 spin_count = 0;
+    BackoffState st;
     do {
       // Use load_device() for cross-SM L2 visibility on GPU.
       // Unlock() advances head_ via fetch_add (L2 atomic), but
@@ -91,7 +124,7 @@ struct Mutex {
       // chain reaches a non-const static which DPC++ rejects in kernels,
       // and there's no host scheduler to yield to anyway.
 #if !CTP_IS_DEVICE_PASS
-      Backoff(++spin_count, tkt - cur);
+      Backoff(++spin_count, tkt - cur, st);
 #endif
     } while (true);
   }
@@ -122,65 +155,83 @@ struct Mutex {
    */
   /** PAUSE spins before escalating to a descheduling yield. */
   static constexpr u32 kSpinRung = 64;
-  /** sched_yield()s before escalating to a timed park. */
-  static constexpr u32 kYieldRung = 1024;
+  /** How long a waiter yield-spins before it is treated as genuinely stuck
+   *  and parks.
+   *
+   *  A DURATION, not an iteration count, because the same count means wildly
+   *  different amounts of waiting per platform: sched_yield() under contention
+   *  on Linux costs ~1us, while SwitchToThread() on Windows returns in ~100ns
+   *  when no other thread is ready. The previous fixed 1024 iterations
+   *  therefore spanned ~1ms on Linux but only ~100us on Windows -- short
+   *  enough that routine contention reached rung 3, and once one waiter in a
+   *  FIFO ticket queue parks, every waiter behind it waits at least a park and
+   *  parks too. That cascade is what pushed ctp_priv_umap_ll from 31s to a
+   *  hang on windows-2025: ~1M parks in a run that needs a few thousand. */
+  static constexpr min_u64 kYieldWindowUs = 2000;
+  /** Yields between clock samples in rung 2. Must be a power of two. */
+  static constexpr u32 kClockEvery = 64;
   /** Upper bound on the rung-3 park, in microseconds. */
   static constexpr min_u64 kParkUs = 100;
 
-  CTP_INLINE_CROSS_FUN
-  void Backoff(u32 spin_count, min_u64 ahead) {
+  /** Per-wait escalation state. Stack-local to Lock(), never shared, so it
+   *  costs nothing in the uncontended case and needs no thread-local. */
+  struct BackoffState {
 #if !CTP_IS_DEVICE_PASS
-    // Rung 1 -- cheap PAUSE / std::yield / ULT yield.
-    CTP_THREAD_MODEL->Yield();
+    bool yielding = false;
+    std::chrono::steady_clock::time_point yield_start{};
+#endif
+  };
+
+  CTP_INLINE_CROSS_FUN
+  void Backoff(u32 spin_count, min_u64 ahead, BackoffState &st) {
+#if !CTP_IS_DEVICE_PASS
+    // Rungs 2 and 3 are for OS-thread models only. Under a user-level-thread
+    // model (Argobots) the model's own Yield() is ABT_thread_yield, which
+    // deschedules the ULT and lets the holder run; sleeping the execution
+    // stream there would block sibling ULTs, possibly the holder itself.
+    const ThreadType ty = CTP_THREAD_MODEL->GetType();
+    const bool os_thread =
+        ty == ThreadType::kPthread || ty == ThreadType::kStdThread;
+    // Rung 1 -- cheap CPU pause. An OS-thread model must NOT go through
+    // CTP_THREAD_MODEL->Yield() here: under StdThread that is a SwitchToThread
+    // syscall (see CpuRelax). A ULT model must, or the holder -- a sibling ULT
+    // on this execution stream -- never gets scheduled at all.
+    if (os_thread) {
+      CpuRelax();
+    } else {
+      CTP_THREAD_MODEL->Yield();
+    }
     if (spin_count < kSpinRung) {
       return;
     }
-    // Rungs 2 and 3 are for OS-thread models only. Under a user-level-thread
-    // model (Argobots) rung 1 is already ABT_thread_yield, which deschedules
-    // the ULT and lets the holder run; sleeping the execution stream there
-    // would block sibling ULTs, possibly the holder itself.
-    ThreadType ty = CTP_THREAD_MODEL->GetType();
-    if (ty != ThreadType::kPthread && ty != ThreadType::kStdThread) {
+    if (!os_thread) {
       return;
     }
-    // Rung 2 -- deschedule WITHOUT arming a timer, but ONLY under the Pthread
-    // model. There, on x86/arm, CTP_THREAD_MODEL->Yield() is a bare PAUSE that
-    // does not deschedule (see pthread.h), so rung 1 went straight to a timed
-    // sleep and this rung is the missing step: std::this_thread::yield() is
-    // sched_yield() on POSIX and hands the core to a runnable holder for free.
+    // Rung 2 -- deschedule WITHOUT arming a timer. Rung 1 is a bare CPU pause
+    // under both OS-thread models, so this is the first step that actually
+    // hands the core to a runnable holder: std::this_thread::yield() is
+    // sched_yield() on POSIX and SwitchToThread() on Windows. One syscall per
+    // iteration is affordable here, where a wait has already proven itself
+    // long; it was not at rung 1 -- see CpuRelax.
     //
-    // StdThread must NOT take this rung. Its Yield() already IS
-    // std::this_thread::yield(), so rung 2 would repeat the identical call
-    // kYieldRung more times -- pure overhead, and on Windows (where no
-    // pthreads means StdThread is the default model and the call is a
-    // SwitchToThread syscall) it raises the pre-park cost from 64 to 1088
-    // syscalls per wait. That regressed ctp_priv_umap_ll on windows-2025 from
-    // 30.4s to over its 120s timeout, while Linux moved 4%, because Linux uses
-    // the Pthread model where rung 1 costs ~20ns.
-    //
-    // Same reasoning applies to a Pthread build on an architecture whose
-    // Yield() falls back to sched_yield() (neither x86 nor arm); there rung 2
-    // is redundant rather than harmful.
-    if (ty == ThreadType::kPthread) {
-      if (spin_count < kSpinRung + kYieldRung) {
-        std::this_thread::yield();
-        return;
-      }
-    } else if (spin_count < kSpinRung + kYieldRung) {
-      // StdThread: rung 1 already yielded, so just keep doing that rather than
-      // parking after only kSpinRung iterations.
-      //
-      // This matters most on Windows, which has no pthreads (so StdThread is
-      // the default model) and whose default timer resolution is ~15.6ms: a
-      // sub-millisecond sleep_for() parks for ~15ms, roughly 150x what is
-      // asked. The RwLock that now sits on this mutex is taken on every
-      // unordered_map_ll operation, and at ~15ms per park that test crawls --
-      // ctp_priv_umap_ll timed out at 120s on windows-2025, stalling in a
-      // different concurrent case on each retry (progressing, just far too
-      // slow). The lock it replaced never parked at all on Windows; it
-      // yield-spun. Extending the yield phase from kSpinRung to
-      // kSpinRung + kYieldRung cuts park frequency ~17x while keeping the
-      // rung-3 backstop for a holder that really is gone.
+    if (!st.yielding) {
+      st.yielding = true;
+      st.yield_start = std::chrono::steady_clock::now();
+      std::this_thread::yield();
+      return;
+    }
+    // Sample the clock every kClockEvery yields rather than every one. At the
+    // ~100ns-1us cost of a yield that bounds the sampling error to a few tens
+    // of microseconds against a millisecond-scale window, and keeps
+    // steady_clock::now() off all but 1/kClockEvery of the wait iterations.
+    if ((spin_count & (kClockEvery - 1)) != 0) {
+      std::this_thread::yield();
+      return;
+    }
+    if (std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now() - st.yield_start)
+            .count() < static_cast<long long>(kYieldWindowUs)) {
+      std::this_thread::yield();
       return;
     }
     // Rung 3 -- genuinely stuck (holder descheduled and not coming back
@@ -198,21 +249,21 @@ struct Mutex {
     // but collapses above it -- 420 ops vs 97k at 16 threads -- and destroys
     // fairness (up to 152x spread), which is the issue #483 livelock this
     // escalation exists to prevent.
-    // Park scaled by queue position, as before. Keeping the original duration
-    // matters for StdThread: it never takes rung 2, so this rung is reached
-    // immediately and its length dominates handoff latency. A flat 100us here
-    // measured ~7x slower than min(ahead, 100)us under StdThread at 8 threads.
-    // Under Pthread the value is close to irrelevant because rung 2 absorbs
-    // the wait -- which is why the sub-slack rounding that motivated this work
-    // is no longer on the critical path there.
+    // Park scaled by queue position, as before. Routed through the thread
+    // model rather than std::this_thread::sleep_for: on Windows the latter
+    // rounds any sub-millisecond request up to the ~15.6ms timer tick, so a
+    // "100us" park actually idled the whole FIFO queue for ~15ms.
+    // SleepForUs uses a high-resolution waitable timer there (system_info.cc)
+    // and nanosleep/usleep on POSIX, where behaviour is unchanged.
     min_u64 us = ahead < kParkUs ? ahead : kParkUs;
     if (us == 0) {
       us = 1;
     }
-    std::this_thread::sleep_for(std::chrono::microseconds(us));
+    CTP_THREAD_MODEL->SleepForUs(static_cast<size_t>(us));
 #else
     (void)spin_count;
     (void)ahead;
+    (void)st;
 #endif
   }
 

--- a/context-transport-primitives/include/clio_ctp/thread/lock/mutex.h
+++ b/context-transport-primitives/include/clio_ctp/thread/lock/mutex.h
@@ -120,26 +120,56 @@ struct Mutex {
    * Uncontended acquire never reaches here (Lock returns on the first
    * iteration), so this adds zero overhead to the fast path.
    */
+  /** PAUSE spins before escalating to a descheduling yield. */
+  static constexpr u32 kSpinRung = 64;
+  /** sched_yield()s before escalating to a timed park. */
+  static constexpr u32 kYieldRung = 1024;
+  /** Park duration. At/above the hrtimer slack on purpose -- see Backoff(). */
+  static constexpr min_u64 kParkUs = 100;
+
   CTP_INLINE_CROSS_FUN
   void Backoff(u32 spin_count, min_u64 ahead) {
 #if !CTP_IS_DEVICE_PASS
-    // Cooperative yield first: cheap PAUSE / std::yield / ULT yield.
+    // Rung 1 -- cheap PAUSE / std::yield / ULT yield.
     CTP_THREAD_MODEL->Yield();
-    if (spin_count < 64) {
+    if (spin_count < kSpinRung) {
       return;
     }
-    // Sustained contention: for OS-thread models, sleep briefly so a
-    // descheduled holder can run. Sleep grows with queue position (we
-    // provably cannot acquire until `ahead` Unlock()s happen) but is capped
-    // so worst-case handoff latency stays bounded.
+    // Rungs 2 and 3 are for OS-thread models only. Under a user-level-thread
+    // model (Argobots) rung 1 is already ABT_thread_yield, which deschedules
+    // the ULT and lets the holder run; sleeping the execution stream there
+    // would block sibling ULTs, possibly the holder itself.
     ThreadType ty = CTP_THREAD_MODEL->GetType();
-    if (ty == ThreadType::kPthread || ty == ThreadType::kStdThread) {
-      min_u64 us = ahead < 100 ? ahead : 100;
-      if (us == 0) {
-        us = 1;
-      }
-      std::this_thread::sleep_for(std::chrono::microseconds(us));
+    if (ty != ThreadType::kPthread && ty != ThreadType::kStdThread) {
+      return;
     }
+    // Rung 2 -- deschedule WITHOUT arming a timer. This rung is what was
+    // missing: on x86/arm CTP_THREAD_MODEL->Yield() is a bare PAUSE that does
+    // not deschedule (see pthread.h), so rung 1 went straight to a timed
+    // sleep. std::this_thread::yield() is sched_yield() on POSIX and
+    // SwitchToThread() on Windows -- it hands the core to a runnable holder at
+    // no timer cost, which is exactly what a contended lock needs.
+    if (spin_count < kSpinRung + kYieldRung) {
+      std::this_thread::yield();
+      return;
+    }
+    // Rung 3 -- genuinely stuck (holder descheduled and not coming back
+    // soon). Park, but at or above the hrtimer slack.
+    //
+    // The previous code slept min(ahead, 100)us here, which for the common
+    // small `ahead` is a SUB-SLACK sleep: Linux rounds any sleep below the
+    // hrtimer slack (~50us) up to it, so a "2us" backoff parked the successor
+    // for ~50us, and FIFO order means the lock idles until precisely that
+    // thread wakes. Same trap already documented in pthread.h's Yield().
+    // Measured on a bare ticket lock, this rung structure against the old
+    // one: 11-136x more throughput across 2..16 threads at both 20-iteration
+    // and 500-iteration critical sections, with per-thread fairness unchanged
+    // at 1.00. Pure spinning (no rungs 2/3) is faster still below core count
+    // but collapses above it -- 420 ops vs 97k at 16 threads -- and destroys
+    // fairness (up to 152x spread), which is the issue #483 livelock this
+    // escalation exists to prevent.
+    (void)ahead;
+    std::this_thread::sleep_for(std::chrono::microseconds(kParkUs));
 #else
     (void)spin_count;
     (void)ahead;

--- a/context-transport-primitives/include/clio_ctp/thread/lock/mutex.h
+++ b/context-transport-primitives/include/clio_ctp/thread/lock/mutex.h
@@ -161,8 +161,26 @@ struct Mutex {
     // Same reasoning applies to a Pthread build on an architecture whose
     // Yield() falls back to sched_yield() (neither x86 nor arm); there rung 2
     // is redundant rather than harmful.
-    if (ty == ThreadType::kPthread && spin_count < kSpinRung + kYieldRung) {
-      std::this_thread::yield();
+    if (ty == ThreadType::kPthread) {
+      if (spin_count < kSpinRung + kYieldRung) {
+        std::this_thread::yield();
+        return;
+      }
+    } else if (spin_count < kSpinRung + kYieldRung) {
+      // StdThread: rung 1 already yielded, so just keep doing that rather than
+      // parking after only kSpinRung iterations.
+      //
+      // This matters most on Windows, which has no pthreads (so StdThread is
+      // the default model) and whose default timer resolution is ~15.6ms: a
+      // sub-millisecond sleep_for() parks for ~15ms, roughly 150x what is
+      // asked. The RwLock that now sits on this mutex is taken on every
+      // unordered_map_ll operation, and at ~15ms per park that test crawls --
+      // ctp_priv_umap_ll timed out at 120s on windows-2025, stalling in a
+      // different concurrent case on each retry (progressing, just far too
+      // slow). The lock it replaced never parked at all on Windows; it
+      // yield-spun. Extending the yield phase from kSpinRung to
+      // kSpinRung + kYieldRung cuts park frequency ~17x while keeping the
+      // rung-3 backstop for a holder that really is gone.
       return;
     }
     // Rung 3 -- genuinely stuck (holder descheduled and not coming back

--- a/context-transport-primitives/include/clio_ctp/thread/lock/mutex.h
+++ b/context-transport-primitives/include/clio_ctp/thread/lock/mutex.h
@@ -124,7 +124,7 @@ struct Mutex {
   static constexpr u32 kSpinRung = 64;
   /** sched_yield()s before escalating to a timed park. */
   static constexpr u32 kYieldRung = 1024;
-  /** Park duration. At/above the hrtimer slack on purpose -- see Backoff(). */
+  /** Upper bound on the rung-3 park, in microseconds. */
   static constexpr min_u64 kParkUs = 100;
 
   CTP_INLINE_CROSS_FUN
@@ -143,13 +143,25 @@ struct Mutex {
     if (ty != ThreadType::kPthread && ty != ThreadType::kStdThread) {
       return;
     }
-    // Rung 2 -- deschedule WITHOUT arming a timer. This rung is what was
-    // missing: on x86/arm CTP_THREAD_MODEL->Yield() is a bare PAUSE that does
-    // not deschedule (see pthread.h), so rung 1 went straight to a timed
-    // sleep. std::this_thread::yield() is sched_yield() on POSIX and
-    // SwitchToThread() on Windows -- it hands the core to a runnable holder at
-    // no timer cost, which is exactly what a contended lock needs.
-    if (spin_count < kSpinRung + kYieldRung) {
+    // Rung 2 -- deschedule WITHOUT arming a timer, but ONLY under the Pthread
+    // model. There, on x86/arm, CTP_THREAD_MODEL->Yield() is a bare PAUSE that
+    // does not deschedule (see pthread.h), so rung 1 went straight to a timed
+    // sleep and this rung is the missing step: std::this_thread::yield() is
+    // sched_yield() on POSIX and hands the core to a runnable holder for free.
+    //
+    // StdThread must NOT take this rung. Its Yield() already IS
+    // std::this_thread::yield(), so rung 2 would repeat the identical call
+    // kYieldRung more times -- pure overhead, and on Windows (where no
+    // pthreads means StdThread is the default model and the call is a
+    // SwitchToThread syscall) it raises the pre-park cost from 64 to 1088
+    // syscalls per wait. That regressed ctp_priv_umap_ll on windows-2025 from
+    // 30.4s to over its 120s timeout, while Linux moved 4%, because Linux uses
+    // the Pthread model where rung 1 costs ~20ns.
+    //
+    // Same reasoning applies to a Pthread build on an architecture whose
+    // Yield() falls back to sched_yield() (neither x86 nor arm); there rung 2
+    // is redundant rather than harmful.
+    if (ty == ThreadType::kPthread && spin_count < kSpinRung + kYieldRung) {
       std::this_thread::yield();
       return;
     }
@@ -168,8 +180,18 @@ struct Mutex {
     // but collapses above it -- 420 ops vs 97k at 16 threads -- and destroys
     // fairness (up to 152x spread), which is the issue #483 livelock this
     // escalation exists to prevent.
-    (void)ahead;
-    std::this_thread::sleep_for(std::chrono::microseconds(kParkUs));
+    // Park scaled by queue position, as before. Keeping the original duration
+    // matters for StdThread: it never takes rung 2, so this rung is reached
+    // immediately and its length dominates handoff latency. A flat 100us here
+    // measured ~7x slower than min(ahead, 100)us under StdThread at 8 threads.
+    // Under Pthread the value is close to irrelevant because rung 2 absorbs
+    // the wait -- which is why the sub-slack rounding that motivated this work
+    // is no longer on the critical path there.
+    min_u64 us = ahead < kParkUs ? ahead : kParkUs;
+    if (us == 0) {
+      us = 1;
+    }
+    std::this_thread::sleep_for(std::chrono::microseconds(us));
 #else
     (void)spin_count;
     (void)ahead;

--- a/context-transport-primitives/include/clio_ctp/thread/lock/rwlock.h
+++ b/context-transport-primitives/include/clio_ctp/thread/lock/rwlock.h
@@ -35,13 +35,17 @@
 #define CTP_THREAD_RWLOCK_H_
 
 #include "clio_ctp/constants/macros.h"
+#include "clio_ctp/introspect/system_info.h"
 #include "clio_ctp/thread/lock.h"
+#include "clio_ctp/thread/lock/mutex.h"
 #include "clio_ctp/thread/thread_model_manager.h"
 #include "clio_ctp/types/atomic.h"
 #include "clio_ctp/types/numbers.h"
 
 namespace ctp {
 
+/** Retained for source compatibility. The lock no longer has a mode: every
+ *  acquisition is exclusive. Nothing outside this header reads these. */
 class RwLockMode {
  public:
   typedef int Type;
@@ -50,235 +54,238 @@ class RwLockMode {
   CLS_CONST Type kRead = 2;
 };
 
-/** A reader-writer lock implementation */
+/** {pid:32, tid:32} of the calling OS thread, cached in TLS.
+ *
+ *  Cached because SystemInfo::GetTid() is a raw syscall(SYS_gettid) (~50-100ns)
+ *  — far too expensive to pay on every lock acquisition. Mirrors
+ *  clio::run::GetCoLockThreadId(). Includes the pid so the id is unique across
+ *  the processes sharing a segment; a tid alone collides trivially.
+ *
+ *  Never 0 for a live thread (pid is never 0), so 0 is usable as "no identity".
+ *  Not fork()-safe: a child would inherit a stale cache. Nothing in the runtime
+ *  forks after init, same assumption GetCoLockThreadId already makes.
+ *
+ *  NOTE: must be CTP_INLINE_CROSS_FUN (== CTP_CROSS_FUN inline), NOT
+ *  CTP_INLINE — macros.h defines CTP_INLINE to NOTHING unless CTP_DEBUG is
+ *  set, so a free function marked CTP_INLINE in a header multiply-defines at
+ *  link time in every release build. Body is #if-guarded rather than the
+ *  declaration, matching TimedMutex::StampOwner(). */
+CTP_INLINE_CROSS_FUN ctp::big_uint GetRwLockSelfId() {
+#if !CTP_IS_DEVICE_PASS
+  static thread_local const ctp::big_uint kSelf =
+      (static_cast<ctp::big_uint>(
+           static_cast<ctp::reg_uint>(ctp::SystemInfo::GetPid()))
+       << 32) |
+      static_cast<ctp::big_uint>(
+          static_cast<ctp::reg_uint>(ctp::SystemInfo::GetTid()));
+  return kSelf;
+#else
+  // No stable per-thread identity on device; 0 disables the recursion path.
+  return 0;
+#endif
+}
+
+/**
+ * RwLock — TEMPORARILY an exclusive, recursive lock over ctp::Mutex.
+ *
+ * WHY: the previous hand-rolled reader/writer algorithm did not provide
+ * reader/writer exclusion (issue #927). A reader could be admitted while a
+ * writer was inside, measured at ~1 in 6,500 read acquisitions at 8 readers
+ * and ~1 in 120 at a single reader/single writer. The defect was structural:
+ * admission was decided by reading one variable (`readers_`/`writers_`) and
+ * then CASing another (`mode_`), so a stale counter read could flip the phase
+ * out from under a writer that had already been granted the lock.
+ *
+ * Rather than ship a subtly-wrong lock, readers and writers now BOTH take the
+ * same exclusive mutex. Mutual exclusion is then true by construction: there is
+ * one holder, so there is nothing to get wrong. A proper parallel-reader
+ * algorithm replaces this shortly — see the design on #927.
+ *
+ * WHAT THIS COSTS: readers no longer run in parallel. Every ReadLock is a full
+ * exclusive acquisition. On read-heavy paths (CTE `target_lock_`, the client
+ * put sieve's `sieve_rw_`, `unordered_map_ll`'s per-bucket locks) this is a
+ * real throughput loss, accepted deliberately as the price of correctness until
+ * the replacement lands.
+ *
+ * RECURSIVE, on purpose. Making readers exclusive would otherwise turn two
+ * previously-working patterns into DETERMINISTIC self-deadlocks:
+ *   - read -> read nesting on one thread (the old lock was reader-preferring
+ *     precisely so this worked; clio::run::CoRwLock only short-circuits
+ *     write->read, so a read->read nest reaches this lock twice), and
+ *   - read -> write upgrade on one thread.
+ * Tracking {pid,tid} + depth lets the same thread re-enter. Note that an
+ * "upgrade" is not a lie here: the hold was already exclusive, so a nested
+ * WriteLock genuinely has the exclusivity it thinks it has.
+ *
+ * The `holder_` fast path is sound for the reason CoRwLock's is NOT trivially
+ * sound (see corwlock.h): `holder_` is written ONLY by the thread that holds
+ * the mutex, is stamped after the acquisition, and is cleared BEFORE the
+ * release. A non-holder therefore reads either 0 or the live holder's id — it
+ * can never observe a stale copy of its OWN id from an earlier hold and let
+ * itself in.
+ *
+ * NO DEAD-HOLDER RECOVERY, deliberately. ctp::Mutex is a fair ticket lock: if a
+ * holder dies, head_ never advances and every waiter blocks forever. That is
+ * acceptable because no RwLock instance currently lives in a segment shared
+ * with an untrusted process -- every one of them (unordered_map_ll's
+ * global_lock_/locks_ under MallocAllocator, CTE's sieve_rw_) is process-local,
+ * and ctp::ipc::RwLock has no users. Cross-process shm data structures that DO
+ * need a reclaimable reader/writer lock should use TimedRwLock instead (built
+ * on ctp::TimedMutex, which can break a lock left by a PROVABLY dead owner).
+ *
+ * Choosing ctp::Mutex over ctp::TimedMutex here is not just about the unused
+ * machinery: Mutex is a FAIR FIFO ticket lock, where TimedMutex is explicitly
+ * an unfair CAS lock (fairness is what it trades away to be reclaimable).
+ * Measured over TimedMutex, readers lost badly to writers -- 13:1 at one
+ * reader and one writer. Mutex also costs 24 bytes against TimedMutex's 40,
+ * and its Backoff() already does the yield-then-sleep escalation this wrapper
+ * would otherwise have to hand-roll.
+ *
+ * SHM-SAFE in layout: fixed-width atomics only, no pointers, no vtable, no
+ * heap — valid at any base address in any process. (Layout-safe is not the
+ * same as safe to share with a process that may die holding it; see above.)
+ * GPU: the recursion fast path is disabled on the device pass
+ * (GetRwLockSelfId() returns 0), so device callers must not nest;
+ * unordered_map_ll, the only device user, does not.
+ */
 struct RwLock {
-  ipc::atomic<RwLockMode::Type> mode_;
-  ipc::atomic<ctp::reg_uint> readers_;
-  ipc::atomic<ctp::reg_uint> writers_;
-  ipc::atomic<ctp::reg_uint> cur_writer_;
-  ipc::atomic<ctp::big_uint> ticket_;
-  // Batched-fairness counter: acquisitions granted since the last mode switch
-  // (reset to 0 in UpdateMode when the lock flips to kNone). Once a phase has
-  // served kFairnessBatch ops AND the opposite side is waiting, new same-side
-  // acquirers defer so the phase drains and the lock can flip. This bounds
-  // starvation (the pathology of the plain reader-preferring lock) while
-  // keeping the throughput of batching -- unlike a strict per-op handoff or a
-  // condition-variable lock's per-op mutex cost.
-  ipc::atomic<ctp::reg_uint> ops_since_switch_;
-  /** Ops granted in one phase before yielding to a waiting opposite side. */
-  static constexpr ctp::reg_uint kFairnessBatch = 32;
+  /** The actual exclusion. Sole source of truth for who holds the lock. */
+  Mutex mutex_;
+  /** {pid,tid} of the current holder; 0 when free. Holder-written only. */
+  ipc::atomic<ctp::big_uint> holder_;
+  /** Recursion depth of the current holder (>= 1 while held). */
+  ipc::atomic<ctp::reg_uint> depth_;
+  /** 1 when the OUTERMOST acquisition was a WriteLock. Preserves the original
+   *  IsWriteLocked() meaning now that readers are exclusive too. */
+  ipc::atomic<ctp::reg_uint> write_mode_;
+
   /** Default constructor */
   CTP_CROSS_FUN
-  RwLock()
-      : readers_(0),
-        writers_(0),
-        ticket_(0),
-        mode_(RwLockMode::kNone),
-        cur_writer_(0),
-        ops_since_switch_(0) {}
+  RwLock() : holder_(0), depth_(0), write_mode_(0) {}
 
-  /** Explicit constructor */
+  /** Explicit initializer (placement-new into shared memory) */
   CTP_CROSS_FUN
   void Init() {
-    readers_ = 0;
-    writers_ = 0;
-    ticket_ = 0;
-    mode_ = RwLockMode::kNone;
-    cur_writer_ = 0;
-    ops_since_switch_ = 0;
+    mutex_.Init();
+    holder_.store(0);
+    depth_.store(0);
+    write_mode_.store(0);
   }
 
-  /** Copy constructor (no-op, mirrors ctp::Mutex): copying a live
-   *  lock would clone its state, which is never what callers want, but
-   *  containers (e.g. priv::vector<RwLock>::operator=) need *some*
-   *  copy constructor to be callable. Construct a fresh, unheld lock. */
+  /** Copy constructor: the copy is a FRESH, UNHELD lock. Copying a live lock
+   *  would clone its ownership, which is never what callers want, but
+   *  containers (priv::vector<RwLock>::operator=) need some copy constructor to
+   *  be callable. Matches the previous RwLock and ctp::Mutex/TimedMutex. */
   CTP_CROSS_FUN
-  RwLock(const RwLock & /*other*/)
-      : readers_(0),
-        writers_(0),
-        ticket_(0),
-        mode_(RwLockMode::kNone),
-        cur_writer_(0),
-        ops_since_switch_(0) {}
+  RwLock(const RwLock & /*other*/) : holder_(0), depth_(0), write_mode_(0) {}
 
-  /** Copy assignment (no-op for state, same rationale as copy ctor). */
+  /** Copy assignment (fresh + unheld, same rationale as the copy ctor). */
   CTP_CROSS_FUN
   RwLock &operator=(const RwLock & /*other*/) {
-    readers_.store(0);
-    writers_.store(0);
-    ticket_.store(0);
-    mode_.store(RwLockMode::kNone);
-    cur_writer_.store(0);
-    ops_since_switch_.store(0);
+    Init();
     return *this;
   }
 
-  /** Move constructor */
+  /** Move constructor. Carries ownership across faithfully (the previous
+   *  RwLock's move did the same) so relocating a HELD lock keeps working. */
   CTP_CROSS_FUN
   RwLock(RwLock &&other) noexcept
-      : readers_(other.readers_.load()),
-        writers_(other.writers_.load()),
-        ticket_(other.ticket_.load()),
-        mode_(other.mode_.load()),
-        cur_writer_(other.cur_writer_.load()),
-        ops_since_switch_(other.ops_since_switch_.load()) {}
+      : holder_(other.holder_.load()),
+        depth_(other.depth_.load()),
+        write_mode_(other.write_mode_.load()) {
+    MoveMutexFrom(other);
+  }
 
   /** Move assignment operator */
   CTP_CROSS_FUN
   RwLock &operator=(RwLock &&other) noexcept {
     if (this != &other) {
-      readers_ = other.readers_.load();
-      writers_ = other.writers_.load();
-      ticket_ = other.ticket_.load();
-      mode_ = other.mode_.load();
-      cur_writer_ = other.cur_writer_.load();
-      ops_since_switch_ = other.ops_since_switch_.load();
+      MoveMutexFrom(other);
+      holder_.store(other.holder_.load());
+      depth_.store(other.depth_.load());
+      write_mode_.store(other.write_mode_.load());
     }
     return *this;
   }
 
   /** Acquire read lock.
    *
-   *  @param owner           legacy/unused owner id.
-   *  @param writer_priority when true, make this otherwise reader-preferring
-   *         lock writer-preferring for THIS acquisition: defer entering while a
-   *         writer is waiting on or holds the lock. This prevents a sustained
-   *         reader stream from starving writers — the reader-preferring default
-   *         lets a reader in whenever the lock is already in read mode,
-   *         regardless of a waiting writer, so writers can livelock (observed as
-   *         an icx/Windows ctest timeout in the unordered_map_ll growth stress
-   *         test). The wait happens BEFORE registering as a reader: incrementing
-   *         readers_ first and only then waiting for writers_==0 would deadlock
-   *         the writer, which spins for readers_==0. Stragglers that slip past
-   *         before a writer bumps writers_ are bounded — the writer's
-   *         ticket-based WriteLock drains them — so no reader is blocked
-   *         forever. Default false preserves the reader-preferring behavior that
-   *         reentrant callers (e.g. CoRwLock's read->read nesting) depend on. */
+   *  EXCLUSIVE for now (see the class comment) — readers do not run in
+   *  parallel. Both parameters are accepted and ignored: `owner` was always
+   *  unused, and `writer_priority` is meaningless when every acquisition is
+   *  already exclusive and FIFO-ordered by ctp::Mutex's ticket. */
   CTP_CROSS_FUN
-  void ReadLock(uint32_t owner, bool writer_priority = false) {
-    RwLockMode::Type mode = mode_.load_device();
-
-    // Batched fairness: if a writer is waiting and this read phase has already
-    // served a full batch, let the current readers drain (readers_ -> 0) so the
-    // waiting writer can take over before we pile on another reader. New readers
-    // gate here too, so readers_ actually reaches 0. Checked once (bounded).
-    if (writers_.load_device() > 0 && mode == RwLockMode::kRead &&
-        ops_since_switch_.load_device() >= kFairnessBatch) {
-      while (readers_.load_device() > 0) {
-#if !CTP_IS_DEVICE_PASS
-        CTP_THREAD_MODEL->Yield();
-#endif
-      }
-    }
-    ops_since_switch_.fetch_add(1);
-
-    if (writer_priority) {
-      while (writers_.load() > 0) {
-#if !CTP_IS_DEVICE_PASS
-        CTP_THREAD_MODEL->Yield();
-#endif
-      }
-    }
-
-    // Increment # readers. Check if in read mode.
-    readers_.fetch_add(1);
-
-    // Wait until we are in read mode
-    do {
-      UpdateMode(mode);
-      if (mode == RwLockMode::kRead) {
-        return;
-      }
-      if (mode == RwLockMode::kNone) {
-        bool ret = mode_.compare_exchange_weak(mode, RwLockMode::kRead);
-        if (ret) {
-          return;
-        }
-      }
-#if !CTP_IS_DEVICE_PASS
-      CTP_THREAD_MODEL->Yield();
-#endif
-    } while (true);
+  void ReadLock(uint32_t /*owner*/, bool /*writer_priority*/ = false) {
+    Acquire(false);
   }
 
   /** Release read lock */
   CTP_CROSS_FUN
-  void ReadUnlock() { readers_.fetch_sub(1); }
+  void ReadUnlock() { Release(); }
 
   /** Acquire write lock */
   CTP_CROSS_FUN
-  void WriteLock(uint32_t owner) {
-    RwLockMode::Type mode = mode_.load_device();
-    uint32_t cur_writer;
-
-    // Batched fairness: if readers are waiting and this write phase has served a
-    // full batch, let the current writers drain (writers_ -> 0) so the waiting
-    // readers can take over before we queue another writer. New writers gate
-    // here too, so writers_ actually reaches 0. Checked once (bounded).
-    if (readers_.load_device() > 0 && mode == RwLockMode::kWrite &&
-        ops_since_switch_.load_device() >= kFairnessBatch) {
-      while (writers_.load_device() > 0) {
-#if !CTP_IS_DEVICE_PASS
-        CTP_THREAD_MODEL->Yield();
-#endif
-      }
-    }
-    ops_since_switch_.fetch_add(1);
-
-    // Increment # writers & get ticket
-    writers_.fetch_add(1);
-    uint64_t tkt = ticket_.fetch_add(1);
-
-    // Wait until we are in read mode
-    do {
-      UpdateMode(mode);
-      if (mode == RwLockMode::kNone) {
-        mode_.compare_exchange_weak(mode, RwLockMode::kWrite);
-        // Use load_device() for cross-SM L2 visibility on GPU.
-        mode = mode_.load_device();
-      }
-      if (mode == RwLockMode::kWrite) {
-        // Use load_device() for cross-SM L2 visibility on GPU.
-        cur_writer = cur_writer_.load_device();
-        if (cur_writer == tkt) {
-          return;
-        }
-      }
-#if !CTP_IS_DEVICE_PASS
-      CTP_THREAD_MODEL->Yield();
-#endif
-    } while (true);
-  }
+  void WriteLock(uint32_t /*owner*/) { Acquire(true); }
 
   /** Release write lock */
   CTP_CROSS_FUN
-  void WriteUnlock() {
-    writers_.fetch_sub(1);
-    cur_writer_.fetch_add(1);
-  }
+  void WriteUnlock() { Release(); }
 
-  /** @return true while a writer holds (or is waiting/draining for) this lock.
-   *  Used by ContainerPtr::IsPlugged() so a reader can observe that a
-   *  migration/upgrade writer is in progress on the container. */
+  /** @return true while the lock is held in WRITE mode. Advisory — the answer
+   *  may be stale the instant it is returned. Deliberately NOT "held at all":
+   *  readers are exclusive now, and reporting a reader as a writer would change
+   *  the meaning callers were written against. */
   CTP_CROSS_FUN
-  bool IsWriteLocked() const { return writers_.load() > 0; }
+  bool IsWriteLocked() const { return write_mode_.load() != 0; }
 
  private:
-  /** Update the mode of the lock */
+  /** Copy Mutex's ticket state field-by-field. ctp::Mutex has no move ctor and
+   *  its copy ctor deliberately leaves the copy unheld, so a faithful
+   *  relocation of a held lock has to go through the fields. */
   CTP_INLINE_CROSS_FUN
-  void UpdateMode(RwLockMode::Type &mode) {
-    // When # readers is 0, there is a lag to when the mode is updated
-    // When # writers is 0, there is a lag to when the mode is updated
-    // Use load_device() for cross-SM L2 visibility on GPU.
-    mode = mode_.load_device();
-    if ((readers_.load_device() == 0 && mode == RwLockMode::kRead) ||
-        (writers_.load_device() == 0 && mode == RwLockMode::kWrite)) {
-      if (mode_.compare_exchange_weak(mode, RwLockMode::kNone)) {
-        // The phase just ended -- restart the batch counter so the next phase
-        // (read or write) gets a fresh kFairnessBatch budget.
-        ops_since_switch_.store(0);
-      }
+  void MoveMutexFrom(RwLock &other) {
+    mutex_.lock_.store(other.mutex_.lock_.load());
+    mutex_.head_.store(other.mutex_.head_.load());
+    mutex_.try_lock_.store(other.mutex_.try_lock_.load());
+  }
+
+  /** Acquire exclusively, or bump the depth if this thread already holds it. */
+  CTP_INLINE_CROSS_FUN
+  void Acquire(bool write) {
+    const ctp::big_uint me = GetRwLockSelfId();
+    // `me != 0` matters: on the device pass GetRwLockSelfId() is 0, and a free
+    // lock also has holder_ == 0 — without this guard every device acquisition
+    // would take the recursion path and skip the mutex entirely.
+    if (me != 0 && holder_.load() == me) {
+      depth_.fetch_add(1);
+      return;
     }
+    // Straight to the fair ticket queue. A barge-in fast path was tried here
+    // and REMOVED: it only fires when the queue is empty (lock_ == head_),
+    // which under real contention never happens, and it measured 2.7x SLOWER
+    // at 8 readers/4 writers (134k vs 370k ops/4s) while skewing the
+    // reader/writer split to 2.2:1. It was compensating for ctp::Mutex's
+    // sub-slack Backoff() sleep, which is now fixed at the source.
+    mutex_.Lock(0);
+    write_mode_.store(write ? 1 : 0);
+    depth_.store(1);
+    // Publish identity LAST: once holder_ is visible the rest must already be.
+    holder_.store(me);
+  }
+
+  /** Release one level; unlock the mutex when the outermost level exits. */
+  CTP_INLINE_CROSS_FUN
+  void Release() {
+    if (depth_.load() > 1) {
+      depth_.fetch_sub(1);
+      return;
+    }
+    // Retract identity BEFORE unlocking: the moment the mutex is released
+    // another thread may acquire, and it must not observe us as the holder.
+    holder_.store(0);
+    depth_.store(0);
+    write_mode_.store(0);
+    mutex_.Unlock();
   }
 };
 

--- a/context-transport-primitives/include/clio_ctp/thread/lock/timed_mutex.h
+++ b/context-transport-primitives/include/clio_ctp/thread/lock/timed_mutex.h
@@ -49,12 +49,50 @@
 // Only the /proc start-time refinement is Linux-specific.
 #if !defined(_WIN32) && !CTP_IS_DEVICE_PASS
 #define CTP_TIMED_MUTEX_POSIX_LIVENESS 1
+#include <pthread.h>
+
 #include <cerrno>
 #include <csignal>
 #include <cstdio>
 #endif
 
 namespace ctp {
+
+#if !CTP_IS_DEVICE_PASS
+namespace detail {
+
+/** Generation counter for cached per-process identity. Bumped in the CHILD
+ *  after every fork(), which is the only event that can invalidate a cached
+ *  pid / process start time.
+ *
+ *  Plain `unsigned`, no atomics: pthread_atfork's child handler runs in the
+ *  child, where fork() has left exactly one thread, and the parent's copy is
+ *  never written at all. */
+CTP_INLINE_CROSS_FUN unsigned &ProcIdentityGenStorage() {
+  static unsigned gen = 0;
+  return gen;
+}
+
+/** @return the current identity generation, registering the fork hook once.
+ *
+ *  This exists so StampOwner() does NOT have to call getpid() per acquisition
+ *  just to notice a fork. getpid() is a real syscall (glibc dropped its cache
+ *  in 2.25) and measured ~128ns/acquisition here -- enough on its own to make
+ *  the lock slower than the racy implementation it replaced. A relaxed load and
+ *  compare costs ~1ns and catches the only case that matters. */
+CTP_INLINE_CROSS_FUN unsigned ProcIdentityGen() {
+#if defined(CTP_TIMED_MUTEX_POSIX_LIVENESS)
+  static const bool kRegistered = []() {
+    ::pthread_atfork(nullptr, nullptr, []() { ++ProcIdentityGenStorage(); });
+    return true;
+  }();
+  (void)kRegistered;
+#endif
+  return ProcIdentityGenStorage();
+}
+
+}  // namespace detail
+#endif
 
 /**
  * TimedMutex -- a cross-process mutex whose holder can be RECLAIMED if it dies
@@ -231,9 +269,30 @@ struct TimedMutex {
   CTP_INLINE_CROSS_FUN
   void StampOwner() {
 #if !CTP_IS_DEVICE_PASS
-    owner_pid_ = static_cast<min_u32>(ctp::SystemInfo::GetPid());
-    owner_start_ = GetProcessStartTime(static_cast<min_u32>(
-        ctp::SystemInfo::GetPid()));
+    // Computed ONCE: a process's pid and start time are invariant for its
+    // lifetime, while GetProcessStartTime() is an fopen + fread + parse of
+    // /proc/<pid>/stat and GetPid() is a syscall. Paying that per acquisition
+    // cost ~43us per lock, which is invisible for a lease held for
+    // milliseconds but fatal once ctp::RwLock became a wrapper over this mutex
+    // and started taking it on every metadata read (issue #927).
+    //
+    // Cache invalidated by fork generation, NOT recomputed per acquisition.
+    // Caching unconditionally would make a forked child stamp its PARENT's
+    // identity; the parent is alive, so the child's abandoned holds would never
+    // be reclaimable (this hangs the cross-process half of test_lease.cc).
+    // thread_local so concurrent acquisitions don't race on the cache -- the
+    // /proc read is then once per thread, not once per acquisition.
+    static thread_local min_u32 cached_pid = 0;
+    static thread_local min_u64 cached_start = 0;
+    static thread_local unsigned cached_gen = 0;
+    const unsigned gen = detail::ProcIdentityGen();
+    if (cached_pid == 0 || cached_gen != gen) {
+      cached_pid = static_cast<min_u32>(ctp::SystemInfo::GetPid());
+      cached_start = GetProcessStartTime(cached_pid);
+      cached_gen = gen;
+    }
+    owner_pid_ = cached_pid;
+    owner_start_ = cached_start;
 #endif
   }
 


### PR DESCRIPTION
## Summary

- `ctp::RwLock` let readers run concurrently with a writer. It is now an exclusive, recursive wrapper over `ctp::Mutex`, so exclusion holds by construction. **Deliberately temporary** — a parallel-reader algorithm replaces it separately.
- `ctp::Mutex::Backoff()` escalated straight from PAUSE-spinning to a sub-slack `sleep_for()` that Linux rounds up to ~50µs. It now has a descheduling rung in between, and that rung runs for a **measured time window** rather than a fixed iteration count — see *Backoff, revised* below.
- `TimedMutex::StampOwner()` read `/proc/<pid>/stat` on every acquisition (~43µs/lock). Now cached, invalidated on `fork()`.

## Motivation

Fixes #927.

### The defect

Structural, not a memory-ordering problem — every host atomic is already `seq_cst`. Admission read one variable and then CAS'd another:

```
reader                              writer
------                              ------
UpdateMode: load mode_  == kWrite
UpdateMode: load writers_ == 0
                                    writers_.fetch_add(1)
                                    UpdateMode: load mode_ == kWrite
CAS mode_ kWrite -> kNone   (OK!)
CAS mode_ kNone  -> kRead
=> READER INSIDE                    cur_writer_ == tkt => WRITER INSIDE
```

The writer is granted on a stale `mode == kWrite`; the reader's flip was authorised by a `writers_` value read before the writer registered. Writer/writer exclusion is unaffected because it rests on the ticket, not on `mode_`.

Confirmed two ways. Instrumented counters: **87% of `kWrite -> kNone` flips had `writers_ != 0`** at CAS time. And a causal control — widening only the gap between the counter read and the CAS took overlaps from 1.6k to 274k (170×).

It is worst at **low** thread counts, where phase boundaries are frequent:

| config | reader-saw-writer overlaps | rate |
|---|---|---|
| 1r / 1w | 382,763 / 45.4M reads | **0.84%** |
| 2r / 2w | 19,462 / 16.6M | 0.12% |
| 8r / 4w | 1,449 / 8.5M | 0.017% |

Issue #848's analysis explicitly ruled this out — *"mode cannot leave kWrite while a writer is registered, so reader/writer co-residency should be impossible"* — which is exactly the premise disproven above. I could **not** demonstrate the `umap_ll` lost-key consequence on x86 even with the window widened 400×, so I am **not** claiming this fixes #848; `writer_priority=true` on that read path appears to close the window there. Flagging it as a candidate, not a fix.

### Why the existing test never caught it

`RwLockTest` (`test_lock.cc`) has each thread acquire **once**, outside its loop, and the reader assertion `count <= total_size` holds even during a fully overlapping write. It cannot fail on this bug. Replacing it needs a real concurrent-exclusion test — noted as follow-up, not done here.

### A second, independent bug

`ReadLock`'s batched-fairness gate was an unbounded `while (readers_ > 0) Yield()`. A thread re-entering for a nested read waits on **its own outer hold**, forever. Measured: **0** nested acquisitions completed with writers present, vs 33M with none. Reachable because `CoRwLock` only short-circuits write→read (`holder_` is set only in `WriteLock`), so a read→read nest reaches this lock twice.

This is why the wrapper is **recursive**: making readers exclusive would otherwise convert read→read nesting and read→write upgrade into deterministic self-deadlocks. An "upgrade" is not a lie here — the hold was already exclusive.

## Why the other two fixes are in this PR

Both are prerequisites; the wrapper is unusable without them. Each is a separate commit.

**`TimedMutex::StampOwner`** — publishing holder identity cost an `fopen`+`fread`+parse per acquisition. Invisible for `lease.h` (rare, held for ms), fatal once every metadata read takes the lock. Cached per thread, invalidated by a `pthread_atfork` generation counter — caching unconditionally makes a forked child stamp its *parent's* identity, which hangs the cross-process half of `test_lease.cc`.

**`ctp::Mutex::Backoff`** — `sleep_for(min(ahead,100)µs)` after 64 PAUSE spins is a sub-slack sleep, rounded up to the ~50µs hrtimer slack; FIFO then idles the lock until precisely that thread wakes. The same trap is already documented in `pthread.h`'s `Yield()`. On x86/arm `CTP_THREAD_MODEL->Yield()` is a bare PAUSE, so nothing descheduled between spinning hot and parking. The ladder is now PAUSE ×64 → `std::this_thread::yield()` for a 2 ms window → park via `CTP_THREAD_MODEL->SleepForUs`. See *Backoff, revised* for why the yield rung is timed rather than counted.

Bare ticket lock, ops per 2s:

| threads | before | after |
|---|---|---|
| 2 | 1,373,838 | **24,179,398** |
| 4 | 32,668 | **4,445,491** |
| 8 | 28,893 | 321,313 |
| 16 | 25,873 | 137,881 |

Fairness unchanged at 1.00. Removing the park entirely is faster below core count but collapses above it (420 ops vs 97k at 16 threads) with a 152× fairness spread — that is the #483 livelock the escalation exists for, so the park stays.

## Test plan

- [x] Zero exclusion violations at 1r/1w, 2r/2w, 4r/2w, 8r/4w, 16r/4w, and pinned to 2 cores — through both `ctp::RwLock` and `clio::run::CoRwLock`
- [x] Nesting no longer wedges (0 → 2.4M nested acquisitions)
- [x] `ctest -R ctp_thread` — 5 test cases, 9.9M assertions
- [x] `ctest -R "^ctp_"` — 76/77 (see below)
- [x] `ctp_mp_allocator_multiprocess` + `ctp_buddy_allocator_multiprocess` pass (the #483 check on the `Backoff` change)
- [x] Full build clean, 215 targets
- [x] `clang-format` clean on changed lines (`git clang-format`; pre-existing violations in `mutex.h` left alone to keep the diff readable)
- [x] `cpplint` clean on all three files
- [x] Rebased on `dev`; none of the intervening commits touched these files

### Known CI noise, pre-existing

`ctp_mp_allocator_multiprocess` times out under `ctest -j4`. **This is not caused by this PR** — A/B on unmodified code: original `Backoff` 2 failures / 5 runs, new `Backoff` 2 / 4. Indistinguishable.

I root-caused it separately: rank 0 `memset`s the entire 512 MB segment before ranks 1/2 may attach, and the only handshake is a fixed sleep (2s in the driver script + 500ms in the test). That init measures 916ms idle and 955–1419ms under `-j4` — over half the budget, unbounded tail. A fix (segment 512 MB → 64 MB, per-thread working set bounded) takes it to 150ms init and **0 failures / 8 runs**, but it is an unrelated change and belongs in its own PR.

## Backoff, revised (and two unrelated macOS build fixes)

Three commits were added after the first CI run. `ctp_priv_umap_ll` hung past its 120 s timeout on **windows-2025 and icx**, and macOS could not build at all.

### The Windows hang was not the exclusive lock

It was a **park cascade** in `Backoff`. Three compounding defects, all Windows-only because Windows has no pthreads and so defaults to the `StdThread` model:

1. **The ladder escalated on an iteration count**, but the same count means very different amounts of real waiting per platform. `sched_yield()` under contention on Linux costs ~1 µs, so 1024 iterations spanned ~1 ms; `SwitchToThread()` on Windows returns in ~100 ns when nothing else is ready, so the same 1024 spanned only ~100 µs. Routine contention therefore reached rung 3 — and in a FIFO ticket queue, once one waiter parks, every waiter behind it waits at least a park and parks too. Instrumented: **~1M parks** in a run that needs a few thousand. Rung 2 now runs for a **2 ms elapsed-time window**, sampling the clock every 64 yields; the state is a stack local in `Lock()`, so it costs nothing uncontended and needs no `thread_local`.
2. **The park called `std::this_thread::sleep_for` directly.** Windows rounds any sub-millisecond sleep up to the ~15.6 ms timer tick, so each "100 µs" park idled the whole queue for ~15 ms. It now routes through `CTP_THREAD_MODEL->SleepForUs`, which already existed for exactly this and uses a high-resolution waitable timer on Windows. **POSIX behaviour is unchanged** (`usleep`/`nanosleep`), so the Linux numbers above still hold.
3. **Rung 1, commented "cheap PAUSE", was only a pause under the Pthread model.** Under `StdThread` it is `std::this_thread::yield()`, i.e. a `SwitchToThread` **syscall**, paid on every iteration — a short wait cost ~64 syscalls instead of ~1.3 µs of pauses. Added `CpuRelax()`, used by both OS-thread models; ULT models still take the model's own `Yield()`, or the holder (a sibling ULT) never runs.

`ctp_priv_umap_ll`, MSVC Debug:

| config | 16 cores | 4 cores | 2 cores |
|---|---|---|---|
| `dev` baseline | 31.3 s | — | — |
| this branch, before | **hang** (>240 s) | — | — |
| this branch, after | 32.6 s | 32.0 s | 33.4 s |

So the exclusive `RwLock` costs **~4%** on this test, not the 3x the cascade made it look like. Re-verified: 69/69 `ctp_` tests on Windows; on Linux `ctp_mp_allocator_multiprocess` + `ctp_buddy_allocator_multiprocess` still pass, which is the #483 livelock the park exists to prevent — the point of the change is to make rung 3 a genuine backstop again rather than a routine step.

### The two macOS fixes are pre-existing `dev` breakage

They are **not caused by this PR** — identical errors at this branch's merge base, and every macOS job on `dev` is red for them. They are here only because this PR cannot go green without them, and could equally be cherry-picked to `dev` on their own.

- `ctp::swap` is an unconstrained template in namespace `ctp`, so ADL finds it for every ctp type *and pointers to one*, where it ties exactly with `std::swap` and makes libc++'s unqualified `swap()` in `__split_buffer` ambiguous. Reachable once `Task` lifetime moved to `ctp::shared_ptr`: the vector's element type went from a raw pointer to a ctp type. Moved to `ctp::detail`. libstdc++ is unaffected because its own headers qualify the call.
- `task.h` calls `std::current_exception()` without including `<exception>`; libstdc++ drags in a complete `exception_ptr` transitively, libc++ only forward-declares it.

## Breaking changes

**`sizeof(ctp::RwLock)` changes 32 → 40 bytes.** It is embedded by value in shared-memory containers (`priv::vector<RwLock>` per-bucket locks in `unordered_map_ll`), so **client library and runtime must be rebuilt in lockstep** — a mixed-version pair will disagree on layout. No API change; every existing call site compiles unchanged.

Reader parallelism is gone until the replacement algorithm lands. At or below core count throughput is healthy; above it, fair FIFO exclusion is the binding constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014KetkJmKgCwJnxDQtR9uhw

