### PR TITLE
fix(ctp): actually unmap shared views on Windows

### DIFF
--- a/context-transport-primitives/include/clio_ctp/memory/backend/posix_shm_mmap.h
+++ b/context-transport-primitives/include/clio_ctp/memory/backend/posix_shm_mmap.h
@@ -94,8 +94,18 @@ class PosixShmMmap : public MemoryBackend, public UrlMemoryBackend {
       // shm_open(), and the Win32 one does not set errno at all, so this used
       // to report a commit-limit failure as "Resource temporarily
       // unavailable". Ask the platform what actually went wrong.
+      //
+      // Read it into a local BEFORE logging. GetLastError() is thread-global
+      // and clobbered by any intervening Win32 call, successful ones included
+      // -- and HLOG's first use in a process constructs the Logger singleton,
+      // which looks up CTP_LOG_LEVEL and CTP_LOG_OUT and so leaves
+      // ERROR_ENVVAR_NOT_FOUND behind. Passed as an argument to HLOG this
+      // raced the singleton's construction, and the first shm failure of every
+      // process was reported as "could not find the environment option that
+      // was entered" instead of its real cause.
+      std::string shm_err = SystemInfo::GetLastSharedMemoryError();
       HLOG(kError, "could not create shared memory segment {} of {} bytes: {}",
-           url, backend_size, SystemInfo::GetLastSharedMemoryError());
+           url, backend_size, shm_err);
       return false;
     }
     url_ = url;

--- a/context-transport-primitives/src/system_info.cc
+++ b/context-transport-primitives/src/system_info.cc
@@ -866,7 +866,33 @@ void SystemInfo::UnmapMemory(void *ptr, size_t size) {
 #if CTP_ENABLE_PROCFS_SYSINFO
   munmap(ptr, size);
 #elif CTP_ENABLE_WINDOWS_SYSINFO
-  VirtualFree(ptr, size, MEM_RELEASE);
+  // munmap() releases both kinds of mapping this class hands out. Win32 needs
+  // a different call for each, and VirtualFree(ptr, size, MEM_RELEASE) is
+  // neither of them: MEM_RELEASE REQUIRES dwSize == 0, so with a non-zero size
+  // it fails with ERROR_INVALID_PARAMETER, and it cannot release a
+  // MapViewOfFile view at any size. This function was therefore a silent
+  // no-op on Windows -- nothing was ever unmapped, private or shared.
+  //
+  // That went unnoticed while the sections were pagefile-backed, because a
+  // leaked view only costs address space. Once they became file-backed (to
+  // stop charging the commit limit), a live view keeps the section alive,
+  // which keeps the backing FILE alive: DestroySharedMemory's DeleteFile then
+  // fails, and re-creating a segment of the same name fails in CreateFile
+  // with ERROR_USER_MAPPED_FILE. That is the cte_shm_metadata_cache failure --
+  // several fixtures share one per-pid segment name, and only the first could
+  // create it.
+  (void)size;
+  if (ptr == nullptr) {
+    return;
+  }
+  // Try a view first: MapSharedMemory is the common case, and UnmapViewOfFile
+  // simply reports ERROR_INVALID_ADDRESS for anything that is not a view base.
+  if (UnmapViewOfFile(ptr)) {
+    return;
+  }
+  // Otherwise it came from MapPrivateMemory's VirtualAlloc, whose release
+  // takes a zero size.
+  VirtualFree(ptr, 0, MEM_RELEASE);
 #endif
 }
 

--- a/context-transport-primitives/test/unit/util/test_system_info.cc
+++ b/context-transport-primitives/test/unit/util/test_system_info.cc
@@ -199,3 +199,52 @@ TEST_CASE("SystemInfoSharedMemoryCreateFailure") {
   SystemInfo::DestroySharedMemory(too_long);
   SystemInfo::DestroySharedMemory("ctp_no_such_segment_xyz");
 }
+
+TEST_CASE("SystemInfoSharedMemoryRecreateSameName") {
+  // Regression: creating a segment, tearing it down, and creating one of the
+  // SAME name again must work -- a process holds one segment name per purpose
+  // (test_cte_shm_metadata_cache derives its from the pid) and builds it up
+  // and down repeatedly.
+  //
+  // On Windows this used to fail from the second round on. UnmapMemory() was
+  // VirtualFree(ptr, size, MEM_RELEASE), which cannot release a MapViewOfFile
+  // view -- and fails outright for any non-zero size -- so no view was ever
+  // unmapped. A live view pins the section, the section pins the file backing
+  // it, DestroySharedMemory's delete then fails, and the next CreateFile over
+  // that path fails with ERROR_USER_MAPPED_FILE.
+  const std::string seg = "ctp_sysinfo_recreate_seg";
+  constexpr size_t kSize = 1024 * 1024;
+
+  for (int round = 0; round < 3; ++round) {
+    INFO("round " << round);
+    ctp::File fd;
+    REQUIRE(SystemInfo::CreateNewSharedMemory(fd, seg, kSize));
+    void *mapped = SystemInfo::MapSharedMemory(fd, kSize, 0);
+    REQUIRE(mapped != nullptr);
+    // Touch it, so a round that reused a stale mapping instead of a fresh one
+    // would still be writing to something real.
+    memset(mapped, round + 1, kSize);
+    SystemInfo::UnmapMemory(mapped, kSize);
+    SystemInfo::CloseSharedMemory(fd);
+    SystemInfo::DestroySharedMemory(seg);
+    REQUIRE_FALSE(SystemInfo::SharedMemoryExists(seg));
+  }
+}
+
+TEST_CASE("PosixShmMmapRecreateSameName") {
+  // The same property one layer up, where the failure was actually observed:
+  // shm_init() destroys any stale segment of that name first, so a second
+  // backend over the same url must come up cleanly.
+  const std::string seg = "ctp_shm_mmap_recreate_seg";
+  constexpr size_t kSize = 4 * 1024 * 1024;
+
+  for (int round = 0; round < 3; ++round) {
+    INFO("round " << round);
+    PosixShmMmap backend;
+    REQUIRE(backend.shm_init(ctp::ipc::MemoryBackendId::GetRoot(), kSize, seg));
+    REQUIRE(backend.data_ != nullptr);
+    REQUIRE(backend.data_capacity_ > 0);
+    memset(backend.data_, round + 1, backend.data_capacity_);
+    backend.shm_destroy();
+  }
+}


