### PR TITLE
Let the configured tier score decide placement, not a bandwidth guess

### DIFF
--- a/context-transfer-engine/core/src/dpe/max_bw_dpe.cc
+++ b/context-transfer-engine/core/src/dpe/max_bw_dpe.cc
@@ -100,14 +100,44 @@ std::vector<TargetInfo> MaxBwDpe::SelectTargets(const std::vector<TargetInfo>& t
     }
   }
 
-  // Sort low_score targets by performance (already correct order for placement)
-  std::sort(low_score_targets.begin(), low_score_targets.end(), perf_comparator);
+  // Rank the PREFERRED bucket by target_score_ (hottest tier first), using
+  // measured performance only to break ties.
+  //
+  // Ranking this bucket on predicted bandwidth alone -- as it did until now --
+  // makes the operator's declared tiering irrelevant whenever the numbers
+  // disagree with it. Concretely: a config with a volatile RAM tier at
+  // score 1.0 and a file tier at 0.2 admits BOTH to this bucket for a hot blob
+  // (score 1.0), and if the file's measured/predicted write bandwidth happens
+  // to exceed the RAM tier's, the file wins and a "DRAM cache" copy is written
+  // to durable storage. That was observed on Vista (RAM predicted at 476 MB/s
+  // vs the file at 741 MB/s), where it put the cache primary on disk, made it
+  // survive a reboot, and broke cte_replication_persist_integration.
+  //
+  // The scores in the YAML are an explicit statement about which tier data of
+  // a given temperature belongs on. Bandwidth is an estimate -- sometimes a
+  // cold-model one. When they disagree, the declared intent wins; among tiers
+  // the operator scored the SAME, the faster device is the better choice, so
+  // performance still decides.
+  auto score_then_perf = [&perf_comparator](const TargetInfo& a,
+                                            const TargetInfo& b) {
+    if (a.target_score_ != b.target_score_) {
+      return a.target_score_ > b.target_score_;  // hottest tier first
+    }
+    return perf_comparator(a, b);
+  };
+  std::sort(low_score_targets.begin(), low_score_targets.end(), score_then_perf);
 
-  // Sort high_score targets by performance in REVERSE order
-  // (when falling back to higher tiers, prefer lower-performing ones first)
+  // The FALLBACK bucket holds tiers HOTTER than this blob was scored for, so
+  // the pick is "least over-provisioned first": closest score to the blob's,
+  // i.e. ascending target_score_, again with performance breaking ties. This
+  // keeps the previous intent -- do not burn the hottest tier on cold data --
+  // while expressing it in the same currency as the bucket above.
   std::sort(high_score_targets.begin(), high_score_targets.end(),
             [&perf_comparator](const TargetInfo& a, const TargetInfo& b) {
-              return perf_comparator(b, a);  // Reverse by swapping arguments
+              if (a.target_score_ != b.target_score_) {
+                return a.target_score_ < b.target_score_;  // closest first
+              }
+              return perf_comparator(a, b);
             });
 
   // Build result: low_score targets first (preferred), then high_score (fallback)


### PR DESCRIPTION
## Summary
- Rank `MaxBwDpe`'s **preferred** tier bucket by the operator's configured `target_score_` (hottest tier first), using the existing performance comparator only to break ties.
- Rank the **fallback** bucket (tiers hotter than the blob was scored for) least-over-provisioned first, instead of as a reversed performance sort.
- Fixes `cte_replication_persist_integration`, which has been red on `vista / dev/r/gpu` since 2026-08-19.

## The bug

The preferred bucket was ranked purely on predicted write bandwidth, which makes the tiering an operator writes in YAML irrelevant whenever the numbers disagree with it.

The failing test's config is a volatile RAM tier at `score: 1.0` and a file tier at `score: 0.2`. A hot blob (score 1.0) admits **both** to the preferred bucket, so the winner was simply whichever device the model believed was faster. Measured on Vista:

```
[DIAG dpe] blob_score=1  minlvl=0
  avail: 512.1 (tscore=1.0, bw=476.61)   <- RAM tier
         513.1 (tscore=0.2, bw=741.52)   <- file tier
  -> ordered: 513.1 512.1
```

So all 50 "DRAM cache" primaries were written to durable storage — confirmed at the write side, not inferred:

```
[DIAG put] blob=persist_blob_0 replica_ctx=0 score=-1 primary: 513.1(sz=4096)
   50 x primary: 513.1   (never once 512.1)
```

`replica_ctx=0` confirms these are primary writes. A copy that is supposed to die with the machine therefore survived the reboot, which is exactly what Phase 2 asserts against:

```
Phase 2: blob 0 primary survived reboot?! size=4096 rc=0
```

## Why the inputs can't be trusted for this decision

Those bandwidths are **not measurements**. `bdev::Runtime::GetStats` derives them by running the learned wall-clock model over a *synthetic* 1 MiB I/O; the per-method coefficient starts at a 1.0 seed and only moves once real traffic reinforces it. Early in a run the ranking is a property of the seed, not of the device — and both tiers seed from the same file-shaped defaults (100/80 MB/s), so nothing tells the model a RAM tier should be an order of magnitude faster than a file.

Hence the fix at the decision point rather than on the inputs: the scores are an explicit statement about which tier data of a given temperature belongs on; bandwidth is an estimate, sometimes a cold one. When they disagree, the declared intent wins. Among tiers scored the same, the faster device is still chosen.

## Test plan
Verified on TACC Vista (GH200 `sm_90`, CUDA 12.5, Release + CUDA). A/B on a single commit with **only this file** differing:

- [x] Without the change: `cte_replication_persist_integration` **FAILS** (`primary survived reboot?!`)
- [x] With the change: **passes in 15.95 s**
- [x] With the change, full suite: **391/391, `ctest rc=0`** — zero regressions (baseline at the same commit was 390/391, this test being the only failure)
- [x] 0 compiler errors

The A/B is worth noting because a related fix landed upstream in the same window — memory-class bdevs no longer restoring a persisted perf profile. That stops a *stale bad* estimate being restored; it does **not** stop a *cold-model* estimate rating RAM below a file inside a single run, and on its own it leaves this test failing. This change is what fixes it.

## Alternatives considered

Two input-side fixes were implemented and verified first, then withdrawn in favour of this one:

1. **Per-device-class perf seeds** (RAM ≫ file) so the ranking starts sane.
2. **A model warm-up guard** — report the seeded profile until the device has served N real I/Os.

Both work, but they correct the *inputs* so the existing bandwidth ranking happens to come out right; placement still depends on the estimate being trustworthy. They also required updating five test expectations that encoded the old uniform defaults. This change required none, and is 35 insertions in one file.

## Risk

This changes what `max_bw` means for every placement decision, so it is a fleet-wide behavioural change, not a local fix. The mitigation is the full-suite result above (391/391). Deployments that scored all their tiers identically see no change at all — the tie-break is the pre-existing comparator.

## Breaking changes
None in API or config. Behavioural: tier `score:` values in existing configs now influence placement where previously they could be overridden by a bandwidth estimate. For most configs this is the behaviour the scores were written to express.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
