### PR TITLE
Give the nightly quarantine job the deps it needs to build

### DIFF
--- a/.github/workflows/nightly-full-sweep.yml
+++ b/.github/workflows/nightly-full-sweep.yml
@@ -36,19 +36,41 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: dev
           submodules: recursive
 
-      - name: Install build dependencies
+      - name: Install system libraries
         run: |
           bash CI/retry.sh sudo apt-get update
           bash CI/retry.sh sudo apt-get install -y libhdf5-dev liburing-dev
 
+      # The apt packages above are not the whole dependency set -- yaml-cpp,
+      # cereal, thallium and the rest live in the `iowarp` conda env that
+      # CI/ci-deps.sh builds, which is why every other Linux job runs this and
+      # then activates the env before configuring. This job did neither and
+      # died at `find_package(yaml-cpp REQUIRED)` before it ever reached ctest.
+      - name: Install dependencies (conda env)
+        run: |
+          chmod +x CI/ci-deps.sh
+          ./CI/ci-deps.sh --only-deps
+
+      # `--preset release` rather than a bare -DCMAKE_BUILD_TYPE=Release: the
+      # preset is what turns CLIO_CORE_ENABLE_TESTS on. Without it the build
+      # produces no test targets at all, so `ctest -L flaky` would have had
+      # nothing to run even once configure succeeded.
       - name: Configure and build
         run: |
-          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+          if [ -f "$HOME/miniconda3/etc/profile.d/conda.sh" ]; then
+            source "$HOME/miniconda3/etc/profile.d/conda.sh"
+          elif [ -f "$HOME/anaconda3/etc/profile.d/conda.sh" ]; then
+            source "$HOME/anaconda3/etc/profile.d/conda.sh"
+          elif command -v conda &>/dev/null; then
+            eval "$(conda shell.bash hook)"
+          fi
+          conda activate iowarp
+          cmake --preset release
           cmake --build build -j"$(nproc)"
 
       # -L (not -LE): run ONLY what the gates skip. No --repeat here -- the
@@ -62,11 +84,28 @@ jobs:
       - name: Run quarantined tests
         id: quarantined
         run: |
+          if [ -f "$HOME/miniconda3/etc/profile.d/conda.sh" ]; then
+            source "$HOME/miniconda3/etc/profile.d/conda.sh"
+          elif [ -f "$HOME/anaconda3/etc/profile.d/conda.sh" ]; then
+            source "$HOME/anaconda3/etc/profile.d/conda.sh"
+          elif command -v conda &>/dev/null; then
+            eval "$(conda shell.bash hook)"
+          fi
+          conda activate iowarp
           set -o pipefail
           rc=0
           ctest --test-dir build -L flaky --output-on-failure --timeout 300 \
             2>&1 | tee /tmp/quarantined.log || rc=$?
           echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          # An EMPTY pen and a green pen are not the same result, and ctest
+          # reports both as exit 0. "All quarantined tests passed" printed over
+          # a run that executed nothing is the exact failure mode this workflow
+          # exists to prevent, so the two are distinguished for the summary.
+          if grep -q "No tests were found" /tmp/quarantined.log; then
+            echo "empty=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "empty=0" >> "$GITHUB_OUTPUT"
+          fi
           echo "quarantined suite exited $rc (reported, not gating)"
 
       - name: Summarize quarantine
@@ -75,7 +114,12 @@ jobs:
           {
             echo "## Quarantined tests (\`flaky\` label)"
             echo
-            if [ "${{ steps.quarantined.outputs.rc }}" = "0" ]; then
+            if [ "${{ steps.quarantined.outputs.empty }}" = "1" ]; then
+              echo "No test currently carries the \`flaky\` ctest label — the"
+              echo "quarantine pen is empty and nothing was run. This is a real"
+              echo "result, not a pass: the gates' \`-LE flaky\` exclusions are"
+              echo "matching nothing."
+            elif [ "${{ steps.quarantined.outputs.rc }}" = "0" ]; then
               echo "All quarantined tests passed. Candidates for requalification —"
               echo "check each against a measured baseline before removing the label."
             else
@@ -101,7 +145,7 @@ jobs:
         os: [ubuntu-24.04, ubuntu-24.04-arm, macos-14, macos-15, windows-2025]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: dev
           submodules: recursive


### PR DESCRIPTION
Fixes #1071.

The `quarantined tests (flaky label)` job dies during *Configure and build* on every scheduled run (2026-08-31, 2026-09-01; ~25s to failure):

```
CMake Error at CMakeLists.txt:307 (find_package):
  Could not find a package configuration file provided by "yaml-cpp"
```

It installed `libhdf5-dev liburing-dev` from apt and then ran a bare `cmake -S . -B build`. yaml-cpp, cereal, thallium and the rest live in the `iowarp` conda env that `CI/ci-deps.sh` builds; every other Linux job runs that script and activates the env before configuring, and this one did neither.

## Changes

- **Install the actual dependency set.** Added `./CI/ci-deps.sh --only-deps` plus the standard conda-activation prologue before the configure and the ctest step, matching `ci-linux.yml`'s leak-check and boost-native jobs.
- **Configure with `--preset release`** instead of a bare `-DCMAKE_BUILD_TYPE=Release`. The preset is what sets `CLIO_CORE_ENABLE_TESTS=ON`; the failing run's log shows `CLIO_CORE_ENABLE_TESTS: OFF`, so no test targets were being built and `ctest -L flaky` would have found nothing even once the dependency problem was solved. Two bugs, one of them hidden behind the other.
- **Report an empty quarantine pen as empty.** No test currently carries the `flaky` label, so ctest prints `No tests were found!!!` and exits 0 — which the summary step reported as *"All quarantined tests passed. Candidates for requalification"*. A green report over a run that executed nothing is precisely what this workflow was written to prevent, so the empty case now says so.
- `actions/checkout@v4` → `@v5`, clearing the Node 20 deprecation annotations on this workflow.

## Verification

Ran the workflow on the fixed branch: https://github.com/hyoklee/core/actions/runs/33526155327 — all six jobs green, quarantined-tests 19m46s (previously 25s to failure). From the job log rather than the checkmark:

```
-- found yaml-cpp at /home/runner/miniconda3/envs/iowarp/lib/cmake/yaml-cpp
--     Enable Tests:               ON
No tests were found!!!
quarantined suite exited 0 (reported, not gating)
```

so the env supplies yaml-cpp, tests are enabled, and the new empty-pen branch fires.

## Deliberately not addressed

The job now builds, runs to completion, and honestly reports that **it ran zero tests**. `grep -rn LABELS` over the CMakeLists finds no `flaky` anywhere, and a local release configure registers 320 tests with `ctest -L flaky -N` returning `Total Tests: 0`. So the gates' `-LE "ollama|force_net|flaky"` exclusions are matching nothing on that term — either dead code, or tests that should be quarantined never got labeled. That is a quarantine-policy decision for whoever owns it, and this PR does not guess at it; see #1071.