### PR TITLE
clio-vfd: fix section 9 under HDF5_PLUGIN_PATH and stop a spurious HDF5 error

### DIFF
--- a/context-transfer-engine/adapter/vfd/H5FDclio.cc
+++ b/context-transfer-engine/adapter/vfd/H5FDclio.cc
@@ -150,6 +150,51 @@ unsigned long H5FDclio_cache_truncate_failures_g = 0;
     }                                                                      \
   } while (0)
 
+/* Ask a FAPL a question without HDF5 reporting an error we did not have.
+ *
+ * H5Pget_driver_info() documents that a FAPL carrying no driver-info block
+ * returns NULL "although no error is pushed on the stack in this case". HDF5
+ * 2.x pushes H5E_PLIST/H5E_CANTGET whenever the block is absent (H5Pfapl.c),
+ * and being an API function it auto-prints on the way out -- so every open of
+ * a FAPL built the documented way, H5Pset_driver(fapl, id, NULL), emitted an
+ * HDF5-DIAG block reporting a failure that did not happen. Thirteen per run of
+ * the VFD suite, in a dashboard log people are supposed to read.
+ *
+ * "Absent" is a legitimate answer to this question, so silence the auto-printer
+ * for the duration of the call and put back the stack the enclosing operation
+ * was accumulating. Both halves are needed: the printing happens inside the
+ * call (H5E_dump_api_stack at FUNC_LEAVE_API), so restoring the stack
+ * afterwards does not stop it. Neither H5Eget_current_stack nor
+ * H5Eset_current_stack touches the pause counter, so HDF5's own error
+ * bookkeeping is unaffected.
+ *
+ * Scope this around the QUERY ONLY -- a diagnostic the driver pushes while it
+ * is in scope would be discarded by the restore. */
+class H5FD__clio_QuietQuery {
+ public:
+  H5FD__clio_QuietQuery() : saved_(H5Eget_current_stack()) {
+    H5Eget_auto2(H5E_DEFAULT, &auto_func_, &auto_data_);
+    H5Eset_auto2(H5E_DEFAULT, nullptr, nullptr);
+  }
+  ~H5FD__clio_QuietQuery() {
+    H5Eset_auto2(H5E_DEFAULT, auto_func_, auto_data_);
+    if (saved_ >= 0) {
+      /* Restores the saved entries and closes saved_; on failure the id still
+         must not leak. */
+      if (H5Eset_current_stack(saved_) < 0) {
+        H5Eclose_stack(saved_);
+      }
+    }
+  }
+  H5FD__clio_QuietQuery(const H5FD__clio_QuietQuery &) = delete;
+  H5FD__clio_QuietQuery &operator=(const H5FD__clio_QuietQuery &) = delete;
+
+ private:
+  hid_t saved_;
+  H5E_auto2_t auto_func_ = nullptr;
+  void *auto_data_ = nullptr;
+};
+
 /* POSIX I/O mode used as the third parameter to open/_open
  * when creating a new file (O_CREAT is set). */
 #if defined(H5_HAVE_WIN32_API)
@@ -334,6 +379,14 @@ typedef struct H5FD_clio_fapl_t {
   hbool_t fsync_on_flush; /* fsync(2) the native file in flush (default off) */
   size_t sieve_max;      /* vector-I/O coalescing window, bytes (0 = off) */
 } H5FD_clio_fapl_t;
