### PR TITLE
Give the Windows wheel/package test jobs the retry helper they call

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -519,6 +519,20 @@ jobs:
     timeout-minutes: 45
     if: always() && needs.build-windows.result == 'success'
     steps:
+    # Runs FIRST, before any artifact download: this job has no source
+    # checkout by design (a repo working directory could shadow the extracted
+    # package), but it does need CI/Retry.ps1 -- and actions/checkout DELETES
+    # the contents of a workspace that is not already a git repo, so running it
+    # after "Download Windows package" would take the package with it.
+    #
+    # Non-cone mode is required: cone mode always adds the top-level files,
+    # pyproject.toml among them, which is exactly the shadowing this job avoids.
+    - name: Fetch the CI retry helper
+      uses: actions/checkout@v4
+      with:
+        sparse-checkout: CI
+        sparse-checkout-cone-mode: false
+
     - name: Download Windows package
       uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/build-pip.yml
+++ b/.github/workflows/build-pip.yml
@@ -654,6 +654,20 @@ jobs:
     timeout-minutes: 30
 
     steps:
+    # Runs FIRST, before any artifact download: this job has no source
+    # checkout by design (a repo working directory could shadow the installed
+    # package), but it does need CI/Retry.ps1 -- and actions/checkout DELETES
+    # the contents of a workspace that is not already a git repo, so running it
+    # after "Download Windows wheels" would take the wheels with it.
+    #
+    # Non-cone mode is required: cone mode always adds the top-level files,
+    # pyproject.toml among them, which is exactly the shadowing this job avoids.
+    - name: Fetch the CI retry helper
+      uses: actions/checkout@v4
+      with:
+        sparse-checkout: CI
+        sparse-checkout-cone-mode: false
+
     - name: Set up Python
       uses: actions/setup-python@v5
       with:

--- a/CI/Retry.ps1
+++ b/CI/Retry.ps1
@@ -22,9 +22,17 @@
 
 [CmdletBinding()]
 param(
+    # Named-only, and that is load-bearing. An advanced function makes every
+    # parameter positional in declaration order unless something claims a
+    # position, so `Retry.ps1 choco install ...` bound "choco" to -Attempts and
+    # died with "Cannot convert value \"choco\" to type System.Int32". Giving
+    # -Command the explicit Position 0 leaves these two reachable by name only,
+    # so both call shapes work: with and without -Attempts/-DelaySeconds.
+    [Parameter()]
     [int]$Attempts = 3,
+    [Parameter()]
     [int]$DelaySeconds = 5,
-    [Parameter(ValueFromRemainingArguments = $true)]
+    [Parameter(Position = 0, ValueFromRemainingArguments = $true)]
     [string[]]$Command
 )
 


### PR DESCRIPTION
Follow-up to #1031, which fixed the `--` binding bug in `CI/Retry.ps1`. That fix let `Test Windows wheels` actually run for the first time, and it failed in 11 seconds:

```
The argument 'CI/Retry.ps1' is not recognized as the name of a script file.
```

`test-wheels-windows` (build-pip.yml) and `test-windows` (build-packages.yml) both call `CI/Retry.ps1`, but neither job has a checkout step, so the helper is not on disk. This shipped with the helper itself and stayed invisible because the build job upstream failed first — neither test job ever reached its WinFsp step.

Neither job checks out the source **on purpose**: they install the built artifact and test it in isolation, and a repo tree in the working directory could shadow the very package under test. So this pulls in `CI/` and nothing else.

Two details that are easy to get wrong, both verified rather than assumed:

- **The step must run first, before the artifact download.** `actions/checkout` deletes the contents of a workspace that is not already a git repo — placing it after `Download Windows wheels` would delete the wheels it exists to help test. (My first attempt did exactly that.)
- **Non-cone mode is required.** Cone mode always adds the top-level files, `pyproject.toml` among them, which is precisely the shadowing these jobs avoid. Checked against a scratch repo: `git sparse-checkout set --no-cone CI` yields `CI/Retry.ps1` and `CI/retry.sh` alone — no root files, no source tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U95XdU4TKKpSsDN9JJH4Nu