### PR TITLE
Give snapshot replica records their own entry tag

### DIFF
--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -5252,11 +5252,24 @@ clio::run::TaskResume Runtime::FlushMetadata(clio::run::shared_ptr<FlushMetadata
       }
       task->entries_flushed_++;
 
-      // Entry type 3 == one replica's layout (issue #886), written right
-      // after its blob's type-2 record so restore can attach it to the
+      // Entry type 4 == one replica's layout (issue #886), written right
+      // after its blob's record so restore can attach it to the
       // just-inserted BlobInfo. A NEW type for the same no-version-header
       // reason as type 2: an old reader stops loudly instead of parsing
-      // replica blocks as the next entry. The snapshot MUST carry replicas —
+      // replica blocks as the next entry.
+      //
+      // It MUST NOT be 3, which is what it was until this fix: 3 is already
+      // the tag of the BLOB record written just above (droppable_ layout), and
+      // the reader's blob branch accepts 1|2|3. Every replica record was
+      // therefore parsed as a blob record, which desynchronised the whole
+      // stream: the reader went on to interpret string bytes as binary fields
+      // and produced garbage bdev pool ids (observed: 1936876912 == "pers",
+      // 1650422899 == "st_b"). Those ids matched no registered target, so the
+      // volatile-block filter -- which keeps a block when the target is
+      // unknown -- failed OPEN and the DRAM primary survived a reboot, which
+      // is exactly what cte_replication_persist_integration asserts against.
+      // The replica branch in the reader was dead code for the same reason.
+      // The snapshot MUST carry replicas —
       // FlushMetadata may truncate the WAL below, and the kExtendReplica
       // records being truncated are the only other place these layouts live.
       // Empty replicas are skipped; they hold nothing to restore and are
