### PR TITLE
Revert "vfd: never let a failed callback push nothing onto the HDF5 error stack"

### DIFF
--- a/context-transfer-engine/adapter/vfd/H5FDclio.cc
+++ b/context-transfer-engine/adapter/vfd/H5FDclio.cc
@@ -139,30 +139,15 @@ unsigned long H5FDclio_cache_truncate_failures_g = 0;
  * FAIL/NULL to signal the failure to the library; this records a diagnosable
  * reason (incl. errno) that composes with HDF5's own stack and is surfaced by
  * the normal H5Eprint auto-handler at the API boundary -- instead of failing
- * silently.
- *
- * The push is UNCONDITIONAL. It used to be skipped whenever the driver's own
- * error class had not been registered, which turned "fail closed and say why"
- * into "fail closed silently" -- the exact defect section 9 of the unit suite
- * exists to catch, and the one failure mode that leaves a caller with an open
- * that failed for no stated reason. The class ids are a nicety (they label the
- * frame "CLIO VFD"); when any of them is unavailable the message still goes on
- * the stack under HDF5's own VFL class, because the message is the part that
- * matters. Note all three ids are checked, not just the class: H5Epush2 fails
- * outright on an invalid major/minor, so a half-registered class was another
- * way to push nothing. */
+ * silently. No-op until the class is registered by H5FD_clio_init(). */
 #define H5FD_CLIO_ERROR(msg)                                               \
   do {                                                                     \
-    const int h5fd_clio_errno = errno;                                     \
-    const bool h5fd_clio_own_cls =                                         \
-        (H5FDclio_err_class_g >= 0 && H5FDclio_err_major_g >= 0 &&         \
-         H5FDclio_err_minor_g >= 0);                                       \
-    H5Epush2(H5E_DEFAULT, __FILE__, __func__, __LINE__,                    \
-             h5fd_clio_own_cls ? H5FDclio_err_class_g : H5E_ERR_CLS,       \
-             h5fd_clio_own_cls ? H5FDclio_err_major_g : H5E_VFL,           \
-             h5fd_clio_own_cls ? H5FDclio_err_minor_g : H5E_CANTINIT,      \
-             "%s (errno=%d: %s)", (msg), h5fd_clio_errno,                  \
-             strerror(h5fd_clio_errno));                                   \
+    if (H5FDclio_err_class_g >= 0) {                                       \
+      H5Epush2(H5E_DEFAULT, __FILE__, __func__, __LINE__,                  \
+               H5FDclio_err_class_g, H5FDclio_err_major_g,                 \
+               H5FDclio_err_minor_g, "%s (errno=%d: %s)", (msg), errno,    \
+               strerror(errno));                                           \
+    }                                                                      \
   } while (0)
 
 /* POSIX I/O mode used as the third parameter to open/_open
@@ -375,37 +360,6 @@ static inline bool H5FD__clio_sieve_valid(size_t v) {
 static const H5FD_clio_fapl_t H5FD_clio_fapl_default_g = {
     /*cache_enabled*/ 1, /*fsync_on_flush*/ 0,
     /*sieve_max*/ H5FD_CLIO_SIEVE_MAX_DEF};
