### PR TITLE
clio-vfd: do not attach a cache handle to a read-only open

### DIFF
--- a/context-transfer-engine/adapter/vfd/H5FDclio.cc
+++ b/context-transfer-engine/adapter/vfd/H5FDclio.cc
@@ -690,6 +690,25 @@ static H5FD_t *H5FD__clio_open(const char *name, unsigned flags,
     fa.fsync_on_flush = 1;
   }
 
+  /* A read-only open has nothing to gain from the cache tier, so do not attach
+     one. The tier is write-populated and not yet served on reads:
+     H5FD__clio_do_read goes to the authoritative descriptor unconditionally,
+     and H5FD__clio_do_write -- the only writer -- cannot run on a file HDF5
+     opened without H5F_ACC_RDWR. The handle would therefore be opened, never
+     used, and closed.
+     It is not free: the attach waits on a CFS Open task here and close() waits
+     on a Close, so a read-only open/close cycle pays two blocking round trips --
+     and the open one is serviced by Runtime::Open, which for an open without
+     O_CREAT awaits a TagQuery and then a GetTagSize inside the runtime. A
+     workload that opens and closes files in a loop spends its entire time there:
+     netCDF-C's nc_test4/tst_files4 does 32768 read-only open/close cycles, i.e.
+     ~66k client round trips for a tier no byte is ever read from.
+     Decided before the H5FD__clio_cache_available() probe below so a read-only
+     open also skips the runtime attach and its retry timeout. */
+  if (fa.cache_enabled && !(H5F_ACC_RDWR & flags)) {
+    fa.cache_enabled = 0;
+  }
+
   // Attach to the CLIO runtime ONLY when this file wants the cache tier: the
   // native file is authoritative, so the native-only configuration is a
   // complete driver on its own and must not require CLIO to be running.


### PR DESCRIPTION
Fixes #1056.

`H5FD__clio_open` attaches a CTE cache handle whenever the FAPL asks for the
tier, without consulting `flags`. On a read-only file that handle can never be
used: `H5FD__clio_do_read` goes to the authoritative descriptor unconditionally
(the tier is "populated on write, not yet served on reads"), and
`H5FD__clio_do_write` — the only writer — cannot run without `H5F_ACC_RDWR`. The
handle is opened, never touched, and closed.

That is two blocking client round trips per open/close cycle, and the open one is
serviced by `Runtime::Open`, which for an open without `O_CREAT` awaits a
`TagQuery` and then a `GetTagSize` inside the runtime.

The fix turns the cache off for a read-only open, decided before the
`H5FD__clio_cache_available()` probe so such an open also skips the runtime
attach and its retry timeout. Every tier operation in the driver is already
guarded by `H5FD__clio_cache_live(file->fd)`, false when no handle was opened, so
nothing else changes. Writable opens are unaffected.

## Effect

netCDF-C's `nc_test4/tst_files4` does 32768 read-only `nc_open`/`nc_close` cycles
on one file — ~66k client round trips for a tier no byte is ever read from. On
macOS 12.7.6 Intel, 4 cores, `ctest --timeout 1200`:

| test | stock HDF5 | `dev` | this branch |
| --- | ---: | ---: | ---: |
| `nc_test4_tst_files4` | 21.9 s | timeout | **21 s** |

A loop of read-only `H5Fopen`/`H5Fclose` on a one-dataset file, which is that
test's inner loop isolated: **18.370 ms** per cycle on `dev`, **0.129 ms** here,
against 0.073 ms with no driver loaded.

## Full suite

The whole netCDF-C test suite, same build, one `clio_run` per variant,
`ctest -j4 --timeout 1200`:

| variant | result | wall clock |
| --- | --- | ---: |
| `baseline` (sec2 / native VOL) | 215/215 passed | 156 s |
| `clio_vfd` | **215/215 passed** | 618 s |
| `clio_vol` | **215/215 passed** | 1106 s |

No test regressed, and both CLIO variants now pass everything the stock stack
does. For comparison, the published macOS run has `clio_vfd` at 1 failure /
28m31s and `clio_vol` at 4 failures / 45m55s.

## Review note

When the tier does start serving reads this becomes a decision to revisit — but
then it would be revisited with a reason, which is not the case today.
