### PR TITLE
with_runtime: fence the blob phase off from the bring-up race

### DIFF
--- a/context-runtime/test/integration/with_runtime/test_with_runtime_cache.cc
+++ b/context-runtime/test/integration/with_runtime/test_with_runtime_cache.cc
@@ -24,13 +24,16 @@
  *                the four. Two runtimes on a port is the failure this issue
  *                exists to prevent, and "all eight attached to nothing" is the
  *                opposite failure — both are caught here.
- *   3. put/get   Each rank PutBlobs a rank-stamped payload under a shared tag,
- *                barrier, then GetBlobs the payload written by its node-local
- *                predecessor — a rank that STARTED the runtime reads what a
- *                rank that ATTACHED wrote and vice versa, so the two bring-up
- *                paths are proven to land in the same runtime. Each rank also
- *                reads its own blob back, and rank 0 additionally reads a blob
- *                written on the other node.
+ *   3. put/get   Fenced off from the bring-up race by a cluster-wide barrier,
+ *                so no rank writes into a peer node's runtime while that
+ *                runtime is still composing its pools (see the barrier's
+ *                comment). Each rank PutBlobs a rank-stamped payload under a
+ *                shared tag, barrier, then GetBlobs the payload written by
+ *                its node-local predecessor — a rank that STARTED the runtime
+ *                reads what a rank that ATTACHED wrote and vice versa, so the
+ *                two bring-up paths are proven to land in the same runtime.
+ *                Each rank also reads its own blob back, and rank 0
+ *                additionally reads a blob written on the other node.
  *
  * Exit code 0 == every rank's checks passed (max-reduced onto rank 0).
  */
@@ -179,6 +182,28 @@ int main(int argc, char **argv) {
                   " runtime owners (expected exactly 1)");
     if (local_rc == 0) local_rc = 3;
   }
+
+  // The bring-up race ends here. Phase 1 is deliberately unsynchronized --
+  // that race IS issue #1015 -- but phase 3 is about where the blobs land, not
+  // about who started what, and it must not begin until EVERY node's runtime
+  // has finished composing.
+  //
+  // Without this barrier the node-0 ranks are structurally the early ones: they
+  // reach phase 3 as soon as rank 0's own runtime is up and its tag is created,
+  // while the node-1 ranks cannot start until rank 0's MPI_Bcast reaches them.
+  // A node-0 rank whose blob hashes to the container on node 1 then issues its
+  // PutBlob into a runtime that is listening but whose clio_cte_core Create has
+  // not yet run RegisterTarget, so ExtendBlob finds an empty target list and
+  // the put fails "no target has remaining space" (PutBlob rc=11 = 10 + the
+  // allocator's code 1). That is what the CI flake was: the failing ranks were
+  // always node-0 ranks, and which of them failed moved with the tag id,
+  // because the tag id feeds HashBlobToContainer.
+  //
+  // Every rank's CLIO_INIT has returned once this barrier releases, and a
+  // node's losing ranks only return from CLIO_INIT after the rank that won the
+  // start lock has finished ServerInit (compose included) -- so both nodes'
+  // targets are registered before the first blob op.
+  MPI_Barrier(MPI_COMM_WORLD);
 
   // --- phase 3: PutBlob / GetBlob through the (possibly shared) runtime ---
   std::uint64_t tag_u64 = 0;


### PR DESCRIPTION
Fixes the intermittent `Runtime CLIO_WITH_RUNTIME=1 attach-or-start test` failure in Cluster Tests. Observed on a fork running the same job, in 4 of ~12 consecutive runs.

The runtime behavior underneath it is #1077; this PR is only the test's ordering.

## The failure

```
[with_runtime rank0] FAIL: PutBlob rc=11
[with_runtime rank3] FAIL: PutBlob rc=11
[with_runtime rank2] FAIL: GetBlob(rank3) rc=1     <- nobody wrote rank3's blob
```

`rc=11` is `10 +` `ExtendBlob`'s `kCteAllocNoTargetSpace`, set when `available_targets` is **empty** — the container has no registered target at all, not a tier that filled up. (The tier here is a fresh 2 GB file bdev holding eight 64 KB blobs, so a real ENOSPC is not on the table.)

Two details pin it to a bring-up window rather than a full tier:

- The failing ranks are **always** node-0 ranks; node-1 ranks passed in all four failing runs.
- *Which* node-0 ranks fail moves between runs (`{0,3}`, `{0,2,3}`), tracking the tag id — `HashBlobToContainer` hashes `(tag_id, blob_name)` to choose the container.

## Cause

Phase 3 had no cluster-wide sync ahead of it, and node-0's ranks are structurally the early ones: they enter it as soon as rank 0's own runtime is up and its tag exists, while node-1 ranks cannot start until rank 0's `MPI_Bcast` reaches them. A node-0 rank whose blob hashes to node 1's container then issues its `PutBlob` into a runtime that is already listening but whose `clio_cte_core` `Create` has not yet reached `RegisterTarget` — `ServerInit` binds the port and starts workers *before* it composes. `ExtendBlob` finds no targets, the put is rejected as "no target has remaining space", and the peer that later reads that blob fails `rc=1` on a blob nobody wrote.

## The change

One `MPI_Barrier(MPI_COMM_WORLD)` between phase 2 and phase 3, plus a comment recording the above.

Phase 1 stays unsynchronized on purpose — that race is what #1015 is about, and this does not touch it. Phase 2 still proves exactly one runtime owner per node. The barrier only says the blob phase starts once the cluster is up: every rank's `CLIO_INIT` has returned when it releases, and a node's runtime-owning rank returns only after its `ServerInit` (compose included) finished, so both nodes' targets are registered before the first blob op. Ranks carrying a nonzero `local_rc` reach the barrier too, so a failing rank still cannot hang the job.

## Verification

Cluster Tests run on this commit — whole job green in 21m36s:

```
[with_runtime rank0] init ok=1 node=0 runtime_owner=1
[with_runtime rank4] init ok=1 node=1 runtime_owner=1
all 8 ranks: PASS
✓ CLIO_WITH_RUNTIME=1 attach-or-start PASSED (#1015)
```

Exactly one owner per node, so the bring-up race still happened and phase 2 still proved what it exists to prove — the barrier did not neuter the test.

One green run on a race is weaker evidence than one red one. Re-running a couple more times before merging is cheap insurance if you want it.

## Scope

This fixes the test's ordering, not the runtime behavior under it: a runtime accepts cross-node tasks for a composed pool before that pool's local container has registered its targets, and reports the miss to the caller as "tier is full" rather than "not ready yet" — a code band the HDF5 VOL adapter uses to arm back-pressure. That is #1077.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014NCwCnHB8hoix5zgPJ2Rou