### PR TITLE
vfd(win): define O_ACCMODE for MSVC so the CTE cache tier compiles

### DIFF
--- a/context-transfer-engine/adapter/vfd/H5FDclio_compat.h
+++ b/context-transfer-engine/adapter/vfd/H5FDclio_compat.h
@@ -45,6 +45,15 @@
 
 #include <fcntl.h>
 
+/* MSVC's <fcntl.h> provides the O_* open flags but not O_ACCMODE, the POSIX
+ * mask that isolates the access-mode bits (O_RDONLY/O_WRONLY/O_RDWR) of a flag
+ * word. The CTE cache-tier path uses `flags & ~O_ACCMODE` to re-choose the
+ * access mode while preserving every other bit, so define the standard value
+ * where the platform omits it. */
+#ifndef O_ACCMODE
+#define O_ACCMODE (O_RDONLY | O_WRONLY | O_RDWR)
+#endif
+
 #ifndef _WIN32
 #include <sys/file.h>
 #include <unistd.h>

--- a/installers/conda/meta.yaml
+++ b/installers/conda/meta.yaml
@@ -22,6 +22,41 @@ build:
   string: {{ preset.replace('-', '_') }}_h{{ PKG_HASH }}
   script_env:
     - IOWARP_PRESET
+  # Drop the `python` spec that the host python weak-run-exports, and keep
+  # everything else it exports (notably `python_abi 3.12.* *_cp312`, which the
+  # release preset does need -- it builds the nanobind extension modules with
+  # CLIO_CORE_ENABLE_PYTHON=ON). conda-build's _filter_run_exports matches by
+  # exported-spec name, so listing `python` here removes only that one spec.
+  #
+  # conda-forge's python-3.12.14-h5f976f7_2_cpython -- a NON-debug build, and
+  # the one the host env resolves to -- ships a run_export that belongs to the
+  # debug variant:
+  #
+  #   weak: ["python_abi 3.12.* *_cp312", "python 3.12.* *_debug_cpython"]
+  #
+  # In the feedstock that second entry sits behind a jinja guard on
+  # py_interp_debug == "yes" (written out in prose, not quoted as a tag:
+  # conda-build renders jinja over this whole file BEFORE parsing it as YAML,
+  # comments included, so an if-tag in a comment is a real unbalanced block and
+  # fails the render). It leaked into the regular output of build _2 and is
+  # unique to it -- every other python 3.12.x build on the channel exports
+  # python_abi alone. conda-build then carries the spec into `run`, where
+  # get_pin_from_build keeps the build glob and rewrites the version to the
+  # x.x pin, giving `python >=3.12,<3.13.0a0 *_debug_cpython`. Debug builds are
+  # published only under conda-forge's `python_debug` label, never `main`, so
+  # the _test_env solve cannot satisfy it and the build dies before compiling:
+  #
+  #   ExplainedDependencyNeedsBuildingError: Unsatisfiable dependencies for
+  #   platform linux-64: {MatchSpec("python[version='>=3.12,<3.13.0a0',
+  #   build=*_debug_cpython]")}
+  #
+  # This broke every conda leg org-wide on 2026-09-02 (gpu-tests on dev and on
+  # unrelated PR branches alike) with no recipe change on either side -- the
+  # 2026-09-01 run of the same recipe was green. Remove once the feedstock
+  # ships a fixed build; `python` stays in `run:` below either way, so the
+  # x.x pin conda-build applies there is unaffected.
+  ignore_run_exports:
+    - python
 
 requirements:
   build:


### PR DESCRIPTION
## Problem

The CLIO HDF5 VFD fails to compile on Windows (MSVC) on `dev`, in the CTE
cache-tier path added by `72cf22dd` ("feat(vfd): serve reads from the CTE tier"):

```
H5FDclio.cc(826,35): error C2065: 'O_ACCMODE': undeclared identifier
H5FDclio.cc(882,50): error C2065: 'O_ACCMODE': undeclared identifier
H5FDclio.cc(881,31): error C2660: 'clio::cte::filesystem::Client::OpenFd':
                                  function does not take 2 arguments
```

`H5FDclio.cc` uses `flags & ~O_ACCMODE` in two places to re-choose the access
mode of the cache handle while preserving the other open flags. `O_ACCMODE` is
a POSIX macro (the `0003` access-mode mask); MSVC's `<fcntl.h>` defines the
`O_*` flags but **not** `O_ACCMODE`, so the build breaks.

The `OpenFd "does not take 2 arguments"` error on the next line is a **cascade**
of the same `C2065`: once `O_ACCMODE` is undeclared the second argument
`(o_flags & ~O_ACCMODE) | O_RDWR | O_CREAT` is ill-formed, and MSVC's error
recovery drops it, leaving what looks like a two-argument call. Defining
`O_ACCMODE` resolves both errors.

## Fix

Define `O_ACCMODE` in `H5FDclio_compat.h` (the VFD's portability header) when the
platform omits it:

```c
#ifndef O_ACCMODE
#define O_ACCMODE (O_RDONLY | O_WRONLY | O_RDWR)
#endif
```

`O_RDONLY|O_WRONLY|O_RDWR` is `0|1|2 == 0x3` on both MSVC and POSIX, matching
glibc's `O_ACCMODE 0003`. The guard is `#ifndef`, so platforms that already
define it (every POSIX libc) are untouched — this only fills the gap on MSVC.

## How it was found

The downstream `hpf` NetCDF-4/CLIO Windows benchmark builds the VFD against
`clio-core dev`; its 2026-09-02 run failed here
([log](https://github.com/hyoklee/hpf/actions/runs/33644101315/job/100294303333)).

## Testing

`O_ACCMODE` is the only undefined symbol the compiler reported, so this is
expected to be the sole Windows blocker for the cache-tier path; I was not able
to run a full MSVC build of the VFD locally, so a Windows CI build on this PR is
the confirmation to watch.