+
+/* The driver-specific FAPL block, or NULL when the FAPL carries none (the
+ * default-policy open). Reports nothing either way -- see
+ * H5FD__clio_QuietQuery. */
+static const H5FD_clio_fapl_t *H5FD__clio_peek_fapl(hid_t fapl_id) {
+  H5FD__clio_QuietQuery quiet;
+  return (const H5FD_clio_fapl_t *)H5Pget_driver_info(fapl_id);
+}
 
 /* Coalescing window for vector I/O. 64 KiB matches HDF5's own default sieve
  * buffer (H5Pset_sieve_buf_size), which is the mechanism this replaces for
@@ -686,8 +739,7 @@ static H5FD_t *H5FD__clio_open(const char *name, unsigned flags,
 
   // Driver-specific FAPL config: use the caller's policy if a driver-info block
   // was set (H5Pset_fapl_clio), else the default (cache on).
-  const H5FD_clio_fapl_t *fa_in =
-      (const H5FD_clio_fapl_t *)H5Pget_driver_info(fapl_id);
+  const H5FD_clio_fapl_t *fa_in = H5FD__clio_peek_fapl(fapl_id);
   H5FD_clio_fapl_t fa = fa_in ? *fa_in : H5FD_clio_fapl_default_g;
 
   /* Driver config string. HDF5 does not hand this to a callback the way it does
@@ -1965,8 +2017,7 @@ herr_t H5Pget_fapl_clio(hid_t fapl_id, hbool_t *cache_enabled /*out*/) {
   // No driver-info block means the file would open with the default policy
   // (H5Pset_driver(fapl, driver, NULL)); report that same default so the getter
   // always describes what an open would actually do.
-  const H5FD_clio_fapl_t *fa =
-      (const H5FD_clio_fapl_t *)H5Pget_driver_info(fapl_id);
+  const H5FD_clio_fapl_t *fa = H5FD__clio_peek_fapl(fapl_id);
   *cache_enabled =
       fa ? fa->cache_enabled : H5FD_clio_fapl_default_g.cache_enabled;
   return SUCCEED;

--- a/context-transfer-engine/test/unit/adapters/vfd/test_vfd_adapter.cc
+++ b/context-transfer-engine/test/unit/adapters/vfd/test_vfd_adapter.cc
@@ -70,6 +70,16 @@ inline void TestSetenv(const char *name, const char *value, int overwrite) {
 #endif
 }
 
+/** Remove a variable from this process's environment. Windows spells "unset"
+ *  as "assign the empty string" -- _putenv_s(name, "") deletes the entry. */
+inline void TestUnsetenv(const char *name) {
+#ifdef _WIN32
+  (void)_putenv_s(name, "");
+#else
+  (void)unsetenv(name);
+#endif
+}
+
 /** access(path, F_OK) stand-in. The error_code overload is deliberate: one
  *  call site probes a "clio::"-marked name, and a bare colon in a path makes
  *  the throwing overload unhappy on Windows. */
@@ -404,6 +414,37 @@ int main() {
   // of sub-4 KiB metadata I/O still covers the single-pass case. Must be set
   // before the driver's first use -- it is read once.
   TestSetenv("CLIO_VFD_MAX_IO_BYTES", "4096", /*overwrite*/ 0);
+
+  // Section 9 asserts that a failed open leaves the DRIVER's own error on
+  // HDF5's stack, and HDF5_PLUGIN_PATH makes that unobservable -- so make this
+  // process's environment a precondition of the suite instead of a property of
+  // whoever launched it. The dashboard exports HDF5_PLUGIN_PATH for the VOL
+  // tests (clio-core-cdash-c.dev.slurm), ctest runs every test in that one
+  // environment, and section 9 then failed on the dashboard while passing
+  // everywhere else.
+  //
+  // Why it breaks, traced rather than guessed. With a plugin path set, a failed
+  // H5Fopen on a FAPL using the default VOL connector does not simply fail:
+  // H5VL_file_open searches the path for a connector that might read the file,
+  // registering each candidate and probing it with H5VL_FILE_IS_ACCESSIBLE ->
+  // H5F__is_hdf5 -> H5FD_open. So this driver's open() runs TWICE for one
+  // H5Fopen, and instrumenting both passes showed:
+  //
+  //   open ENTER absent.h5 depth=0
+  //   pushed 'authoritative native file' depth=1   <- pass 1 records it
+  //   open ENTER absent.h5 depth=0                 <- already wiped
+  //   pushed 'authoritative native file' depth=0   <- suppressed
+  //
+  // Pass 1's error is gone before pass 2 even begins (HDF5 clears the stack
+  // while setting up the candidate connector), and pass 2 runs inside
+  // H5E_PAUSE_ERRORS, where H5Epush2 honours estack->paused and records
+  // nothing. The application is left with only HDF5's generic "open failed".
+  // That is HDF5 losing a VFD's diagnostics -- it would do the same to sec2 --
+  // not this driver failing to report, which the trace above proves it does.
+  //
+  // The plugin path is still supplied explicitly to the one child process that
+  // needs it (see the CLIO_VFD_TRACE section), which is where it belongs.
+  TestUnsetenv("HDF5_PLUGIN_PATH");
 
   if (!InitRuntime()) {
     std::fprintf(stderr, "[vfd-suite] FAIL: runtime/CTE init\n");


### PR DESCRIPTION
## Summary
- Section 9 of `clio_cte_vfd_unit_tests` no longer depends on how ctest was launched: the suite unsets `HDF5_PLUGIN_PATH` in its own process, which its existing comment already required.
- The driver no longer reports an HDF5 error when a FAPL simply carries no driver-info block, removing 13 spurious `HDF5-DIAG` blocks per run.

Two independent defects, kept as two commits. They share one root theme (the VFD's interaction with HDF5 2.x's error stack) and were found and verified together from one dashboard build, so they are filed as one issue and one PR; each commit stands alone if you would rather they were split.

## Motivation
Fixes #1080. The single FAILED test on [CDash build 4023331](https://my.cdash.org/builds/4023331) (site `vista`, build `dev/r/gpu`):

```
[vfd-suite] FAIL: 9: the driver pushed a diagnosable error onto the HDF5 stack
```

The driver **does** push its diagnostic. With `HDF5_PLUGIN_PATH` set — which the dashboard exports for the VOL tests — a failed `H5Fopen` sends `H5VL_file_open` searching for a connector that might read the file, re-entering the VFD's `open()` a second time inside `H5E_PAUSE_ERRORS`. Instrumenting both passes:

```
open ENTER absent.h5 depth=0
pushed 'authoritative native file' depth=1   <- pass 1 records it
open ENTER absent.h5 depth=0                 <- already wiped
pushed 'authoritative native file' depth=0   <- suppressed
```

HDF5 clears the stack while setting up the candidate connector, and `H5Epush2` honours `estack->paused` in pass 2. That is HDF5 discarding a VFD's diagnostics — it would do the same to sec2 — so the fix belongs in the test's preconditions, not the driver.

The second defect is separate: `H5Pget_driver_info()` documents that an absent driver-info block returns NULL "although no error is pushed on the stack in this case", but HDF5 2.x pushes `H5E_PLIST/H5E_CANTGET` and auto-prints it. `H5Pset_driver(fapl, id, NULL)` is a documented way to select a driver, so the ordinary open reported a failure that never happened.

## Test plan
Verified on TACC Vista (`gh` partition, GH200), Release + CUDA, HDF5 2.3.0 built from tip, using a build script derived from the cron dashboard job (`clio-core-cdash-c.dev.slurm`) so the environment matches the failing build — **including `HDF5_PLUGIN_PATH` exported**, since the fix has to hold under the dashboard's real condition rather than by avoiding it.

- [x] Target test passes, 3/3 consecutive runs: `ctest -R clio_cte_vfd_unit_tests` → `Passed` (2.2–2.7 s)
- [x] All 25 sections of the suite report `ok`, no `FAIL`/`WARN`; binary exits 0
- [x] Spurious `H5Pget_driver_info` blocks: **13 → 0**
- [x] No regressions: full suite `100% tests passed, 0 tests failed out of 406` (1373 s)
- [x] The 4 pre-existing `Skipped` tests still skip for their own reasons (missing `h5py` / `fastapi`+`lightgbm`), unchanged
- [x] No new compiler warnings; added lines are within the 80-column limit and tab-free
- [x] No new files, so no BSD 3-Clause headers needed
- [ ] `clang-format` not run — not available on this host; formatting was checked by hand against the 80-column rule
- [ ] `CI/run_sanitizers.sh` not run — the sanitizer presets were not built in this tree

## Breaking changes
None. No public API, ABI, or config surface changes. `H5FD__clio_QuietQuery` and `H5FD__clio_peek_fapl` are file-local; behaviour changes only in that a query that legitimately finds nothing no longer manufactures an error.
