### PR TITLE
Unmap Windows mappings with the deallocator that can free them

### DIFF
--- a/context-transport-primitives/include/clio_ctp/introspect/system_info.h
+++ b/context-transport-primitives/include/clio_ctp/introspect/system_info.h
@@ -232,6 +232,15 @@ class SystemInfo {
 
   CTP_DLL static void DestroySharedMemory(const std::string &name);
 
+  /** Why the last CreateNewSharedMemory/OpenSharedMemory call failed.
+   *
+   *  Callers used to report this as strerror(errno), which is right on POSIX
+   *  and meaningless on Windows: the Win32 shared-memory calls do not set
+   *  errno, so a commit-limit failure (ERROR_COMMITMENT_LIMIT) was reported as
+   *  whatever errno happened to hold -- in practice "Resource temporarily
+   *  unavailable", which points at the wrong problem entirely. */
+  CTP_DLL static std::string GetLastSharedMemoryError();
+
   CTP_DLL static void *MapPrivateMemory(size_t size);
 
   CTP_DLL static void *MapSharedMemory(const File &fd, size_t size, i64 off);

--- a/context-transport-primitives/include/clio_ctp/memory/backend/posix_shm_mmap.h
+++ b/context-transport-primitives/include/clio_ctp/memory/backend/posix_shm_mmap.h
@@ -94,8 +94,21 @@ class PosixShmMmap : public MemoryBackend, public UrlMemoryBackend {
       // shm_open(), and the Win32 one does not set errno at all, so this used
       // to report a commit-limit failure as "Resource temporarily
       // unavailable". Ask the platform what actually went wrong.
+      //
+      // Read it into a local BEFORE logging, and not as an argument to HLOG.
+      // GetLastError() is thread-global, and HLOG's first use in a process
+      // constructs the Logger singleton, which looks up CTP_LOG_LEVEL and
+      // CTP_LOG_OUT -- leaving ERROR_ENVVAR_NOT_FOUND behind when they are
+      // unset, as they normally are. The order of the two is unspecified, and
+      // in practice the singleton wins, so the FIRST shm failure in a process
+      // was reported as "could not find the environment option that was
+      // entered (Win32 error 203)" -- a code nothing in the create path can
+      // produce -- while later ones reported the truth. That is exactly what
+      // the two failures in CDash build 4029381 look like: 203 from the first,
+      // the real ERROR_USER_MAPPED_FILE from the second.
+      std::string shm_err = SystemInfo::GetLastSharedMemoryError();
       HLOG(kError, "could not create shared memory segment {} of {} bytes: {}",
-           url, backend_size, SystemInfo::GetLastSharedMemoryError());
+           url, backend_size, shm_err);
       return false;
     }
     url_ = url;

