### PR TITLE
Serve HDF5 VFD reads from the CLIO cache tier

### DIFF
--- a/context-transfer-engine/adapter/clio_coherence_stamp.h
+++ b/context-transfer-engine/adapter/clio_coherence_stamp.h
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved. BSD 3-Clause license.
+ *
+ * Coherence-stamp primitives shared by the HDF5 VOL and VFD connectors.
+ *
+ * Coherence asks whether the tier's copy still corresponds to the authoritative
+ * native file -- a different question from residency, which asks only whether
+ * the bytes are present. Only an adapter can answer it, because only it knows
+ * which POSIX file a cache entry stands for.
+ *
+ * Shared because two copies would drift, and drift here does not fail loudly:
+ * it leaves a tier answering for a file it can no longer vouch for.
+ *
+ * The layout-version prefix is NOT shared. It guards "the tier's representation
+ * changed", and the two connectors store bytes differently, so each prefixes
+ * the identity with its own and bumps it when its layout changes. That is the
+ * one staleness file identity cannot catch: a tier populated under a different
+ * layout reads back hole-zeros while the file is unchanged.
+ */
+#ifndef CLIO_ADAPTER_COHERENCE_STAMP_H_
+#define CLIO_ADAPTER_COHERENCE_STAMP_H_
+
+#include <sys/stat.h>
+
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <string>
+
+namespace clio::adapter::stamp {
+
+/* Modification time, split into seconds and nanoseconds.
+ *
+ * `struct stat` disagrees across platforms: glibc names the timespec member
+ * st_mtim, Darwin st_mtimespec, and MSVC has no sub-second member at all. The
+ * halves stay separate because the stamp embeds them as "<sec>.<nsec>", and
+ * that text is compared against stamps already stored in a tier. */
+inline void StatMtime(const struct stat &st, long long *sec, long long *nsec) {
+#if defined(_WIN32)
+  /* No sub-second field exists; see GranularityNs, which widens the ambiguity
+     window to match this coarser clock. */
+  *sec = static_cast<long long>(st.st_mtime);
+  *nsec = 0;
+#elif defined(__APPLE__)
+  *sec = static_cast<long long>(st.st_mtimespec.tv_sec);
+  *nsec = static_cast<long long>(st.st_mtimespec.tv_nsec);
+#else
+  *sec = static_cast<long long>(st.st_mtim.tv_sec);
+  *nsec = static_cast<long long>(st.st_mtim.tv_nsec);
+#endif
+}
+
+/* Wall-clock now, in nanoseconds. system_clock rather than clock_gettime:
+ * MSVC has neither the function nor the macro, and this cannot fail, so
+ * callers need no "clock unreadable" arm. */
+inline long long RealtimeNowNs() {
+  return static_cast<long long>(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(
+          std::chrono::system_clock::now().time_since_epoch())
+          .count());
+}
+
+/* Width of the window in which mtime cannot discriminate a later write.
+ *
+ * Filesystem timestamps are coarse -- the kernel stamps an inode on a tick, so
+ * two writes inside one tick get identical mtimes. There is no portable way to
+ * ask a filesystem for this number, so it is a bound, not a measurement: too
+ * large costs cache misses, too small costs correctness. The default covers
+ * HZ=1000 and HZ=250, and does NOT cover second-granularity timestamps (some
+ * NFS mounts, FAT); raise it there.
+ *
+ * A property of the filesystem rather than of a connector, so one knob governs
+ * both. CLIO_VOL_STAMP_GRANULARITY_NS is still honoured as the documented
+ * name. */
+inline uint64_t GranularityNs() {
+  static const uint64_t g = []() -> uint64_t {
+    const char *e = std::getenv("CLIO_STAMP_GRANULARITY_NS");
+    if (e == nullptr || *e == '\0') {
+      e = std::getenv("CLIO_VOL_STAMP_GRANULARITY_NS");
+    }
+    if (e != nullptr && *e != '\0') {
+      char *end = nullptr;
+      unsigned long long v = std::strtoull(e, &end, 10);
+      if (end != e && *end == '\0') return static_cast<uint64_t>(v);
+    }
+#if defined(_WIN32)
+    /* Windows' stat() reports mtime in whole seconds (and only to two on a
+       FAT-formatted volume), so a 10 ms granule would call a file unambiguous
+       whose very next write lands in the same reported second -- exactly the
+       case this check exists to refuse. One second is the smallest default that
+       still fails closed there. */
+    return 1000ull * 1000ull * 1000ull; /* 1 s */
+#else
+    return 10ull * 1000ull * 1000ull; /* 10 ms */
+#endif
+  }();
+  return g;
+}
+
+/* Identity + state of the native file, WITHOUT a layout-version prefix -- the
+   caller prepends its own.
+
+   dev/ino catch the file being replaced (a new inode at the same path:
+   h5repack, rsync, mv); size and mtime catch modification in place. Empty when
+   the file cannot be stat'd, which callers must treat as "cannot vouch for
+   this" rather than as a comparable value. */
+inline std::string FileIdentity(const char *path) {
+  struct stat st;
+  if (!path || stat(path, &st) != 0) return std::string();
+  long long mtime_sec = 0, mtime_nsec = 0;
+  StatMtime(st, &mtime_sec, &mtime_nsec);
+  return std::to_string(static_cast<unsigned long long>(st.st_dev)) + ":" +
+         std::to_string(static_cast<unsigned long long>(st.st_ino)) + ":" +
+         std::to_string(static_cast<unsigned long long>(st.st_size)) + ":" +
+         std::to_string(mtime_sec) + "." + std::to_string(mtime_nsec);
+}
+
+/* Can this file's mtime still discriminate a LATER modification?
+ *
+ * For an in-place, same-size edit mtime is the only signal -- dev, ino and size
+ * are unchanged by definition. So a file whose mtime is younger than one
+ * granule would produce an identical stamp after a write landing right now.
+ *
+ * True means "cannot tell": the caller must WITHHOLD the stamp so the next open
+ * fails closed. */
+inline bool Ambiguous(const char *path) {
+  struct stat st;
+  if (!path || stat(path, &st) != 0) return true;
+  long long mtime_sec = 0, mtime_nsec = 0;
+  StatMtime(st, &mtime_sec, &mtime_nsec);
+  const int64_t now_ns = static_cast<int64_t>(RealtimeNowNs());
+  const int64_t mtime_ns = static_cast<int64_t>(mtime_sec) * 1000000000LL +
+                           static_cast<int64_t>(mtime_nsec);
+  /* A negative age means the mtime is in the future (clock skew, or a network
+     filesystem stamping from a different host). Nothing can be concluded from
+     it, so it is ambiguous too. */
+  const int64_t age_ns = now_ns - mtime_ns;
+  return age_ns < 0 || static_cast<uint64_t>(age_ns) < GranularityNs();
+}
+
+}  // namespace clio::adapter::stamp
+
+#endif  // CLIO_ADAPTER_COHERENCE_STAMP_H_

--- a/context-transfer-engine/adapter/hdf5_vol/clio_vol.cc
+++ b/context-transfer-engine/adapter/hdf5_vol/clio_vol.cc
@@ -23,6 +23,7 @@
  */
 
 #include "clio_vol.h"
+#include "adapter/clio_coherence_stamp.h"
 
 #include <H5PLextern.h>     /* H5PLget_plugin_type / H5PLget_plugin_info */
 #ifdef H5_HAVE_PARALLEL
