### PR TITLE
vfd: never let a failed callback push nothing onto the HDF5 error stack

### DIFF
--- a/context-transfer-engine/adapter/vfd/H5FDclio.cc
+++ b/context-transfer-engine/adapter/vfd/H5FDclio.cc
@@ -139,15 +139,30 @@ unsigned long H5FDclio_cache_truncate_failures_g = 0;
  * FAIL/NULL to signal the failure to the library; this records a diagnosable
  * reason (incl. errno) that composes with HDF5's own stack and is surfaced by
  * the normal H5Eprint auto-handler at the API boundary -- instead of failing
- * silently. No-op until the class is registered by H5FD_clio_init(). */
+ * silently.
+ *
+ * The push is UNCONDITIONAL. It used to be skipped whenever the driver's own
+ * error class had not been registered, which turned "fail closed and say why"
+ * into "fail closed silently" -- the exact defect section 9 of the unit suite
+ * exists to catch, and the one failure mode that leaves a caller with an open
+ * that failed for no stated reason. The class ids are a nicety (they label the
+ * frame "CLIO VFD"); when any of them is unavailable the message still goes on
+ * the stack under HDF5's own VFL class, because the message is the part that
+ * matters. Note all three ids are checked, not just the class: H5Epush2 fails
+ * outright on an invalid major/minor, so a half-registered class was another
+ * way to push nothing. */
 #define H5FD_CLIO_ERROR(msg)                                               \
   do {                                                                     \
-    if (H5FDclio_err_class_g >= 0) {                                       \
-      H5Epush2(H5E_DEFAULT, __FILE__, __func__, __LINE__,                  \
-               H5FDclio_err_class_g, H5FDclio_err_major_g,                 \
-               H5FDclio_err_minor_g, "%s (errno=%d: %s)", (msg), errno,    \
-               strerror(errno));                                           \
-    }                                                                      \
+    const int h5fd_clio_errno = errno;                                     \
+    const bool h5fd_clio_own_cls =                                         \
+        (H5FDclio_err_class_g >= 0 && H5FDclio_err_major_g >= 0 &&         \
+         H5FDclio_err_minor_g >= 0);                                       \
+    H5Epush2(H5E_DEFAULT, __FILE__, __func__, __LINE__,                    \
+             h5fd_clio_own_cls ? H5FDclio_err_class_g : H5E_ERR_CLS,       \
+             h5fd_clio_own_cls ? H5FDclio_err_major_g : H5E_VFL,           \
+             h5fd_clio_own_cls ? H5FDclio_err_minor_g : H5E_CANTINIT,      \
+             "%s (errno=%d: %s)", (msg), h5fd_clio_errno,                  \
+             strerror(h5fd_clio_errno));                                   \
   } while (0)
 
 /* POSIX I/O mode used as the third parameter to open/_open
@@ -360,6 +375,37 @@ static inline bool H5FD__clio_sieve_valid(size_t v) {
 static const H5FD_clio_fapl_t H5FD_clio_fapl_default_g = {
     /*cache_enabled*/ 1, /*fsync_on_flush*/ 0,
     /*sieve_max*/ H5FD_CLIO_SIEVE_MAX_DEF};