-
-/* H5Pget_driver_info() reports "this FAPL carries no driver-info block" exactly
-   the way it reports a real failure: NULL, plus H5E_PLIST/H5E_CANTGET pushed on
-   the error stack. Here the absent block is the NORMAL case -- H5Pset_driver(
-   fapl, id, NULL), H5Pset_driver_by_name(), HDF5_DRIVER=clio_vfd and the
-   defaults all leave it unset; only H5Pset_fapl_clio() sets one -- so calling it
-   bare made every single open print an HDF5-DIAG error block to stderr and leave
-   a bogus frame sitting underneath the driver's own messages. Nothing failed,
-   so nothing should be reported: take the value with the auto-printer muted and
-   drop whatever the call pushed.
-
-   Counted rather than assumed to be one frame, and popped rather than cleared:
-   H5Eclear2() here would also discard anything the CALLER had on the stack
-   before the open. */
-static const H5FD_clio_fapl_t *H5FD__clio_peek_fapl(hid_t fapl_id) {
-  H5E_auto2_t auto_func = nullptr;
-  void *auto_data = nullptr;
-  H5Eget_auto2(H5E_DEFAULT, &auto_func, &auto_data);
-  H5Eset_auto2(H5E_DEFAULT, nullptr, nullptr);
-
-  const ssize_t before = H5Eget_num(H5E_DEFAULT);
-  const H5FD_clio_fapl_t *fa =
-      (const H5FD_clio_fapl_t *)H5Pget_driver_info(fapl_id);
-  const ssize_t after = H5Eget_num(H5E_DEFAULT);
-  if (before >= 0 && after > before) {
-    H5Epop(H5E_DEFAULT, (size_t)(after - before));
-  }
-
-  H5Eset_auto2(H5E_DEFAULT, auto_func, auto_data);
-  return fa;
-}
 
 /*
  * Apply the driver config string, if the FAPL carries one.
@@ -732,7 +686,8 @@ static H5FD_t *H5FD__clio_open(const char *name, unsigned flags,
 
   // Driver-specific FAPL config: use the caller's policy if a driver-info block
   // was set (H5Pset_fapl_clio), else the default (cache on).
-  const H5FD_clio_fapl_t *fa_in = H5FD__clio_peek_fapl(fapl_id);
+  const H5FD_clio_fapl_t *fa_in =
+      (const H5FD_clio_fapl_t *)H5Pget_driver_info(fapl_id);
   H5FD_clio_fapl_t fa = fa_in ? *fa_in : H5FD_clio_fapl_default_g;
 
   /* Driver config string. HDF5 does not hand this to a callback the way it does
@@ -2010,10 +1965,8 @@ herr_t H5Pget_fapl_clio(hid_t fapl_id, hbool_t *cache_enabled /*out*/) {
   // No driver-info block means the file would open with the default policy
   // (H5Pset_driver(fapl, driver, NULL)); report that same default so the getter
   // always describes what an open would actually do.
-  // Peeked, not fetched bare: this getter SUCCEEDS when there is no block, so it
-  // must not leave H5Pget_driver_info's "can't get driver info" behind on the
-  // caller's error stack. See H5FD__clio_peek_fapl.
-  const H5FD_clio_fapl_t *fa = H5FD__clio_peek_fapl(fapl_id);
+  const H5FD_clio_fapl_t *fa =
+      (const H5FD_clio_fapl_t *)H5Pget_driver_info(fapl_id);
   *cache_enabled =
       fa ? fa->cache_enabled : H5FD_clio_fapl_default_g.cache_enabled;
   return SUCCEED;

--- a/context-transfer-engine/test/unit/adapters/vfd/test_vfd_adapter.cc
+++ b/context-transfer-engine/test/unit/adapters/vfd/test_vfd_adapter.cc
@@ -393,35 +393,6 @@ herr_t FindClioErr(unsigned n, const H5E_error2_t *err, void *data) {
   }
   return 0;
 }