### PR DESCRIPTION
## The failure

CDash [build 4029381](https://my.cdash.org/builds/4029381/tests) (site `win-10`, `dev/ninja/icx-2025.3.0`) had exactly one failing test: **`cte_shm_metadata_cache_all`**, 6 of 8 cases passing. The last two could not create their fixture:

```
shm_init could not create shared memory segment cte_shm_cache_test_7604 of 67108864 bytes:
  The system could not find the environment option that was entered (Win32 error 203)
  The requested operation cannot be performed on a file with a user-mapped section open (Win32 error 1224)
```

## Root cause

`SystemInfo::UnmapMemory`'s Windows branch was `VirtualFree(ptr, size, MEM_RELEASE)`. That is not the release call for either mapping the class hands out:

- `MEM_RELEASE` **requires** `dwSize == 0`, so a non-zero size fails with `ERROR_INVALID_PARAMETER`;
- `VirtualFree` cannot release a `MapViewOfFile` view at **any** size.

Nothing was ever unmapped on Windows — shared views or private `VirtualAlloc` memory. Confirmed with a standalone Win32 repro:

```
private VirtualFree(ptr,65536,MEM_RELEASE) -> 0 err=87     # ERROR_INVALID_PARAMETER
private VirtualFree(ptr,0,MEM_RELEASE)     -> 1 err=87     # succeeds
    VirtualFree(data,size,MEM_RELEASE) -> 0 err=87
    VirtualFree(hdr,size,MEM_RELEASE)  -> 0 err=87
    DeleteFileA -> 0 err=5
[2] CreateFileA -> FAIL err=1224                           # ERROR_USER_MAPPED_FILE
```

A leaked view only cost address space while the sections were pagefile-backed. Since fc7d738a ("stop charging the Windows commit limit for shared memory nobody touched") they are file-backed, so the chain bites: a live view pins the section, the section pins the backing file, `DestroySharedMemory`'s `DeleteFile` fails, and the next `CreateFile(CREATE_ALWAYS)` over that path fails with `ERROR_USER_MAPPED_FILE`.

`test_cte_shm_metadata_cache`'s fixtures all share one per-pid segment name, so only the first could ever create it. That commit landed 2026-08-28, between the last green Windows build and 4029381.

### The bogus "error 203"

A second, smaller bug made the first failure lie about its cause. `GetLastSharedMemoryError()` was passed as an argument to `HLOG`, and `HLOG`'s first use in a process constructs the `Logger` singleton, which looks up `CTP_LOG_LEVEL` and `CTP_LOG_OUT` and leaves `ERROR_ENVVAR_NOT_FOUND` in the thread's last-error. Evaluation order let that race the read, so the *first* shm failure of every process reported "could not find the environment option that was entered" while the second (logger already built) reported the true `ERROR_USER_MAPPED_FILE`.

## The fix

- `UnmapViewOfFile(ptr)` for views, falling back to `VirtualFree(ptr, 0, MEM_RELEASE)` for `MapPrivateMemory`'s `VirtualAlloc`. `UnmapViewOfFile` simply reports `ERROR_INVALID_ADDRESS` for anything that is not a view base, so the two cases separate cleanly.
- Read the error string into a local before logging it.

## Test plan

Two regression cases in `test_system_info.cc` build a segment of the same name up and down three times — one at the `SystemInfo` layer, one at the `PosixShmMmap` layer where the failure surfaced.

- Reproduced the exact CDash failure locally first (same site/toolchain).
- Both new cases **fail at round 1** with the fix reverted, with the same `ERROR_USER_MAPPED_FILE`; both pass with it.
- `cte_shm_metadata_cache_all` now passes 8/8.
- Full suite on win-10 / Ninja / icx-2025.3.0 Debug: **237/237 passing** (was 236/237).

Since the unmap now genuinely happens on Windows, the full-suite run also covers the risk that the old leak was masking a use-after-unmap somewhere; nothing regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