+
+/* H5Pget_driver_info() reports "this FAPL carries no driver-info block" exactly
+   the way it reports a real failure: NULL, plus H5E_PLIST/H5E_CANTGET pushed on
+   the error stack. Here the absent block is the NORMAL case -- H5Pset_driver(
+   fapl, id, NULL), H5Pset_driver_by_name(), HDF5_DRIVER=clio_vfd and the
+   defaults all leave it unset; only H5Pset_fapl_clio() sets one -- so calling it
+   bare made every single open print an HDF5-DIAG error block to stderr and leave
+   a bogus frame sitting underneath the driver's own messages. Nothing failed,
+   so nothing should be reported: take the value with the auto-printer muted and
+   drop whatever the call pushed.
+
+   Counted rather than assumed to be one frame, and popped rather than cleared:
+   H5Eclear2() here would also discard anything the CALLER had on the stack
+   before the open. */
+static const H5FD_clio_fapl_t *H5FD__clio_peek_fapl(hid_t fapl_id) {
+  H5E_auto2_t auto_func = nullptr;
+  void *auto_data = nullptr;
+  H5Eget_auto2(H5E_DEFAULT, &auto_func, &auto_data);
+  H5Eset_auto2(H5E_DEFAULT, nullptr, nullptr);
+
+  const ssize_t before = H5Eget_num(H5E_DEFAULT);
+  const H5FD_clio_fapl_t *fa =
+      (const H5FD_clio_fapl_t *)H5Pget_driver_info(fapl_id);
+  const ssize_t after = H5Eget_num(H5E_DEFAULT);
+  if (before >= 0 && after > before) {
+    H5Epop(H5E_DEFAULT, (size_t)(after - before));
+  }
+
+  H5Eset_auto2(H5E_DEFAULT, auto_func, auto_data);
+  return fa;
+}
 
 /*
  * Apply the driver config string, if the FAPL carries one.
@@ -686,8 +732,7 @@ static H5FD_t *H5FD__clio_open(const char *name, unsigned flags,
 
   // Driver-specific FAPL config: use the caller's policy if a driver-info block
   // was set (H5Pset_fapl_clio), else the default (cache on).
-  const H5FD_clio_fapl_t *fa_in =
-      (const H5FD_clio_fapl_t *)H5Pget_driver_info(fapl_id);
+  const H5FD_clio_fapl_t *fa_in = H5FD__clio_peek_fapl(fapl_id);
   H5FD_clio_fapl_t fa = fa_in ? *fa_in : H5FD_clio_fapl_default_g;
 
   /* Driver config string. HDF5 does not hand this to a callback the way it does
@@ -1965,8 +2010,10 @@ herr_t H5Pget_fapl_clio(hid_t fapl_id, hbool_t *cache_enabled /*out*/) {
   // No driver-info block means the file would open with the default policy
   // (H5Pset_driver(fapl, driver, NULL)); report that same default so the getter
   // always describes what an open would actually do.
-  const H5FD_clio_fapl_t *fa =
-      (const H5FD_clio_fapl_t *)H5Pget_driver_info(fapl_id);
+  // Peeked, not fetched bare: this getter SUCCEEDS when there is no block, so it
+  // must not leave H5Pget_driver_info's "can't get driver info" behind on the
+  // caller's error stack. See H5FD__clio_peek_fapl.
+  const H5FD_clio_fapl_t *fa = H5FD__clio_peek_fapl(fapl_id);
   *cache_enabled =
       fa ? fa->cache_enabled : H5FD_clio_fapl_default_g.cache_enabled;
   return SUCCEED;

--- a/context-transfer-engine/test/unit/adapters/vfd/test_vfd_adapter.cc
+++ b/context-transfer-engine/test/unit/adapters/vfd/test_vfd_adapter.cc
@@ -393,6 +393,35 @@ herr_t FindClioErr(unsigned n, const H5E_error2_t *err, void *data) {
   }
   return 0;
 }