@@ -932,66 +933,12 @@ static void clio_resolve_config(hid_t fapl_id, size_t *chunk_size,
    which HDF5 always renders with a leading '/'. */
 static constexpr const char *kStampBlobName = "__clio_coherence_stamp";
 
-/* The file's modification time, split into whole seconds and nanoseconds.
- *
- * `struct stat` does not agree across the platforms this connector builds on:
- * POSIX-2008 (and glibc) names the timespec member st_mtim, Darwin predates
- * that name and calls the same member st_mtimespec, and MSVC's struct stat has
- * no sub-second member at all -- only st_mtime, in whole seconds. Reading
- * st_mtim unconditionally is what stopped this file compiling anywhere but
- * glibc; every use goes through here instead.
- *
- * Callers keep the two halves separate rather than taking a single nanosecond
- * count, because the stamp string embeds them as "<sec>.<nsec>" and that text
- * is compared against stamps already stored in a tier. */
-static void clio_stat_mtime(const struct stat &st, long long *sec,
-                            long long *nsec) {
-#if defined(_WIN32)
-  /* No sub-second field exists; see clio_stamp_granularity_ns, which widens the
-     ambiguity window to match this coarser clock. */
-  *sec = static_cast<long long>(st.st_mtime);
-  *nsec = 0;
-#elif defined(__APPLE__)
-  *sec = static_cast<long long>(st.st_mtimespec.tv_sec);
-  *nsec = static_cast<long long>(st.st_mtimespec.tv_nsec);
-#else
-  *sec = static_cast<long long>(st.st_mtim.tv_sec);
-  *nsec = static_cast<long long>(st.st_mtim.tv_nsec);
-#endif
-}
-
-/* Wall-clock now, in nanoseconds since the epoch.
- *
- * std::chrono::system_clock rather than clock_gettime(CLOCK_REALTIME): MSVC has
- * neither the function nor the macro, and system_clock is the same wall clock
- * on every implementation this builds against. It also cannot fail, so callers
- * need no "clock unreadable" arm. */
-static long long clio_realtime_now_ns() {
-  return static_cast<long long>(
-      std::chrono::duration_cast<std::chrono::nanoseconds>(
-          std::chrono::system_clock::now().time_since_epoch())
-          .count());
-}
-
-/* Identity + state of the native file, as a string. dev/ino catch the file
-   being replaced (a new inode at the same path -- h5repack, rsync, mv); size
-   and mtime catch it being modified in place.
-
-   The leading "2:" is the cache-layout version. A tier populated under a
-   different blob layout reads back hole-zeros while the file itself is
-   unchanged -- the one staleness file identity cannot catch -- so any layout
-   change must bump this and let the mismatch drop the tag. */
+/* "2:" is this connector's cache-layout version -- bump it when the blob
+   layout changes, so the mismatch drops the tag. */
 static std::string clio_file_stamp(const char *path) {
-  struct stat st;
-  if (!path || stat(path, &st) != 0) return std::string();
-  long long mtime_sec = 0, mtime_nsec = 0;
-  clio_stat_mtime(st, &mtime_sec, &mtime_nsec);
-  return std::string("2:") +
-         std::to_string(static_cast<unsigned long long>(st.st_dev)) + ":" +
-         std::to_string(static_cast<unsigned long long>(st.st_ino)) + ":" +
-         std::to_string(static_cast<unsigned long long>(st.st_size)) + ":" +
-         std::to_string(mtime_sec) + "." +
-         std::to_string(mtime_nsec);
+  const std::string id = clio::adapter::stamp::FileIdentity(path);
+  if (id.empty()) return std::string();
+  return std::string("2:") + id;
 }
 
 /* Does the stored stamp still describe this file? Anything but kMatched means
@@ -1025,78 +972,6 @@ static clio::trace::Stamp clio_stamp_matches(
                        : clio::trace::Stamp::kMismatched;
 }
 
-/* Width of the window in which mtime cannot discriminate, in nanoseconds.
- *
- * Filesystem timestamps are coarse: the kernel stamps an inode from a clock it
- * samples on a tick, so two writes inside one tick get byte-identical mtimes.
- * Measured on ext4-over-overlayfs here: consecutive in-place writes report
- * deltas of either exactly 0 or ~1.00002 ms, never anything between -- a 1 ms
- * granule at HZ=1000.
- *
- * There is no portable way to ASK a filesystem for this number (clock_getres
- * describes the clock, not the inode), so this is a bound rather than a
- * measurement. Too large costs cache misses; too small costs correctness, so
- * the default is deliberately several granules wide and covers the common
- * cases (HZ=1000 -> 1 ms, HZ=250 -> 4 ms). It does NOT cover a filesystem with
- * second-granularity timestamps (some NFS mounts, FAT); raise it there, and
- * consider that such a filesystem is where storing a content hash at close
- * starts to earn its cost. */
-static uint64_t clio_stamp_granularity_ns() {
-  static const uint64_t g = []() -> uint64_t {
-    if (const char *e = std::getenv("CLIO_VOL_STAMP_GRANULARITY_NS")) {
-      if (*e != '\0') {
-        char *end = nullptr;
-        unsigned long long v = std::strtoull(e, &end, 10);
-        if (end != e && *end == '\0') return static_cast<uint64_t>(v);
-      }
-    }
-#if defined(_WIN32)
-    /* Windows' stat() reports mtime in whole seconds (and only to two on a
-       FAT-formatted volume), so a 10 ms granule would call a file unambiguous
-       whose very next write lands in the same reported second -- exactly the
-       case this check exists to refuse. One second is the smallest default that
-       still fails closed there. */
-    return 1000ull * 1000ull * 1000ull;  /* 1 s */
-#else
-    return 10ull * 1000ull * 1000ull;  /* 10 ms */
-#endif
-  }();
-  return g;
-}
-
-/* Can this file's mtime still discriminate a LATER modification?
- *
- * The stamp's only signal for an in-place, same-size edit is mtime: dev, ino
- * and size are unchanged by definition. So if the file's mtime is younger than
- * one timestamp granule, a write happening right now would land in the same
- * granule and produce an identical stamp -- and the next open would conclude
- * "unchanged" about a file that changed. That is the corrupt-checksum parity
- * case: it passed or failed purely on whether the test's write happened to
- * cross a tick boundary, which is why it looked flaky rather than broken.
- *
- * True means "cannot tell", and the caller withholds the stamp so the next
- * open fails closed -- the same rule the rest of the stamp path follows, where
- * absent, unreadable and unstattable all mean do-not-trust. */
-static bool clio_stamp_ambiguous(const char *path) {
-  struct stat st;
-  if (!path || stat(path, &st) != 0) return true;
-  long long mtime_sec = 0, mtime_nsec = 0;
-  clio_stat_mtime(st, &mtime_sec, &mtime_nsec);
-  const int64_t now_ns = static_cast<int64_t>(clio_realtime_now_ns());
-  const int64_t mtime_ns = static_cast<int64_t>(mtime_sec) * 1000000000LL +
-                           static_cast<int64_t>(mtime_nsec);
-  /* A negative age means the mtime is in the future (clock skew, or a network
-     filesystem stamping from a different host). Nothing can be concluded from
-     it, so it is ambiguous too. */
-  const int64_t age_ns = now_ns - mtime_ns;
-  return age_ns < 0 ||
-         static_cast<uint64_t>(age_ns) < clio_stamp_granularity_ns();
-}
-
-/* Record the file's current identity as consistent with the cache. Called
-   AFTER the native close, so size and mtime are final -- stamping before it
-   would record a state the file has not reached yet and the next open would
-   reject a cache that is actually good. */
 static void clio_write_stamp(clio::cte::core::Client *cte_client,
                              const clio::cte::core::TagId &tag_id,
                              const char *path, clio::trace::FileTrace *ft) {
@@ -1107,7 +982,7 @@ static void clio_write_stamp(clio::cte::core::Client *cte_client,
      instead, which makes the next open see kAbsent and fail closed
      deterministically -- rather than leaving an older stamp whose mismatch
      happens to produce the same outcome for a different reason. */
-  if (clio_stamp_ambiguous(path)) {
+  if (clio::adapter::stamp::Ambiguous(path)) {
     clio::trace::record_stamp(ft, clio::trace::Stamp::kAmbiguous);
     auto del = cte_client->AsyncDelBlob(tag_id, std::string(kStampBlobName));
     del.Wait();
@@ -1142,10 +1017,9 @@ static void clio_write_stamp(clio::cte::core::Client *cte_client,
                                       kCliovolPutFlags);
   put.Wait();  /* the stamp must land before the tag is reused */
   if (put->GetReturnCode() != 0) {
-    /* Checked, and loudly. An unchecked failure here is invisible at the moment
-       it happens and reappears later as "the cache stopped working", because
-       the next open finds no stamp, fails closed and drops a tag that was
-       perfectly good. That is exactly how this defect hid. */
+    /* Loudly: unchecked, this is invisible now and resurfaces later as "the
+       cache stopped working", when the next open finds no stamp, fails closed
+       and drops a tag that was perfectly good. */
     HLOG(kWarning, "clio-vol: coherence stamp for {} failed to store (rc={}); "
                    "the cache will be dropped on the next open",
          path, put->GetReturnCode());
@@ -1249,15 +1123,10 @@ static bool clio_file_bind_tag(clio_file_t *file) {
   }
   file->tag_id = tag_task->tag_id_;
 
-  /* Coherence check. A tag we did not just create may describe a file that
-     changed on disk while this connector was not watching, and the cache must
-     not answer for it -- serving a pre-change copy would mask the file's own
-     state, including its errors. Compare the stamp written at the last close
-     against the file as it is now; anything but an exact match drops the tag,
-     the same response H5F_ACC_TRUNC gets above.
-
-     Skipped when we just truncated: the tag is empty, so there is nothing to
-     be stale. */
+  /* A tag we did not just create may describe a file that changed on disk
+     while this connector was not watching; serving a pre-change copy would
+     mask the file's own state, including its errors. Anything but an exact
+     match drops the tag. Skipped after a truncate: the tag is already empty. */
   const clio::trace::Stamp verdict =
       truncated ? clio::trace::Stamp::kAbsent
                 : clio_stamp_matches(cte_client, file->tag_id,

--- a/context-transfer-engine/adapter/vfd/H5FDclio.cc
+++ b/context-transfer-engine/adapter/vfd/H5FDclio.cc
@@ -58,6 +58,7 @@
 #include "H5PLextern.h"
 #include "adapter/clio_config_str.h"
 #include "adapter/clio_require_runtime.h"
+#include "adapter/clio_coherence_stamp.h"
 #include "H5FDclio_trace.h"
 #include <clio_cte/filesystem/filesystem_client.h>
 #include "clio_cte/core/core_client.h"
@@ -96,6 +97,42 @@ unsigned long H5FDclio_vec_max_span_g = 0;
  * it holds and does not -- the stale-data hazard any read tier has to contain.
  * Exported (not static) so tests can assert on them. */
 unsigned long H5FDclio_cache_write_failures_g = 0;
+/* Reads served from the tier, and reads that fell through to the native file.
+ * Both are needed: a cache that is off and one that never hits are otherwise
+ * indistinguishable -- same bytes, same success. */
+unsigned long H5FDclio_cache_read_hits_g = 0;
+unsigned long H5FDclio_cache_read_misses_g = 0;
+/* Cached copies dropped because the file changed underneath them. Distinct
+ * from a read miss: a workload that invalidates on every open is paying to
+ * populate a cache it can never use. */
+unsigned long H5FDclio_cache_stale_invalidations_g = 0;
+
+/* Also governs the coherence stamp: coherence exists only to make the read
+ * tier safe, so with the tier off, validating and stamping is pure cost. Safe
+ * to skip -- a session that never stamps leaves none, and the next open that
+ * cares fails closed. */
+static bool H5FD__clio_read_tier_on() {
+  static const bool on = [] {
+    const char *e = getenv("CLIO_VFD_READ_TIER");
+    return e != nullptr && *e != '\0' && *e != '0';
+  }();
+  return on;
+}
+
+/* An xattr on the TIER's copy, so it travels with the cached bytes and is
+   dropped with them. Never on the native file: this driver must leave the
+   authoritative image exactly as a native writer would. */
+static constexpr const char *H5FD_CLIO_STAMP_XATTR = "user.clio.coherence";
+
+/* "1:" is this connector's cache-layout version -- bump it when the CFS page
+   layout changes, so old cached bytes are invalidated. Empty when the file
+   cannot be stat'd, which callers treat as "no verdict". */
+static std::string H5FD__clio_stamp_of(const char *native_path) {
+  const std::string id = clio::adapter::stamp::FileIdentity(native_path);
+  if (id.empty()) return std::string();
+  return std::string("1:") + id;
+}
+
 unsigned long H5FDclio_cache_truncate_failures_g = 0;
 
 /* Push a driver error onto HDF5's default error stack. Callbacks still return
@@ -444,6 +481,14 @@ typedef struct H5FD_clio_t {
    * index on Windows, where st_ino is always 0. See H5FDclio_compat.h. */
   clio_vfd_file_id_t file_id;
   clio::vfdtrace::FileTrace *trace; /* byte-altitude telemetry; null when off */
+  /* May the tier answer for this file? Decided once at open; default-refuse. */
+  bool tier_coherent;
+  /* The tier copy may be incomplete (a populate, truncate, invalidation or
+     cache close failed), so it must not be stamped. */
+  bool cache_degraded;
+  /* Identity at open, NULL if unstattable. Compared at close so a file that
+     changed underneath the session is not stamped over stale cached bytes. */
+  char *open_stamp_;
 } H5FD_clio_t;
 
 /* Was this file opened with write intent? H5F_ACC_RDWR is what open() keyed
@@ -749,15 +794,86 @@ static H5FD_t *H5FD__clio_open(const char *name, unsigned flags,
     return nullptr;
   }
 
-  // CTE cache handle: populated on write, not yet served on reads. Opening it
-  // is best-effort -- the authoritative native file already succeeded, so a
-  // cache-open failure must not sink the open; fd == -1 just means "no cache
-  // this session".
+  // CTE cache handle. Best-effort: the authoritative file is already open, so
+  // a cache-open failure must not sink this one -- fd == -1 just means no
+  // cache this session.
+  //
+  // O_RDWR|O_CREAT regardless of the application's flags: the tier copy is
+  // ours, and a read-only HDF5 open must still be able to create it, stamp it,
+  // and populate on a miss. O_TRUNC is preserved.
   int fd = -1;
 #if H5FD_CLIO_HAVE_CACHE_TIER
   if (fa.cache_enabled) {
-    fd = CLIO_CFS_CLIENT->OpenFd(name, o_flags, H5FD_CLIO_POSIX_CREATE_MODE_RW);
+    int cache_flags = (o_flags & ~O_ACCMODE) | O_RDWR | O_CREAT;
+    fd = CLIO_CFS_CLIENT->OpenFd(name, cache_flags,
+                                 H5FD_CLIO_POSIX_CREATE_MODE_RW);
     HLOG(kDebug, "");
+  }
+#endif
+
+  // Coherence gate. The tier may only answer for this file if the stamp taken
+  // at its last close still describes the file as it is NOW. Anything else --
+  // mismatch, no stamp, unstattable -- means the cached copy cannot be vouched
+  // for, so it is dropped and this session starts with an empty tier.
+  //
+  // Gated on a cache handle actually existing. Every step here is a CFS RPC,
+  // and where no filesystem pool is composed those go to a pool that is not
+  // there: issuing them before knowing a handle could be had is what wedged
+  // the compat suite, whose runtime composes only bdev + cte_core. fd >= 0 is
+  // the proof that the pool answered.
+  //
+  // A truncating open skips the check: O_TRUNC already emptied the tier copy,
+  // so there is nothing left to be stale.
+  bool tier_coherent = false;
+  bool cache_degraded = false;
+#if H5FD_CLIO_HAVE_CACHE_TIER
+  if (fd >= 0 && H5FD__clio_read_tier_on()) {
+    if (o_flags & O_TRUNC) {
+      // OpenFd fires its own truncate for O_TRUNC but discards the result and
+      // still hands back a valid fd, so "the tier copy is empty" was an
+      // assumption. Do it explicitly and check: if the previous file's pages
+      // survive, marking the tier coherent would serve them.
+      if (CLIO_CFS_CLIENT->FtruncateFd(fd, 0) == 0) {
+        tier_coherent = true;
+      } else {
+        cache_degraded = true;
+      }
+    } else {
+      const std::string want = H5FD__clio_stamp_of(native_path.c_str());
+      auto got = CLIO_CFS_CLIENT->AsyncGetxattr(name, H5FD_CLIO_STAMP_XATTR);
+      got.Wait();
+      const bool have = got->GetReturnCode() == 0 && got->found_ == 1;
+      // want.empty() means the file could not be stat'd: no verdict is
+      // possible, so refuse rather than compare against nothing.
+      tier_coherent = have && !want.empty() && got->value_.str() == want;
+      if (!tier_coherent) {
+        // Drop the cached copy and take a fresh handle on the empty one. This
+        // removes only the tier's pages and xattrs -- CFS is a blob-backed
+        // namespace with no native backing, so it cannot touch the user's
+        // file.
+        //
+        // The drop is CHECKED, not assumed. If it fails the stale pages
+        // survive, and while this session is safe (it will not read them), its
+        // close must not stamp -- a stamp would tell the NEXT session that a
+        // tier still holding pre-change pages describes the file.
+        CLIO_CFS_CLIENT->CloseFd(fd);
+        const int rc = CLIO_CFS_CLIENT->RemovePath(name);
+        H5FDclio_cache_stale_invalidations_g++;
+        fd = CLIO_CFS_CLIENT->OpenFd(name,
+                                     (o_flags & ~O_ACCMODE) | O_RDWR | O_CREAT,
+                                     H5FD_CLIO_POSIX_CREATE_MODE_RW);
+        if (rc == 0 && fd >= 0) {
+          // The copy really is gone and the handle really is fresh, so the
+          // tier is empty and consistent with the file: this session may use
+          // it. Without this the session paid read-through on every miss with
+          // no possibility of a hit -- and since a file's first open never
+          // has a stamp, that was the common case.
+          tier_coherent = true;
+        } else {
+          cache_degraded = true;
+        }
+      }
+    }
   }
 #endif
 
@@ -801,6 +917,12 @@ static H5FD_t *H5FD__clio_open(const char *name, unsigned flags,
 
   /* Pack file */
   file->filename_ = strdup(name);
+  file->tier_coherent = tier_coherent;
+  file->cache_degraded = cache_degraded;
+  {
+    const std::string ident = H5FD__clio_stamp_of(native_path.c_str());
+    file->open_stamp_ = ident.empty() ? nullptr : strdup(ident.c_str());
+  }
   if (!file->filename_) {
     errno = ENOMEM;
     H5FD_CLIO_ERROR("strdup() of file name failed");
@@ -872,12 +994,59 @@ static herr_t H5FD__clio_close(H5FD_t *_file) {
   // process is already running its exit handlers, in which case the client
   // that would service the close no longer has a receive thread and the wait
   // never returns. The handle goes down with the process.
+  //
+  // Closed before the stamp is decided: CloseFd is the only place a deferred
+  // CFS write failure surfaces, since deferred writes report success at submit.
 #if H5FD_CLIO_HAVE_CACHE_TIER
-  if (H5FD__clio_cache_live(file->fd)) {
-    CLIO_CFS_CLIENT->CloseFd(file->fd);
+  const bool cache_live = H5FD__clio_cache_live(file->fd);
+  if (cache_live) {
+    if (CLIO_CFS_CLIENT->CloseFd(file->fd) != 0) {
+      file->cache_degraded = true;
+    }
     HLOG(kDebug, "");
   }
+  file->fd = -1;
+
+  // Stamp only what this session can vouch for. Withheld when the cached copy
+  // may be incomplete (degraded), when the file moved underneath the session --
+  // stamping the new identity over a tier holding the old bytes is the exact
+  // staleness this prevents -- or when mtime is too young to discriminate a
+  // later write. Taken after the native fsync/close above, so the mtime it
+  // embeds is the one the file will keep.
+  //
+  // Skipped entirely once exit handlers are running: these are blocking CFS
+  // calls, and a client being torn down can no longer answer them.
+  if (cache_live && file->filename_ != nullptr && H5FD__clio_read_tier_on()) {
+    const std::string now = H5FD__clio_stamp_of(file->filename_);
+    const bool changed = file->open_stamp_ == nullptr || now.empty() ||
+                         now != std::string(file->open_stamp_);
+    const std::string stamp =
+        (file->cache_degraded || changed ||
+         clio::adapter::stamp::Ambiguous(file->filename_))
+            ? std::string()
+            : now;
+    if (stamp.empty()) {
+      auto rm = CLIO_CFS_CLIENT->AsyncRemovexattr(
+          std::string(file->filename_), H5FD_CLIO_STAMP_XATTR);
+      rm.Wait();
+    } else {
+      // flags 0 = create-or-replace: a file opened, closed and reopened must
+      // overwrite its own previous stamp rather than fail with EEXIST.
+      auto set = CLIO_CFS_CLIENT->AsyncSetxattr(
+          std::string(file->filename_), H5FD_CLIO_STAMP_XATTR, stamp, 0);
+      set.Wait();
+      if (set->GetReturnCode() != 0) {
+        HLOG(kWarning,
+             "clio-vfd: coherence stamp for {} failed to store (rc={}); the "
+             "cached copy will be dropped on the next open",
+             file->filename_, set->GetReturnCode());
+      }
+    }
+  }
 #endif
+  if (file->open_stamp_) {
+    free(file->open_stamp_);
+  }
   if (file->filename_) {
     free(file->filename_);
   }
@@ -1030,6 +1199,34 @@ static herr_t H5FD__clio_do_read(H5FD_clio_t *file, haddr_t addr, size_t size,
     H5FD_CLIO_ERROR("read region is undefined or out of range");
     return FAIL;
   }
+  // Serve from the tier only when it holds the WHOLE range and this session's
+  // coherence check passed.
+  //
+  // TryReadShmResident rather than a plain CFS read: CFS zero-fills holes and
+  // reports a full read. Right for a filesystem; wrong here, where a range the
+  // tier does not hold is not zeros but bytes living in the native file.
+  //
+  // All-or-nothing per request: splitting a read between tier and file would
+  // mean tracking which half came from where on every failure path.
+#if H5FD_CLIO_HAVE_CACHE_TIER
+  if (H5FD__clio_read_tier_on() && file->tier_coherent && file->fd >= 0 &&
+      file->filename_ != nullptr) {
+    const ssize_t served = CLIO_CFS_CLIENT->TryReadShmResident(
+        file->filename_, static_cast<clio::run::u64>(addr), buf, size);
+    if (served == static_cast<ssize_t>(size)) {
+      H5FDclio_cache_read_hits_g++;
+      if (getenv("CLIO_VFD_DEBUG"))
+        fprintf(stderr, "[vfd] READ(tier) addr=%llu size=%llu\n",
+                (unsigned long long)addr, (unsigned long long)size);
+      return SUCCEED;
+    }
+    // A SHORT read is refused too, not stitched: the tier held only part of
+    // the range, and the rest is the file's. Fall through and take it all from
+    // the file rather than track a split.
+    H5FDclio_cache_read_misses_g++;
+  }
+#endif
+
   char *dst = static_cast<char *>(buf);
   size_t remaining = size;
   clio_vfd_off_t off = static_cast<clio_vfd_off_t>(addr);
@@ -1059,6 +1256,24 @@ static herr_t H5FD__clio_do_read(H5FD_clio_t *file, haddr_t addr, size_t size,
     off += got;
     remaining -= static_cast<size_t>(got);
   }
+  // Populate on a miss. Not an optimisation: a writing session's own close
+  // flushes the file, so its mtime is always fresh and its stamp always
+  // withheld -- a tier filled only by writes is never stamped, and so never
+  // readable. The open either matched the stamp or dropped the copy, so what
+  // is written here came from the file as it now stands.
+#if H5FD_CLIO_HAVE_CACHE_TIER
+  if (H5FD__clio_read_tier_on() && file->fd >= 0) {
+    if (CLIO_CFS_CLIENT->PwriteFd(file->fd, buf, size,
+                                  static_cast<off_t>(addr)) < 0) {
+      H5FDclio_cache_write_failures_g++;
+      // A populate that failed leaves a hole the tier does not know about, so
+      // this copy can no longer be vouched for as a whole. Counting it is not
+      // enough: without latching, close would still stamp it.
+      file->cache_degraded = true;
+    }
+  }
+#endif
+
   if (getenv("CLIO_VFD_DEBUG"))
     fprintf(stderr, "[vfd] READ  addr=%llu size=%llu\n",
             (unsigned long long)addr, (unsigned long long)size);

--- a/context-transfer-engine/core/include/clio_cte/core/autogen/core_methods.h
+++ b/context-transfer-engine/core/include/clio_cte/core/autogen/core_methods.h
@@ -71,7 +71,19 @@ GLOBAL_CROSS_CONST clio::run::u32 kMultiPutBlob = 48;
 // registered node's copy (write-invalidate) before completing.
 GLOBAL_CROSS_CONST clio::run::u32 kRegisterReplicaContainer = 49;
 
-GLOBAL_CROSS_CONST clio::run::u32 kMaxMethodId = 50;
+/**
+ * Residency (issue #980 follow-on / VFD_VOL_PLAN §1): "is this byte range
+ * actually PRESENT in the tier, or a hole the tier would silently zero-fill?"
+ *
+ * Distinct from coherence, which asks whether the tier's copy still matches
+ * the authoritative native file — only an adapter can answer that, because
+ * only it knows which POSIX file a tag stands for. Residency is the opposite:
+ * only the TIER can answer it, which is why this is a chimod op and not
+ * per-adapter interval bookkeeping repeated in the VFD, the VOL and CFS.
+ */
+GLOBAL_CROSS_CONST clio::run::u32 kGetResidency = 50;
+
+GLOBAL_CROSS_CONST clio::run::u32 kMaxMethodId = 51;
 
 inline const std::vector<std::string>& GetMethodNames() {
   static const std::vector<std::string> names = [] {
@@ -115,6 +127,7 @@ inline const std::vector<std::string>& GetMethodNames() {
     v[47] = "Evict";
     v[48] = "MultiPutBlob";
     v[49] = "RegisterReplicaContainer";
+    v[50] = "GetResidency";
     return v;
   }();
   return names;

--- a/context-transfer-engine/core/include/clio_cte/core/core_client.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_client.h
@@ -3221,6 +3221,31 @@ class Client : public clio::run::ContainerClient {
    * @param blob_name Name of the blob
    * @param pool_query Pool query for task routing (default: Dynamic)
    */
+  /**
+   * Ask whether a byte range of a blob is physically present in the tier.
+   *
+   * Metadata only — it moves no payload, so it is far cheaper than the read
+   * it lets a caller avoid. The intended shape is: try the shared-memory
+   * path, and on a miss ask this rather than abandoning the whole request,
+   * because a miss in the SHM mirror does not distinguish a hole (zeros are
+   * correct) from bytes that exist but are only reachable by RPC.
+   *
+   * @param tag_id Tag owning the blob
+   * @param blob_name Blob name
+   * @param offset Start of the range of interest
+   * @param size Length of the range; 0 means "to the end of the blob"
+   */
+  clio::run::Future<GetResidencyTask> AsyncGetResidency(
+      const TagId &tag_id, const std::string &blob_name,
+      clio::run::u64 offset = 0, clio::run::u64 size = 0,
+      const clio::run::PoolQuery &pool_query = clio::run::PoolQuery::Dynamic()) {
+    auto *ipc_manager = CLIO_CPU_IPC;
+    auto task = ipc_manager->NewTask<GetResidencyTask>(
+        clio::run::CreateTaskId(), pool_id_, pool_query, tag_id, blob_name,
+        offset, size);
+    return ipc_manager->Send(task);
+  }
+
   clio::run::Future<DelBlobTask> AsyncDelBlob(
       const TagId &tag_id,
       const std::string &blob_name,

--- a/context-transfer-engine/core/include/clio_cte/core/core_runtime.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_runtime.h
@@ -817,6 +817,11 @@ private:
    */
   clio::run::TaskResume GetBlobSize(clio::run::shared_ptr<GetBlobSizeTask> &task);
 
+  /** Residency: is this byte range physically present in the tier?
+   *  See GetResidencyTask for why only the tier can answer this. */
+  clio::run::TaskResume GetResidency(
+      clio::run::shared_ptr<GetResidencyTask> &task);
+
   /**
    * Get contained blobs operation - returns all blob names in a tag
    * @param task GetContainedBlobs task containing tag ID and results

--- a/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
@@ -4033,6 +4033,125 @@ struct GetBlobSizeTask : public clio::run::Task {
 };
 
 /**
+ * Ask the tier whether a byte range of a blob is physically present.
+ *
+ * The question this exists to answer is the one a client CANNOT answer from
+ * its shared-memory mirror: a lookup miss there means "not in the mirror",
+ * which conflates "no such bytes exist" with "exists, but not reachable from
+ * here". Those need opposite responses — the first is a hole, where zeros are
+ * the correct data and no round trip is needed; the second requires the RPC
+ * path. Only the runtime is authoritative about which it is.
+ *
+ * Deliberately one operation, not a residency framework: it reports what the
+ * tier already knows from BlobInfo's block list and does not build, cache or
+ * maintain interval state of its own. Interval bookkeeping in a telemetry or
+ * lookup path is what this is meant to prevent, not introduce.
+ */
+struct GetResidencyTask : public clio::run::Task {
+  IN TagId tag_id_;                       // Tag owning the blob
+  IN clio::run::priv::string blob_name_;  // Blob name (required)
+  IN clio::run::u64 offset_;              // Start of the range of interest
+  IN clio::run::u64 size_;                // Length of the range, 0 = whole blob
+
+  /** 1 if the blob exists at all. 0 means a hole: zeros are the correct
+   *  answer for the range and the caller needs no further round trip. */
+  OUT clio::run::u32 exists_;
+  /** Bytes of the requested range physically present, counting from
+   *  `offset_`. Short of the request means the range runs off the end of what
+   *  is stored (a sparse write or an ftruncate-grow), and the remainder is a
+   *  hole.
+   *
+   *  Derived from the total of the blob's stored blocks, which the block list
+   *  represents in logical order with no per-block logical offset -- so this
+   *  is the length of the stored PREFIX, not a map of which sub-ranges exist.
+   *  A caller needing per-range detail inside a blob does not get it here. */
+  OUT clio::run::u64 present_bytes_;
+  /** 1 if a shared-memory read can serve the requested range: every block
+   *  covering it is on a directly-readable target AND the range lies inside
+   *  the prefix the SHM record actually describes. 0 means present but only
+   *  reachable through the RPC path — a file/remote/GPU tier, transformed
+   *  bytes, or a range past the record's cached prefix. */
+  OUT clio::run::u32 direct_readable_;
+
+  // SHM constructor
+  GetResidencyTask()
+      : clio::run::Task(),
+        tag_id_(TagId::GetNull()),
+        blob_name_(CLIO_PRIV_ALLOC),
+        offset_(0),
+        size_(0),
+        exists_(0),
+        present_bytes_(0),
+        direct_readable_(0) {}
+
+  // Emplace constructor
+  CTP_CROSS_FUN explicit GetResidencyTask(const clio::run::TaskId &task_id,
+                                          const clio::run::PoolId &pool_id,
+                                          const clio::run::PoolQuery &pool_query,
+                                          const TagId &tag_id,
+                                          const std::string &blob_name,
+                                          clio::run::u64 offset = 0,
+                                          clio::run::u64 size = 0)
+      : clio::run::Task(task_id, pool_id, pool_query, Method::kGetResidency),
+        tag_id_(tag_id),
+        blob_name_(CLIO_PRIV_ALLOC, blob_name),
+        offset_(offset),
+        size_(size),
+        exists_(0),
+        present_bytes_(0),
+        direct_readable_(0) {
+    task_id_ = task_id;
+    pool_id_ = pool_id;
+    method_ = Method::kGetResidency;
+    task_flags_.Clear();
+    pool_query_ = pool_query;
+  }
+
+  template <typename Archive>
+  CTP_CROSS_FUN void SerializeIn(Archive &ar) {
+    Task::SerializeIn(ar);
+    ar(tag_id_, blob_name_, offset_, size_);
+  }
+
+  template <typename Archive>
+  CTP_CROSS_FUN void SerializeOut(Archive &ar) {
+    Task::SerializeOut(ar);
+    ar(exists_, present_bytes_, direct_readable_);
+  }
+
+  void Copy(const ctp::ipc::FullPtr<GetResidencyTask> &other) {
+    Task::Copy(other.template Cast<Task>());
+    tag_id_ = other->tag_id_;
+    blob_name_ = other->blob_name_;
+    offset_ = other->offset_;
+    size_ = other->size_;
+    exists_ = other->exists_;
+    present_bytes_ = other->present_bytes_;
+    direct_readable_ = other->direct_readable_;
+  }
+
+  void AggregateOut(const ctp::ipc::FullPtr<clio::run::Task> &other_base) {
+    Task::AggregateOut(other_base);
+    // OUT fields ONLY -- never Copy() (issue #915): a whole-task assignment
+    // destroys this ORIGIN's identity and re-assigns IN shm members across
+    // allocator segments. See Task::AggregateOut for the full contract.
+    auto replica = other_base.template Cast<GetResidencyTask>();
+    // The blob lives on one container; non-owners answer 0 for all three, so
+    // max yields the owner's verdict for one replica and for many. exists_ and
+    // direct_readable_ are 0/1, where max is a logical OR.
+    if (replica->exists_ > exists_) {
+      exists_ = replica->exists_;
+    }
+    if (replica->present_bytes_ > present_bytes_) {
+      present_bytes_ = replica->present_bytes_;
+    }
+    if (replica->direct_readable_ > direct_readable_) {
+      direct_readable_ = replica->direct_readable_;
+    }
+  }
+};
+
+/**
  * Block information for GetBlobInfo response
  * Contains the target pool ID and size for each block
  */

--- a/context-transfer-engine/core/src/autogen/core_lib_exec.cc
+++ b/context-transfer-engine/core/src/autogen/core_lib_exec.cc
@@ -203,6 +203,11 @@ clio::run::TaskResume Runtime::Run(clio::run::u32 method, clio::run::shared_ptr<
       CLIO_CO_AWAIT(GetBlobScore(typed_task));
       break;
     }
+    case Method::kGetResidency: {
+      auto& typed_task = task_ptr.template Cast<GetResidencyTask>();
+      CLIO_CO_AWAIT(GetResidency(typed_task));
+      break;
+    }
     case Method::kGetBlobSize: {
       // Cast task FullPtr to specific type
       auto& typed_task = task_ptr.template Cast<GetBlobSizeTask>();
@@ -426,6 +431,11 @@ void Runtime::SaveTask(clio::run::u32 method, clio::run::SaveTaskArchive& archiv
       archive << *typed_task;
       break;
     }
+    case Method::kGetResidency: {
+      auto& typed_task = task_ptr.template Cast<GetResidencyTask>();
+      archive << *typed_task;
+      break;
+    }
     case Method::kGetBlobSize: {
       auto& typed_task = task_ptr.template Cast<GetBlobSizeTask>();
       archive << *typed_task;
@@ -628,6 +638,11 @@ void Runtime::LoadTask(clio::run::u32 method, clio::run::LoadTaskArchive& archiv
     }
     case Method::kGetBlobScore: {
       auto& typed_task = task_ptr.template Cast<GetBlobScoreTask>();
+      archive >> *typed_task;
+      break;
+    }
+    case Method::kGetResidency: {
+      auto& typed_task = task_ptr.template Cast<GetResidencyTask>();
       archive >> *typed_task;
       break;
     }
@@ -862,6 +877,12 @@ void Runtime::LocalLoadTask(clio::run::u32 method, clio::run::DefaultLoadArchive
     }
     case Method::kGetBlobScore: {
       auto& typed_task = task_ptr.template Cast<GetBlobScoreTask>();
+      // Use archive operator which respects msg_type
+      archive >> *typed_task;
+      break;
+    }
+    case Method::kGetResidency: {
+      auto& typed_task = task_ptr.template Cast<GetResidencyTask>();
       // Use archive operator which respects msg_type
       archive >> *typed_task;
       break;
@@ -1106,6 +1127,12 @@ void Runtime::LocalSaveTask(clio::run::u32 method, clio::run::DefaultSaveArchive
     }
     case Method::kGetBlobScore: {
       auto& typed_task = task_ptr.template Cast<GetBlobScoreTask>();
+      // Use archive operator which respects msg_type
+      archive << *typed_task;
+      break;
+    }
+    case Method::kGetResidency: {
+      auto& typed_task = task_ptr.template Cast<GetResidencyTask>();
       // Use archive operator which respects msg_type
       archive << *typed_task;
       break;
@@ -1480,6 +1507,17 @@ clio::run::shared_ptr<clio::run::Task> Runtime::NewCopyTask(clio::run::u32 metho
       }
       break;
     }
+    case Method::kGetResidency: {
+      // Allocate new task
+      auto new_task_ptr = ipc_manager->NewTask<GetResidencyTask>();
+      if (!new_task_ptr.IsNull()) {
+        // Copy task fields (includes base Task fields)
+        auto& task_typed = orig_task_ptr.template Cast<GetResidencyTask>();
+        new_task_ptr->Copy(ctp::ipc::FullPtr<GetResidencyTask>(task_typed.get()));
+        return new_task_ptr.template Cast<clio::run::Task>();
+      }
+      break;
+    }
     case Method::kGetBlobSize: {
       // Allocate new task
       auto new_task_ptr = ipc_manager->NewTask<GetBlobSizeTask>();
@@ -1724,6 +1762,10 @@ clio::run::shared_ptr<clio::run::Task> Runtime::NewTask(clio::run::u32 method) {
       auto new_task_ptr = ipc_manager->NewTask<GetBlobScoreTask>();
       return new_task_ptr.template Cast<clio::run::Task>();
     }
+    case Method::kGetResidency: {
+      auto new_task_ptr = ipc_manager->NewTask<GetResidencyTask>();
+      return new_task_ptr.template Cast<clio::run::Task>();
+    }
     case Method::kGetBlobSize: {
       auto new_task_ptr = ipc_manager->NewTask<GetBlobSizeTask>();
       return new_task_ptr.template Cast<clio::run::Task>();
@@ -1916,6 +1958,11 @@ void Runtime::AggregateOut(clio::run::u32 method, clio::run::shared_ptr<clio::ru
     }
     case Method::kGetBlobScore: {
       auto& typed_task = orig_task.template Cast<GetBlobScoreTask>();
+      typed_task->AggregateOut(ctp::ipc::FullPtr<clio::run::Task>(replica_task.get()));
+      break;
+    }
+    case Method::kGetResidency: {
+      auto& typed_task = orig_task.template Cast<GetResidencyTask>();
       typed_task->AggregateOut(ctp::ipc::FullPtr<clio::run::Task>(replica_task.get()));
       break;
     }

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -972,6 +972,16 @@ clio::run::PoolQuery Runtime::ScheduleTask(const clio::run::shared_ptr<clio::run
       auto typed = task.template Cast<GetBlobSizeTask>();
       return HashBlobToContainer(typed->tag_id_, typed->blob_name_.str());
     }
+    case Method::kGetResidency: {
+      // Blob-keyed, so it must reach the container that OWNS the blob.
+      // Without this the task fell to the default (the client's Dynamic
+      // query, resolved as LOCAL), and on more than one node a probe for a
+      // remotely-owned blob would find no BlobInfo and report exists_ = 0 --
+      // which a caller is entitled to read as "hole, zeros are correct".
+      // Absence is the one answer this op must never get wrong.
+      auto typed = task.template Cast<GetResidencyTask>();
+      return HashBlobToContainer(typed->tag_id_, typed->blob_name_.str());
+    }
     case Method::kRegisterReplicaContainer: {
       // Coherence registration must land on the blob's OWNER container —
       // that is whose next primary write performs the invalidation.
@@ -6231,6 +6241,7 @@ clio::run::TaskStat Runtime::GetTaskStats(const clio::run::Task *task) const {
       return stat;
     }
     case Method::kGetBlobSize:
+    case Method::kGetResidency:
     case Method::kGetOrCreateTag:
     case Method::kGetTagSize:
     case Method::kGetTagName:
@@ -7619,6 +7630,111 @@ clio::run::TaskResume Runtime::GetBlobScore(clio::run::shared_ptr<GetBlobScoreTa
          blob_info_ptr->score_);
 
   } catch (const std::exception &e) {
+    task->return_code_ = 1;
+  }
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
+clio::run::TaskResume Runtime::GetResidency(
+    clio::run::shared_ptr<GetResidencyTask> &task) {
+  CLIO_TASK_BODY_BEGIN
+  try {
+    TagId tag_id = task->tag_id_;
+    std::string blob_name = task->blob_name_.str();
+    if (blob_name.empty()) {
+      task->return_code_ = 1;
+      CLIO_CO_RETURN;
+    }
+
+    std::shared_ptr<BlobInfo> info = CheckBlobExists(blob_name, tag_id);
+    if (info == nullptr) {
+      // Absence is the ANSWER here, not a failure, so rc stays 0. This is the
+      // whole point of the op: a caller that cannot tell "no such bytes" from
+      // "cannot reach these bytes" has to assume the worst and take the slow
+      // path. exists_ = 0 says zeros are correct for this range.
+      task->exists_ = 0;
+      task->present_bytes_ = 0;
+      task->direct_readable_ = 0;
+      CLIO_CO_RETURN;
+    }
+    // Pin the extents before touching blocks_ (issue #753). This handler walks
+    // the block list twice -- once to total it, once inside
+    // BuildShmBlobRecord -- and an extent-freeing mutator on another worker
+    // (DelBlob, truncate, reorganize) may run concurrently: DelBlob documents
+    // the resulting use-after-free on exactly this list. Reading it unpinned
+    // was a torn read at best.
+    //
+    // Never wait while pinned: TryPinRead fails rather than blocks when a
+    // drainer is active, and yielding with a pin held would deadlock the
+    // drainer's poll for pins == 0.
+    while (!info->TryPinRead()) {
+      CLIO_CO_AWAIT(clio::run::yield(BlobWriteLockPollUs()));
+    }
+    BlobReadPinGuard residency_pin(info.get());
+
+    // Liveness re-check, and it MUST be after the pin (issue #753). The lookup
+    // above resolved a shared_ptr that keeps this BlobInfo alive even after a
+    // DelBlob has released the token, freed every extent and erased the name
+    // binding. Deciding existence before the pin leaves the whole delete free
+    // to complete in that window, and this op would then report exists_ = 1
+    // with an empty block list -- "the blob is real, your range just is not
+    // backed", when the truth is that it is gone.
+    //
+    // A deleted blob must read as ABSENT, which is the answer that actually
+    // helps a caller: it is the verdict that licenses zeros.
+    if (info->GetTotalSize() == 0) {
+      task->exists_ = 0;
+      task->present_bytes_ = 0;
+      task->direct_readable_ = 0;
+      CLIO_CO_RETURN;
+    }
+    task->exists_ = 1;
+
+    // Present bytes = the sum of the block sizes, i.e. what is physically
+    // stored. Deliberately NOT the blob's logical size: after a sparse write
+    // or an ftruncate-grow the logical span covers bytes that were never
+    // written, and reporting those as present is exactly the confusion this
+    // op exists to remove.
+    clio::run::u64 stored = 0;
+    for (size_t i = 0; i < info->blocks_.size(); ++i) {
+      stored += info->blocks_[i].size_;
+    }
+    const clio::run::u64 off = task->offset_;
+    if (off >= stored) {
+      task->present_bytes_ = 0;
+    } else {
+      const clio::run::u64 avail = stored - off;
+      clio::run::u64 want = task->size_;
+      if (want == 0 || want > avail) {
+        want = avail;  // 0 means "to the end"; a longer ask is clamped
+      }
+      task->present_bytes_ = want;
+    }
+
+    // Direct-readability is answered by BUILDING the mirror record and asking
+    // it, rather than re-deriving the rule. The rule is subtle (node-local RAM
+    // only, transformed bytes never qualify, unknown target refuses) and a
+    // second copy of it that drifts would make this op confidently wrong about
+    // the very path it exists to steer.
+    // direct_readable_ must be bounded by what the SHM record actually
+    // describes, not merely by the blob qualifying. A record is truncated at
+    // kMaxInlineBlocks, so IsDirectReadable() can be true while the cached
+    // blocks cover only a prefix -- and a caller told "a shared-memory read
+    // can serve this range" would then read past CoveredBytes(). The two
+    // fields are derived from different block sets (present_bytes_ from the
+    // blob, this from the record), so the narrower one has to win.
+    ShmBlobRecord rec;
+    task->direct_readable_ = 0;
+    if (BuildShmBlobRecord(*info, &rec) && rec.IsDirectReadable()) {
+      const clio::run::u64 covered = rec.CoveredBytes();
+      const clio::run::u64 end = task->offset_ + task->present_bytes_;
+      task->direct_readable_ = (task->present_bytes_ > 0 && end <= covered)
+                                   ? 1
+                                   : 0;
+    }
+  } catch (const std::exception &e) {
+    HLOG(kError, "GetResidency failed: {}", e.what());
     task->return_code_ = 1;
   }
   CLIO_CO_RETURN;

--- a/context-transfer-engine/filesystem/include/clio_cte/filesystem/filesystem_client.h
+++ b/context-transfer-engine/filesystem/include/clio_cte/filesystem/filesystem_client.h
@@ -1066,10 +1066,72 @@ class Client : public clio::cte::core::Client {
     return v;
   }
 
+  /**
+   * What a caller wants done about a byte range the tier does not hold.
+   *
+   * The two consumers need OPPOSITE answers from the same lookup, and getting
+   * it backwards is silent data corruption rather than an error:
+   *
+   *   kZeroFillHoles -- POSIX filesystem semantics. This client IS the
+   *     filesystem, so a range inside the file with nothing behind it was
+   *     never written and reads as zeros. Correct for CfsIo.
+   *
+   *   kRefuseHoles -- cache-over-authoritative semantics. The tier is a cache
+   *     in front of a file that holds the real bytes, so "not here" means "ask
+   *     the authoritative copy", NEVER "the answer is zeros". Correct for the
+   *     HDF5 VFD, which write-throughs to a native file.
+   */
+  enum class ShmHolePolicy { kZeroFillHoles, kRefuseHoles };
+
+  /**
+   * Read committed bytes from shared memory, refusing rather than inventing
+   * anything the tier does not hold. See ShmHolePolicy::kRefuseHoles.
+   *
+   * @return bytes read, or -1 meaning "not fast-pathable, use the
+   *         authoritative source" -- which for this policy also covers "some
+   *         of that range is not cached".
+   */
+  FsSsize TryReadShmResident(const std::string &path, clio::run::u64 off,
+                             void *buf, size_t count) {
+    return TryReadShmImpl(path, off, buf, count, ShmHolePolicy::kRefuseHoles);
+  }
+
   // FsSsize, not ssize_t: MSVC has no ssize_t, and this layer's whole
   // vocabulary was ported to FsSsize/FsOff so it builds on Windows.
   FsSsize TryReadShm(const std::string &path, clio::run::u64 off, void *buf,
                      size_t count) {
+    return TryReadShmImpl(path, off, buf, count, ShmHolePolicy::kZeroFillHoles);
+  }
+
+  FsSsize TryReadShmImpl(const std::string &path, clio::run::u64 off, void *buf,
+                         size_t count, ShmHolePolicy policy) {
+    // Read-your-own-writes, here rather than only in Read().
+    //
+    // CFS writes defer by default, and in-flight bytes are visible ONLY
+    // through this registry -- the page blob still holds the previously
+    // committed content until they land. Read() consults it before calling
+    // this function, so for that caller the check below costs an atomic load
+    // and returns 0. But TryReadShmResident is a PUBLIC entry point the VFD
+    // calls directly, and it never runs Read(): an in-place rewrite followed
+    // by a read in the same session would otherwise find the stale committed
+    // page, succeed, and hand back pre-write bytes. kShmFilePendingAppend does
+    // not cover it either, because an in-place rewrite is not an append.
+    //
+    // Depending on the caller for a correctness precondition is what made that
+    // reachable, so the function now establishes it itself.
+    const clio::run::u64 defer_key = FileKey(path);
+    const int served =
+        DeferTryServe(defer_key, off, static_cast<char *>(buf), count);
+    if (served > 0) {
+      // Fully covered by in-flight writes: those bytes ARE the current value.
+      return static_cast<FsSsize>(count);
+    }
+    if (served == -1) {
+      // Partial coverage: the bytes outside the in-flight writes are stale
+      // until those writes land, so this is the one case that has to wait.
+      DeferAwaitKey(defer_key);
+    }
+
     if (!ShmReadFastPathEnabled()) {
       return -1;
     }
@@ -1116,6 +1178,12 @@ class Client : public clio::cte::core::Client {
     char *dst = static_cast<char *>(buf);
     clio::run::u64 done = 0;
     clio::run::u64 cur = off;
+    // Bound on residency probes per request. Each probe is metadata-only and
+    // replaces a whole-request data RPC, so a few are a clear win -- but they
+    // are still round trips, and a heavily perforated range would spend more
+    // on asking than the single RPC it is trying to avoid. Past the bound,
+    // take the RPC, which answers everything in one go.
+    unsigned residency_probes = 0;
     while (done < want) {
       clio::run::u64 page_off = cur % kFsPageSize;
       clio::run::u64 to_read = kFsPageSize - page_off;
@@ -1125,10 +1193,44 @@ class Client : public clio::cte::core::Client {
       if (!cte->TryReadBlobShm(rec.tag_id_, PageName(cur), dst + done,
                                static_cast<size_t>(to_read),
                                static_cast<size_t>(page_off))) {
-        // Abandon the WHOLE request rather than mixing sources. A hole reads
-        // as zeros and a missing page is indistinguishable from an uncached
-        // one, so the only safe reading of a failure here is "let the runtime
-        // answer".
+        // A miss here used to abandon the WHOLE request, because "hole" and
+        // "cached elsewhere" were indistinguishable from this side and only
+        // one of them can be answered with zeros. GetResidency draws that
+        // distinction at the tier, which is the only place that knows it.
+        //
+        // Zeroing is correct for an absent page, and specifically here:
+        //   * the range is already clamped to the LOGICAL size above, so this
+        //     page lies inside the file, and a page inside the file with no
+        //     blob behind it was never written -- POSIX says zeros. This is
+        //     the same rule the runtime's own read path applies when it
+        //     pre-zeros before GetBlob.
+        //   * uncommitted writes cannot be hiding here. Read() serves or
+        //     awaits the deferred registry BEFORE calling this path, and
+        //     IsFastPathable() refuses a record carrying kShmFilePendingAppend.
+        //
+        // Anything other than a definite absence -- present but unreachable,
+        // or a failed probe -- still falls back, because those are exactly the
+        // cases where zeros would be wrong.
+        // kRefuseHoles: the authoritative copy has these bytes, so there is
+        // nothing to decide -- do not probe, do not invent, just refuse.
+        if (policy == ShmHolePolicy::kRefuseHoles) {
+          ShmReadMisses().fetch_add(1, std::memory_order_relaxed);
+          return -1;
+        }
+        if (residency_probes < kMaxResidencyProbes) {
+          ++residency_probes;
+          auto res = cte->AsyncGetResidency(rec.tag_id_, PageName(cur),
+                                            static_cast<clio::run::u64>(page_off),
+                                            static_cast<clio::run::u64>(to_read));
+          res.Wait();
+          if (res->GetReturnCode() == 0 && res->exists_ == 0) {
+            std::memset(dst + done, 0, static_cast<size_t>(to_read));
+            ShmReadHoles().fetch_add(1, std::memory_order_relaxed);
+            done += to_read;
+            cur += to_read;
+            continue;
+          }
+        }
         ShmReadMisses().fetch_add(1, std::memory_order_relaxed);
         return -1;
       }
@@ -1149,6 +1251,18 @@ class Client : public clio::cte::core::Client {
     });
     ShmReadHits().fetch_add(1, std::memory_order_relaxed);
     return static_cast<FsSsize>(done);
+  }
+
+  /** Max GetResidency probes in one ShmRead (see the call site). */
+  static constexpr unsigned kMaxResidencyProbes = 8;
+
+  /** Pages served as holes: absent at the tier, so zeros are the answer and no
+   *  data round trip was needed. Counted apart from hits because they are a
+   *  different thing -- bytes produced locally, not bytes read from the tier --
+   *  and folding them into hits would overstate what the cache served. */
+  static std::atomic<clio::run::u64> &ShmReadHoles() {
+    static std::atomic<clio::run::u64> n{0};
+    return n;
   }
 
   // Zero-IPC read accounting. A silently-disabled fast path and a working one

--- a/context-transfer-engine/test/unit/CMakeLists.txt
+++ b/context-transfer-engine/test/unit/CMakeLists.txt
@@ -138,6 +138,11 @@ add_executable(test_bdev_free_visibility
     test_bdev_free_visibility.cc
 )
 
+# Residency op (VFD_VOL_PLAN §1): present vs absent vs unreachable.
+add_executable(test_residency_op
+    test_residency_op.cc
+)
+
 # Batching benchmark (#820): many small writes at ONE blob, A/B'd on the same
 # binary via CLIO_TASK_BATCHING.
 add_executable(bench_same_blob_batching
@@ -469,6 +474,18 @@ target_link_libraries(test_vectored_blob_io
 
 # Link test_bdev_fragmentation (#820) - same deps.
 target_link_libraries(test_bdev_fragmentation
+    clio_cte_core_runtime
+    clio_cte_core_client
+    clio::run::admin_runtime
+    clio::run::admin_client
+    clio::run::bdev_runtime
+    clio::run::bdev_client
+    ctp::cxx
+    ${CMAKE_THREAD_LIBS_INIT}
+)
+
+# Link test_residency_op - same deps.
+target_link_libraries(test_residency_op
     clio_cte_core_runtime
     clio_cte_core_client
     clio::run::admin_runtime
@@ -889,6 +906,13 @@ set_tests_properties(cte_bdev_fragmentation PROPERTIES
 
 # issue #919: placement must see space freed since the last StatTargets tick.
 # Four fill/stat/delete/put cycles; a stray periodic tick can rescue one, not all.
+add_test(NAME cte_residency_op
+    COMMAND test_residency_op)
+set_tests_properties(cte_residency_op PROPERTIES
+    TIMEOUT 300
+    LABELS "cte;residency"
+    ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CLIO_TEST_DATA_DIR=${CMAKE_BINARY_DIR};CLIO_BIND_ADDR=127.0.0.1")
+
 add_test(NAME cte_bdev_free_visibility
     COMMAND test_bdev_free_visibility)
 set_tests_properties(cte_bdev_free_visibility PROPERTIES

--- a/context-transfer-engine/test/unit/test_cfs_shm_read.cc
+++ b/context-transfer-engine/test/unit/test_cfs_shm_read.cc
@@ -799,4 +799,84 @@ TEST_CASE("clio-fs descriptor layer: sequential read, seek, tell",
   cfs_io->RemovePath(path);
 }
 
+// A sparse file must be served BY the fast path, not around it.
+//
+// Before GetResidency, one absent page anywhere in a request sent the ENTIRE
+// request to the RPC path: a miss in the SHM mirror could not distinguish "no
+// such bytes" from "bytes exist but are not reachable from here", and only the
+// first can be answered with zeros. So a file with any hole in it lost the fast
+// path for every read touching the hole, however much of the rest was resident.
+//
+// This asserts both halves: that the bytes are right, and that they came from
+// the fast path. Checking only the bytes would pass just as happily against the
+// old fall-back-to-RPC behaviour, which is also correct -- the hole counter is
+// what separates "still correct" from "correct AND not paying a round trip".
+TEST_CASE("clio-fs SHM read serves holes in a sparse file",
+          "[cfs][shm][residency][noleak]") {
+  REQUIRE(InitRuntime());
+  auto *cfs_io = CLIO_CFS_CLIENT;
+  REQUIRE(cfs_io != nullptr);
+
+  if (CLIO_CPU_IPC == nullptr ||
+      CLIO_CPU_IPC->GetMetadataAllocator() == nullptr) {
+    std::printf("[residency] SKIP: no metadata SHM segment on this platform\n");
+    return;
+  }
+
+  const std::string path = "clio::/tmp/clio_cfs_sparse_test.bin";
+  const size_t kPage = static_cast<size_t>(clio::cte::filesystem::kFsPageSize);
+  cfs_io->RemovePath(path);
+
+  // Two FULL pages, three pages apart. Whole pages on purpose: a partially
+  // written page leaves a blob that EXISTS but is short, which is a different
+  // case (present-but-not-covering) and correctly still takes the RPC path.
+  // Pages 1 and 2 have no blob at all, which is the hole this is about.
+  std::vector<char> page(kPage);
+  for (size_t i = 0; i < kPage; ++i) {
+    page[i] = static_cast<char>((i * 17 + 3) % 251);
+  }
+  int fd = cfs_io->OpenFd(path, O_CREAT | O_RDWR | O_TRUNC, 0644);
+  REQUIRE(fd >= 0);
+  REQUIRE(cfs_io->PwriteFd(fd, page.data(), kPage, 0) ==
+          static_cast<ssize_t>(kPage));
+  REQUIRE(cfs_io->PwriteFd(fd, page.data(), kPage,
+                           static_cast<off_t>(3 * kPage)) ==
+          static_cast<ssize_t>(kPage));
+  cfs_io->CloseFd(fd);
+  cfs_io->Flush(path);
+
+  fd = cfs_io->OpenFd(path, O_RDONLY, 0644);
+  REQUIRE(fd >= 0);
+
+  const clio::run::u64 holes_before =
+      clio::cte::filesystem::Client::ShmReadHoles().load(
+          std::memory_order_relaxed);
+
+  std::vector<char> got(4 * kPage, '\xAA');
+  const ssize_t nr = cfs_io->PreadFd(fd, got.data(), 4 * kPage, 0);
+  REQUIRE(nr == static_cast<ssize_t>(4 * kPage));
+
+  // Written pages come back verbatim; the gap reads as zeros, which is what
+  // POSIX says an unwritten region inside a file contains.
+  REQUIRE(std::memcmp(got.data(), page.data(), kPage) == 0);
+  REQUIRE(std::memcmp(got.data() + 3 * kPage, page.data(), kPage) == 0);
+  for (size_t i = kPage; i < 3 * kPage; ++i) {
+    if (got[i] != 0) {
+      FAIL("hole byte at offset " << i << " is " << static_cast<int>(got[i])
+                                  << ", expected 0");
+      break;
+    }
+  }
+
+  const clio::run::u64 holes_after =
+      clio::cte::filesystem::Client::ShmReadHoles().load(
+          std::memory_order_relaxed);
+  REQUIRE(holes_after > holes_before);
+  std::printf("[residency] holes served from the fast path: %llu\n",
+              static_cast<unsigned long long>(holes_after - holes_before));
+
+  cfs_io->CloseFd(fd);
+  cfs_io->RemovePath(path);
+}
+
 SIMPLE_TEST_MAIN()

--- a/context-transfer-engine/test/unit/test_residency_op.cc
+++ b/context-transfer-engine/test/unit/test_residency_op.cc
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved. BSD 3-Clause license.
+ */
+
+// GetResidency: "are these bytes actually PRESENT in the tier?" (VFD_VOL_PLAN §1)
+//
+// The distinction under test is the one a client cannot draw for itself. A miss
+// in the shared-memory mirror conflates two opposite situations:
+//
+//   * the bytes do not exist  -> a hole; zeros ARE the correct answer, and no
+//                                round trip is needed to produce them
+//   * the bytes exist but are not reachable from here (file/remote/GPU tier, or
+//     transformed) -> the RPC path is required
+//
+// Collapsing both to "false" is why CfsIo's SHM fast path abandons a whole
+// request when any single page misses. So the assertions that matter are not
+// "the call succeeded" but that ABSENT and PRESENT-BUT-NOT-DIRECT are reported
+// as different things, and that absence is not an error.
+
+#include <clio_runtime/clio_runtime.h>
+#include <clio_runtime/bdev/bdev_client.h>
+#include <clio_cte/core/core_client.h>
+#include <clio_cte/core/core_tasks.h>
+
+#include <chrono>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "simple_test.h"
+
+namespace {
+
+const char *kTargetName = "residency_target";
+constexpr clio::run::u64 kTargetSize = 32ULL * 1024 * 1024;
+constexpr size_t kBlobSize = 4096;
+
+class Fixture {
+ public:
+  bool initialized_ = false;
+  Fixture() {
+    bool ok = clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, true);
+    REQUIRE(ok);
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    ok = clio::cte::core::CLIO_CTE_CLIENT_INIT();
+    REQUIRE(ok);
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    auto *cte = CLIO_CTE_CLIENT;
+    clio::run::PoolId bdev_pool_id(941, 0);
+    clio::run::bdev::Client bdev_client(bdev_pool_id);
+    auto create = bdev_client.AsyncCreate(
+        clio::run::PoolQuery::Dynamic(), kTargetName, bdev_pool_id,
+        clio::run::bdev::BdevType::kRam, kTargetSize);
+    create.Wait();
+    auto reg = cte->AsyncRegisterTarget(
+        kTargetName, clio::run::bdev::BdevType::kRam, kTargetSize,
+        clio::run::PoolQuery::Local(), bdev_pool_id);
+    reg.Wait();
+    REQUIRE(reg->GetReturnCode() == 0);
+    initialized_ = true;
+  }
+};
+
+Fixture *g_fixture = nullptr;
+
+}  // namespace
+
+TEST_CASE("Residency - absent blob reports absent, not an error",
+          "[cte][residency]") {
+  auto *cte = CLIO_CTE_CLIENT;
+  clio::cte::core::Tag tag{std::string("residency_absent_tag")};
+
+  auto r = cte->AsyncGetResidency(tag.GetTagId(), "no_such_blob", 0, 512);
+  r.Wait();
+
+  // rc 0: "it is not there" is an ANSWER. Reporting absence as a failure would
+  // put the caller back to guessing, which is the defect this op removes.
+  REQUIRE(r->GetReturnCode() == 0);
+  REQUIRE(r->exists_ == 0);
+  REQUIRE(r->present_bytes_ == 0);
+  REQUIRE(r->direct_readable_ == 0);
+}
+
+TEST_CASE("Residency - a RAM-tier blob is present and directly readable",
+          "[cte][residency]") {
+  auto *cte = CLIO_CTE_CLIENT;
+  clio::cte::core::Tag tag{std::string("residency_present_tag")};
+  std::vector<char> buf(kBlobSize, 'r');
+
+  auto put = cte->AsyncPutBlob(tag.GetTagId(), std::string("blob0"), 0,
+                               kBlobSize, buf.data());
+  put.Wait();
+  REQUIRE(put->GetReturnCode() == 0);
+
+  auto r = cte->AsyncGetResidency(tag.GetTagId(), "blob0", 0, kBlobSize);
+  r.Wait();
+  REQUIRE(r->GetReturnCode() == 0);
+  REQUIRE(r->exists_ == 1);
+  REQUIRE(r->present_bytes_ == kBlobSize);
+  // The target registered above is node-local RAM, which is exactly the case
+  // the SHM path can serve.
+  REQUIRE(r->direct_readable_ == 1);
+}
+
+TEST_CASE("Residency - a range past the stored extent is short, not absent",
+          "[cte][residency]") {
+  auto *cte = CLIO_CTE_CLIENT;
+  clio::cte::core::Tag tag{std::string("residency_short_tag")};
+  std::vector<char> buf(kBlobSize, 's');
+
+  auto put = cte->AsyncPutBlob(tag.GetTagId(), std::string("blob0"), 0,
+                               kBlobSize, buf.data());
+  put.Wait();
+  REQUIRE(put->GetReturnCode() == 0);
+
+  // Ask for twice what was written. The blob exists, so this is not a hole in
+  // the "no such blob" sense -- but only the stored prefix is present, and the
+  // caller needs the length to know where the hole starts.
+  auto over = cte->AsyncGetResidency(tag.GetTagId(), "blob0", 0, kBlobSize * 2);
+  over.Wait();
+  REQUIRE(over->GetReturnCode() == 0);
+  REQUIRE(over->exists_ == 1);
+  REQUIRE(over->present_bytes_ == kBlobSize);
+
+  // Starting entirely past the stored bytes: present_bytes_ 0 while exists_
+  // stays 1. That pair is what tells a caller "this blob is real, but nothing
+  // backs the range you asked about" -- distinct from the absent case above.
+  auto past = cte->AsyncGetResidency(tag.GetTagId(), "blob0", kBlobSize * 4,
+                                     kBlobSize);
+  past.Wait();
+  REQUIRE(past->GetReturnCode() == 0);
+  REQUIRE(past->exists_ == 1);
+  REQUIRE(past->present_bytes_ == 0);
+
+  // size 0 means "to the end of what is stored", not "nothing".
+  auto rest = cte->AsyncGetResidency(tag.GetTagId(), "blob0", 1024, 0);
+  rest.Wait();
+  REQUIRE(rest->GetReturnCode() == 0);
+  REQUIRE(rest->present_bytes_ == kBlobSize - 1024);
+}
+
+int main(int argc, char **argv) {
+  Fixture fixture;
+  g_fixture = &fixture;
+  int result = SimpleTest::run_all_tests(argc > 1 ? argv[1] : "");
+  SIMPLE_TEST_PROCESS_EXIT(result);
+  if (SimpleTest::g_test_finalize) SimpleTest::g_test_finalize();
+  return result;
+}


### PR DESCRIPTION
The CLIO VFD currently populates the CTE tier but never reads from it. This PR makes the tier able to serve data in place of the native HDF5 file.

Residency (whether the requested bytes are actually in the CTE) is added as a chimod op. A client can't distinguish "no such bytes exist" from "they exist but this client cannot read them directly" (e.g. they sit on a non-RAM target, or are transformed by a codec, or fall outside the prefix its shared-memory mirror describes), and those need opposite responses. In the first case the range is a hole, which the caller can fill locally with zeros.  In the second case the data must be fetched over RPC. Only the tier can say which case it is.

Coherence (whether the cached copy still corresponds to the authoritative native file) lets the VFD read the tier safely. The VOL has had a coherence stamp since #967. This PR moves that into a shared header and uses it in the VFD as well. 

The read tier is off by default behind CLIO_VFD_READ_TIER. It works, but read-through costs a tier write on every miss and there is no admission policy or back-pressure yet, so the trade-off is plausibly net-negative for read-once workloads. The residency op and the CFS hole-serving in the first commit make sense in isolation and are enabled.

This PR also includes a small fix for the VOL compat suite, which had been looking up dataset telemetry by bare name after the connector moved to full paths.