--- a/context-transport-primitives/include/clio_ctp/memory/backend/posix_shm_mmap.h
+++ b/context-transport-primitives/include/clio_ctp/memory/backend/posix_shm_mmap.h
@@ -90,8 +90,12 @@ class PosixShmMmap : public MemoryBackend, public UrlMemoryBackend {
 
     SystemInfo::DestroySharedMemory(url);
     if (!SystemInfo::CreateNewSharedMemory(fd_, url, backend_size)) {
-      char *err_buf = strerror(errno);
-      HLOG(kError, "shm_open failed: {}", err_buf);
+      // NOT strerror(errno): none of the three platform implementations is
+      // shm_open(), and the Win32 one does not set errno at all, so this used
+      // to report a commit-limit failure as "Resource temporarily
+      // unavailable". Ask the platform what actually went wrong.
+      HLOG(kError, "could not create shared memory segment {} of {} bytes: {}",
+           url, backend_size, SystemInfo::GetLastSharedMemoryError());
       return false;
     }
     url_ = url;

--- a/context-transport-primitives/src/system_info.cc
+++ b/context-transport-primitives/src/system_info.cc
@@ -664,8 +664,13 @@ bool SystemInfo::CreateNewSharedMemory(File &fd, const std::string &name,
   end.QuadPart = static_cast<LONGLONG>(size);
   if (!SetFilePointerEx(hfile, end, nullptr, FILE_BEGIN) ||
       !SetEndOfFile(hfile)) {
+    // Same reason as the CreateFileMappingA path below: preserve the error
+    // across the cleanup call so the caller reports this failure, not
+    // CloseHandle's.
+    const DWORD size_err = GetLastError();
     CloseHandle(hfile);
     fd.windows_fd_ = nullptr;
+    SetLastError(size_err);
     return false;
   }
 
@@ -676,6 +681,7 @@ bool SystemInfo::CreateNewSharedMemory(File &fd, const std::string &name,
       static_cast<DWORD>(size >> 32),              // size, high-order DWORD
       static_cast<DWORD>(size & 0xFFFFFFFFull),    // size, low-order DWORD
       win_name.c_str());                           // mapping object name
+  const DWORD map_err = GetLastError();
 
   // The section holds its own reference to the file, so the file handle has
   // done its job. Closing it here keeps File a union of one handle and leaves
@@ -683,7 +689,14 @@ bool SystemInfo::CreateNewSharedMemory(File &fd, const std::string &name,
   CloseHandle(hfile);
 
   if (fd.windows_fd_ == nullptr) {
+    // Restore the error AFTER the cleanup call. The caller reports the failure
+    // with GetLastSharedMemoryError(), which reads GetLastError() -- so the
+    // DeleteFileA below would otherwise be what gets reported, and the real
+    // reason would be lost. That is how a create failure came to be blamed on
+    // "Win32 error 203" (ERROR_ENVVAR_NOT_FOUND), a code nothing in this
+    // function can produce.
     DeleteFileA(shm_path.c_str());
+    SetLastError(map_err);
     return false;
   }
   return true;
@@ -866,7 +879,38 @@ void SystemInfo::UnmapMemory(void *ptr, size_t size) {
 #if CTP_ENABLE_PROCFS_SYSINFO
   munmap(ptr, size);
 #elif CTP_ENABLE_WINDOWS_SYSINFO
-  VirtualFree(ptr, size, MEM_RELEASE);
+  // This is the counterpart of TWO allocators, because on POSIX one munmap()
+  // serves both: MapSharedMemory() (MapViewOfFile) and MapPrivateMemory()
+  // (VirtualAlloc). Win32 has a separate deallocator for each, and the one
+  // that used to be here -- VirtualFree(ptr, size, MEM_RELEASE) -- was wrong
+  // for both:
+  //
+  //   * A MapViewOfFile region is MEM_MAPPED. VirtualFree cannot free it at
+  //     all; only UnmapViewOfFile can.
+  //   * For a VirtualAlloc region, MEM_RELEASE REQUIRES dwSize to be 0.
+  //     Passing the region's size fails with ERROR_INVALID_PARAMETER.
+  //
+  // Both failures were silent -- the return value is discarded -- so every
+  // view and every private mapping leaked for the life of the process. That
+  // was invisible while Windows segments were pagefile-backed, but once they
+  // gained a sparse backing file (#1063) a leaked view keeps a live section on
+  // that file, and CreateNewSharedMemory's CREATE_ALWAYS cannot truncate a
+  // file with a mapped section: ERROR_USER_MAPPED_FILE. See #1069.
+  //
+  // Ask the OS which kind of region this is rather than threading a flag
+  // through every caller: the callers are shared with the POSIX build, where
+  // the distinction does not exist.
+  if (ptr == nullptr) {
+    return;
+  }
+  MEMORY_BASIC_INFORMATION mbi;
+  if (VirtualQuery(ptr, &mbi, sizeof(mbi)) == sizeof(mbi) &&
+      mbi.Type == MEM_MAPPED) {
+    UnmapViewOfFile(ptr);
+    return;
+  }
+  VirtualFree(ptr, 0, MEM_RELEASE);
+  (void)size;
 #endif
 }
 

--- a/context-transport-primitives/src/system_info.cc
+++ b/context-transport-primitives/src/system_info.cc
@@ -603,20 +603,90 @@ bool SystemInfo::CreateNewSharedMemory(File &fd, const std::string &name,
   return true;
 #endif
 #elif CTP_ENABLE_WINDOWS_SYSINFO
+  // Back the section with a SPARSE FILE, not the paging file.
+  //
+  // The obvious spelling, CreateFileMapping(INVALID_HANDLE_VALUE, ...), asks
+  // for a pagefile-backed section -- and a section created without SEC_RESERVE
+  // is SEC_COMMIT, so the WHOLE size is charged against the system commit
+  // limit the moment it is created, before a single byte is touched. Neither
+  // POSIX branch above behaves that way: Linux's memfd_create + ftruncate and
+  // macOS's regular file are both sparse and charge per touched page.
+  //
+  // That asymmetry is not academic. A CLIO client's per-process data segment
+  // defaults to 512 MB (+32 MB metadata), so on Windows every process that
+  // called ClientInit charged 544 MB of commit whether it used any of it or
+  // not. Measured on a 32 GB host: eight such segments cost 4361 MB of commit
+  // with zero bytes written. Run a test suite that starts several client
+  // processes at once and the commit limit is reached, at which point
+  // CreateFileMapping fails with ERROR_COMMITMENT_LIMIT, ZeroMQ cannot create
+  // a thread, and unrelated processes on the machine start failing to fork.
+  //
+  // A file-backed section is charged to the file instead, and a sparse file
+  // allocates only the ranges written. The same eight segments then cost 0 MB
+  // of commit. FILE_ATTRIBUTE_TEMPORARY keeps the pages in memory unless the
+  // system is actually short of it, so this is not a trip to the disk.
+  //
+  // Everything else is unchanged: the section still carries the same
+  // "Local\<base>" name, so OpenSharedMemory/SharedMemoryExists are untouched,
+  // and a second process still attaches by name.
+  //
   // POSIX shared memory names start with `/` (e.g. "/ctp_shm_42"). Win32
   // kernel object names can't contain `/`, so map to "Local\<base>" — the
   // per-session namespace, which is right for single-host SHM. Without
   // this the mapping was created anonymously (nullptr name) and could
   // not be reopened by name, breaking every OpenSharedMemory.
   std::string win_name = WinShmName(name);
-  fd.windows_fd_ =
-      CreateFileMappingA(INVALID_HANDLE_VALUE,   // use paging file
-                         nullptr,                // default security
-                         PAGE_READWRITE,         // read/write access
-                         0,          // maximum object size (high-order DWORD)
-                         static_cast<DWORD>(size),  // low-order DWORD
-                         win_name.c_str());         // mapping object name
-  return fd.windows_fd_ != nullptr;
+
+  EnsureMemfdDir();
+  std::string shm_path = GetMemfdPath(name);
+
+  // FILE_SHARE_DELETE so DestroySharedMemory can unlink the path the way the
+  // POSIX branches do while a mapping is still live.
+  HANDLE hfile = CreateFileA(shm_path.c_str(), GENERIC_READ | GENERIC_WRITE,
+                             FILE_SHARE_READ | FILE_SHARE_WRITE |
+                                 FILE_SHARE_DELETE,
+                             nullptr, CREATE_ALWAYS,
+                             FILE_ATTRIBUTE_TEMPORARY, nullptr);
+  if (hfile == INVALID_HANDLE_VALUE) {
+    fd.windows_fd_ = nullptr;
+    return false;
+  }
+
+  // Sparse, so extending the file below reserves no disk either. Best effort:
+  // a filesystem without sparse support still gives a correct (if eagerly
+  // sized) file, and the commit-charge problem this function exists to avoid
+  // is solved by the file backing regardless.
+  DWORD unused = 0;
+  DeviceIoControl(hfile, FSCTL_SET_SPARSE, nullptr, 0, nullptr, 0, &unused,
+                  nullptr);
+
+  LARGE_INTEGER end;
+  end.QuadPart = static_cast<LONGLONG>(size);
+  if (!SetFilePointerEx(hfile, end, nullptr, FILE_BEGIN) ||
+      !SetEndOfFile(hfile)) {
+    CloseHandle(hfile);
+    fd.windows_fd_ = nullptr;
+    return false;
+  }
+
+  fd.windows_fd_ = CreateFileMappingA(
+      hfile,                                       // backing file
+      nullptr,                                     // default security
+      PAGE_READWRITE,                              // read/write access
+      static_cast<DWORD>(size >> 32),              // size, high-order DWORD
+      static_cast<DWORD>(size & 0xFFFFFFFFull),    // size, low-order DWORD
+      win_name.c_str());                           // mapping object name
+
+  // The section holds its own reference to the file, so the file handle has
+  // done its job. Closing it here keeps File a union of one handle and leaves
+  // CloseSharedMemory unchanged.
+  CloseHandle(hfile);
+
+  if (fd.windows_fd_ == nullptr) {
+    DeleteFileA(shm_path.c_str());
+    return false;
+  }
+  return true;
 #endif
 }
 
@@ -672,6 +742,47 @@ void SystemInfo::DestroySharedMemory(const std::string &name) {
   unlink(shm_path.c_str());
 #endif
 #elif CTP_ENABLE_WINDOWS_SYSINFO
+  // The segment is the sparse file CreateNewSharedMemory made; remove it, as
+  // the POSIX branches remove theirs. This used to be an empty branch, from
+  // when the Windows section was backed by the paging file and had no path to
+  // remove -- so every segment ever created leaked its name until the machine
+  // was rebooted, and shm_init's "destroy any stale segment first" call did
+  // nothing at all.
+  //
+  // Best effort, exactly like unlink() above: the file was opened with
+  // FILE_SHARE_DELETE, so this succeeds even while a mapping is live on a
+  // filesystem with POSIX delete semantics, and where it does not, the
+  // CREATE_ALWAYS in CreateNewSharedMemory still resets the contents.
+  DeleteFileA(GetMemfdPath(name).c_str());
+#endif
+}
+
+std::string SystemInfo::GetLastSharedMemoryError() {
+#if CTP_ENABLE_PROCFS_SYSINFO
+  return strerror(errno);
+#elif CTP_ENABLE_WINDOWS_SYSINFO
+  DWORD err = GetLastError();
+  char *buf = nullptr;
+  DWORD n = FormatMessageA(
+      FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+          FORMAT_MESSAGE_IGNORE_INSERTS,
+      nullptr, err, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+      reinterpret_cast<char *>(&buf), 0, nullptr);
+  std::string msg;
+  if (n && buf) {
+    msg.assign(buf, n);
+    while (!msg.empty() && (msg.back() == '\r' || msg.back() == '\n' ||
+                            msg.back() == '.' || msg.back() == ' ')) {
+      msg.pop_back();
+    }
+  }
+  if (buf) {
+    LocalFree(buf);
+  }
+  if (msg.empty()) {
+    msg = "unknown error";
+  }
+  return msg + " (Win32 error " + std::to_string(err) + ")";
 #endif
 }
 

--- a/context-transport-primitives/test/unit/util/test_system_info.cc
+++ b/context-transport-primitives/test/unit/util/test_system_info.cc
@@ -13,12 +13,14 @@
 #include "basic_test.h"
 
 #include <clio_ctp/introspect/system_info.h>
+#include <clio_ctp/memory/backend/posix_shm_mmap.h>
 
 #include <cstdlib>
 #include <string>
 #include <vector>
 
 using ctp::SystemInfo;
+using ctp::ipc::PosixShmMmap;
 
 TEST_CASE("SystemInfoCpu") {
   int cpus = SystemInfo::GetCpuCount();
@@ -154,4 +156,46 @@ TEST_CASE("SystemInfoProcessAndModule") {
 #else
   REQUIRE(mod_dir.front() == '/');
 #endif
+}
+
+TEST_CASE("SystemInfoSharedMemoryError") {
+  // GetLastSharedMemoryError() renders whatever the platform's shared-memory
+  // calls last reported: strerror(errno) on POSIX, FormatMessage over
+  // GetLastError() plus the numeric code on Windows. It must always produce
+  // something a human can read -- the point of it is that the previous
+  // "shm_open failed: {strerror(errno)}" reported a Win32 commit-limit failure
+  // as EAGAIN, because the Win32 calls do not set errno at all.
+  std::string msg = SystemInfo::GetLastSharedMemoryError();
+  REQUIRE(!msg.empty());
+
+  // After a call that genuinely failed it must still be non-empty, and must
+  // not fall through to the "unknown error" placeholder.
+  ctp::File missing;
+  REQUIRE_FALSE(
+      SystemInfo::OpenSharedMemory(missing, "ctp_no_such_segment_xyz"));
+  std::string after = SystemInfo::GetLastSharedMemoryError();
+  REQUIRE(!after.empty());
+  REQUIRE(after != "unknown error");
+}
+
+TEST_CASE("SystemInfoSharedMemoryCreateFailure") {
+  // A name far past any platform's limit: memfd_create(2) caps the name at
+  // 249 bytes, and the macOS/Windows branches open a file whose path this
+  // makes far too long. Every platform therefore fails the create, which is
+  // the one path that reports through GetLastSharedMemoryError().
+  const std::string too_long(4096, 'x');
+
+  ctp::File fd;
+  REQUIRE_FALSE(SystemInfo::CreateNewSharedMemory(fd, too_long, 1024 * 1024));
+
+  // The same failure one layer up: shm_init() must report it and return false
+  // rather than going on to map a backend it never created.
+  PosixShmMmap backend;
+  REQUIRE_FALSE(backend.shm_init(ctp::ipc::MemoryBackendId::GetRoot(),
+                                 1024 * 1024, too_long));
+
+  // Destroying a segment that was never created is a no-op everywhere, and
+  // must stay one now that the Windows branch actually deletes a file.
+  SystemInfo::DestroySharedMemory(too_long);
+  SystemInfo::DestroySharedMemory("ctp_no_such_segment_xyz");
 }

--- a/context-transport-primitives/test/unit/util/test_system_info.cc
+++ b/context-transport-primitives/test/unit/util/test_system_info.cc
@@ -199,3 +199,35 @@ TEST_CASE("SystemInfoSharedMemoryCreateFailure") {
   SystemInfo::DestroySharedMemory(too_long);
   SystemInfo::DestroySharedMemory("ctp_no_such_segment_xyz");
 }
+
+TEST_CASE("SystemInfoShmRecreateAfterDestroy") {
+  // Regression for #1069. shm_destroy() must actually release the mapping, so
+  // the same segment name can be created again -- the pattern every test
+  // fixture and every restarting client uses.
+  //
+  // On Windows this failed: UnmapMemory() called VirtualFree(ptr, size,
+  // MEM_RELEASE), which cannot free a MapViewOfFile region at all (and, for a
+  // VirtualAlloc region, MEM_RELEASE requires dwSize == 0). Nothing was ever
+  // unmapped. Once segments gained a sparse backing file (#1063), the leaked
+  // view kept a live section on that file and the second create could not
+  // truncate it: ERROR_USER_MAPPED_FILE. The whole cycle has to run at least
+  // three times, because the first create is the one that passed even when
+  // this was broken.
+  const std::string name = "ctp_shm_recreate_test_" +
+                           std::to_string(SystemInfo::GetPid());
+  const size_t kSize = 4 * 1024 * 1024;
+
+  for (int i = 0; i < 3; ++i) {
+    PosixShmMmap backend;
+    REQUIRE(backend.shm_init(ctp::ipc::MemoryBackendId::GetRoot(), kSize,
+                             name));
+    // Touch the region: a create that "succeeded" against a stale section
+    // from a previous iteration must not be mistaken for a good one.
+    REQUIRE(backend.data_ != nullptr);
+    backend.data_[0] = static_cast<char>('a' + i);
+    REQUIRE(backend.data_[0] == static_cast<char>('a' + i));
+    backend.shm_destroy();
+  }
+
+  SystemInfo::DestroySharedMemory(name);
+}

--- a/installers/vcpkg/overlay-ports/zeromq/README.md
+++ b/installers/vcpkg/overlay-ports/zeromq/README.md
@@ -1,0 +1,41 @@
+# zeromq overlay port
+
+A verbatim copy of vcpkg's `ports/zeromq` (4.3.5#3) plus one upstream patch,
+`windows-ipc-connect-fallback.patch`. Nothing else differs; diff it against
+the registry port before touching anything here.
+
+## Why
+
+On Windows, libzmq's mailbox signaler is an `AF_UNIX` socketpair created by
+`make_fdpair()` in `src/ip.cpp`. That function has a tcp/ip fallback for
+systems where `AF_UNIX` does not work, but it clears the fallback flag as soon
+as `bind()` succeeds -- on the assumption that a successful bind means IPC
+works. It does not always: a later `listen()` or `connect()` on the bound
+socket can still fail, and the function then returns -1 with no fallback left.
+
+`signaler_t`'s constructor does not check that return value. It leaves `_r`
+and `_w` at `retired_fd`, `get_fd()` hands that invalid descriptor to the
+poller, and `epoll_ctl(EPOLL_CTL_ADD)` aborts the process:
+
+    Bad file descriptor (src/epoll.cpp:73)
+    not a socket (src/epoll.cpp:73)
+
+The two spellings are the same assert with a different `errno`.
+
+This is zeromq/libzmq#4730, fixed by zeromq/libzmq#4734 (merged 2024-08-26).
+The fix has never been released: v4.3.5 (2023-10-09) is still the newest tag,
+so every vcpkg build of libzmq carries the bug. vcpkg's port already passes
+`-DZMQ_HAVE_IPC=0` for MinGW, which sidesteps it there; MSVC keeps IPC on.
+
+It reaches clio because every client process builds a ZMQ context during
+`IpcManager::ClientInit`, so any workload that spawns short-lived clients can
+hit it. It was found via the netCDF-C suite, where `ncdump_tst_nccopy5` failed
+under both the CLIO VFD and the CLIO VOL while passing on the baseline --
+reproducibly, and even with the test run in isolation on a clean runner.
+
+## Removing this
+
+Drop the whole directory once a libzmq release past v4.3.5 exists and vcpkg's
+port has moved to it. Check with:
+
+    gh api repos/zeromq/libzmq/releases --jq '.[0].tag_name'

--- a/installers/vcpkg/overlay-ports/zeromq/fix-arm.patch
+++ b/installers/vcpkg/overlay-ports/zeromq/fix-arm.patch
@@ -1,0 +1,16 @@
+diff --git a/src/clock.cpp b/src/clock.cpp
+index 79522ad..0667c59 100644
+--- a/src/clock.cpp
++++ b/src/clock.cpp
+@@ -41,8 +41,10 @@
+ #include <cmnintrin.h>
+ #else
+ #include <intrin.h>
+-#if defined(_M_ARM) || defined(_M_ARM64)
++#if defined(_M_ARM)
+ #include <arm_neon.h>
++#elif defined(_M_ARM64)
++#include <arm64_neon.h>
+ #endif
+ #endif
+ #endif

--- a/installers/vcpkg/overlay-ports/zeromq/pkgconfig.diff
+++ b/installers/vcpkg/overlay-ports/zeromq/pkgconfig.diff
@@ -1,0 +1,40 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0346227..56d34e6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -569,6 +569,23 @@ else()
+   check_cxx_symbol_exists(SO_BUSY_POLL sys/socket.h ZMQ_HAVE_BUSY_POLL)
+ endif()
+ 
++if(WITH_LIBSODIUM)
++  string(APPEND pkg_config_names_private " libsodium")
++endif()
++if(WIN32)
++  string(APPEND pkg_config_libs_private " -ladvapi32 -liphlpapi -lrpcrt4 -lws2_32")
++endif()
++string(APPEND pkg_config_libs_private " ${CMAKE_THREAD_LIBS_INIT}")
++foreach(lib IN LISTS CMAKE_CXX_IMPLICIT_LINK_LIBRARIES)
++  if(lib IN_LIST CMAKE_C_IMPLICIT_LINK_LIBRARIES)
++    continue()
++  elseif(EXISTS "${lib}")
++    string(APPEND pkg_config_libs_private " ${lib}")
++  else()
++    string(APPEND pkg_config_libs_private " -l${lib}")
++  endif()
++endforeach()
++
+ if(NOT MINGW)
+   find_library(RT_LIBRARY rt)
+   if(RT_LIBRARY)
+diff --git a/src/libzmq.pc.in b/src/libzmq.pc.in
+index 233bc3a..3c2bf0d 100644
+--- a/src/libzmq.pc.in
++++ b/src/libzmq.pc.in
+@@ -7,6 +7,6 @@ Name: libzmq
+ Description: 0MQ c++ library
+ Version: @VERSION@
+ Libs: -L${libdir} -lzmq
+-Libs.private: -lstdc++ @pkg_config_libs_private@
++Libs.private: @pkg_config_libs_private@
+ Requires.private: @pkg_config_names_private@
+ Cflags: -I${includedir} @pkg_config_defines@

--- a/installers/vcpkg/overlay-ports/zeromq/portfile.cmake
+++ b/installers/vcpkg/overlay-ports/zeromq/portfile.cmake
@@ -1,0 +1,97 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO zeromq/libzmq
+    REF "v${VERSION}"
+    SHA512 108d9c5fa761c111585c30f9c651ed92942dda0ac661155bca52cc7b6dbeb3d27b0dd994abde206eacfc3bc88d19ed24e45b291050c38469e34dca5f8c9a037d
+    PATCHES
+        # zeromq/libzmq#4734, merged upstream 2024-08-26 but not in any release:
+        # v4.3.5 is still the latest tag. On Windows the mailbox signaler is an
+        # AF_UNIX socketpair, and make_fdpair() clears its tcp/ip fallback as
+        # soon as bind() succeeds -- so a later listen()/connect() failure
+        # returns -1 with no fallback. signaler_t ignores that, leaves _r as
+        # retired_fd, and the poller aborts registering it:
+        #   Bad file descriptor / not a socket (src/epoll.cpp:73)
+        # Every clio client process builds a ZMQ context, so this reaches any
+        # workload that spawns short-lived clients (iowarp/clio-core#1064).
+        # Drop this file when a release past v4.3.5 carries the fix.
+        windows-ipc-connect-fallback.patch
+        fix-arm.patch
+        pkgconfig.diff
+        rename-sha1.diff
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BUILD_STATIC)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED)
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        sodium            WITH_LIBSODIUM
+        draft             ENABLE_DRAFTS
+        websockets        ENABLE_WS
+        websockets-secure WITH_TLS
+        curve             ENABLE_CURVE
+)
+
+set(PLATFORM_OPTIONS "")
+if(VCPKG_TARGET_IS_MINGW)
+    list(APPEND PLATFORM_OPTIONS "-DCMAKE_SYSTEM_VERSION=6.0" "-DZMQ_HAVE_IPC=0")
+endif()
+
+vcpkg_find_acquire_program(PKGCONFIG)
+set(ENV{PKG_CONFIG} "${PKGCONFIG}")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_STATIC=${BUILD_STATIC}
+        -DBUILD_SHARED=${BUILD_SHARED}
+        -DCMAKE_POLICY_DEFAULT_CMP0057=NEW  # IN_LIST
+        -DCMAKE_REQUIRE_FIND_PACKAGE_GnuTLS=ON
+        -DWITH_DOCS=OFF
+        -DWITH_PERF_TOOL=OFF
+        -DWITH_LIBBSD=OFF
+        -DWITH_LIBSODIUM_STATIC=${BUILD_STATIC}
+        -DWITH_NSS=OFF
+        -DZEROMQ_CMAKECONFIG_INSTALL_DIR=share/${PORT}
+        -DZMQ_BUILD_TESTS=OFF
+        ${FEATURE_OPTIONS}
+        ${PLATFORM_OPTIONS}
+    OPTIONS_DEBUG
+        "-DCMAKE_PDB_OUTPUT_DIRECTORY=${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg"
+    MAYBE_UNUSED_VARIABLES
+        CMAKE_REQUIRE_FIND_PACKAGE_GnuTLS
+        WITH_LIBBSD
+        WITH_PERF_TOOL
+        WITH_TLS
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup()
+vcpkg_fixup_pkgconfig()
+
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    file(GLOB libzmq_release "${CURRENT_PACKAGES_DIR}/lib/libzmq*.lib")
+    cmake_path(GET libzmq_release STEM LAST_ONLY libzmq_spec)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libzmq.pc" " -lzmq" " -l${libzmq_spec}")
+    if(NOT VCPKG_BUILD_TYPE)
+        file(GLOB libzmq_debug "${CURRENT_PACKAGES_DIR}/debug/lib/libzmq*.lib")
+        cmake_path(GET libzmq_debug STEM LAST_ONLY libzmq_spec)
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libzmq.pc" " -lzmq" " -l${libzmq_spec}")
+    endif()
+endif()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/zmq.h" "defined ZMQ_STATIC" "(1)")
+      file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin" "${CURRENT_PACKAGES_DIR}/bin") # empty
+endif()
+
+file(COPY
+    "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share" "${CURRENT_PACKAGES_DIR}/share/zmq")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/installers/vcpkg/overlay-ports/zeromq/portfile.cmake
+++ b/installers/vcpkg/overlay-ports/zeromq/portfile.cmake
@@ -12,7 +12,7 @@ vcpkg_from_github(
         # retired_fd, and the poller aborts registering it:
         #   Bad file descriptor / not a socket (src/epoll.cpp:73)
         # Every clio client process builds a ZMQ context, so this reaches any
-        # workload that spawns short-lived clients (iowarp/clio-core#1064).
+        # workload that spawns short-lived clients (iowarp/clio-core#1067).
         # Drop this file when a release past v4.3.5 carries the fix.
         windows-ipc-connect-fallback.patch
         fix-arm.patch

--- a/installers/vcpkg/overlay-ports/zeromq/rename-sha1.diff
+++ b/installers/vcpkg/overlay-ports/zeromq/rename-sha1.diff
@@ -1,0 +1,18 @@
+diff --git a/external/sha1/sha1.h b/external/sha1/sha1.h
+index 7354d13..93d717a 100644
+--- a/external/sha1/sha1.h
++++ b/external/sha1/sha1.h
+@@ -45,6 +45,13 @@ extern "C" {
+ #include <stdlib.h>
+ #include "../../src/stdint.hpp"
+ 
++/* Avoid collision with libssh et al. */
++#define sha1_ctxt   zmq_sha1_ctxt
++#define sha1_init   zmq_sha1_init
++#define sha1_pad    zmq_sha1_pad
++#define sha1_loop   zmq_sha1_loop
++#define sha1_result zmq_sha1_result
++
+ struct sha1_ctxt
+ {
+ 	union

--- a/installers/vcpkg/overlay-ports/zeromq/vcpkg-cmake-wrapper.cmake
+++ b/installers/vcpkg/overlay-ports/zeromq/vcpkg-cmake-wrapper.cmake
@@ -1,0 +1,9 @@
+_find_package(${ARGS})
+
+if(TARGET libzmq AND NOT TARGET libzmq-static)
+    add_library(libzmq-static INTERFACE IMPORTED)
+    set_target_properties(libzmq-static PROPERTIES INTERFACE_LINK_LIBRARIES libzmq)
+elseif(TARGET libzmq-static AND NOT TARGET libzmq)
+    add_library(libzmq INTERFACE IMPORTED)
+    set_target_properties(libzmq PROPERTIES INTERFACE_LINK_LIBRARIES libzmq-static)
+endif()

--- a/installers/vcpkg/overlay-ports/zeromq/vcpkg.json
+++ b/installers/vcpkg/overlay-ports/zeromq/vcpkg.json
@@ -1,0 +1,56 @@
+{
+  "name": "zeromq",
+  "version": "4.3.5",
+  "port-version": 4,
+  "description": "The ZeroMQ lightweight messaging kernel is a library which extends the standard socket interfaces with features traditionally provided by specialised messaging middleware products",
+  "homepage": "https://github.com/zeromq/libzmq",
+  "license": "MPL-2.0",
+  "supports": "!uwp & !xbox",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "curve": {
+      "description": "Enable CURVE security"
+    },
+    "draft": {
+      "description": "Build and install draft APIs"
+    },
+    "sodium": {
+      "description": "Using libsodium for CURVE security",
+      "dependencies": [
+        "libsodium",
+        {
+          "name": "zeromq",
+          "default-features": false,
+          "features": [
+            "curve"
+          ]
+        }
+      ]
+    },
+    "websockets": {
+      "description": "Enable WebSocket transport"
+    },
+    "websockets-secure": {
+      "description": "Enable WebSocket transport with TSL (wss)",
+      "dependencies": [
+        "libgnutls",
+        {
+          "name": "zeromq",
+          "default-features": false,
+          "features": [
+            "websockets"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/installers/vcpkg/overlay-ports/zeromq/windows-ipc-connect-fallback.patch
+++ b/installers/vcpkg/overlay-ports/zeromq/windows-ipc-connect-fallback.patch
@@ -1,0 +1,100 @@
+diff --git a/src/ip.cpp b/src/ip.cpp
+index 1aaf6ad6b1..30d70eb022 100644
+--- a/src/ip.cpp
++++ b/src/ip.cpp
+@@ -23,6 +23,11 @@
+ #include "tcp.hpp"
+ #ifdef ZMQ_HAVE_IPC
+ #include "ipc_address.hpp"
++// Don't try ipc if it fails once
++namespace zmq
++{
++static bool try_ipc_first = true;
++}
+ #endif
+ 
+ #include <direct.h>
+@@ -555,9 +560,14 @@ int zmq::make_fdpair (fd_t *r_, fd_t *w_)
+ 
+     // It appears that a lack of runtime AF_UNIX support
+     // can fail in more than one way.
+-    // At least: open_socket can fail or later in bind
++    // At least: open_socket can fail or later in bind or even in connect after bind
+     bool ipc_fallback_on_tcpip = true;
+ 
++    if (!zmq::try_ipc_first) {
++        // a past ipc attempt failed, skip straight to try_tcpip in the future;
++        goto try_tcpip;
++    }
++
+     //  Create a listening socket.
+     const SOCKET listener = open_socket (AF_UNIX, SOCK_STREAM, 0);
+     if (listener == retired_fd) {
+@@ -585,8 +595,7 @@ int zmq::make_fdpair (fd_t *r_, fd_t *w_)
+         goto error_closelistener;
+     }
+     // if we got here, ipc should be working,
+-    // so raise any remaining errors
+-    ipc_fallback_on_tcpip = false;
++    // but there are at least some cases where connect can still fail
+ 
+     //  Listen for incoming connections.
+     rc = listen (listener, 1);
+@@ -597,11 +606,11 @@ int zmq::make_fdpair (fd_t *r_, fd_t *w_)
+ 
+     rc = getsockname (listener, reinterpret_cast<struct sockaddr *> (&lcladdr),
+                       &lcladdr_len);
+-    wsa_assert (rc != -1);
++    wsa_assert (rc == 0);
+ 
+     //  Create the client socket.
+     *w_ = open_socket (AF_UNIX, SOCK_STREAM, 0);
+-    if (*w_ == -1) {
++    if (*w_ == retired_fd) {
+         errno = wsa_error_to_errno (WSAGetLastError ());
+         goto error_closelistener;
+     }
+@@ -609,12 +618,16 @@ int zmq::make_fdpair (fd_t *r_, fd_t *w_)
+     //  Connect to the remote peer.
+     rc = ::connect (*w_, reinterpret_cast<const struct sockaddr *> (&lcladdr),
+                     lcladdr_len);
+-    if (rc == -1) {
++    if (rc != 0) {
++        errno = wsa_error_to_errno (WSAGetLastError ());
+         goto error_closeclient;
+     }
++    // if we got here, ipc should be working,
++    // so raise any remaining errors
++    ipc_fallback_on_tcpip = false;
+ 
+     *r_ = accept (listener, NULL, NULL);
+-    errno_assert (*r_ != -1);
++    wsa_assert (*r_ != retired_fd);
+ 
+     //  Close the listener socket, we don't need it anymore.
+     rc = closesocket (listener);
+@@ -636,6 +649,7 @@ int zmq::make_fdpair (fd_t *r_, fd_t *w_)
+     saved_errno = errno;
+     rc = closesocket (*w_);
+     wsa_assert (rc == 0);
++    *w_ = retired_fd;
+     errno = saved_errno;
+ 
+ error_closelistener:
+@@ -663,9 +677,13 @@ int zmq::make_fdpair (fd_t *r_, fd_t *w_)
+ 
+ try_tcpip:
+     // try to fallback to TCP/IP
+-    // TODO: maybe remember this decision permanently?
+-#endif
+-
++    rc = make_fdpair_tcpip (r_, w_);
++    if (rc == 0 && zmq::try_ipc_first) {
++        // ipc didn't work but tcp/ip did; skip ipc in the future
++        zmq::try_ipc_first = false;
++    }
++    return rc;
++#endif // ZMQ_HAVE_IPC
+     return make_fdpair_tcpip (r_, w_);
+ #elif defined ZMQ_HAVE_OPENVMS
+ 


### PR DESCRIPTION
## Summary

- Release Windows mappings with the deallocator that can actually free them: `UnmapViewOfFile` for `MEM_MAPPED` regions, `VirtualFree(ptr, 0, MEM_RELEASE)` for private ones.
- Stop `CreateNewSharedMemory` from losing the reason it failed, so a shared-memory failure reports the call that actually failed.
- Add `SystemInfoShmRecreateAfterDestroy`, a create/touch/destroy cycle over one segment name.

## Motivation

Fixes #1069.

`UnmapMemory()` is the counterpart of **two** allocators, because on POSIX a single `munmap()` serves both — `MapSharedMemory()` (`MapViewOfFile`) and `MapPrivateMemory()` (`VirtualAlloc`). Win32 needs a different call for each, and `VirtualFree(ptr, size, MEM_RELEASE)` was wrong for both:

* it cannot free a `MEM_MAPPED` region at all;
* for a `VirtualAlloc` region, `MEM_RELEASE` requires `dwSize` to be 0, so the non-zero size was rejected too.

The return value is discarded, so nothing was ever unmapped and nothing said so.

That was survivable while Windows segments were pagefile-backed. Since #1063 backed them with a sparse file, a leaked view keeps a live section **on that file**, and `CreateNewSharedMemory` opens it `CREATE_ALWAYS` — truncation, which Windows refuses on a file with a mapped section:

```
shm_init could not create shared memory segment cte_shm_cache_test_5432 of 67108864 bytes:
  The requested operation cannot be performed on a file with a user-mapped section open (Win32 error 1224)
```

The fix asks `VirtualQuery` which kind of region it is rather than threading a flag through callers that are shared with the POSIX build, where the distinction does not exist.

The second commit hunk addresses a defect this exposed: `CreateNewSharedMemory`'s cleanup (`DeleteFileA`, `CloseHandle`) ran before the caller read `GetLastError()`, so the reported code could come from the cleanup rather than the failure. That is how the same test reported `Win32 error 203` (`ERROR_ENVVAR_NOT_FOUND`), which nothing in that function can produce.

## Test plan

- [x] Regression test added: `ctest -R ctp_system_info` (`SystemInfoShmRecreateAfterDestroy`). It runs the cycle three times deliberately — two is not enough, because the first create succeeded even with the bug present.
- [x] `ctest -R cte_shm_metadata_cache_all` passes on `windows-2022` (it was the failing test).
- [x] Full Windows matrix green, 8/8 jobs — `build-test` and `icx` on windows-2022 / windows-2025 / windows-2025-vs2026 / windows-11-arm, plus the boost variant.
- [x] No new compiler warnings.
- [x] 80-column limit respected.

Before → after on the two jobs that were failing:

| job | before | after |
| --- | --- | --- |
| `build-test (windows-2022)` | 236/237 — `cte_shm_metadata_cache_all` | **237/237, 0 failed** |
| `icx (windows-2022)` | 235/236 — `cte_shm_metadata_cache_all` | **236/236, 0 failed** |

The POSIX path is untouched (`munmap` for both, as before), so Linux and macOS behaviour is unchanged by construction.

### One thing I did not prove

The failing test reported two different Win32 errors: `1224` on one case and `203` on the other. The `1224` mechanism is established and follows from documented Win32 behaviour. The `203` I believe was a stale value surfaced by the error-reporting defect — it disappeared with this change, but that is inference, not a proof. If anything like it recurs, the reporting fix now names the call that actually failed.

## Breaking changes

None.