+
+// H5Ewalk callback: print one frame. Used only when a stack-content assertion
+// is about to fail.
+herr_t PrintErrFrame(unsigned n, const H5E_error2_t *err, void *data) {
+  (void)data;
+  std::fprintf(stderr, "[vfd-suite]   stack[%u] %s:%u %s(): %s\n", n,
+               err && err->file_name ? err->file_name : "?",
+               err ? err->line : 0u,
+               err && err->func_name ? err->func_name : "?",
+               err && err->desc ? err->desc : "(no description)");
+  return 0;
+}
+
+// "The driver pushed no diagnosable error" is the least actionable sentence a
+// CI log can contain: it says what is NOT there and nothing about what is. The
+// distinction between "the driver never ran", "the driver pushed a DIFFERENT
+// message" and "something wiped the stack" is entirely in the frames, so print
+// them. Call this BEFORE restoring the auto-printer -- H5Eset_auto2 is harmless
+// to the stack, but the frames are the evidence and nothing should get between
+// the walk that failed and the walk that reports it.
+void DumpErrStack(const char *what) {
+  std::fprintf(stderr, "[vfd-suite] %s -- HDF5 error stack follows:\n", what);
+  if (H5Ewalk2(H5E_DEFAULT, H5E_WALK_UPWARD, PrintErrFrame, nullptr) < 0) {
+    std::fprintf(stderr, "[vfd-suite]   (H5Ewalk2 failed)\n");
+  }
+  if (H5Eget_num(H5E_DEFAULT) == 0) {
+    std::fprintf(stderr, "[vfd-suite]   (the stack is empty)\n");
+  }
+}
 }  // namespace
 
 int main() {
@@ -685,15 +714,25 @@ int main() {
   // the auto-printer so the expected stack doesn't clutter output, and walk the
   // stack to confirm the driver's own error (not just HDF5's) was recorded.
   {
+    const char *kAbsent = "/tmp/clio_cte_vfd_absent_xyz.h5";
+    // "Non-existent" is an assumption about /tmp, not a fact: a leftover from an
+    // earlier run (or from another user on a shared node -- /tmp is not private
+    // on an HPC compute node) turns this case into "open a file that is not
+    // HDF5", which fails in the superblock reader without the driver's open
+    // path ever failing. Same red X, entirely different cause. Make it a fact.
+    std::remove(kAbsent);
+
     H5E_auto2_t old_func = nullptr;
     void *old_data = nullptr;
     H5Eget_auto2(H5E_DEFAULT, &old_func, &old_data);
     H5Eset_auto2(H5E_DEFAULT, nullptr, nullptr);
     H5Eclear2(H5E_DEFAULT);
-    hid_t missing = H5Fopen("/tmp/clio_cte_vfd_absent_xyz.h5",
-                            H5F_ACC_RDONLY, fapl);
+    hid_t missing = H5Fopen(kAbsent, H5F_ACC_RDONLY, fapl);
     bool found_clio_err = false;
     H5Ewalk2(H5E_DEFAULT, H5E_WALK_UPWARD, FindClioErr, &found_clio_err);
+    if (!found_clio_err) {
+      DumpErrStack("9: no driver error found on the stack");
+    }
     H5Eset_auto2(H5E_DEFAULT, old_func, old_data);
     CHECK(missing < 0, "9: H5Fopen of a missing file must fail closed");
     CHECK(found_clio_err,
@@ -1266,6 +1305,9 @@ int main() {
     hid_t blocked = H5Fopen(kClioBusy, H5F_ACC_RDWR, fapl_lk);
     bool found_clio_err = false;
     H5Ewalk2(H5E_DEFAULT, H5E_WALK_UPWARD, FindClioErr, &found_clio_err);
+    if (!found_clio_err) {
+      DumpErrStack("21: no driver error found on the stack");
+    }
     H5Eset_auto2(H5E_DEFAULT, of, od);
 
     CHECK(blocked < 0, "21: opening a file locked by another holder fails");


### PR DESCRIPTION
## The failure

CDash [build 4023331](https://my.cdash.org/builds/4023331/tests?filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22status%22%3A%22FAILED%22%7D%7D%5D%7D) (`dev/r/gpu`, vista, conda toolchain, HDF5 2.3.0) fails one test, `clio_cte_vfd_unit_tests`, at section 9:

```
[vfd-suite] FAIL: 9: the driver pushed a diagnosable error onto the HDF5 stack
```

Section 9 opens a missing file and requires the open to fail **and** leave the driver's own message on HDF5's error stack. The open failed closed; the message was not there.

## Ruled out

Built HDF5 2.3.0 (vista's version) locally and ran a standalone VFD reproducer against it and against conda's 1.14.6. **HDF5 version, thread-safety, `H5FD_class_t` layout drift, and the VOL plugin search** all behave identically and pass. None of them is the cause.

## Two defects in the driver's error path

**1. `H5FD_CLIO_ERROR` could push nothing at all.**

The macro was a no-op unless `H5FDclio_err_class_g >= 0`, and it passed `H5FDclio_err_major_g` / `H5FDclio_err_minor_g` through unchecked — `H5Epush2` returns FAIL and stores nothing when a message id is invalid (verified on both 1.14.6 and 2.3.0). An unregistered class *or* a half-registered one turns "fail closed and say why" into "fail closed silently" — the precise defect section 9 exists to catch, and the only in-code path that produces exactly the observed symptom.

The push is now unconditional. The driver's class ids only label the frame "CLIO VFD"; when any of the three is unavailable the message still lands, under HDF5's own `H5E_ERR_CLS`/`H5E_VFL`.

**2. Every open pushed a spurious error of its own.**

`H5Pget_driver_info()` reports "this FAPL carries no driver-info block" the same way it reports a real failure: NULL, plus `H5E_PLIST/H5E_CANTGET`. That absent block is the *normal* case — `H5Pset_driver(fapl, id, NULL)`, `H5Pset_driver_by_name()`, `HDF5_DRIVER=clio_vfd` and the defaults all leave it unset; only `H5Pset_fapl_clio()` sets one. Calling it bare printed an `HDF5-DIAG` error block for every file operation and left a bogus frame underneath every genuine driver message.

Measured over the unit suite: **32 such blocks before, 0 after.**

`H5FD__clio_peek_fapl()` now takes the value with the auto-printer muted and pops what the call added — counted rather than assumed to be one frame, and popped rather than cleared, so anything the caller had on the stack before the open survives. `H5Pget_fapl_clio()` gets the same treatment; it too succeeds when there is no block.

## Test side

- Section 9 removes its target file first. "Non-existent" was an assumption about `/tmp`, not a fact; a leftover on a shared compute node turns the case into "open a file that is not HDF5", which fails in the superblock reader without the driver's open path failing at all — same red X, different cause.
- Sections 9 and 21 dump the error stack when the assertion trips. "The driver pushed no diagnosable error" says what is *not* there and nothing about what is; the frames separate "the driver never ran" from "the driver pushed a different message" from "something wiped the stack".

## Verification

- `clio_cte_vfd_unit_tests`: all 25 sections pass against HDF5 1.14.6, zero `HDF5-DIAG` output.
- `clio_cte_vfd_no_runtime_tests`: still passes.
- Standalone VFD reproducer confirms both fixes behave identically on HDF5 1.14.6 and a source build of 2.3.0.

## Caveat

vista's exact trigger could not be reproduced from here — no access to that node, and the four environment hypotheses testable locally all came back clean. Fix 1 closes the only code path that yields precisely this symptom. If vista still fails, section 9 now prints the frames, which diagnoses it in one run instead of a bare boolean.

## Coverage note (not in this PR)

`CLIO_CTE_ENABLE_VFD` defaults to `OFF`, and the ares nightly scripts (`core_dev`, `core_spack_dev`) do not set it — so `dev/r/cnd` and `dev/r/spack` contain zero VFD tests. The suite runs in only two places today: vista `dev/r/gpu` and `ubu-24/WSL dev/cnd/vfd/vol`. Those cron scripts are being updated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