-
-// H5Ewalk callback: print one frame. Used only when a stack-content assertion
-// is about to fail.
-herr_t PrintErrFrame(unsigned n, const H5E_error2_t *err, void *data) {
-  (void)data;
-  std::fprintf(stderr, "[vfd-suite]   stack[%u] %s:%u %s(): %s\n", n,
-               err && err->file_name ? err->file_name : "?",
-               err ? err->line : 0u,
-               err && err->func_name ? err->func_name : "?",
-               err && err->desc ? err->desc : "(no description)");
-  return 0;
-}
-
-// "The driver pushed no diagnosable error" is the least actionable sentence a
-// CI log can contain: it says what is NOT there and nothing about what is. The
-// distinction between "the driver never ran", "the driver pushed a DIFFERENT
-// message" and "something wiped the stack" is entirely in the frames, so print
-// them. Call this BEFORE restoring the auto-printer -- H5Eset_auto2 is harmless
-// to the stack, but the frames are the evidence and nothing should get between
-// the walk that failed and the walk that reports it.
-void DumpErrStack(const char *what) {
-  std::fprintf(stderr, "[vfd-suite] %s -- HDF5 error stack follows:\n", what);
-  if (H5Ewalk2(H5E_DEFAULT, H5E_WALK_UPWARD, PrintErrFrame, nullptr) < 0) {
-    std::fprintf(stderr, "[vfd-suite]   (H5Ewalk2 failed)\n");
-  }
-  if (H5Eget_num(H5E_DEFAULT) == 0) {
-    std::fprintf(stderr, "[vfd-suite]   (the stack is empty)\n");
-  }
-}
 }  // namespace
 
 int main() {
@@ -714,25 +685,15 @@ int main() {
   // the auto-printer so the expected stack doesn't clutter output, and walk the
   // stack to confirm the driver's own error (not just HDF5's) was recorded.
   {
-    const char *kAbsent = "/tmp/clio_cte_vfd_absent_xyz.h5";
-    // "Non-existent" is an assumption about /tmp, not a fact: a leftover from an
-    // earlier run (or from another user on a shared node -- /tmp is not private
-    // on an HPC compute node) turns this case into "open a file that is not
-    // HDF5", which fails in the superblock reader without the driver's open
-    // path ever failing. Same red X, entirely different cause. Make it a fact.
-    std::remove(kAbsent);
-
     H5E_auto2_t old_func = nullptr;
     void *old_data = nullptr;
     H5Eget_auto2(H5E_DEFAULT, &old_func, &old_data);
     H5Eset_auto2(H5E_DEFAULT, nullptr, nullptr);
     H5Eclear2(H5E_DEFAULT);
-    hid_t missing = H5Fopen(kAbsent, H5F_ACC_RDONLY, fapl);
+    hid_t missing = H5Fopen("/tmp/clio_cte_vfd_absent_xyz.h5",
+                            H5F_ACC_RDONLY, fapl);
     bool found_clio_err = false;
     H5Ewalk2(H5E_DEFAULT, H5E_WALK_UPWARD, FindClioErr, &found_clio_err);
-    if (!found_clio_err) {
-      DumpErrStack("9: no driver error found on the stack");
-    }
     H5Eset_auto2(H5E_DEFAULT, old_func, old_data);
     CHECK(missing < 0, "9: H5Fopen of a missing file must fail closed");
     CHECK(found_clio_err,
@@ -1305,9 +1266,6 @@ int main() {
     hid_t blocked = H5Fopen(kClioBusy, H5F_ACC_RDWR, fapl_lk);
     bool found_clio_err = false;
     H5Ewalk2(H5E_DEFAULT, H5E_WALK_UPWARD, FindClioErr, &found_clio_err);
-    if (!found_clio_err) {
-      DumpErrStack("21: no driver error found on the stack");
-    }
     H5Eset_auto2(H5E_DEFAULT, of, od);
 
     CHECK(blocked < 0, "21: opening a file locked by another holder fails");


### PR DESCRIPTION
Backs today's two commits on `dev` — `3b0a46d4` and its merge `9af0ce88` (PR #1079) — out of the branch, at the author's request.

`dev` carries `non_fast_forward` and `pull_request` rules with no bypass actors, so the history cannot be rewound in place. This revert (`git revert -m 1 9af0ce88`) is the equivalent the rules allow: the resulting tree is **identical to `ddf1a4a9`**, `dev`'s state before the merge.

Note for whoever picks this up: PR #1081 currently contains a merge of `dev` taken while #1079 was still on it, including a deduplication of the two branches' competing `H5FD__clio_peek_fapl` helpers. If this revert lands first, #1081 should be re-based on the reverted `dev` before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012W6JLrtnBushoh7HvasnH6