@@ -5266,7 +5279,7 @@ clio::run::TaskResume Runtime::FlushMetadata(clio::run::shared_ptr<FlushMetadata
         if (rep.blocks_.empty()) {
           continue;
         }
-        uint8_t rep_entry_type = 3;
+        uint8_t rep_entry_type = 4;
         uint32_t rep_idx = static_cast<uint32_t>(rep_i + 1);
         uint32_t rep_name_len = static_cast<uint32_t>(rep.name_.size());
         float rep_score = rep.score_;
@@ -5736,10 +5749,14 @@ void Runtime::RestoreMetadataFromLog() {
       MirrorBlobToShm(composite_key, blob_info);
       blobs_restored++;
 
-    } else if (entry_type == 3) {
-      // Replica layout (issue #886), attached to the blob whose type-2 record
+    } else if (entry_type == 4) {
+      // Replica layout (issue #886), attached to the blob whose record
       // FlushMetadata wrote just before it. Same volatile-block filter as the
       // primary restore.
+      //
+      // Tag 4, not 3: the blob branch above accepts 1|2|3, so while replicas
+      // were written as 3 this branch was unreachable and every replica record
+      // was misparsed as a blob (see the writer for the full consequence).
       uint32_t key_len;
       ifs.read(reinterpret_cast<char *>(&key_len), sizeof(key_len));
       std::string composite_key(key_len, '\0');

--- a/context-transfer-engine/test/unit/test_blob_replicas.cc
+++ b/context-transfer-engine/test/unit/test_blob_replicas.cc
@@ -28,11 +28,14 @@
 #include <clio_cte/core/core_client.h>
 #include <clio_cte/core/core_tasks.h>
 #include <clio_cte/replication/replication_client.h>
+#include <clio_runtime/admin/admin_client.h>
+#include <clio_runtime/config_manager.h>
 
 #include <chrono>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <sstream>
 #include <string>
 #include <thread>
 #include <vector>
@@ -689,6 +692,95 @@ TEST_CASE("BlobReplicas - metadata snapshot covers replica layouts",
   REQUIRE(GetFrom(client, tag_id, "snap_blob", &got, 0) == 0);
   REQUIRE(std::memcmp(got.data(), primary_val.data(), kValSize) == 0);
   REQUIRE(GetFrom(client, tag_id, "snap_blob", &got, 1) == 0);
+  REQUIRE(std::memcmp(got.data(), replica_val.data(), kValSize) == 0);
+}
+
+TEST_CASE("BlobReplicas - snapshot replica layouts restore into a fresh pool",
+          "[cte][replicas][wal][886]") {
+  // Covers RestoreMetadataFromLog's REPLICA branch, which nothing else in the
+  // unit suite reaches.
+  //
+  // That branch was dead code until the entry tag was separated: replica
+  // records were written as type 3, the blob branch above it claims 1|2|3, so
+  // every replica record was parsed as a blob and the stream desynchronised
+  // from there (the reader went on to read string bytes as binary fields --
+  // observed as bdev "pool ids" that decode to ASCII, 1936876912 == "pers").
+  // It went unnoticed because no test ever restored a snapshot holding
+  // replicas.
+  //
+  // Restarting the EXISTING pool cannot test this: the container is already
+  // live, so a re-create returns it with its in-memory metadata intact and
+  // RestoreMetadataFromLog never runs. Compose a SECOND CTE pool instead --
+  // new id, same metadata_log_path, restart_ = true -- which is a genuinely
+  // cold container and must rebuild its state from the snapshot alone. That is
+  // the same path admin's RestartContainers drives after a reboot.
+  auto *client = CLIO_CTE_CLIENT;
+  REQUIRE(client != nullptr);
+
+  clio::cte::core::Tag tag("replica_restore_tag");
+  const clio::cte::core::TagId tag_id = tag.GetTagId();
+
+  const std::string primary_val(kValSize, 'p');
+  const std::string replica_val(kValSize, 'r');
+  PutTo(client, tag_id, "restore_blob", primary_val, 0);
+  // PERSISTENT, so the replica lands on the file tier. A plain replica would
+  // land on the volatile RAM tier, and RestoreMetadataFromLog drops volatile
+  // blocks by design -- the copy is meant to die with the machine. Only a
+  // non-volatile replica has a layout that SHOULD survive, which is what makes
+  // its absence after a restore a real defect rather than correct behaviour.
+  {
+    clio::cte::core::Context ctx = ReplicaCtx(1);
+    ctx.replica_flags_ = clio::cte::core::REPLICA_PERSISTENT;
+    auto fut = client->AsyncPutBlob(tag_id, "restore_blob", 0, kValSize,
+                                    replica_val.data(), -1.0f, ctx);
+    fut.Wait();
+    REQUIRE(fut->GetReturnCode() == 0);
+  }
+
+  // Snapshot. This truncates the WAL, so afterwards the replica's layout lives
+  // ONLY in the snapshot and the restore below has to parse it correctly.
+  auto flush = client->AsyncFlushMetadata(clio::run::PoolQuery::Local(), 0);
+  flush.Wait();
+  REQUIRE(flush->GetReturnCode() == 0);
+
+  // Second CTE pool over the same storage + the same metadata log.
+  clio::run::PoolConfig cfg;
+  cfg.mod_name_ = "clio_cte_core";
+  cfg.pool_name_ = "clio_cte_restored";
+  cfg.pool_id_ = clio::run::PoolId(514, 0);
+  cfg.pool_query_ = clio::run::PoolQuery::Local();
+  cfg.restart_ = true;  // -> Runtime::Restart -> is_restart_ -> replay the log
+  {
+    std::ostringstream y;
+    y << "targets:\n"
+      << "  neighborhood: 1\n"
+      << "storage:\n"
+      << "  - path: \"ram::blob_replicas_dram\"\n"
+      << "    bdev_type: \"ram\"\n"
+      << "    capacity_limit: \"64MB\"\n"
+      << "    score: 1.0\n"
+      << "  - path: \"" << chi_test_data_dir() + "/blob_replicas_file.dat" << "\"\n"
+      << "    bdev_type: \"file\"\n"
+      << "    capacity_limit: \"1MB\"\n"
+      << "    score: 0.2\n"
+      << "    persistence_level: \"temporary\"\n"
+      << "performance:\n"
+      << "  metadata_log_path: " << chi_test_data_dir() + "/blob_replicas_meta.log" << "\n";
+    cfg.config_ = y.str();
+  }
+
+  clio::run::admin::Client admin_client(clio::run::kAdminPoolId);
+  auto compose = admin_client.AsyncCompose(cfg);
+  compose.Wait();
+  REQUIRE(compose->GetReturnCode() == 0);
+
+  // Read the replica back THROUGH THE RESTORED POOL. Its metadata came from
+  // the snapshot and nowhere else, so a misparsed replica record shows up here
+  // as a lost layout: a non-zero rc or the wrong bytes.
+  clio::cte::core::Client restored(clio::run::PoolId(514, 0));
+  std::vector<char> got;
+  REQUIRE(GetFrom(&restored, tag_id, "restore_blob", &got, 1) == 0);
+  REQUIRE(got.size() == kValSize);
   REQUIRE(std::memcmp(got.data(), replica_val.data(), kValSize) == 0);
 }
 

--- a/context-transfer-engine/test/unit/test_blob_replicas.cc
+++ b/context-transfer-engine/test/unit/test_blob_replicas.cc
@@ -696,7 +696,7 @@ TEST_CASE("BlobReplicas - metadata snapshot covers replica layouts",
 }
 
 TEST_CASE("BlobReplicas - snapshot replica layouts restore into a fresh pool",
-          "[cte][replicas][wal][886]") {
+          "[cte][replicas][wal][886][noleak]") {
   // Covers RestoreMetadataFromLog's REPLICA branch, which nothing else in the
   // unit suite reaches.
   //
@@ -779,7 +779,27 @@ TEST_CASE("BlobReplicas - snapshot replica layouts restore into a fresh pool",
   // as a lost layout: a non-zero rc or the wrong bytes.
   clio::cte::core::Client restored(clio::run::PoolId(514, 0));
   std::vector<char> got;
-  REQUIRE(GetFrom(&restored, tag_id, "restore_blob", &got, 1) == 0);
+  const clio::run::u32 read_rc =
+      GetFrom(&restored, tag_id, "restore_blob", &got, 1);
+
+  // Tear the restored pool down BEFORE asserting, so a failing assertion does
+  // not leave a stray pool composed for the tests that follow.
+  //
+  // [noleak] on this case: composing a pool builds a container the PoolManager
+  // owns for the PROCESS lifetime -- DestroyPool unregisters it but does not
+  // return its rebuilt metadata image (~96 KB here) to the runtime private
+  // heap, which only ServerFinalize's DestroyAllContainers does. Measured with
+  // -DCLIO_CORE_ENABLE_LEAK_CHECK=ON: the delta is identical with and without
+  // this DestroyPool call, so the tag reflects real runtime-lifetime state
+  // rather than papering over a leak this test could actually release.
+  {
+    clio::run::admin::Client admin_cleanup(clio::run::kAdminPoolId);
+    auto destroy = admin_cleanup.AsyncDestroyPool(clio::run::PoolQuery::Local(),
+                                                  clio::run::PoolId(514, 0));
+    destroy.Wait();
+  }
+
+  REQUIRE(read_rc == 0);
   REQUIRE(got.size() == kValSize);
   REQUIRE(std::memcmp(got.data(), replica_val.data(), kValSize) == 0);
 }


### PR DESCRIPTION
## Summary
- `FlushMetadata` wrote **blob** records and **replica** records with the same `entry_type = 3`, so every replica record was parsed as a blob record.
- The reader's own replica branch (`else if (entry_type == 3)`) was therefore **unreachable dead code** — the blob branch above accepts `1|2|3`.
- Move replica records to `entry_type = 4` and point the reader's replica branch at 4.

## The bug

Writer, in `Runtime::FlushMetadata`:

| Location | Tag |
|---|---|
| `core_runtime.cc:5204` blob record | `uint8_t entry_type = 3;` |
| `core_runtime.cc:5269` replica record | `uint8_t rep_entry_type = 3;` ← collision |

Reader, in `Runtime::RestoreMetadataFromLog`:

| Location | Branch |
|---|---|
| `core_runtime.cc:5634` | `else if (entry_type == 1 \|\| entry_type == 2 \|\| entry_type == 3)` — claims 3 |
| `core_runtime.cc:5739` | `else if (entry_type == 3)` — **never reached** |

The writer's own comment says the replica record uses "a NEW type … so an old reader stops loudly instead of parsing replica blocks as the next entry." The intent was right; the value chosen was already taken by the blob record written immediately above it.

## Why it is not cosmetic

Parsing a replica record as a blob record desynchronises the stream — the reader continues, interpreting string bytes as binary fields. The wreckage identifies itself, because the resulting "bdev pool ids" decode to ASCII:

| value read as a pool id | bytes |
|---|---|
| 1936876912 | `"pers"` |
| 1650422899 | `"st_b"` |
| 774975024 | `"0.1."` |
| 1769173605 | `"ersi"` |

— fragments of `persist_blob_*` names and `<major>.<minor>.<name>` composite keys.

Those ids match no registered target, and the volatile-block filter **fails open**: it tests `if (tinfo && tinfo->persistence_level_ == kVolatile)`, so a block whose target cannot be resolved is *kept*. Blocks that a restore is supposed to drop therefore survive it.

Observed alongside this on a 50-blob snapshot: `RestoreMetadataFromLog: Restored 1 tags and 2 blobs` — 48 blobs lost to the desync.

## Compatibility

Types `1|2|3` still parse as blob records, so existing snapshots keep restoring their blobs.

Snapshots **already written** cannot be fully recovered: a type-3 record in them is genuinely ambiguous between a blob and a replica, and the format has no version header to disambiguate. This change stops *new* snapshots being written into that ambiguity, and makes replica layouts restore at all. An older reader meeting a type-4 record hits the existing `Unknown entry type` warning — the "stop loudly" behaviour the writer's comment intended.

## Test plan
- [x] Compiles clean (0 errors) on TACC Vista, GH200, Release + CUDA
- [x] Reader's replica branch is reachable for the first time (was dead code)
- [x] Applies cleanly to current `dev` (`d68f4f2b`); bug confirmed still present there
- [x] Full-suite run at the PR head (`b227b202`): **390/391**, the single failure being the
      pre-existing `cte_replication_persist_integration` (the placement bug fixed in #1052,
      which this PR does not claim to fix). 0 build errors. `cte_blob_replicas` and
      `cte_blob_replicas_force_net` both pass in-suite, with zero runtime-heap leak reports.

## What this does NOT fix

Found while investigating `cte_replication_persist_integration`. It is **not** that test's failure, and the test still fails identically with this applied — that one is a data-placement bug, fixed separately in #1052. This is landed on its own merits.

## Verification status

All items above are now done. Summary of what was measured, on TACC Vista
(GH200, CUDA 12.5, Release + CUDA) unless noted:

* **Full suite at the PR head:** 390/391; the one failure is pre-existing (#1052).
* **The fix discriminates:** the added restore test fails without the entry-tag
  change and passes with it, in both the plain and `force_net` variants.
* **Leak check:** verified on a `-DCLIO_CORE_ENABLE_LEAK_CHECK=ON` build — the
  config CI uses, and the only one where the assertion is compiled in at all.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
